### PR TITLE
Fix LaTeX images everywhere

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -20,7 +20,7 @@ NO INVERT
 [style*="background-image: url"] *
 input
 [background] *
-img.latex
+img[src^="https://s0.wp.com/latex.php"]
 
 REMOVE BG
 .compatibility-with-darkreader-below-4-3-3

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -20,6 +20,7 @@ NO INVERT
 [style*="background-image: url"] *
 input
 [background] *
+img.latex
 
 REMOVE BG
 .compatibility-with-darkreader-below-4-3-3
@@ -771,7 +772,6 @@ body
 jeremykun.com
 
 NO INVERT
-img.latex
 img[src*=".gif"]
 img[src*=".png"]
 


### PR DESCRIPTION
I realize it's probably best to avoid adding things to the "*" section, but I keep enabling this rule locally using the dev tools and I'm not sure what else to do. I don't want to spam PRs or fill up `inversion-fixes.config` with this same rule for a dozen different sites. This appears to be a very common way to embed LaTeX on a page and I can't imagine inverting `img.latex` is going to break very much (how many non-LaTeX images have a `.latex` class?).