### PR TITLE
Darkened etymology and word usage info in google

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -146,6 +146,7 @@ www.google.*.*
 INVERT
 .gb_hc
 .gb_ec
+#dictionary-modules img
 
 ================================
 


### PR DESCRIPTION
When searching for the definition of a word, google also shows etymology and word usage information.
This is presented as images with a blinding white background. Inverting those images makes them fit way better into the dark interface.