### PR TITLE
Fix github search bar background color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -431,7 +431,7 @@ rect.day[data-count="0"]{
     fill: {#fff} !important;
 }
 .js-site-search-form {
-    background-color: black !important;
+    background-color: ${white} !important;
     border-radius: 2pt !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -430,6 +430,10 @@ CSS
 rect.day[data-count="0"]{
     fill: {#fff} !important;
 }
+.js-site-search-form {
+    background-color: black !important;
+    border-radius: 2pt !important;
+}
 
 ================================
 


### PR DESCRIPTION
Github search bar color fixed from being blended with the navbar to have a black background that makes it stand out and add a rounded border to conform with GitHub design