### PR TITLE
Added CSS Fix for pgatour.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -615,6 +615,16 @@ INVERT
 
 ================================
 
+pgatour.com
+
+CSS
+.score-card tr td.birdie {
+    background-image: initial;
+    background-color: rgb(1, 76, 181);
+}
+
+================================
+
 play.google.com
 
 INVERT


### PR DESCRIPTION
Website normally changes background color of birdies on the scorecard page to highlight them. Darkreader takes away that highlighting. This fix adds it back by coloring the background like other "non-par" scores.