### PR TITLE
Dynamic Theme Fix: Datadog: Time Cursor on graphs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -69,6 +69,9 @@ CSS
 .log-dt-event.active, .log-dt-event.active:hover, .log-dt-event:hover {
     background-color: rgb(37, 45, 58) !important;
 }
+svg text.time_cursor {
+    fill: ${black} !important;
+}
 
 ================================
 


### PR DESCRIPTION
In the Datadog app the text on time cursors wasn't being inverted, causing a blank white box:

![image](https://user-images.githubusercontent.com/867375/60454322-8910f100-9c01-11e9-95d4-f86fe13c3568.png)

The added CSS resolves it:

![image](https://user-images.githubusercontent.com/867375/60454349-9b8b2a80-9c01-11e9-84a9-387e42d8bf44.png)
