### PR TITLE
Fix FFMPEG's wiki being bright?

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -49,6 +49,7 @@ eternal.abimon.org
 faceit.com
 fanatical.com
 ffmpeg.org
+^trac.ffmpeg.org
 filterblade.xyz
 flooxer.com
 frootvpn.com


### PR DESCRIPTION
I haven't tested this at all, but shouldn't this allow that specific sub domain to be darkified via Dark Reader? If not please tell me what to change in order for this to work.