### PR TITLE
Updated dynamic-theme-fixes.config Google profile fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -828,6 +828,7 @@ INVERT
 #dictionary-modules img
 a[title="Google Apps"]
 a.gb_b > div
+.gbii
 
 CSS
 .RNNXgb {


### PR DESCRIPTION
The profile picture in the top right corner was inverted, now it's fixed by inverting it again.

Should work for all sites that have the small profile picture.