### PR TITLE
Add overdodactyl.github.io/ShadowFox to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -109,6 +109,7 @@ open.spotify.com
 opencritic.com
 opendota.com
 orteil.dashnet.org/cookieclicker
+overdodactyl.github.io/ShadowFox
 parahumans.wordpress.com
 pathof.info
 pathofexile.com


### PR DESCRIPTION
The ShadowFox page is [as one might expect] already dark-themed. Welcome to the dark side, ShadowFox.