### PR TITLE
Add yuque.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1257,6 +1257,13 @@ html:not(.style-scope) {
 
 ================================
 
+yuque.com
+
+INVERT
+.lake-math-content-preview-img > img
+
+================================
+
 zhuanlan.zhihu.com
 
 INVERT


### PR DESCRIPTION
Fix the bug that formulas can't be inverted by Dark Reader on `yuque.com`.

Before:
![image](https://user-images.githubusercontent.com/30370926/61183431-ec743780-a673-11e9-8f79-1673a5f959dc.png)

After:
![image](https://user-images.githubusercontent.com/30370926/61183438-1594c800-a674-11e9-9129-2ddcfa36c2fd.png)
