### PR TITLE
Added not inverted elements on Google Keep

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -71,6 +71,14 @@ nav li img
 
 ================================
 
+keep.google.com
+
+INVERT
+.gb_xc
+.JNdkSc-tJHJj
+
+================================
+
 news.ycombinator.com
 
 INVERT


### PR DESCRIPTION
A couple elements in the sidebar where not inverted correctly in the dynamic mode, so I just added them in the config file.