### PR TITLE
added canvas tag to INVERT list on facebook.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -445,6 +445,7 @@ INVERT
 .uiTooltipX
 body.UIPage_LoggedOut #blueBarDOMInspector
 body.UIPage_LoggedOut #blueBarDOMInspector .inputtext
+canvas
 
 NO INVERT
 .uiStreamStory video


### PR DESCRIPTION
Saw a 3D photo for the first time uploaded to facebook, clicking on it to make it full-screen confused the inversion. The propsed change fixes that, and doesn't break normal photos on the timeline or in full-screen view.