### PR TITLE
Fix wrong inversion of Wikipedia & Wikimedia logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -387,6 +387,8 @@ wikipedia.org
 INVERT
 .mwe-math-element
 .mw-wiki-logo
+.central-textlogo__image
+.svg-Wikimedia-logo_black
 
 ================================
 


### PR DESCRIPTION
On the main wikipedia.org domain the main logo and Wikimedia foundation logo in the footer is currently black on black.
Inverting CSS classes .central-textlogo__image and .svg-Wikimedia-logo_black fixes this.