### PR TITLE
Make Facebook icons more legible

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26,7 +26,16 @@ facebook.com
 INVERT
 ._2n_9
 ._59fc
-._5lxr
+._5lxs._3qct._p
+.uiToggle._4962._1z4y._330i._4kgv.openToggler
+.uiToggle._4962._4xi2._z9r.openToggler
+.uiToggle._4962._3nzl._24xk.openToggler
+.uiToggle._8-a._1kj2._4d1i._-57._5-sk.openToggler
+._6a._6b.uiPopover._1io_._5v-0.openToggler.selected
+.__tw._4xi1.uiToggleFlyout
+.__tw._3nzk.uiToggleFlyout
+.__tw.toggleTargetClosed._1y2l.uiToggleFlyout
+.__tw._8-b._tdb.toggleTargetClosed.uiToggleFlyout
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21,6 +21,15 @@ INVERT
 
 ================================
 
+facebook.com
+
+INVERT
+._2n_9
+._59fc
+._5lxr
+
+================================
+
 farside.ph.utexas.edu
 mathpages.com
 mathprofi.ru


### PR DESCRIPTION
Makes the Facebook icons in the top bar more legible for the dynamic theme engine.

Before: 
![image](https://user-images.githubusercontent.com/7811371/39666124-2211ec6e-5064-11e8-9f7d-097c5b51f143.png)

After: 
![image](https://user-images.githubusercontent.com/7811371/39666169-f46fbc04-5064-11e8-8c7f-5761c61c7259.png)

