### PR TITLE
Fix matched interest text color on SLOWLY

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1376,6 +1376,15 @@ CSS
 
 ================================
 
+web.getslowly.com
+
+CSS
+.badge-active {
+    color: rgb(47, 51, 58);
+}
+
+================================
+
 web.whatsapp.com
 
 INVERT
@@ -1387,15 +1396,6 @@ CSS
     border-color: white !important;
     border-width: 15px !important;
     border-style: solid !important;
-}
-
-================================
-
-web.getslowly.com
-
-CSS
-.badge-active {
-    color: rgb(47, 51, 58);
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1391,6 +1391,15 @@ CSS
 
 ================================
 
+web.getslowly.com
+
+CSS
+.badge-active {
+    color: rgb(47, 51, 58);
+}
+
+================================
+
 webtoons.com
 
 CSS


### PR DESCRIPTION
The text color for text in badges marked "active" (because the interests of another user matches with yours) was too bright.
This commit adds a CSS rule that darkens the text-color in these active interest badges for web.getslowly.com.