### PR TITLE
Update inversion-fixes.config for codecademy.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7,6 +7,14 @@ INVERT
 
 ================================
 
+codecademy.com
+
+INVERT
+.CodeMirror-cursors
+span[class^="burger"]
+
+================================
+
 docs.google.com
 
 INVERT


### PR DESCRIPTION
codecademy has a partially dark UI. This makes it entirely dark, at least during the lessons. (There are other areas of the site, like documentation, that I haven't touched)

These are the page elements I made sure to cover:
- Beginning of a lesson before the editor loads, the editor pane on the right
- Code elements (short ones inline with instructions)
- Code elements (larger boxes)
- Side navigation drawer (choose different exercises in the current lesson)
- Top and bottom nav bars
- codecademy logo in the top nav bar