### PR TITLE
Update dynamic-theme-fixes.config for web.archive.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -573,7 +573,9 @@ INVERT
 #wm-logo
 
 CSS
-.measure{z-index:0!important}
+.measure {
+    z-index: 0 !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -567,6 +567,13 @@ web.archive.org
 INVERT
 #wm-sparkline-canvas
 .yt
+.sparkline-canvas
+.sparkline-mouse-highlight
+.search-toolbar-logo
+#wm-logo
+
+CSS
+.measure{z-index:0!important}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -562,6 +562,14 @@ div.jfk-button-img
 
 ================================
 
+web.archive.org
+
+INVERT
+#wm-sparkline-canvas
+.yt
+
+================================
+
 web.whatsapp.com
 
 INVERT


### PR DESCRIPTION
Added entry for web.archive.org
Made timeline readable in dark mode
Made circles on the homepage calendar visible
Inverted logo

Timeline
before:
![from](https://user-images.githubusercontent.com/36012278/52915653-cb3b3500-32e7-11e9-9eb1-8e0697fe310d.png)

after:
![after2](https://user-images.githubusercontent.com/36012278/52957929-f5522d00-33a3-11e9-99e6-044bbeb952b8.png)

Homepage
before:
![hpb](https://user-images.githubusercontent.com/36012278/52958247-bcff1e80-33a4-11e9-8a0e-8cc237408c03.png)

after:
![hpa](https://user-images.githubusercontent.com/36012278/52958257-c12b3c00-33a4-11e9-9e2c-6f0fa501a850.png)