### PR TITLE
remove steamdb.info from global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -139,7 +139,6 @@ sites.google.com/site/igotdemthingsyoulike/
 spacespacespaaace.space
 speedtest.net
 steamcommunity.com
-steamdb.info
 store.steampowered.com
 streamelements.com
 streamlabs.com


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9652227/60930820-e1bf4880-a2e9-11e9-9aab-7af30a6faa87.png)

![image](https://user-images.githubusercontent.com/9652227/60930839-fac7f980-a2e9-11e9-918b-4a0bb02b72db.png)

![image](https://user-images.githubusercontent.com/9652227/60930845-07e4e880-a2ea-11e9-86c8-0c9a399bb459.png)

![image](https://user-images.githubusercontent.com/9652227/60930855-13d0aa80-a2ea-11e9-9b82-88bf4c916b20.png)

It worked fine in dark mode before.

Thank you for your consideration.