### PR TITLE
Compatibility with link hinting of VimVixen add-on

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4,6 +4,11 @@ CSS
 .jfk-bubble {
     background-color: ${white} !important;
 }
+.vimvixen-hint {
+    background-color: yellow!important;
+    border-color: gold!important;
+    color: black!important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5,9 +5,9 @@ CSS
     background-color: ${white} !important;
 }
 .vimvixen-hint {
-    background-color: yellow!important;
-    border-color: gold!important;
-    color: black!important;
+    background-color: ${#ffd76e} !important;
+    border-color: ${#c59d00} !important;
+    color: ${#302505} !important;
 }
 
 ================================


### PR DESCRIPTION
In dynamic night mode, inversion of VimVixen's link hinting is not recognizable. This change overrides the inversion to default look on all sites.
Issue here: #630.