### PR TITLE
Add fixes for 4 sites

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -628,6 +628,7 @@ header,
     background: #93c6ff !important;
     color: black !important;
 }
+.HeaderMenu-link,
 .select-menu-item.navigation-focus > .octicon,
 .select-menu-item.navigation-focus.selected > .octicon,
 .select-menu-item.navigation-focus.select-menu-action > .octicon,
@@ -1116,6 +1117,14 @@ medium.com
 
 NO INVERT
 .canvas-renderer
+
+================================
+
+meduza.io
+
+INVERT
+.Header-root
+.Footer-root
 
 ================================
 
@@ -2038,6 +2047,7 @@ INVERT
 .doc_title
 .like_tt::after
 .audio_row__cover_back
+.poster__text
 
 NO INVERT
 #video_player *
@@ -2171,6 +2181,13 @@ NO INVERT
 .numberedequation
 .displayformula
 .inlineformula
+
+================================
+
+wolframalpha.com
+
+NO INVERT
+img
 
 ================================
 


### PR DESCRIPTION
vk.com: Fix texts on posters from light to dark (on light image background)
meduza.io: Fix header and footer
github.com: Fix links on header from dark to light (on dark header background)
wolframalpha.com: Fix image outputs