### PR TITLE
Add Discordapp.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -21,7 +21,7 @@ cytu.be
 darkreader.org
 desktop.github.com
 destinytracker.com
-discordapp.com
+discordapp.com/channels
 dota2.com
 dota2.ru
 dotabuff.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -21,6 +21,7 @@ cytu.be
 darkreader.org
 desktop.github.com
 destinytracker.com
+discordapp.com
 dota2.com
 dota2.ru
 dotabuff.com


### PR DESCRIPTION
DarkReader makes the Discord WebApp kinda blue, and discolours role colours. It's already a dark theme by default.