### PR TITLE
Remove max-width on body of DevTools

### DIFF
--- a/src/ui/devtools/style.less
+++ b/src/ui/devtools/style.less
@@ -14,7 +14,6 @@ body {
     flex-direction: column;
     height: 100%;
     margin: 0 auto;
-    max-width: 60rem;
 }
 
 header {


### PR DESCRIPTION
Sometimes I have to look into really long lines in dynamic-fixes.config when I try to understand what goes wrong on a site and fix it. It becomes really tedious due to long lines and expanding DevTools popup doesn't help since its style bears the `max-width: 60rem` property

![image](https://user-images.githubusercontent.com/153191/64029202-75ddbb80-cb87-11e9-912f-af51a9273b71.png)

I propose removal of `max-width` as I believe it basically does nothing in regards to the UI.