### PR TITLE
Update for almost invisible highlights.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -399,6 +399,14 @@ INVERT
 
 ================================
 
+flow.polar.com
+
+CSS
+.highlight {
+    color: ${#ffffff} !important;
+
+================================
+
 github.blog
 
 INVERT


### PR DESCRIPTION
Polar Relieve shows some stats and it is almost invisible in default dark settings. This will make them black (like they are without dark mode). You can check https://flow.polar.com/training/relive/4002051395 to see the problem. ;)