### PR TITLE
fix inversion of equation icons for google docs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -204,6 +204,8 @@ INVERT
 .punch-filmstrip-controls-icon
 #docs-editor canvas
 .docs-homescreen-icon
+.kix-equation-toolbar-icon
+.kix-equation-toolbar-palette-icon
 
 ================================
 


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/5302085/59692168-a77bf300-91e4-11e9-95a7-bc3440f971dc.png)
New:
![image](https://user-images.githubusercontent.com/5302085/59692291-e3af5380-91e4-11e9-8076-dafb46143a96.png)

