### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -50,6 +50,7 @@ dotapicker.com
 dpreview.com
 draculatheme.com
 draftkings.com
+discord.com
 easttv.org
 editor.method.ac
 egee.io
@@ -118,7 +119,6 @@ pathof.info
 pathofexile.com
 play.hbogo.com
 play.mubert.com
-pluralsight.com
 poe-racing.com
 poe.trade
 poeapp.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -50,7 +50,6 @@ dotapicker.com
 dpreview.com
 draculatheme.com
 draftkings.com
-discord.com
 easttv.org
 editor.method.ac
 egee.io


### PR DESCRIPTION
Got blinded reading Plural sight article at night.
Added Discord to the list, as the default dark mode is alright, adding the dark reader makes it font for some fonts to be readable.
Removed PluralSlight from the slight cause blinding people is mean

Ideally there should be a useful defined list for this, but for now this will do since this issue has multiple complaints and many people have complained asking for not to be blinded.