### PR TITLE
Fixes for dynamic theme on tjournal.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1149,9 +1149,6 @@ CSS
 mark a {
   color: ${#346eb8} !important;
 }
-#page_wrapper {
-  background-color: ${#fff4e0} !important;
-}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1146,6 +1146,9 @@ INVERT
 mark
 
 CSS
+mark a {
+  color: ${#346eb8} !important;
+}
 #page_wrapper {
   background-color: ${#fff4e0} !important;
 }


### PR DESCRIPTION
Links inside marks were hard to read. See https://github.com/darkreader/darkreader/pull/1502#issuecomment-523499683 for before/after screencaps.

Also, the PR removes a CSS rule which is no longer needed due to redesign. 