### PR TITLE
Fix structural formulas on Wikipedia

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1807,6 +1807,7 @@ NO INVERT
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
 .mwe-popups image
+img[src*="svg.png"]
 
 ================================
 


### PR DESCRIPTION
The structural formulas of chemicals on Wikipedia are often rendered on a transparent background, making them illegible. For example:
https://en.wikipedia.org/wiki/Polyethylene