### PR TITLE
DataCamp.com video player transformation fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -192,8 +192,8 @@ datacamp.com
 
 CSS
 video#vjs_video_3_html5_api.vjs-tech {
-transform: translate(0px, 0px) !important;
-background-color: rgb(175, 175, 175, 0.5);
+    transform: translate(0px, 0px) !important;
+    background-color: rgb(175, 175, 175, 0.5);
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -193,6 +193,7 @@ datacamp.com
 CSS
 video#vjs_video_3_html5_api.vjs-tech {
 transform: translate(0px, 0px) !important;
+background-color: rgb(175, 175, 175, 0.5);
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -188,6 +188,15 @@ span[class^="skycon swip"]
 
 ================================
 
+datacamp.com
+
+CSS
+video#vjs_video_3_html5_api.vjs-tech {
+transform: translate(0px, 0px) !important;
+}
+
+================================
+
 developer.mozilla.org
 
 INVERT


### PR DESCRIPTION
The lesson video player on DataCamp.com was being transform-translated to the right by 70-ish pixels, causing it to spill out of the right side of its container, and making the speaker's presentation points difficult to read, since they are dark text, and the background behind the video is also dark.

Screenshot:
![image](https://user-images.githubusercontent.com/37491308/63124852-d824a280-bf71-11e9-9dc1-16b8d191fc74.png)
