### PR TITLE
Invert Reddit logo text on Reddit redesign (again)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -57,7 +57,7 @@ INVERT
 reddit.com
 
 INVERT
-.iAsPXl
+#header a[href="/"] svg:nth-child(2)
 
 ================================
 


### PR DESCRIPTION
The CSS classes the Reddit redesign uses are apparently not very stable.

As per @risualiser 's comment in https://github.com/darkreader/darkreader/pull/497#issuecomment-389833203, the CSS class changed to `.gPxcKZ`, then as of this moment is yet again changed to `.eeHZFh`.

This attempt takes a (hopefully) more robust approach.  The top navigation bar has the element ID of `header`.  Within it is a link to the main page (`a[href="/"]`), and within this, the SVG logo is contained.  It is split into two elements.  The first, the logo circle does not need inverting.  The second - the text (`svg:nth-child(2)`), does.

For reference, the element we are targeting (and surrounding DOM) looks like such:

<img width="765" alt="screen shot 2018-05-17 at 5 58 27 pm" src="https://user-images.githubusercontent.com/178348/40206177-ea64d6a8-59fc-11e8-8010-68161882ccd5.png">