### PR TITLE
Remove humblebundle.com from dark sites

### DIFF
--- a/src/config/dark_sites.json
+++ b/src/config/dark_sites.json
@@ -35,7 +35,6 @@
     "hangouts.google.com",
     "hardcoregaming101.net",
     "heavybit.com",
-    "humblebundle.com",
     "hyper.is",
     "illicoweb.videotron.com",
     "imgur.com",


### PR DESCRIPTION
Humble Bundle uses a lot of light themes, for example in game info and profile view.