### PR TITLE
eBay/itm background fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24,6 +24,16 @@ INVERT
 
 ================================
 
+ebay.com/itm
+
+INVERT
+#Body
+#gh-gb
+#glbfooter
+.vi-contv2
+
+================================
+
 elearning.utdallas.edu
 
 INVERT


### PR DESCRIPTION
This is one way to fix go around background image issue on /itm pages on dynamic theme such as  https://www.ebay.com/itm/ASRock-H270M-ITX-ac-Mini-Itx-MotherBoard/263839765302

An alternative would be to fix add CSS capability to dynamic and hide/add styles such as hiding the background from https://ir.ebaystatic.com/pictures/aw/pics/cmp/ds3/imgbg.jpg