### PR TITLE
leagueoflegends.com is not a dark site (white background)

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -51,7 +51,6 @@ inker.co
 isthereanydeal.com
 jsfiddle.net
 killtheradio.net
-leagueoflegends.com
 linux.org.ru
 lolesports.com
 lutris.net


### PR DESCRIPTION
leagueoflegends.com is not a dark site (white background)