### PR TITLE
Add fantasy.premierleague.com to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -108,6 +108,13 @@ canvas
 
 ================================
 
+fantasy.premierleague.com
+
+INVERT
+.ism-table
+
+================================
+
 farside.ph.utexas.edu
 mathpages.com
 mathprofi.ru


### PR DESCRIPTION
With this rule the detail tables in the site, like in the player popups, would be readable.