### PR TITLE
GitHub: Zero Contribution Day Fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -285,6 +285,9 @@ CSS
 .refined-github .dashboard-rollup-items .body {
     border-top-color: ${#bbc1c9} !important;
 }
+rect.day[data-count="0"]{
+    fill: {#fff} !important;
+}
 
 ================================
 


### PR DESCRIPTION
The GitHub contribution section shows the number of contributions per day. However, it looks like this currently:
![Light](https://i.ibb.co/k1Sc6fK/image.png)
With the proposed change, the section would look like this:
![Dark](https://i.ibb.co/j6dVW38/image.png)