### PR TITLE
Dynamic theme fix for docs.google.com icons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5,6 +5,14 @@ svg
 
 ================================
 
+docs.google.com
+
+INVERT
+.docs-icon
+.punch-filmstrip-controls-icon
+
+================================
+
 farside.ph.utexas.edu
 mathpages.com
 mathprofi.ru


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/22222179/39650796-335167c6-4faf-11e8-966b-4416310ef726.png)
![image](https://user-images.githubusercontent.com/22222179/39650805-3c09eb0e-4faf-11e8-8534-20c200e21771.png)


After:
![image](https://user-images.githubusercontent.com/22222179/39650767-18e91046-4faf-11e8-835e-8f90397f3536.png)
![image](https://user-images.githubusercontent.com/22222179/39650779-24d398b8-4faf-11e8-8231-d56333e2b188.png)
