### PR TITLE
Dynamic theme fix for wiki.blender.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -41,6 +41,16 @@ INVERT
 
 ================================
 
+wiki.blender.org
+
+INVERT
+.mediawiki
+NO
+img
+.title_link
+
+================================
+
 wikipedia.org
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -45,7 +45,7 @@ wiki.blender.org
 
 INVERT
 .mediawiki
-NO
+NO INVERT
 img
 .title_link
 


### PR DESCRIPTION
 There may be a larger issue at hand here, but here's a temp fix at the very least. #404 

Before:
![image](https://user-images.githubusercontent.com/22222179/39654033-f4bb6d5e-4fb8-11e8-939d-7a84e1f0622d.png)

After:
![image](https://user-images.githubusercontent.com/22222179/39654013-e40f3b0c-4fb8-11e8-9daa-a3968c752e88.png)

