### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12,6 +12,27 @@ CSS
 
 ================================
 
+akinator.com
+
+INVERT
+.bubble
+.bubble-body
+
+CSS
+.bubble {
+    background-color: ${black} !important;
+    color: ${white} !important;
+}
+.bubble-body {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+.question-number {
+    color: ${white} !important;
+}
+
+================================
+
 anilist.co
 
 CSS


### PR DESCRIPTION
Not perfect, but it prevents the light-on-light text in Akinator's results screen speech bubbles without ruining question speech bubbles.