### PR TITLE
Remove background image on askubuntu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -86,6 +86,15 @@ CSS
 
 ================================
 
+askubuntu.com
+
+CSS
+body {
+  background-image: none !important;
+}
+
+================================
+
 atcoder.jp
 
 CSS


### PR DESCRIPTION
This PR removes background image on askubuntu.com. Its presence makes it harder to read the left menu.

See issue #1498 for a screencap. Also, this PR resolves mentioned issue.