### PR TITLE
Fix <a> decoration on medium

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -595,6 +595,11 @@ INVERT
 .svgIcon
 .svgIcon-use
 
+CSS
+a {
+  text-decoration-line: underline !important;
+}
+
 ================================
 
 medium.freecodecamp.org


### PR DESCRIPTION
medium.com cancels text-decoration for links and uses a few CSS classes to draw a tiny dotted line instead. As a result it is almost impossible to spot links on medium in the dark mode. See #1495

Since they use several CSS classes with random names I just decided to force text-decoration back on all `<a>` elements and ignore these classes. It makes it less appealing on some pages like https://medium.com/@kentcdodds but at least links in articles are clearly visible now.

Closes: #1495 