### PR TITLE
Update inversion-fixes.config

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -137,13 +137,6 @@ INVERT
 
 ================================
 
-calendar.google.com
-
-INVERT
-#:4.fc
-
-================================
-
 central.bitdefender.com
 
 INVERT


### PR DESCRIPTION
I saw my account profile images all show up correctly when I removed the inversion fixes... It's possible this change may break whatever `#:4.fc` was INVERT-ing