### PR TITLE
Fix QR code on web.whatsapp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1281,6 +1281,14 @@ web.whatsapp.com
 
 INVERT
 .tail-container
+.selectable-text > span._3PxOr
+
+CSS
+._1pw2F {
+    border-color: white !important;
+    border-width: 15px !important;
+    border-style: solid !important;
+}
 
 ================================
 


### PR DESCRIPTION
It was not possible to scan QR code in dark mode because of the adjacent black background. I added a white border around the code so it's possible to scan it now. Also a few minor icons are correctly inverted.

Closes #545.