### PR TITLE
Added webtoons.com text fix to dynamic theme config file

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -962,6 +962,25 @@ INVERT
 
 ================================
 
+webtoons.com
+
+CSS
+.card_item .info {
+    color: black;
+}
+.card_item .info .subj {
+    text-shadow: -1px 1px white; 
+}
+.card_item .update {
+    color: black;
+    text-shadow: -1px -1px white;
+}
+.card_item .info .author {
+    text-shadow: -1px -1px white;
+}
+
+================================
+
 what-if.xkcd.com
 
 INVERT


### PR DESCRIPTION
Changes the webtoon tile text so that it can actually be seen in dark mode (and light mode) with DR on. 
(before it was kinda really light grey and hard to see)