### PR TITLE
Update dynamic-theme for codecademy highlighting

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11,6 +11,7 @@ codecademy.com
 
 INVERT
 .CodeMirror-cursors
+.CodeMirror-selected
 span[class^="burger"]
 
 ================================


### PR DESCRIPTION
The code editor for codecademy.com appears perfectly inverted. But when selecting text, the highlighted background is dark on top of the editor's dark background. It's almost impossible to see. Inverting this gives it good contrast, very similar to what it has without DarkReader.

Without the fix (DarkReader on):
![image](https://user-images.githubusercontent.com/4809268/44067117-6cb49630-9f39-11e8-9aae-bd4fad6bad3e.png)

With the fix (DarkReader on):
![image](https://user-images.githubusercontent.com/4809268/44067122-74f21958-9f39-11e8-907c-8af8383e9ed4.png)

My apologies about not catching this in the first PR I made for codecademy. Thanks, as always.