### PR TITLE
Add twitch.tv to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -164,6 +164,7 @@ tf2mart.net
 thealiendrew.github.io
 toneden.io
 totalwarwarhammer.gamepedia.com
+twitch.tv
 ufplanets.com
 undergroundcellar.com
 undertale.com


### PR DESCRIPTION
As per [Twitch's rebrand](https://brand.twitch.tv), the site is now in dark theme by default