### PR TITLE
Updated dark-sites..config Youtube Music website

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -89,6 +89,7 @@ lutris.net
 marte.dev
 mixer.com
 mmorpg.com
+music.youtube.com
 mwomercs.com
 open.spotify.com
 opencritic.com


### PR DESCRIPTION
Check for yourself, music.youtube.com is already dark mode by default.