### PR TITLE
Add 'terminal.sexy' to Global Dark List

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -102,6 +102,7 @@ streamelements.com
 takethewalk.net
 tautulli.com
 telecineplay.com.br
+terminal.sexy
 totalwarwarhammer.gamepedia.com
 um.mos.ru
 undertale.com


### PR DESCRIPTION
The site themes the entire page to match the proposed terminal colours. Doesn't make sense to then change these colours (even if they are light!).