### PR TITLE
Fix for Wikia.com

### DIFF
--- a/src/config/dark_sites.json
+++ b/src/config/dark_sites.json
@@ -17,6 +17,7 @@
     "destinytracker.com",
     "discordapp.com",
     "dotabuff.com",
+    "fandom.wikia.com",
     "ffmpeg.org",
     "filterblade.xyz",
     "frootvpn.com",
@@ -58,5 +59,6 @@
     "um.mos.ru",
     "vinesauce.com",
     "www.gdax.com",
+    "^www.wikia.com/explore",
     "yandexdataschool.ru/$"
 ]

--- a/src/config/dark_sites.json
+++ b/src/config/dark_sites.json
@@ -17,7 +17,6 @@
     "destinytracker.com",
     "discordapp.com",
     "dotabuff.com",
-    "fandom.wikia.com",
     "ffmpeg.org",
     "filterblade.xyz",
     "frootvpn.com",
@@ -59,6 +58,5 @@
     "um.mos.ru",
     "vinesauce.com",
     "www.gdax.com",
-    "^www.wikia.com/explore",
     "yandexdataschool.ru/$"
 ]

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -529,9 +529,13 @@
             "url": "*.wikia.com",
             "invert": [
                 "body:not([class*=dark-theme]) #WikiaPage",
-                "body.mobile-wiki, body.mobile-wiki footer, .side-nav-drawer",
                 "#globalNavigation",
-                "div.wds-dropdown__content"
+                "div.wds-dropdown__content",
+                "body.mobile-wiki",
+                "body.mobile-wiki footer",
+                "body.mobile-wiki .wiki-page-header",
+                "body.mobile-wiki header",
+                ".side-nav-drawer"
             ],
             "noinvert": [
                 "html",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -499,6 +499,33 @@
             "rules": ".qrcode { border: 8px solid black; }"
         },
         {
+            "url": [
+                "^www.wikia.com/explore",
+                "^fandom.wikia.com"
+            ],
+            "invert": [
+                ".hero-block",
+                ".hub-feed",
+                "body.search",
+                "body.search > [class*=global-navigation]",
+                "body.search > footer"
+            ],
+            "noinvert": [
+                "html",
+                ".feed-container *",
+                "body.search > [class*=global-navigation] *",
+                "body.search > footer *"
+            ],
+            "rules": "body.search > [class*=global-navigation] { z-index: 1 }"
+        },
+        {
+            "url": "^www.wikia.com/(signin|register)",
+            "invert": [
+                "header",
+                ".signup-provider-facebook"
+            ]
+        },
+        {
             "url": "*.wikia.com",
             "invert": [
                 "body:not([class*=dark-theme]) #WikiaPage",

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -499,6 +499,22 @@
             "rules": ".qrcode { border: 8px solid black; }"
         },
         {
+            "url": "*.wikia.com",
+            "invert": [
+                "body:not([class*=dark-theme]) #WikiaPage",
+                "#globalNavigation",
+                "div.wds-dropdown__content"
+            ],
+            "noinvert": [
+                "html",
+                "body[class*=dark-theme] *",
+                "#globalNavigation *",
+                ".wds-community-header, .wds-community-header *",
+                ".wds-dropdown__content *"
+            ],
+            "rules": "body[class*=wiki-wikia] .WikiaSiteWrapper { background-color: black }"
+        },
+        {
             "url": "wikipedia.org",
             "invert": ".mwe-popups-discreet > svg",
             "noinvert": ".mwe-math-fallback-image-inline"

--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -529,6 +529,7 @@
             "url": "*.wikia.com",
             "invert": [
                 "body:not([class*=dark-theme]) #WikiaPage",
+                "body.mobile-wiki, body.mobile-wiki footer, .side-nav-drawer",
                 "#globalNavigation",
                 "div.wds-dropdown__content"
             ],


### PR DESCRIPTION
Full coverage for all *.wikia.com pages, with support for both light and dark-themed sites, latter are excluded / not changed, background images are generally preserved, to keep the page style intact.

Main pages ([www.wikia.com](http://www.wikia.com), [fandom.wikia.com](http://fandom.wikia.com)), (non-wiki pages) are also covered.

### Notes about possible check fails
The order of the site fixes are important, to prioritize for e.g. the fix for `www.wikia.com` over `*.wikia.com` . This conflicts (possibly) with the alphabetic order of site fixes, but is currently the only solution, as far as I know.