### PR TITLE
Dynamic theme fix for docs.google.com spreadsheet cells

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10,6 +10,8 @@ docs.google.com
 INVERT
 .docs-icon
 .punch-filmstrip-controls-icon
+#waffle-grid-container
+.cell-input.editable
 
 ================================
 


### PR DESCRIPTION
#402 

Before:
![image](https://user-images.githubusercontent.com/22222179/39654533-d2a8f838-4fba-11e8-9436-7eed24c3d690.png)

After:
![image](https://user-images.githubusercontent.com/22222179/39654509-bac34b10-4fba-11e8-8258-5c956abc7456.png)
