### PR TITLE
Add discordapp.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -33,6 +33,7 @@ darkreader.org
 deltarune.com
 desktop.github.com
 destinytracker.com
+discordapp.com
 dota2.com
 dota2.ru
 dotabuff.com


### PR DESCRIPTION
Looks like the Discord web app has a dark theme by default