### PR TITLE
Allow detection and listening for dark mode changes

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -96,7 +96,6 @@ export class Extension {
                 }
                 const url = await this.tabs.getActiveTabURL();
                 const info = await this.getURLInfo(url)
-                handleManual(!info.isProtected && info.isInDarkList)
                 return info;
             },
             changeSettings: (settings) => this.changeSettings(settings),
@@ -314,7 +313,6 @@ export class Extension {
 
     private getTabMessage = (url: string, frameURL: string) => {
         const urlInfo = this.getURLInfo(url);
-        handleManual(!urlInfo.isProtected && urlInfo.isInDarkList)
         if (this.isEnabled() && isURLEnabled(url, this.user.settings, urlInfo)) {
             const custom = this.user.settings.customThemes.find(({url: urlList}) => isURLInList(url, urlList));
             const filterConfig = custom ? custom.theme : this.user.settings.theme;

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -16,6 +16,7 @@ import {getDynamicThemeFixesFor} from '../generators/dynamic-theme';
 import createStaticStylesheet from '../generators/static-theme';
 import {createSVGFilterStylesheet, getSVGFilterMatrixValue, getSVGReverseFilterMatrixValue} from '../generators/svg-filter';
 import {ExtensionData, FilterConfig, News, Shortcuts, UserSettings, TabInfo} from '../definitions';
+import {handleManual} from '../inject/prop';
 
 const AUTO_TIME_CHECK_INTERVAL = getDuration({seconds: 10});
 const CONFIG_SYNC_INTERVAL = getDuration({days: 1});
@@ -94,7 +95,9 @@ export class Extension {
                     await new Promise((resolve) => this.awaiting.push(resolve));
                 }
                 const url = await this.tabs.getActiveTabURL();
-                return await this.getURLInfo(url);
+                const info = await this.getURLInfo(url)
+                handleManual(!info.isProtected && info.isInDarkList)
+                return info;
             },
             changeSettings: (settings) => this.changeSettings(settings),
             setTheme: (theme) => this.setTheme(theme),
@@ -311,6 +314,7 @@ export class Extension {
 
     private getTabMessage = (url: string, frameURL: string) => {
         const urlInfo = this.getURLInfo(url);
+        handleManual(!urlInfo.isProtected && urlInfo.isInDarkList)
         if (this.isEnabled() && isURLEnabled(url, this.user.settings, urlInfo)) {
             const custom = this.user.settings.customThemes.find(({url: urlList}) => isURLInList(url, urlList));
             const filterConfig = custom ? custom.theme : this.user.settings.theme;

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -2,10 +2,10 @@ import {createOrUpdateStyle, removeStyle} from './style';
 import {createOrUpdateSVGFilter, removeSVGFilter} from './svg-filter';
 import {createOrUpdateDynamicTheme, removeDynamicTheme, cleanDynamicThemeCache} from './dynamic-theme';
 import {logWarn} from './utils/log';
-import {setProp} from './prop';
+import {handleProp} from './prop';
 
 function onMessage({type, data}) {
-    setProp(type);
+    handleProp(type, data)
     switch (type) {
         case 'add-css-filter':
         case 'add-static-theme': {

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -2,8 +2,10 @@ import {createOrUpdateStyle, removeStyle} from './style';
 import {createOrUpdateSVGFilter, removeSVGFilter} from './svg-filter';
 import {createOrUpdateDynamicTheme, removeDynamicTheme, cleanDynamicThemeCache} from './dynamic-theme';
 import {logWarn} from './utils/log';
+import {setProp} from './prop';
 
 function onMessage({type, data}) {
+    setProp(type);
     switch (type) {
         case 'add-css-filter':
         case 'add-static-theme': {

--- a/src/inject/prop.ts
+++ b/src/inject/prop.ts
@@ -20,7 +20,7 @@ export function handleProp(type: string, data: Object) {
     user = {
         mode: codeToName[type],
         enabled: type !== 'clean-up',
-        options: JSON.stringify(data)
+        options: data
     }
 
     // Initialise property

--- a/src/inject/prop.ts
+++ b/src/inject/prop.ts
@@ -1,0 +1,25 @@
+const script = document.createElement('script');
+(document.head || document.body).append(script);
+
+const codeToName = {
+    'add-css-filter': 'Filter',
+    'add-static-theme': 'Filter+',
+    'add-svg-filter': 'Static',
+    'add-dynamic-theme': 'Dynamic',
+    'clean-up': null
+};
+
+export function setProp(type: string) {
+    script.innerHTML = `window['darkreader'] = {
+        mode: ${codeToName[type]},
+        dark: ${type !== 'clean-up'}
+    }`
+    if (document.createEvent) {
+        const event = document.createEvent('HTMLEvents');
+        event.initEvent('darkreader:change', true, false);
+        document.dispatchEvent(event);
+    } else {
+        // @ts-ignore <- Ignore error for IE8 and older feature
+        document.fireEvent('ondarkreader:change');
+    }
+}

--- a/src/inject/prop.ts
+++ b/src/inject/prop.ts
@@ -1,25 +1,34 @@
-const script = document.createElement('script');
-(document.head || document.body).append(script);
+// https://richienb.mit-license.org/@2019
+import { remove, trigger } from "../utils/dom"
 
+let script: HTMLScriptElement
+let user: Object
 const codeToName = {
     'add-css-filter': 'Filter',
-    'add-static-theme': 'Filter+',
-    'add-svg-filter': 'Static',
+    'add-svg-filter': 'Filter+',
+    'add-static-theme': 'Static',
     'add-dynamic-theme': 'Dynamic',
     'clean-up': null
 };
 
-export function setProp(type: string) {
-    script.innerHTML = `window['darkreader'] = {
-        mode: ${codeToName[type]},
-        dark: ${type !== 'clean-up'}
-    }`
-    if (document.createEvent) {
-        const event = document.createEvent('HTMLEvents');
-        event.initEvent('darkreader:change', true, false);
-        document.dispatchEvent(event);
-    } else {
-        // @ts-ignore <- Ignore error for IE8 and older feature
-        document.fireEvent('ondarkreader:change');
+export function handleManual(manual: boolean) {
+    // handleManual(!urlInfo.isProtected && urlInfo.isInDarkList)
+    console.log(manual)
+}
+
+export function handleProp(type: string, data: Object) {
+    user = {
+        mode: codeToName[type],
+        enabled: type !== 'clean-up',
+        options: JSON.stringify(data)
     }
+
+    // Initialise property
+    if (script) remove(script)
+    script = document.createElement('script');
+    (document.head || document.body).append(script);
+
+    // Set property
+    script.innerHTML = `window['darkreader'] = ${JSON.stringify(user)}`
+    trigger(document, 'darkreader:change')
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -1,0 +1,18 @@
+/**
+ * Remove an element from the dom.
+ * @param el Element.
+ */
+export function remove(el: HTMLElement) {
+    el.parentNode.removeChild(el);
+}
+
+/**
+ * Trigger an event.
+ * @param el Element.
+ * @param ev Event.
+ */
+export function trigger(el: HTMLElement | Document, ev: string) {
+    const event = document.createEvent('HTMLEvents');
+    event.initEvent(ev, true, false);
+    el.dispatchEvent(event);
+}


### PR DESCRIPTION
This PR allows darkreader to set a Global Window Variable that contains information about the theme and if dark mode is enabled. It also adds an event to the document element.

TODO:
- [ ] Finish implementation
- [ ] Document usage in README
- [ ] Test for all settings.

Closes https://github.com/darkreader/darkreader/issues/1330.