### PR TITLE
Added Discord to Dark Sites Config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -48,6 +48,7 @@ destinytracker.com
 di.fm
 diablo3.com
 diablo3ladder.com
+discordapp.com
 discuss.noisebridge.info
 dota2.com
 dota2.ru


### PR DESCRIPTION
I've added Discord to the dark site theme config, as it already uses a dark theme and Darkreader just messes it up and makes it a thousand times worse