### PR TITLE
Fix Slack highlights

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -700,6 +700,26 @@ slack.com
 INVERT
 .slack_logo > img
 
+CSS
+@keyframes highlight {
+    20% {
+        background: #595959;
+    }
+
+    60% {
+        background: #393939;
+    }
+}
+@keyframes fade-background-highlight {
+    0% {
+        background: #595959
+    }
+
+    to {
+        background: transparent
+    }
+}
+
 ================================
 
 soundcloud.com


### PR DESCRIPTION
When visiting a link to a slack message, the highlights don't look great:

![ugh](https://gervas.io/dontlookgreat.gif)

with these changes, they do:

![yay](https://gervas.io/nicelooking.gif)