### PR TITLE
Fix svg icons in medium.com are not displayed

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -160,6 +160,7 @@ INVERT
 medium.com
 
 INVERT
+.svgIcon
 .svgIcon-use
 
 ================================


### PR DESCRIPTION
Before fix:
![image](https://user-images.githubusercontent.com/15053186/49326208-a86f6f00-f589-11e8-87fa-e0506ddc85ff.png)

After fix:
![image](https://user-images.githubusercontent.com/15053186/49326210-adccb980-f589-11e8-833e-fcbe0ca99fd3.png)
