### PR TITLE
Don't invert docs.microsoft.com dark theme

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -294,6 +294,9 @@ docs.microsoft.com
 INVERT
 .theme-dark
 
+NO INVERT
+.theme_night
+
 ================================
 
 doodle.com


### PR DESCRIPTION
[Example URL reproing this behavior](https://docs.microsoft.com/en-us/rest/api/monitor/metrics/list); use the Light/Dark toggle in the top-right corner to verify.