### PR TITLE
Invert Evernote global logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -61,6 +61,13 @@ INVERT
 
 ================================
 
+evernote.com
+
+INVERT
+.global-logo svg
+
+================================
+
 farside.ph.utexas.edu
 mathpages.com
 mathprofi.ru


### PR DESCRIPTION
It was like this:

<img width="233" alt="screen shot 2018-10-11 at 12 44 55" src="https://user-images.githubusercontent.com/6067712/46816516-86a8f700-cd53-11e8-8604-89e9d33a7758.png">

and became like this:

<img width="243" alt="screen shot 2018-10-11 at 12 44 42" src="https://user-images.githubusercontent.com/6067712/46816515-86a8f700-cd53-11e8-8ea6-029e00a60dfa.png">
