### PR TITLE
Don't invert DevDocs dark theme

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -244,6 +244,13 @@ NO INVERT
 
 ================================
 
+devdocs.io
+
+NO INVERT
+._theme-dark
+
+================================
+
 developer.mozilla.org
 
 INVERT


### PR DESCRIPTION
Prevents inversion in [DevDocs](https://devdocs.io/)' dark theme. To enable/disable dark theme:

1. Click the ellipsis by the search box in the top-left corner
2. Click _Preferences_
3. Toggle _Enable dark theme_