### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -278,7 +278,9 @@ CSS
 .fbNubButton {
     background-image: none !important;
 }
-
+.jewelItemNew ._33e {
+    background-color: #343434 !important;
+}
 ================================
 
 fantasy.premierleague.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -279,7 +279,7 @@ CSS
     background-image: none !important;
 }
 .jewelItemNew ._33e {
-    background-color: #343434 !important;
+    background-color: ${#d0d1d3} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -281,6 +281,7 @@ CSS
 .jewelItemNew ._33e {
     background-color: #343434 !important;
 }
+
 ================================
 
 fantasy.premierleague.com


### PR DESCRIPTION
Updated unread Facebook notification background color so that it's easier to tell which notifications are read vs unread.

Before:
![image](https://user-images.githubusercontent.com/5971649/63218986-072b4780-c11d-11e9-8887-225b7d772933.png)

After:
![image](https://user-images.githubusercontent.com/5971649/63218996-20cc8f00-c11d-11e9-90ed-2fef00cbb551.png)
