### PR TITLE
Google Scripts editor icon fix

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1682,6 +1682,13 @@ INVERT
 
 ================================
 
+script.google.com
+
+INVERT
+.docs-icon-img-container
+
+================================
+
 semlar.com
 
 INVERT


### PR DESCRIPTION
Fixed the icons in the google scripts editor having a black on black background