### PR TITLE
discordapp.com is already dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -40,6 +40,7 @@ desktop.github.com
 destinytracker.com
 diablo3.com
 diablo3ladder.com
+discordapp.com
 dota2.com
 dota2.ru
 dotabuff.com


### PR DESCRIPTION
It already offers a dark theme by default ( + option to switch to light theme ) and Dark Reader only ruins it