### PR TITLE
Fix #1623: Invert the Images for Dynamic/Filter [Java.com]

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -510,6 +510,15 @@ INVERT
 
 ================================
 
+java.com
+
+INVERT
+html #jvc0v2.bg1 .jvc0w1
+html #jvc0v2.bg3 .jvc0w1
+html #jvc0v2.bg5 .jvc0w1
+
+================================
+
 jisho.org
 
 INVERT

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -929,6 +929,17 @@ img[alt*="Equation"]
 
 ================================
 
+java.com
+
+INVERT
+html #jvc0v2.bg1 .jvc0w1
+html #jvc0v2.bg2 .jvc0w1
+html #jvc0v2.bg3 .jvc0w1
+html #jvc0v2.bg4 .jvc0w1
+html #jvc0v2.bg5 .jvc0w1
+
+================================
+
 javarepl.com
 
 INVERT


### PR DESCRIPTION
On Java.com, they displayed a random image out of 5 images every refresh.

On Dynamic Mode, 
It seems that the jpg images displayed properly, so two images were not inverted. 
#jvc0v2.bg4 .jvc0w1
#jvc0v2.bg2 .jvc0w1

For the Filter/Filter+ 
All 5 of the images needed to be inverted

Static 
All the images display properly, no changes required.