### PR TITLE
Update rules for richie-bendall.ml

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -121,6 +121,7 @@ ptt.cc
 raidtime.net
 rawg.io
 realgamernewz.com
+richie-bendall.ml
 runicgames.com
 sanctum.geek.nz/arabesque
 sandervanderburg.blogspot.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -588,31 +588,6 @@ header a[href="/"] svg:nth-child(2)
 
 ================================
 
-richie-bendall.ml
-
-CSS
-.content--card {
-    background-color: #303030;
-}
-::-webkit-scrollbar {
-    width: 0;
-    color: transparent;
-}
-body {
-    background-color: #5c6bc0;
-}
-.app--bar, .drawer--content :not(.mdc-list--non-interactive) > :not(.mdc-list-item--disabled) .mdc-list-item--activated:after, :not(.mdc-list--non-interactive) > :not(.mdc-list-item--disabled) .mdc-list-item--activated:before {
-    background-color: #3f51b5;
-}
-.btc-dialog .mdc-button {
-    color: #3f51b5;
-}
-.btc-dialog svg {
-    fill: white;
-}
-
-================================
-
 richiebendallstatus.ml
 
 CSS


### PR DESCRIPTION
`richie-bendall.ml` now supports dark mode automatically. This PR updates the config files to address that.

The only issue is that there is no way to detect if `darkreader` is requesting dark mode so the user will have to manually activate it. #1330

Depends on #1342.