### PR TITLE
Invert Reddit logo text on Reddit redesign.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -54,6 +54,13 @@ INVERT
 
 ================================
 
+reddit.com
+
+INVERT
+.iAsPXl
+
+================================
+
 thenextweb.com
 
 INVERT


### PR DESCRIPTION
On Reddit's new site, the logo currently does not invert correctly with Dark Reader and the Dynamic Theme engine.

This change updates it so it does.  Screenshots below.

Before:

<img width="964" alt="screen shot 2018-05-13 at 9 21 52 am" src="https://user-images.githubusercontent.com/178348/39967742-48a3e41e-568f-11e8-9254-2ec163e3e317.png">

After:

<img width="966" alt="screen shot 2018-05-13 at 9 22 34 am" src="https://user-images.githubusercontent.com/178348/39967745-4cd187e4-568f-11e8-8dbd-5cf6a4ff89de.png">
