### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -221,6 +221,16 @@ mark
 
 ================================
 
+duckduckgo.com
+
+CSS
+.header__content.header__search, .search--adv {
+    background-color: #fff !important;
+    border-radius: 4px;
+}
+
+================================
+
 education.github.com
 
 INVERT
@@ -564,6 +574,15 @@ news.ycombinator.com
 
 INVERT
 .votearrow
+
+================================
+
+newyorker.com
+
+CSS
+.Logo__logo___3DzHd path {
+    fill: ${#17191C} !important;
+}
 
 ================================
 


### PR DESCRIPTION
Add fix for newyorker.com (fixes the SVG logo)
Add fix for duckduckgo.com (search box janky-ness)

### Screenshot comparing before / after:

DuckDuckGo Homepage:
![ddg home](https://user-images.githubusercontent.com/2184561/59548516-6f836000-8f05-11e9-9c14-9e7bf8370498.png)

DuckDuckGo Result's page search form:
![ddg search](https://user-images.githubusercontent.com/2184561/59548518-71e5ba00-8f05-11e9-95fb-19952fd1da72.png)

New Yorker SVG logo:
![newyorker logo](https://user-images.githubusercontent.com/2184561/59548520-73af7d80-8f05-11e9-9dbc-e0d6862f53e3.png)
