### PR TITLE
Invert Instagram Stories slider

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -365,6 +365,7 @@ INVERT
 ._47KiJ
 .glyphsSpriteSettings__outline__24__grey_9
 .ltpMr
+._7zQEa
 
 ================================
 


### PR DESCRIPTION
The slider for the stories was dark, on a dark background, with no contrast between them. 
With this the "counter" will be white again

Before:
![chrome_2019-03-25_16-00-32](https://user-images.githubusercontent.com/19685105/54935030-6a6ed000-4f17-11e9-9296-bdbdc42cfb96.png)

After:
![image](https://user-images.githubusercontent.com/19685105/54935727-d271e600-4f18-11e9-9bd0-81ae3779b4de.png)
