### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4,6 +4,10 @@ CSS
 .jfk-bubble {
     background-color: ${white} !important;
 }
+/* change chrome highlight color */
+::selection {
+  background: #ffb7b7 !important;
+}
 
 ================================
 


### PR DESCRIPTION
default chrome highlight color is difficult to recognize under dark theme. changed color to orange background with white font color.