### PR TITLE
Remove ffmpeg.org from dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -55,7 +55,6 @@ erai-raws.info
 eternal.abimon.org
 faceit.com
 femto.pw
-ffmpeg.org
 filterblade.xyz
 flooxer.com
 frootvpn.com


### PR DESCRIPTION
[ffmpeg.org](https://ffmpeg.org) is using a dark theme, but [trac.ffmpeg.org](https://trac.ffmpeg.org) isn't.