### PR TITLE
Remove epicgames and fanatical from dark sites config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -43,11 +43,9 @@ draculatheme.com
 draftkings.com
 egee.io
 ego.mail.ru
-epicgames.com
 erai-raws.info
 eternal.abimon.org
 faceit.com
-fanatical.com
 ffmpeg.org
 filterblade.xyz
 flooxer.com


### PR DESCRIPTION
Remove epic games and fanatical from a global dark list. They are not totally dark sites. Epic games account section and fortnite section is not dark. Fanatical support section is not dark.