### PR TITLE
Updated dynamic-theme-fixes.config w/ CheapShark Fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -105,6 +105,15 @@ a[href="/product"]
 
 ================================
 
+cheapshark.com
+
+CSS
+.header {
+    border-top: 10px solid #000 !important;
+}
+
+================================
+
 chtoes.li
 
 INVERT


### PR DESCRIPTION
There was an issue w/ the top border on page header being set to a light color, which resulted in conflict with transparent image.

This will preserve the original style.