### PR TITLE
Fix for inversion of CodeMirror editor cursor on Runkit.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -135,6 +135,13 @@ header a[href="/"] svg:nth-child(2)
 
 ================================
 
+runkit.com
+
+INVERT
+.CodeMirror div.CodeMirror-cursor
+
+================================
+
 stackoverflow.com
 
 INVERT


### PR DESCRIPTION
Fixes CodeMirror editor cursor on Runkit.com. By default it remains black and thus invisible on dark background.