### PR TITLE
Invert math formula image in zhuanlan.zhihu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -92,3 +92,10 @@ INVERT
 .align-by-text.style-scope.ytd-comment-replies-renderer
 g#youtube-red-paths
 .deemphasize.style-scope.yt-formatted-string
+
+================================
+
+zhuanlan.zhihu.com
+
+INVERT
+img[eeimg="1"]


### PR DESCRIPTION
Invert math formula image in zhuanlan.zhihu.com
Note: Such this image is generated by url, for example:

```
<img src="https://www.zhihu.com/equation?tex=Cost+function+%3D+Loss+%28say%2C+binary%5C_+crossentropy%29+%2B+Regularization%5C_+term" alt="Cost function = Loss (say, binary\_ crossentropy) + Regularization\_ term" eeimg="1">
```
 
Tested in: https://zhuanlan.zhihu.com/p/37120298

Before:
![capture](https://user-images.githubusercontent.com/7560132/40341403-97db4f66-5db7-11e8-95ec-505bb8d54dca.PNG)
After:
![capture2](https://user-images.githubusercontent.com/7560132/40341406-9b605fdc-5db7-11e8-9d4c-ee44c638e6b5.PNG)
