### PR TITLE
Android Messages to Google Messages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -484,6 +484,21 @@ INVERT
 
 ================================
 
+messages.google.com
+
+INVERT
+.x4Tquc
+.QrWqSe
+.XCHXxd
+.pXeIKc
+
+CSS
+.input-background {
+  --input-bg-fade-color: #202124 !important;
+}
+
+================================
+
 messenger.com
 
 INVERT


### PR DESCRIPTION
Google changed messages.android.com to messages.google.com. When using Dark Reader, I found that there was a white gradient behind the input text field. Since messages.google.com code was not added yet, I made the respective changes. There is no longer a white gradient behind the input text field.