### PR TITLE
Add fix for ProtonMail composer

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1060,6 +1060,17 @@ REMOVE BG
 
 ================================
 
+mail.protonmail.com
+
+CSS
+.angular-squire-iframe body,
+.angular-squire-iframe body div {
+    background: #000 !important;
+    color: #fff !important;
+}
+
+================================
+
 mailchimp.com
 
 INVERT

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1065,7 +1065,7 @@ mail.protonmail.com
 CSS
 .angular-squire-iframe body,
 .angular-squire-iframe body div {
-    background: #000 !important;
+    background: #0D0E12 !important;
     color: #fff !important;
 }
 


### PR DESCRIPTION
I work at ProtonMail, some users reported us ProtonMail Composer was not readable when inverted, see:

![proton](https://user-images.githubusercontent.com/2578321/51611476-983b9680-1f1f-11e9-9ba1-20931c364285.jpg)

I've added a fix that should do the work, see with user styles:
![protonfix](https://user-images.githubusercontent.com/2578321/51611631-fc5e5a80-1f1f-11e9-8a3f-d9fb247eb2e3.jpg)

Cheers,
Nicolas