### PR TITLE
Fix lenovo megamenu

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -534,6 +534,18 @@ INVERT
 
 ================================
 
+lenovo.com
+
+INVERT
+.m-megaMenu
+
+CSS
+.m-mastheadUtilityLinks {
+    background: none !important;
+}
+
+================================
+
 lirc.org
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -820,6 +820,10 @@ CSS
    background-color: ${#DAE0E6} !important;
 }
 
+._1ump7uMrSA43cqok14tPrG::before {
+  background: transparent !important;
+}
+
 ================================
 
 richie-bendall.ml


### PR DESCRIPTION
Fix lenovo.com site
* Invert drop down megaMenu
* Remove background color for UtilityLinks bar

Link for testing : https://www.lenovo.com/us/en/d/deals/thinkpad-laptops