### PR TITLE
Remove metro.ru

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -50,7 +50,6 @@ killtheradio.net
 leagueoflegends.com
 linux.org.ru
 lolesports.com
-metro.ru
 mmorpg.com
 mwomercs.com
 netflix.com


### PR DESCRIPTION
Because of some white pages like /library and [similar commit with DiscordApp](https://github.com/darkreader/darkreader/commit/39c6f7414b6f31ecc9e01d8831972dc5b5300676).