### PR TITLE
Add a Mastodon instances in dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -152,3 +152,4 @@ www.netflix.com
 yande.re
 yandexdataschool.ru/$
 yts.am
+miaou.drycat.fr


### PR DESCRIPTION
Because miaou.drycat.fr is already a dark site