### PR TITLE
Fix browser theme setting in Firefox

### DIFF
--- a/src/background/window-theme.ts
+++ b/src/background/window-theme.ts
@@ -13,6 +13,7 @@ const themeColorTypes = {
     accentcolor: 'bg',
     button_background_active: 'text',
     button_background_hover: 'text',
+    frame: 'bg',
     icons: 'text',
     icons_attention: 'text',
     popup: 'bg',
@@ -20,6 +21,7 @@ const themeColorTypes = {
     popup_highlight: 'bg',
     popup_highlight_text: 'text',
     popup_text: 'text',
+    tab_background_text: 'text',
     tab_line: 'bg',
     tab_loading: 'bg',
     tab_selected: 'bg',
@@ -30,20 +32,26 @@ const themeColorTypes = {
     toolbar_field_border: 'border',
     toolbar_field_border_focus: 'border',
     toolbar_field_focus: 'bg',
+    toolbar_field_separator: 'border',
     toolbar_field_text: 'text',
     toolbar_field_text_focus: 'text',
-    toolbar_field_separator: 'border',
     toolbar_text: 'text',
     toolbar_top_separator: 'border',
     toolbar_vertical_separator: 'border',
 };
 
 const $colors = {
+    // 'accentcolor' is the deprecated predecessor of 'frame'.
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#colors
     accentcolor: '#111111',
+    frame: '#111111',
     popup: '#cccccc',
     popup_text: 'black',
+    tab_background_text: 'white',
     tab_line: '#23aeff',
     tab_loading: '#23aeff',
+    // 'textcolor' is the predecessor of 'tab_background_text'.
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#colors
     textcolor: 'white',
     toolbar: '#707070',
     toolbar_field: 'lightgray',


### PR DESCRIPTION
The new `frame` and `tab_background_text` properties must be set in
order to avoid setting to defaults in newer Firefox versions (e.g. on
Nightly).

At the moment the old `accentcolor` and `textcolor` properties return a
warning, so we can avoid removing them to work with older versions of
Firefox for as long as possible.

Fixes: https://github.com/darkreader/darkreader/issues/1430
Refs: https://github.com/darkreader/darkreader/commit/181ec067486ab4602d6d1c78ed5be9eac089139d