### PR TITLE
Remove body background image on StackExchange network

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -87,6 +87,7 @@ CSS
 ================================
 
 askubuntu.com
+*.stackexchange.com
 
 CSS
 body {


### PR DESCRIPTION
I've started to toggle DarkReader more frequently and immediately noticed that many of StackExchange sites have body background images which don't look nice in the dark mode. See https://ell.stackexchange.com or https://emacs.stackexchange.com/

Other users have noticed it. See PR #1527, https://github.com/darkreader/darkreader/issues/1498#issuecomment-523196238

While many of StackExchange sites do not have any background image I don't think it is worth it to remove the image by separate fixes. Hence, I've added such a broad fix.

P.S. It also makes PR #1527 obsolete.