### PR TITLE
Add outlook.office.com to the list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -117,6 +117,7 @@ open.spotify.com
 opencritic.com
 opendota.com
 orteil.dashnet.org/cookieclicker
+outlook.office.com
 overdodactyl.github.io/ShadowFox
 parahumans.wordpress.com
 pathof.info


### PR DESCRIPTION
Added outlook.office.com, since they already have a built-in dark theme.