### PR TITLE
fix-pro-coinbase-com-allow-docs-to-be-dark references #660

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,3 +1,4 @@
+^pro.coinbase.com
 alienwarearena.com
 animeonline.su
 app.getpocket.com
@@ -89,7 +90,6 @@ poeapp.com
 poelab.com
 pr0gramm.com
 primevideo.com
-pro.coinbase.com
 raidtime.net
 realgamernewz.com
 runicgames.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,4 +1,3 @@
-^pro.coinbase.com
 alienwarearena.com
 animeonline.su
 app.getpocket.com


### PR DESCRIPTION
Please see my comment in https://github.com/darkreader/darkreader/issues/660 for more info on why I am submitting this PR.

It turns out that in the current implementation it is not possible to set `docs.pro.coinbase.com` to be dark, because `pro.coinbase.com` is in "global dark list".

@alexanderby suggested that I try `^pro.coinbase.com` which did not work for me when I added it to my dark list via the extension UI.

However, I did some digging and realized that in the actual codebase there is a list of sites that are marked as dark by default, and it had `pro.coinbase.com`. Changing it to `^pro.coinbase.com` fixed it.

If someone wishes, they would still be able to add `docs.pro.coinbase.com` to dark list (if for example they preferred the docs to be in light rather than dark).

I am also wondering whether it would be good to add a way to override (in this case I needed a way to remove) items from the dark list.

Also, I had to put the ^pro.coinbase.com in the very beginning of the config file because the test ensures that it's alphabetized.