### PR TITLE
Fix inversion on Google Photos

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1188,7 +1188,7 @@ INVERT
 
 CSS
 .ZSTBVb, .DwJIde .NRbSyd {
-background: white;
+    background: white !important;
 }
 
 ================================

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1181,6 +1181,18 @@ CSS
 
 ================================
 
+photos.google.com
+
+INVERT
+.DwJIde .QtDoYb svg
+
+CSS
+.ZSTBVb, .DwJIde .NRbSyd {
+background: white;
+}
+
+================================
+
 play.afreecatv.com
 
 INVERT


### PR DESCRIPTION
Fix to keep the background black when viewing a photo or video in Google photos