### PR TITLE
Make emoji more visible on slack.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1571,6 +1571,11 @@ NO INVERT
 .client_channels_list_container *
 figure *
 
+CSS
+.emoji {
+    background-color: white;
+}
+
 ================================
 
 slushpool.com


### PR DESCRIPTION
Most emoji with transparent background assume that they are put on white pages.