### PR TITLE
Fix hangouts.google.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -639,6 +639,26 @@ NO INVERT
 
 ================================
 
+hangouts.google.com
+
+INVERT
+.g-Ue-ad
+.g-Ue-v0h5Oe
+.bdXzDb .pTh3n
+.gb_Hc
+.Ik
+
+NO INVERT
+#gbq1
+
+CSS
+.kFx1Ae-xdwExf-eb-m,
+.g-Qx-r4m2rf-wZVHld {
+    display: none;
+}
+
+================================
+
 homestuck.com
 
 INVERT


### PR DESCRIPTION
hangouts.google.com displays an image that covers the entire background, so the CSS rules remove that. The rest are minor fixes to text and SVG fill.