### PR TITLE
Fix formula not inverted in Baidu Baike (百度百科)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -134,6 +134,13 @@ img[alt^="WEB_FreeTier"]
 
 ================================
 
+baike.baidu.com
+
+INVERT
+.formula
+
+================================
+
 bbc.com/news
 bbc.com/sport
 bbc.com/weather

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -144,6 +144,13 @@ INVERT
 
 ================================
 
+baike.baidu.com
+
+INVERT
+.formula
+
+================================
+
 bart.gov/schedules
 
 NO INVERT


### PR DESCRIPTION
Invert `class="formula"` for better formula display.
Demo page: https://baike.baidu.com/item/%E5%85%AC%E5%BC%8F/9991