### PR TITLE
Dynamic theme fix for news.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26,6 +26,16 @@ nav li img
 
 ================================
 
+news.google.com
+
+INVERT
+.gb_qc
+.gb_Cc
+.Ulgu9
+.DPvwYc
+
+================================
+
 wikipedia.org
 
 INVERT


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/22222179/39648170-26d2b412-4fa7-11e8-82b0-c9fdf9d2bbec.png)

After:
![image](https://user-images.githubusercontent.com/22222179/39648274-4f7d75a0-4fa7-11e8-95b6-696fcd68b133.png)


