### PR TITLE
Add anilist.co to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7,6 +7,23 @@ CSS
 
 ================================
 
+anilist.co
+
+CSS
+:root {
+    --color-background: 39,44,56 !important;
+    --color-foreground: 31,35,45 !important;
+    --color-foreground-grey: 25,29,38 !important;
+    --color-foreground-grey-dark: 16,20,25 !important;
+    --color-foreground-blue: 25,29,38 !important;
+    --color-foreground-blue-dark: 19,23,29 !important;
+    --color-text: 159,173,189 !important;
+    --color-text-light: 129,140,153 !important;
+    --color-text-lighter: 133,150,165 !important;
+}
+
+================================
+
 arstechnica.com
 
 CSS


### PR DESCRIPTION
Use the sites dark theme as default

Copied the variable values for the sites native dark theme, which isn't the default theme for the site.