### PR TITLE
Create some custom inversion for search results in bing.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26,6 +26,19 @@ img[src^="/graphs/"]
 
 ================================
 
+bing.*
+bing.*.*
+
+INVERT
+.b_cnvsug
+.b_focusLabel
+.b_richcard
+.cbtn
+.trans_button
+.nosmab
+
+================================
+
 chtoes.li
 
 INVERT


### PR DESCRIPTION
bing.com creates some useful widget for better search results. Currently darkreader is not supporting them well. See the following screenshot:
![image](https://user-images.githubusercontent.com/16146613/50424433-760e1480-089e-11e9-84c4-baad4cf939b9.png)
We provide some fix for these widgets:
![image](https://user-images.githubusercontent.com/16146613/50424436-8c1bd500-089e-11e9-94fe-b74fcd91ed85.png)
