### PR TITLE
Fix wikipedia inverting SVG based equations twice

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -947,11 +947,10 @@ INVERT
 wikipedia.org
 
 INVERT
-span>img[alt^="CDel"]
+.mwe-math-element
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black
-.mwe-math-fallback-image-inline
 
 ================================
 


### PR DESCRIPTION
Issue: #59, #1261 and #1283