### PR TITLE
Added BenLeggiero.blog and BenLeggiero.me to the block list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -13,6 +13,8 @@ bbc.co.uk/iplayer
 beastskills.com
 bedrocklinux.org
 ben-herila.webflow.io
+benleggiero.blog
+benleggiero.me
 beta.jdownloader.org
 bherila.net
 bing.com/$


### PR DESCRIPTION
I assumed Unicode/ASCII sort order means I should put these _after_ `ben-herila.webflow.io`