### PR TITLE
Fix Ally Bank iFrames

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -135,6 +135,16 @@ header a[href="/"] svg:nth-child(2)
 
 ================================
 
+secure.ally.com
+
+INVERT
+.nobd-aob-day
+#lp_invite
+#manageNonAllyAccountsFrame .third-party-iframe
+#billPayFrame
+
+================================
+
 stackoverflow.com
 
 INVERT


### PR DESCRIPTION
Some parts of Ally Bank's site uses 3rd party iFrames (Bill Pay, Transfering from non-Ally Accounts, etc) and they were still white. This fixes that plus a couple of other minor model dialogs.