### PR TITLE
Add inversion fixes for statlect.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1758,6 +1758,17 @@ CSS
 
 ================================
 
+statlect.com
+
+NO INVERT
+span.displayed > img
+span.inm > img
+#lensDIV img
+.gs-image-box img.gs-image
+img[alt="Table of Contents"]
+
+================================
+
 studio.restlet.com
 cloud.rest-let.com
 


### PR DESCRIPTION
Statlect is an excellent (and free) digital textbook on statistics and probability, and now it too has joined the dark side.