### PR TITLE
White background for google search shopping items

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -627,6 +627,9 @@ CSS
 .eB {
     background: rgba(255, 255, 255, 0.4) !important;
 }
+.pla-unit img {
+    background: rgba(255, 255, 255, 0.7) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Heya! Just noticed that the images from google search shopping results weren't showing up well because of the black background.

I tried to fix with the dev tools but wasn't able to apply custom css (or REMOVE BG or NO INVERT features either, for that matter). I just played around in chrome dev tools and was able to get the desired result with the css in this commit. See an example of what I'm trying to fix in the below image.

Cheers!

<img width="818" alt="dark_reader_google_img" src="https://user-images.githubusercontent.com/4802954/50525206-008a8a00-0ad2-11e9-9c46-7d46cd7556b3.PNG">
