### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -82,7 +82,6 @@ hyper.is
 i3wm.org
 illicoweb.videotron.com
 indiexpo.net
-ingress.com
 inker.co
 isthereanydeal.com
 joeydrewstudios.com


### PR DESCRIPTION
removed ingress.com from dark list
They released a new site under community.ingress.com that is all white