### PR TITLE
Add dark websites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -69,6 +69,7 @@ poe-racing.com
 poe.trade
 poeapp.com
 poelab.com
+primevideo.com
 raidtime.net
 realgamernewz.com
 regexr.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -60,6 +60,7 @@ lutris.net
 mmorpg.com
 mwomercs.com
 open.spotify.com
+opendota.com
 pathof.info
 pathofexile.com
 play.hbogo.com


### PR DESCRIPTION
Add primevideo.com and opendota.com to dark websites list.