### PR TITLE
Fix hover inversion for Slack when using Refined's Visible Threads

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -700,6 +700,16 @@ slack.com
 INVERT
 .slack_logo > img
 
+CSS
+.refined-conversation-hover,
+.refined-conversation-hover .c-message--hover {
+    background: #595959 !important;
+}
+.refined-conversation-hover .c-message__reply_bar:hover,
+.refined-conversation-hover .c-message__reply_bar:hover .c-message__reply_bar_view_thread {
+    background: #393939 !important;
+}
+
 ================================
 
 soundcloud.com


### PR DESCRIPTION
[Refined](https://refined.chat/) is an extension for slack that makes a bunch of things better.

One of the things it does is making threads visible (aka: [Visible Threads](https://refined.chat/visible-threads)).

When visible threads are enabled, hovering on a conversation message highlights all the messages in the same conversation. But with Dark Reader, the hover color can't be really appreciated.

In this PR, that's fixed. Steps to see the feature in action:

1. Install Refined
2. Enable visible threads
3. Hover over a reply

Expected behavior: You should see the original message highlighted.
Current behavior: The color change is so subtle it's hard to see.

Here you can see how it looks with this change:

![visibleThreadsOnDark](https://gervas.io/darkReaderThreadsTuned.gif)