### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -93,6 +93,7 @@ kissmanga.com
 linux.org.ru
 marte.dev
 mcrpw.github.io
+messages.google.com
 miaou.drycat.fr
 mixer.com
 mmorpg.com


### PR DESCRIPTION
Adding google.com to Site List will add messages.google.com (which has a dark mode)