### PR TITLE
Add NO INVERT rule for Wikipedia

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1775,7 +1775,7 @@ INVERT
 NO INVERT
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
-.mwe-popups * image
+.mwe-popups image
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1775,6 +1775,7 @@ INVERT
 NO INVERT
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
+.mwe-popups * image
 
 ================================
 


### PR DESCRIPTION
Don't invert the images in the mouseover popups on internal page links.