### PR TITLE
Added missing canvas inversion on regexr.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1497,6 +1497,13 @@ img
 
 ================================
 
+regexr.com
+
+INVERT
+canvas.highlights
+
+================================
+
 rijnijssel.elo.education-online.nl
 
 NO INVERT


### PR DESCRIPTION
The highlights on regexr.com would be light text on light background, thus unreadable