### PR TITLE
Dynamic theme fix for Brand New comments

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -791,6 +791,15 @@ CSS
 
 ================================
 
+underconsideration.com/brandnew
+
+CSS
+.post-message {
+  color: ${black} !important;
+}
+
+================================
+
 vc.ru
 
 INVERT


### PR DESCRIPTION
Comments under articles on the Brand New site were unreadable (black on dark background).