### PR TITLE
Change text color of clock in atcoder.jp for dynamic theme

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -87,6 +87,15 @@ CSS
 
 ================================
 
+atcoder.jp
+
+CSS
+#fixed-server-timer {
+    color: #333;
+}
+
+================================
+
 aws.amazon.com
 
 INVERT


### PR DESCRIPTION
Original:
![Screenshot_2019-08-09 AtCoder](https://user-images.githubusercontent.com/30190448/62788707-17bc3c00-bae5-11e9-814a-c3e6ce0e5aed.png)

After fix:
![Screenshot_2019-08-09 AtCoder(1)](https://user-images.githubusercontent.com/30190448/62788749-2f93c000-bae5-11e9-9b85-8011fab39dfd.png)
