### PR TITLE
Support for custom CSS in Dynamic fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Dark Reader for Google Chrome and Mozilla Firefox
-================
+# Dark Reader for Google Chrome and Mozilla Firefox
 ![Dark Reader screenshot](https://lh3.googleusercontent.com/tTJIIIAqfJWymqPM9LAmivl11kWmF-XXLABues4OwfjOED_ntsJZdLY0VTG0XFCW0W_wYSll7Q=w640-h400-e365)
 
 This extension **inverts brightness** of web pages and aims to **reduce eyestrain** while browsing the web.
@@ -29,9 +28,11 @@ or **[inversion-fixes.config](https://github.com/alexanderby/darkreader/blob/mas
 (for Filter and Filter+ modes)
 *(please, preserve alphabetical order by URL, use short selectors, preserve code style)*.
 
-Notice that merged changes to these files are automatically delivered to all users **within 15 minutes**.
+Please note, that merged changes to these files are automatically delivered to all users **within 15 minutes**.
 
 ### Using Dev Tools
+
+Dev Tools should be used to **fix minor issues** on a web page *(like dark icon on dark background, removing bright background etc.)*. Other issues should be considered as bugs (especially for **Dynamic mode**).
 
 - Open **Chrome Dev Tools** (F12).
 - Click on **element picker** (top-left corner).
@@ -41,6 +42,7 @@ Notice that merged changes to these files are automatically delivered to all use
 - Click **Open developer tools** (at bottom).
 - Find or add a block containing URL and selectors to invert.
 ```
+dynamic-theme-fixes.config
 ================================
 
 example.com
@@ -48,12 +50,24 @@ example.com
 INVERT
 .icon
 
+CSS
+.wrong-element-colors {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+
 ```
-- *WARNING:* For **Dynamic Theme mode** use `INVERT` only for dark images, that are invisible on dark backgrounds (icons, diagrams, charts, `<img>` and `<svg>` elements).
-Image analysis will be improved in future and this rule should become unnecessary.
-- **For Filter and Filter+ config** it is also possible to specify custom CSS rules. If chosen element contains images or other content that becomes wrongly displayed, `NO INVERT` rule can be used. `REMOVE BG` removes background image from element.
-*IMPORTANT: When Dark mode is on, the whole page (root `<html>` element) is inverted by filter. To revert the images, videos etc. `INVERT` selectors are used, so the inversion will be applied to these elements twice. If inverted elements contain other elements that match the `INVERT` selectors, then these elements will be inverted 3 or more times. To prevent it `NO INVERT` selectors are used.*
+- `INVERT` rule inverts specified elements.
+For **Dynamic mode** use `INVERT` only for dark images, that are invisible on dark backgrounds (icons, diagrams, charts, `<img>` and `<svg>` elements).
+- `CSS` rule adds custom CSS to a web page.
+`!important` keyword should be specified for each CSS property to prevent overflows by other stylesheets.
+**Dynamic mode** supports `${COLOR}` template, where `COLOR` is a color value before the inversion (`white` will become `black` in dark mode).
+- **Special notice for Filter and Filter+ config**.
+It works by inverting the whole web page and reverting necessary parts (images, videos etc.) back, listed in `INVERT` section.
+If inverted element contains images or other content that becomes wrongly displayed, `NO INVERT` rule can be used.
+`REMOVE BG` removes background image from element and forces black background.
 ```
+inversion-fixes.config
 ================================
 
 example.com
@@ -117,6 +131,15 @@ For editing the code you can use any text editor or web IDE (like [Visual Studio
 Run tests by executing `npm test`.
 
 Submit a **pull request**, wait for **review**.
+
+## Building for use
+You can install the extension from a file.
+Install [Node.js LTS](https://nodejs.org/en/). Download the source code (or checkout from git).
+Open terminal in root folder and run:
+- `npm install`
+- `npm run release`
+
+This will generate `build.zip` for use in Chromium browsers and `build-firefox.xpi` for use in Firefox.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Please note, that merged changes to these files are automatically delivered to a
 
 ### Using Dev Tools
 
-Dev Tools should be used to **fix minor issues** on a web page *(like dark icon on dark background, removing bright background etc.)*. Other issues should be considered as bugs (especially for **Dynamic mode**).
+Dev Tools should be used to **fix minor issues** on a web page
+*(like dark icon on dark background, removing bright background, adding white background to transparent image etc.)*.
+If page looks partially dark and bright in **Dynamic mode**, it should be considered as a bug.
+For **Filter mode** it is a common practice to invert already dark page parts.
 
 - Open **Chrome Dev Tools** (F12).
 - Click on **element picker** (top-left corner).
@@ -60,7 +63,7 @@ CSS
 - `INVERT` rule inverts specified elements.
 For **Dynamic mode** use `INVERT` only for dark images, that are invisible on dark backgrounds (icons, diagrams, charts, `<img>` and `<svg>` elements).
 - `CSS` rule adds custom CSS to a web page.
-`!important` keyword should be specified for each CSS property to prevent overflows by other stylesheets.
+`!important` keyword should be specified for each CSS property to prevent overrides by other stylesheets.
 **Dynamic mode** supports `${COLOR}` template, where `COLOR` is a color value before the inversion (`white` will become `black` in dark mode).
 - **Special notice for Filter and Filter+ config**.
 It works by inverting the whole web page and reverting necessary parts (images, videos etc.) back, listed in `INVERT` section.

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1,3 +1,24 @@
+*
+
+CSS
+.jfk-bubble {
+    background-color: ${white} !important;
+}
+
+================================
+
+arstechnica.com
+
+CSS
+.listing, .video-thumbnail {
+    background-blend-mode: initial !important;
+}
+.article-single figure img {
+    mix-blend-mode: initial !important;
+}
+
+================================
+
 bbc.com/news
 bbc.com/sport
 bbc.com/weather
@@ -392,6 +413,16 @@ INVERT
 
 ================================
 
+www.ebay.*
+www.ebay.*.*
+
+CSS
+html, body {
+    background-image: none !important;
+}
+
+================================
+
 www.google.*
 www.google.*.*
 
@@ -400,6 +431,11 @@ INVERT
 .gb_ec
 .gb_qc
 #dictionary-modules img
+
+CSS
+.RNNXgb {
+    box-shadow: 0 0 2px 0 ${rgba(0,0,0,0.16)}, 0 0 0 1px ${rgba(0,0,0,0.08)} !important;
+}
 
 ================================
 
@@ -413,6 +449,11 @@ INVERT
 g#youtube-red-paths
 .deemphasize.style-scope.yt-formatted-string
 #like-bar
+
+CSS
+#textarea, paper-button {
+    color: ${black} !important;
+}
 
 ================================
 

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -86,7 +86,8 @@ export interface Shortcuts {
 
 export interface DynamicThemeFix {
     url: string[];
-    invert?: string[];
+    invert: string[];
+    css: string;
 }
 
 export interface InversionFix {

--- a/src/generators/modify-colors.ts
+++ b/src/generators/modify-colors.ts
@@ -28,7 +28,7 @@ function modifyColorWithCache(rgb: RGBA, filter: FilterConfig, modifyHSL: (hsl: 
     const hsl = rgbToHSL(rgb);
     const modified = modifyHSL(hsl);
     const {r, g, b, a} = hslToRGB(modified);
-    const matrix = createFilterMatrix({...filter, mode: 0})
+    const matrix = createFilterMatrix(filter)
     const [rf, gf, bf] = applyColorMatrix([r, g, b], matrix);
 
     const color = (a === 1 ?
@@ -37,6 +37,14 @@ function modifyColorWithCache(rgb: RGBA, filter: FilterConfig, modifyHSL: (hsl: 
 
     fnCache.set(id, color);
     return color;
+}
+
+function noopHSL(hsl: HSLA) {
+    return hsl;
+}
+
+export function modifyColor(rgb: RGBA, theme: FilterConfig) {
+    return modifyColorWithCache(rgb, theme, noopHSL);
 }
 
 function modifyLightModeHSL({h, s, l, a}) {
@@ -97,7 +105,7 @@ export function modifyBackgroundColor(rgb: RGBA, filter: FilterConfig) {
     if (filter.mode === 0) {
         return modifyColorWithCache(rgb, filter, modifyLightModeHSL);
     }
-    return modifyColorWithCache(rgb, filter, modifyBgHSL);
+    return modifyColorWithCache(rgb, {...filter, mode: 0}, modifyBgHSL);
 }
 
 function modifyFgHSL({h, s, l, a}) {
@@ -141,7 +149,7 @@ export function modifyForegroundColor(rgb: RGBA, filter: FilterConfig) {
     if (filter.mode === 0) {
         return modifyColorWithCache(rgb, filter, modifyLightModeHSL);
     }
-    return modifyColorWithCache(rgb, filter, modifyFgHSL);
+    return modifyColorWithCache(rgb, {...filter, mode: 0}, modifyFgHSL);
 }
 
 function modifyBorderHSL({h, s, l, a}) {
@@ -161,7 +169,7 @@ export function modifyBorderColor(rgb: RGBA, filter: FilterConfig) {
     if (filter.mode === 0) {
         return modifyColorWithCache(rgb, filter, modifyLightModeHSL);
     }
-    return modifyColorWithCache(rgb, filter, modifyBorderHSL);
+    return modifyColorWithCache(rgb, {...filter, mode: 0}, modifyBorderHSL);
 }
 
 export function modifyShadowColor(rgb: RGBA, filter: FilterConfig) {

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -119,37 +119,6 @@ export function getModifiedFallbackStyle(filter: FilterConfig, {strict}) {
     return lines.join('\n');
 }
 
-// TODO: Move CSS fixes to config.
-const commonOverride = (theme: FilterConfig) => {
-    return [
-        `.jfk-bubble { background-color: ${modifyBackgroundColor({r: 255, g: 255, b: 255}, theme)} !important; }`,
-    ].join('\n');
-};
-const websiteOverride: {[host: string]: (string | ((theme: FilterConfig) => string))} = {
-    'arstechnica.com': (theme) => theme.mode === 1 ? [
-        '.listing, .video-thumbnail { background-blend-mode: initial !important; }',
-        '.article-single figure img { mix-blend-mode: initial !important; }',
-    ].join('\n') : '',
-    'www.ebay.co.uk': 'html, body { background-image: none !important; }',
-    'www.ebay.com': 'html, body { background-image: none !important; }',
-    'www.ebay.de': 'html, body { background-image: none !important; }',
-    'www.youtube.com': (theme) => `#textarea { color: ${modifyForegroundColor({r: 0, g: 0, b: 0}, theme)} !important; }`,
-};
-
-export function getSiteOverride(host: string, theme: FilterConfig) {
-    const common = commonOverride(theme);
-    let special = '';
-    if (websiteOverride.hasOwnProperty(host)) {
-        const override = websiteOverride[host];
-        if (typeof override === 'function') {
-            special = override(theme);
-        } else {
-            special = override;
-        }
-    }
-    return `${common}${special ? `\n${special}` : ''}`;
-}
-
 const unparsableColors = new Set([
     'inherit',
     'transparent',
@@ -160,7 +129,7 @@ const unparsableColors = new Set([
 
 const colorParseCache = new Map<string, RGBA>();
 
-function parseColorWithCache($color: string) {
+export function parseColorWithCache($color: string) {
     $color = $color.trim();
     if (colorParseCache.has($color)) {
         return colorParseCache.get($color);

--- a/tests/config.tests.ts
+++ b/tests/config.tests.ts
@@ -52,6 +52,9 @@ test('Dynamic Theme Fixes config', async () => {
     const file = await readConfig('dynamic-theme-fixes.config');
     const fixes = parseDynamicThemeFixes(file);
 
+    // there is a common fix
+    expect(fixes[0].url[0]).toEqual('*');
+
     // each fix has valid URL
     expect(fixes.every(({url}) => url.every(isURLPatternValid))).toBe(true);
 
@@ -72,13 +75,14 @@ test('Dynamic Theme Fixes config', async () => {
         'inbox.google.com',
         'mail.google.com',
         'INVERT', 'a', 'b',
+        'CSS', '.x { color: white !important; }',
         'UNSUPPORTED', 'c', 'd',
         '========',
         'twitter.com',
         'UNSUPPORTED', 'a', 'b',
         'INVERT', 'c', 'd',
     ].join('\r\n'))).toEqual([
-        {url: ['inbox.google.com', 'mail.google.com'], invert: ['a', 'b']},
+        {url: ['inbox.google.com', 'mail.google.com'], invert: ['a', 'b'], css: '.x { color: white !important; }'},
         {url: ['twitter.com'], invert: ['c', 'd']},
     ])
 });


### PR DESCRIPTION
Add support for custom `CSS` in `dynamic-theme-fixes.config` for quick hacks. `${color}` template applies filter matrix to color, so that color is properly handled in dark and light mode.

Example:
```
google.*

CSS
.search-box {
    border-color: ${black} !important; /* #ffffff in dark mode and #000000 in light mode */
}
```

- Fixed #967.
- Fixed #564.