### PR TITLE
Invert Google apps, Github Education's, AWS's, The Verge's icon and math element on Wikipedia properly

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -200,6 +200,14 @@ mark
 
 ================================
 
+education.github.com
+
+INVERT
+img[alt="GitHub Education"]
+.octicon-logo-github
+
+================================
+
 elearning.utdallas.edu
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -773,6 +773,7 @@ theverge.com
 
 INVERT
 .c-global-header__logo-large
+.c-masthead__logo
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -940,6 +940,7 @@ INVERT
 .gb_hc
 .gb_ec
 .gb_x.gb_Vb
+.gb_x.gb_Ub
 .gb_0b
 #dictionary-modules img
 a[title="Google Apps"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -769,6 +769,13 @@ INVERT
 
 ================================
 
+theverge.com
+
+INVERT
+.c-global-header__logo-large
+
+================================
+
 tjournal.ru
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -74,6 +74,17 @@ CSS
 
 ================================
 
+aws.amazon.com
+
+INVERT
+a.lb-trigger
+.img-wrapper
+img[alt^="WEB_FreeTier"]
+.lb-is-lazyloaded
+.lb-none-v-margin.lb-img
+
+================================
+
 bbc.com/news
 bbc.com/sport
 bbc.com/weather

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -862,7 +862,7 @@ INVERT
 wikipedia.org
 
 INVERT
-.mwe-math-element
+span>img[alt^="CDel"]
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black


### PR DESCRIPTION
**Example Article: https://en.wikipedia.org/wiki/Megagon**
### Before
![图片](https://user-images.githubusercontent.com/37703689/57787169-73d22700-7767-11e9-9363-8321ec5874ba.png)
![图片](https://user-images.githubusercontent.com/37703689/57787184-7d5b8f00-7767-11e9-9b8f-7ca7a09747ef.png)
### After
![图片](https://user-images.githubusercontent.com/37703689/57787367-d0354680-7767-11e9-993d-d42813b35b5a.png)
![图片](https://user-images.githubusercontent.com/37703689/57787375-d4f9fa80-7767-11e9-8207-f800c31d4601.png)
