### PR TITLE
Invert structural/skeletal formulas on Wikipedia

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1996,6 +1996,8 @@ NO INVERT
 .mwe-math-fallback-image-display
 .mwe-popups image
 img[src*="svg.png"]
+img[alt^="Skeletal" i]
+img[alt^="Structural" i]
 
 ================================
 


### PR DESCRIPTION
Many of these have transparent backgrounds (e.g. https://en.wikipedia.org/wiki/Benzaldehyde) and so are impossible to see.