### PR TITLE
fix font sharpness

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -452,6 +452,11 @@ habr.com
 INVERT
 img[src*="//tex.s2cms.ru/"]
 
+CSS
+html {
+    text-shadow: none !important;
+}
+
 ================================
 
 hdgo.cc
@@ -461,6 +466,15 @@ INVERT
 .hdplayer .big_play_button div
 .hdplayer .hdgo_controls div.hdgo_pause_control div
 .hdplayer .hdgo_controls div.hdgo_play_control div
+
+================================
+
+hh.ru
+
+CSS
+html {
+    text-shadow: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
`text-shadow: 0 0 0 !important;` is redundant because the font is hard to read

![habr com_ru_post_117160_](https://user-images.githubusercontent.com/1476565/65517245-0e4b2f80-deeb-11e9-9d54-c733206c8a93.png)
