### PR TITLE
Fix content in 01net.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,11 +9,10 @@ CSS
 
 01net.com
 
-INVERT
-.titre-article
-.blocx3
-.bloc p
-.display-inline-block
+CSS
+html, body {
+    color: ${#090702} !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7,6 +7,16 @@ CSS
 
 ================================
 
+01net.com
+
+INVERT
+.titre-article
+.blocx3
+.bloc p
+.display-inline-block
+
+================================
+
 anilist.co
 
 CSS


### PR DESCRIPTION
Fix text in titles and content in 01net.com (popular french language tech website).
Better implementation of #1064 

Before:
![01net1](https://user-images.githubusercontent.com/19488251/51994842-e61d4500-24b1-11e9-9e98-8cdb358af749.PNG)

After:
![01net2](https://user-images.githubusercontent.com/19488251/51994853-ea496280-24b1-11e9-81a7-0874bb4c8747.PNG)

