### PR TITLE
Add graydon2.dreamwidth.org to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -56,6 +56,7 @@ giphy.com
 gitkraken.com
 glowing-bear.org
 gogoanime.se
+graydon2.dreamwidth.org
 greenmangaming.com
 gunshipmusic.com
 hackaday.com


### PR DESCRIPTION
Acknowledgement of graydon's allegiance to the dark site