### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -562,6 +562,15 @@ div.jfk-button-img
 
 ================================
 
+webhallen.com
+
+CSS
+.drop-countdown-time {
+    color: rgb(23, 30, 54);
+}
+
+================================
+
 web.whatsapp.com
 
 INVERT


### PR DESCRIPTION
Keep the original countdown color as the dynamic mode makes the text look washed out and unreadable.