### PR TITLE
Dynamic theme fix: INVERT <mark> tags on developer.mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -88,6 +88,7 @@ developer.mozilla.org
 
 INVERT
 .logo
+mark
 
 ================================
 


### PR DESCRIPTION
BEFORE:
<img  alt="mark-before" src="https://user-images.githubusercontent.com/1260554/51403176-e0684c80-1b0c-11e9-8b73-d172d98eed54.png">

AFTER:
<img alt="mark-after" src="https://user-images.githubusercontent.com/1260554/51403227-14437200-1b0d-11e9-8c30-8686dbeb7384.png">
