### PR TITLE
Add giantbomb.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -52,6 +52,7 @@ frootvpn.com
 geektyper.com
 getsharex.com
 ggapp.io
+giantbomb.com
 gidonline.in
 giphy.com
 gitkraken.com


### PR DESCRIPTION
GiantBomb's new website layout is dark by default. https://www.giantbomb.com/