### PR TITLE
Add YouTube and a Mastodon instance in dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -89,9 +89,9 @@ kissmanga.com
 linux.org.ru
 lutris.net
 marte.dev
+miaou.drycat.fr
 mixer.com
 mmorpg.com
-music.youtube.com
 mwomercs.com
 open.spotify.com
 opencritic.com
@@ -151,4 +151,5 @@ www.gotimelinr.com
 www.netflix.com
 yande.re
 yandexdataschool.ru/$
+youtube.com
 yts.am

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -92,6 +92,7 @@ marte.dev
 miaou.drycat.fr
 mixer.com
 mmorpg.com
+music.youtube.com
 mwomercs.com
 open.spotify.com
 opencritic.com
@@ -151,5 +152,4 @@ www.gotimelinr.com
 www.netflix.com
 yande.re
 yandexdataschool.ru/$
-youtube.com
 yts.am


### PR DESCRIPTION
Mastodon is already dark and YouTube provides a dark theme (we can activate it on YouTube, YouTube Gaming and Music are already dark)