### PR TITLE
Update dynamic-theme-fixes for engadget

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5,6 +5,14 @@ svg
 
 ================================
 
+engadget.com
+
+INVERT
+.th-base.o-h
+img
+
+================================
+
 facebook.com
 
 INLINE


### PR DESCRIPTION
Inverts the engadget website. Note that the dividers on the main page can't seem to be made darker using the invert command. Attempting it reversed the inversion on the rest of the page. Looks fine on article pages.