### PR TITLE
Fix virtualbox.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -888,6 +888,15 @@ CSS
 
 ================================
 
+virtualbox.org
+
+CSS
+body {
+    background: transparent !important;
+}
+
+================================
+
 w3.org
 
 INVERT


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/12257112/59977852-41211700-95ce-11e9-8c6f-be29199915cd.png)

After:
![image](https://user-images.githubusercontent.com/12257112/59977847-29e22980-95ce-11e9-8091-cf2c0f97fd91.png)
The logos at the top are images that include the background, so can't be fixed with a simple css tweak