### PR TITLE
Updated Chinese translation to sound more natural

### DIFF
--- a/src/_locales/zh_CN.config
+++ b/src/_locales/zh_CN.config
@@ -8,7 +8,7 @@
 #==== Top section ====
 
 @on
-打开
+开启
 
 @off
 关闭
@@ -54,7 +54,7 @@
 使用系统的配色方案
 
 @system_dark_mode_description
-激活时，系统暗模式开启
+系统夜间设置模式开启时激活
 
 
 #==== Filter ====


### PR DESCRIPTION
Updated the translation for "@on" and "@system_dark_mode_description". The original translation for  "@system_dark_mode_description" is not natural, or even comprehensible. Re-translated based on  `en.config`.