### PR TITLE
Prevent RegEx Matching Infinite `)(`s Vulnerability

### DIFF
--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -169,7 +169,7 @@ function getColorModifier(prop: string, value: string): string | CSSValueModifie
     }
 }
 
-const gradientRegex = /[\-a-z]+gradient\(([^\(\)]*(\(([^\(\)]*(\(.*?\)))*[^\(\)]*\)))*[^\(\)]*\)/g;
+const gradientRegex = /[\-a-z]+gradient\(([^\(\)]*(\(([^\(\)]*(\(.*?\)))*[^\(\)]*\))){0,15}[^\(\)]*\)/g;
 const imageDetailsCache = new Map<string, ImageDetails>();
 const awaitingForImageLoading = new Map<string, ((imageDetails: ImageDetails) => void)[]>();
 


### PR DESCRIPTION
This addresses a [potential RegEx DoS attack found by lgtm](https://lgtm.com/projects/g/darkreader/darkreader/snapshot/b8afe835d0aae678b25bbb9784378f1020ef98db/files/src/inject/dynamic-theme/modify-css.ts?sort=name&dir=ASC&mode=heatmap)