### PR TITLE
Fix for black formulas on some math sites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,3 +9,23 @@ facebook.com
 
 INLINE
 ._50dz > div[style]
+
+================================
+
+farside.ph.utexas.edu
+mathpages.com
+mathprofi.ru
+mathprofi.net
+mathworld.wolfram.com
+reference.wolfram.com
+terrytao.wordpress.com
+
+INVERT
+img
+
+================================
+
+wikipedia.org
+
+INVERT
+.mwe-math-element


### PR DESCRIPTION
It would be cool if this fix will be temporary and you'll make detector of images like these.