### PR TITLE
Old Reddit title color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -95,6 +95,7 @@ INVERT
 reddit.com
 
 INVERT
+.title
 #header a[href="/"] svg:nth-child(2)
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -95,7 +95,7 @@ INVERT
 reddit.com
 
 INVERT
-.title
+a.title
 #header a[href="/"] svg:nth-child(2)
 
 ================================


### PR DESCRIPTION
Reddit redesigned their site to look different a while ago but the old design is still an option under a user's preferences.  This inverts the color for post titles when a user has the old design set in their preferences.  It has no effect on the new design.  Without this, post titles are hard to read since they are a very dark blue on a dark background.