### PR TITLE
Remove border around variable names

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -376,6 +376,15 @@ INVERT
 
 ================================
 
+source.dot.net
+
+CSS
+.r {
+    border-style: none !important;
+}
+
+================================
+
 stackoverflow.com
 
 INVERT


### PR DESCRIPTION
Variables currently contain a yellowish border around them which makes reading the source tough and annoying. This simply removes the border as it would be without darkreader turned on.