### PR TITLE
Fix for logo and More arrow icon for BBC

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1,3 +1,22 @@
+bbc.com/news
+bbc.com/sport
+bbc.com/weather
+bbc.com/travel
+bbc.com/capital
+bbc.com/autos
+bbc.com/culture
+bbc.com/future
+bbc.com/sounds
+bbc.com/food
+bbc.com/bitesize
+bbc.com/earth
+
+INVERT
+.orb-nav-section.orb-nav-blocks
+.orb-icon.orb-icon-arrow
+
+================================
+
 chtoes.li
 
 INVERT


### PR DESCRIPTION
Note that using `bbc.com/*` is not posssible as it breaks the logo at bbc.com/home and bbc.com/reel