### PR TITLE
Fix for chemical structure diagrams in "Vorlage:Infobox_Chemikalien" de:wikipedia

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1785,6 +1785,7 @@ wikipedia.org
 INVERT
 .mwe-popups-discreet > svg
 .mw-mmv-overlay
+#Vorlage_Infobox_Chemikalie > tbody > tr:nth-child(2) > td > a
 
 NO INVERT
 .mwe-math-fallback-image-inline


### PR DESCRIPTION
Some chemical structure diagrams in the template on wikipedia.de were sometimes not visible.