### PR TITLE
Global rule for 'Atlassian Confluence' background

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -7,7 +7,8 @@
             "[style*='background:url'], [style*='background-image:url']",
             "[style*='background: url'], [style*='background-image: url']",
             "[background]",
-            "twitterwidget"
+            "twitterwidget",
+            "[id='main-bg'], [class='main-bg']"
         ],
         "noinvert": [
             "[style*='background:url'] *, [style*='background-image:url'] *",


### PR DESCRIPTION
Atlassian Confluence deployments all contain a ' div id="main-bg" class="main-bg" ' tag at the top of the generated pages that are not matched by any of the global invert rules.  

Site specific invert rules in the form of 
"url": "site.com", 
"invert:" ".main-bg"
work, however adding a rule per site seemed ridiculous as there is an unlimited number of these around the internet (I interface with two on a daily basis myself and they do not share a common URL element to glob).  

This added to the common -> invert section however fixes it for all Confluence sites that I've tried it on.