### PR TITLE
Updated dynamic-theme-fixes.config Youtube pages with a white colored…

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -890,6 +890,9 @@ CSS
 .style-scope.ytd-video-primary-info-renderer {
     color: rgb(255, 255, 255) !important;
 }
+.policies-page, .copyright-page, .experiences-page {
+     background-image: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
… background image

Added code to make background to none, since invert won't work on it (inverts entire page).