### PR TITLE
Guardian.com logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -123,6 +123,13 @@ INVERT
 
 ================================
 
+theguardian.com
+
+INVERT
+.inline-the-guardian-logo__svg
+
+================================
+
 thenextweb.com
 
 INVERT


### PR DESCRIPTION
Fixing inversion of logo on theguardian.com website.