### PR TITLE
Most math elements on Wikipedia are double inverted

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -866,7 +866,6 @@ INVERT
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black
-.mwe-math-fallback-image-inline
 
 ================================
 


### PR DESCRIPTION
Most math elements contain both the `.mwe-math-element` and the `.mwe-math-fallback-image-inline` class, and therefore were being double-inverted (i.e., undoing itself).

`.mwe-math-element` was added as part of #382.  `.mwe-math-fallback-image-inline` was added as part of #1261, likely because there were some elements which contained `.mwe-math-fallback-image-inline` but not `.mwe-math-element`.

However, as far as I can tell, most math elements contain both `.mwe-math-element` or `.mwe-math-fallback-image-inline` and therefore get inverted twice.

Tested in Chrome