### PR TITLE
Add webflow.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -168,6 +168,7 @@ vortetty.k3live.com
 vrv.co
 vuecinemas.nl
 w0rp.com
+webflow.com
 weboas.is
 wiki.factorio.com
 wowhead.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -168,7 +168,7 @@ vortetty.k3live.com
 vrv.co
 vuecinemas.nl
 w0rp.com
-webflow.com
+^webflow.com
 weboas.is
 wiki.factorio.com
 wowhead.com


### PR DESCRIPTION
Actually question
* webflow.com should be excluded
* subdomains i.e. forum.webflow.com should NOT be excluded

How does one achieve this? 

Thanks,
Ben