### PR TITLE
Add CSS for Medium

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -71,6 +71,26 @@ nav li img
 
 ================================
 
+medium.com
+
+CSS
+body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-targeted,
+body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-other {
+background-image: linear-gradient(to bottom, rgb(76, 76, 76), rgb(76, 76, 76));
+}
+
+================================
+
+medium.economist.com
+
+CSS
+body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-targeted,
+body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-other {
+background-image: linear-gradient(to bottom, rgb(76, 76, 76), rgb(76, 76, 76));
+}
+
+================================
+
 news.ycombinator.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -74,8 +74,8 @@ nav li img
 medium.com
 
 CSS
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-targeted,
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-other {
+.markup--quote.is-targeted,
+.markup--quote.is-other {
 background-image: linear-gradient(to bottom, rgb(76, 76, 76), rgb(76, 76, 76));
 }
 
@@ -84,8 +84,8 @@ background-image: linear-gradient(to bottom, rgb(76, 76, 76), rgb(76, 76, 76));
 medium.economist.com
 
 CSS
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-targeted,
-body.is-withMagicUnderlines .postArticle.is-withAccentColors .markup--quote.is-other {
+.markup--quote.is-targeted,
+.markup--quote.is-other {
 background-image: linear-gradient(to bottom, rgb(76, 76, 76), rgb(76, 76, 76));
 }
 


### PR DESCRIPTION
Update background of highlighted text.
Previously light background with light text color.
Updated for domain medium.com and medium.economist.com.