### PR TITLE
Add lichess.org to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -94,6 +94,7 @@ joinmastodon.org
 jsfiddle.net
 killtheradio.net
 kissmanga.com
+lichess.org
 linux.org.ru
 marte.dev
 mcrpw.github.io


### PR DESCRIPTION
Lichess is currently broken with Dark Reader--see issue #1093. Black chess pieces (other than the king) are not drawn. Lichess has its own dark theme, so it's best to disable dark reader globally and have users select the native dark theme that lichess offers.