### PR TITLE
various dynamic theme fixes

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -24,6 +24,7 @@ caniuse.com
 cinema-city.pl
 codepen.io
 codingame.com
+coebot.tv
 coinpot.co
 cryptowat.ch
 cytu.be

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -597,6 +597,10 @@ div.jfk-button-img
 
 vice.com
 
+INVERT
+img.search-icon
+img.icon-close
+
 CSS
 .site-header__logo svg path {
     fill: #fff!important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -110,6 +110,13 @@ INVERT
 
 ================================
 
+daniel.haxx.se
+
+INVERT
+#site-header img
+
+================================
+
 darksky.net
 
 INVERT
@@ -212,9 +219,19 @@ fivethirtyeight.com
 
 INVERT
 .logo
-.site-logo
-#searchform
-.header-espn-link
+
+CSS
+#searchform path,
+.header-espn-link path,
+.site-logo path {
+    fill: #fff;
+}
+.chart svg text.bg {
+    stroke: rgb(23, 24, 28)!important;
+}
+.chart svg text.end-label {
+    fill: #fff;
+}
 
 ================================
 
@@ -331,6 +348,13 @@ INVERT
 
 ================================
 
+jisho.org
+
+INVERT
+h1.logo a
+
+================================
+
 keep.google.com
 
 INVERT
@@ -418,6 +442,15 @@ nicehash.com
 
 INVERT
 .chart
+
+================================
+
+nytimes.com
+
+CSS
+[data-testid="masthead-desktop-logo"] svg {
+    fill: #fff!important;
+}
 
 ================================
 
@@ -559,6 +592,25 @@ INVERT
 div.jfk-button-img
 .tlid-copy-translation-button
 .starbutton
+
+================================
+
+vice.com
+
+CSS
+.site-header__logo svg path {
+    fill: #fff!important;
+}
+
+================================
+
+washingtonpost.com
+
+CSS
+svg.wplogo path,
+#TWP_logo_svg path {
+    fill: #fff!important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -438,6 +438,15 @@ INVERT
 
 ================================
 
+newyorker.com
+
+CSS
+svg[aria-labelledby="tnyLogo"] path {
+    fill: #fff!important;
+}
+
+================================
+
 nicehash.com
 
 INVERT


### PR DESCRIPTION
Various changes to the dynamic themes config:
* daniel.haxx.se: inverted header image
* fivethirtyeight.com: better logo inversion rules, made text in Donald Trump approval graphs readable
* jisho.org: inverted logo
* newyorker.com: inverted logo
* nytimes.com: inverted logo
* vice.com: inverted logo and sidebar buttons
* washingtonpost.com: inverted logo

Also added coebot.tv to the dark sites list.

You may notice that in several cases, I used a CSS rule (`svg path { fill:#fff; }`) to invert logos instead of using an INVERT rule. This is because using an INVERT rule causes those logos to appear as an ugly white rectangle until they've finished loading and rendering. In addition, Dark Reader will sometimes color some of the SVG paths differently than others, causing it to look really weird (this happens really badly on washingtonpost.com and less badly on newyorker.com). Using a CSS fill rule instead causes them to load in much more cleanly, and overrides any inconsistent path coloring that may have occurred.