### PR TITLE
remove double inverted math formula on wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -951,7 +951,6 @@ span>img[alt^="CDel"]
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black
-.mwe-math-fallback-image-inline
 
 ================================
 


### PR DESCRIPTION
## description
by inverting `.mwe-math-element` which is the parent of the image with the class `.mwe-math-fallback-image-inline`, the image is inverted twice.
```
wikipedia.org

INVERT
.mwe-math-element
.mw-wiki-logo
.central-textlogo__image
.svg-Wikimedia-logo_black
.mwe-math-fallback-image-inline
```

## fix
old:
![image](https://user-images.githubusercontent.com/5302085/59840920-a61d0880-9353-11e9-88f6-6bc4abad8322.png)
new: 
![image](https://user-images.githubusercontent.com/5302085/59840947-b2a16100-9353-11e9-8a6e-9d93a40801ff.png)

Tested on:
- https://en.wikipedia.org/wiki/A*_search_algorithm
- [https://en.wikipedia.org/wiki/Iterative_deepening_A*](https://en.wikipedia.org/wiki/Iterative_deepening_A*)
- https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm