### PR TITLE
Invert marks on vc.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -646,6 +646,13 @@ div.jfk-button-img
 
 ================================
 
+vc.ru
+
+INVERT
+mark
+
+================================
+
 web.archive.org
 
 INVERT


### PR DESCRIPTION
Invert `<mark>` on vc.ru.
Changes can be tested at https://vc.ru/marketing/60262-biznes-u-kotorogo-nikogda-ne-budet-klientov-iz-interneta below "«Упакованные» no name-однодневки" section

Related PR - https://github.com/darkreader/darkreader/pull/1150