### PR TITLE
Remove twitch.tv

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -168,7 +168,6 @@ thealiendrew.github.io
 toneden.io
 totalwarwarhammer.gamepedia.com
 trustreaming.tv
-twitch.tv
 ufplanets.com
 undergroundcellar.com
 undertale.com


### PR DESCRIPTION
Theyre using black background and pure white, blinding font color. No reason not to be able to change that to more toned and easy on the eyes version like we could all along until recently.