### PR TITLE
Revert "Remove background from unix.stackoverflow.com (#1527)"

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1224,15 +1224,6 @@ CSS
 
 ================================
 
-unix.stackexchange.com
-
-CSS
-body {
-    background-image: none !important;
-}
-
-================================
-
 vc.ru
 
 INVERT


### PR DESCRIPTION
This reverts commit 3c6d32f8e88089184f68bdb8a73137f3e45665e9 introduced by #1527.

This commit is excessive because #1533 has been merged