### PR TITLE
Making octotree work for all four theme engines

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -520,11 +520,6 @@ INVERT
 .tooltipped:not(.notification-indicator)::before
 .tooltipped:not(.notification-indicator)::after
 .HeaderNavlink [data-ga-click*="(Logged out)"]
-.octotree_sidebar
-.octotree_toggle
-.octotree_toggle span
-.octotree_header_branch
-.octotree_header_repo
 
 CSS
 header {


### PR DESCRIPTION
See https://github.com/darkreader/darkreader/pull/964#issuecomment-451634836.

That's how I made and test the changes (for reproducibility):
- I used https://github.com/darkreader/darkreader/fork and created a new branch ("pr").
- I downloaded https://chrome.google.com/webstore/detail/dark-reader/eimadpbcbfnmbkopoojfekhnkhdbieeh using https://chrome.google.com/webstore/detail/chrome-extension-source-v/jifpbeccnghkjeaalbbjmodiffmgedin.
- I loaded the unpacked extension and observed the issue. 
- I replaced `https://raw.githubusercontent.com/darkreader/darkreader/master/` with `https://github.com/kbulygin/darkreader/pr/` in `background/index.js`.
- I made the change in the branch and reloaded the extension. The issue was gone.