### PR TITLE
Added saidit.net to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -129,6 +129,7 @@ rawg.io
 razer.com
 realgamernewz.com
 runicgames.com
+saidit.net
 sanctum.geek.nz/arabesque
 sandervanderburg.blogspot.com
 serebii.net


### PR DESCRIPTION
saidit.net is using a dark theme mode by default.