### PR TITLE
wikipedia upd: formulas were greyed out

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -862,11 +862,17 @@ INVERT
 wikipedia.org
 
 INVERT
-.mwe-math-element
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black
-.mwe-math-fallback-image-inline
+
+CSS
+.mwe-math-element {
+    filter: invert(100%) !important;
+}
+.mwe-math-fallback-image-inline [
+    filter: invert(100%) !important;
+}
 
 ================================
 


### PR DESCRIPTION
TL;DR: INVERT applies hue shift along with Filter options
which troubles readability of wikipedia formulas
critically with some-sepia-set (for me).
Fixed by applying invert-only rule with CSS.

BUG behaviour:
black text of formulas -> white -> sepia applied, hue shifted or whatever -> formulas unreadable because greyed out

FIX:
Removing them from INVERT section makes them clean which is fine UNLESS we have no sepia set thus getting us to black on black.
So we need INVERT but NO SEPIA and such.
Which I get by copying actual browser (darkreader) CSS rule removing extra modifiers.
Tested once. Problem fixed.

Specs of the local system (just in case):
Firefox 64.0.4(32) from Ubuntu repos; DarkReader v4.7.12; settings were like sepia at 30, Contrast -20 /
problem appeared recently (was said to not having been seen before with the same formulas and the same setup).

Keep up the good work and have a perfect day ahead!
But why does it only break the formulas I wonder?