### PR TITLE
Update dynamic-theme-fixes.config - datadog

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -57,7 +57,7 @@ INVERT
 
 CSS
 .log-dt-event.active, .log-dt-event.active:hover, .log-dt-event:hover {
-    background-color: rgb(37, 45, 58);
+    background-color: rgb(37, 45, 58) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -151,6 +151,18 @@ span[class^="skycon swip"]
 
 ================================
 
+app.datadoghq.com
+
+INVERT
+.HostMap-canvas
+
+CSS
+.log-dt-event.active, .log-dt-event.active:hover, .log-dt-event:hover {
+    background-color: rgb(37, 45, 58);
+}
+
+================================
+
 developer.mozilla.org
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -55,6 +55,11 @@ app.datadoghq.com
 INVERT
 .HostMap-canvas
 
+CSS
+.log-dt-event.active, .log-dt-event.active:hover, .log-dt-event:hover {
+    background-color: rgb(37, 45, 58);
+}
+
 ================================
 
 arstechnica.com
@@ -148,18 +153,6 @@ INVERT
 span[class^="skycon swip"]
 #right-arrow
 #left-arrow
-
-================================
-
-app.datadoghq.com
-
-INVERT
-.HostMap-canvas
-
-CSS
-.log-dt-event.active, .log-dt-event.active:hover, .log-dt-event:hover {
-    background-color: rgb(37, 45, 58);
-}
 
 ================================
 


### PR DESCRIPTION
When the log detail window is opened (by clicking on a log row), the selected row is not visible. This makes it work.

Originally in the config editor I found

```
================================

app.datadoghq.com

INVERT
.HostMap-canvas

```

Adding the CSS section worked.