### PR TITLE
fix wikipedia.org .thumbimage transparency issue

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1157,6 +1157,12 @@ INVERT
 .central-textlogo__image
 .svg-Wikimedia-logo_black
 
+CSS
+div .thumbimage[src$=".png"],
+div .thumbimage img[src$=".png"] {
+    background-color: white;
+}
+
 ================================
 
 wikiwand.com


### PR DESCRIPTION
When .thumbimage png is has transparency, the background should be assumed white.