### PR TITLE
Fix inversion for Instagram and FiveThirtyEigth

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -104,6 +104,15 @@ img
 
 ================================
 
+fivethirtyeight.com
+
+INVERT
+.site-logo
+#searchform
+.header-espn-link
+
+================================
+
 gitlab.com
 
 INVERT
@@ -142,6 +151,14 @@ inbox.google.com
 INVERT
 .actionIcon
 nav li img
+
+================================
+
+instagram.com
+
+INVERT
+.Igw0E.rBNOH.eGOV_.ybXk5._4EzTm
+._47KiJ
 
 ================================
 


### PR DESCRIPTION
For Instagram, I fixed inversion of logo and the top panel so that they
are visible. The website looks better since now we don't have black
title on gray background.
I made similar change to FiveThirtyEight. The title of the website
should be visible as well as the searchbar. This change makes them
visible.