### PR TITLE
Global Dark Sites: Added a few Apple news websites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,5 +1,6 @@
 2600.com
 5stardata.info
+9to5mac.com
 animeonline.su
 app.keeweb.info
 app.plex.tv
@@ -107,6 +108,8 @@ jsfiddle.net
 killtheradio.net
 kissmanga.com
 linux.org.ru
+macrumors.com
+macstories.net
 marte.dev
 mcrpw.github.io
 mcskinhistory.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,6 +1,8 @@
 2600.com
 5stardata.info
+9to5google.com
 9to5mac.com
+9to5toys.com
 animeonline.su
 app.keeweb.info
 app.plex.tv
@@ -61,10 +63,12 @@ dplay.com
 dpreview.com
 draculatheme.com
 draftkings.com
+dronedj.com
 easttv.org
 ecobee.com/consumerportal
 editor.method.ac
 egee.io
+electrek.co
 energized.pro
 enlightenment.org
 erai-raws.info


### PR DESCRIPTION
A few Apple news sites that have been making the switch after the release of iOS 13.