### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -58,6 +58,7 @@ dpreview.com
 draculatheme.com
 draftkings.com
 easttv.org
+ecobee.com/consumerportal
 editor.method.ac
 egee.io
 energized.pro


### PR DESCRIPTION
The consumer portal in ecobee is already in dark mode.