### PR TITLE
[Dynamic] Recolored github.com profiles' contrib grids.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -515,24 +515,24 @@ CSS
     border-radius: 2pt !important;
 }
 .day[fill="#ebedf0"], .legend li[style*="background-color: rgb(235, 237, 240)"] {
-    fill: ${white} !important;
-    background-color: ${white} !important;
+    fill: ${#ebedf0} !important;
+    background-color: ${#ebedf0} !important;
 }
 .day[fill="#c6e48b"], .legend li[style*="background-color: rgb(198, 228, 139)"] {
-    fill: ${silver} !important;
-    background-color: ${silver} !important;
+    fill: ${#c6d4cb} !important;
+    background-color: ${#c6d4cb} !important;
 }
 .day[fill="#7bc96f"], .legend li[style*="background-color: rgb(123, 201, 111)"] {
-    fill: ${darkgray} !important;
-    background-color: ${darkgray} !important;
+    fill: ${#7bb99f} !important;
+    background-color: ${#7bb99f} !important;
 }
 .day[fill="#239a3b"], .legend li[style*="background-color: rgb(35, 154, 59)"] {
-    fill: ${gray} !important;
-    background-color: ${gray} !important;
+    fill: ${#238a5b} !important;
+    background-color: ${#238a5b} !important;
 }
 .day[fill="#196127"], .legend li[style*="background-color: rgb(25, 97, 39)"] {
-    fill: ${dimgray} !important;
-    background-color: ${dimgray} !important;
+    fill: ${#196137} !important;
+    background-color: ${#196137} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -514,35 +514,25 @@ CSS
     background-color: ${white} !important;
     border-radius: 2pt !important;
 }
-.day[fill="#ebedf0"] {
-    fill: ${white} !important
+.day[fill="#ebedf0"], .legend li[style*="background-color: rgb(235, 237, 240)"] {
+    fill: ${white} !important;
+    background-color: ${white} !important;
 }
-.day[fill="#c6e48b"] {
-    fill: ${silver} !important
+.day[fill="#c6e48b"], .legend li[style*="background-color: rgb(198, 228, 139)"] {
+    fill: ${silver} !important;
+    background-color: ${silver} !important;
 }
-.day[fill="#7bc96f"] {
-    fill: ${darkgray} !important
+.day[fill="#7bc96f"], .legend li[style*="background-color: rgb(123, 201, 111)"] {
+    fill: ${darkgray} !important;
+    background-color: ${darkgray} !important;
 }
-.day[fill="#239a3b"] {
-    fill: ${gray} !important
+.day[fill="#239a3b"], .legend li[style*="background-color: rgb(35, 154, 59)"] {
+    fill: ${gray} !important;
+    background-color: ${gray} !important;
 }
-.day[fill="#196127"] {
-    fill: ${dimgray} !important
-}
-.legend li[style*="background-color: rgb(235, 237, 240)"] {
-    background-color: ${white} !important
-}
-.legend li[style*="background-color: rgb(198, 228, 139)"] {
-    background-color: ${silver} !important
-}
-.legend li[style*="background-color: rgb(123, 201, 111)"] {
-    background-color: ${darkgray} !important
-}
-.legend li[style*="background-color: rgb(35, 154, 59)"] {
-    background-color: ${gray} !important
-}
-.legend li[style*="background-color: rgb(25, 97, 39)"] {
-    background-color: ${dimgray} !important
+.day[fill="#196127"], .legend li[style*="background-color: rgb(25, 97, 39)"] {
+    fill: ${dimgray} !important;
+    background-color: ${dimgray} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -510,12 +510,39 @@ CSS
 .refined-github .dashboard-rollup-items .body {
     border-top-color: ${#bbc1c9} !important;
 }
-rect.day[data-count="0"]{
-    fill: {#fff} !important;
-}
 .js-site-search-form {
     background-color: ${white} !important;
     border-radius: 2pt !important;
+}
+.day[fill="#ebedf0"] {
+    fill: ${white} !important
+}
+.day[fill="#c6e48b"] {
+    fill: ${silver} !important
+}
+.day[fill="#7bc96f"] {
+    fill: ${darkgray} !important
+}
+.day[fill="#239a3b"] {
+    fill: ${gray} !important
+}
+.day[fill="#196127"] {
+    fill: ${dimgray} !important
+}
+.legend li[style*="background-color: rgb(235, 237, 240)"] {
+    background-color: ${white} !important
+}
+.legend li[style*="background-color: rgb(198, 228, 139)"] {
+    background-color: ${silver} !important
+}
+.legend li[style*="background-color: rgb(123, 201, 111)"] {
+    background-color: ${darkgray} !important
+}
+.legend li[style*="background-color: rgb(35, 154, 59)"] {
+    background-color: ${gray} !important
+}
+.legend li[style*="background-color: rgb(25, 97, 39)"] {
+    background-color: ${dimgray} !important
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -523,16 +523,16 @@ CSS
     background-color: ${#c6d4cb} !important;
 }
 .day[fill="#7bc96f"], .legend li[style*="background-color: rgb(123, 201, 111)"] {
-    fill: ${#7bb99f} !important;
-    background-color: ${#7bb99f} !important;
+    fill: ${#7bb97f} !important;
+    background-color: ${#7bb97f} !important;
 }
 .day[fill="#239a3b"], .legend li[style*="background-color: rgb(35, 154, 59)"] {
-    fill: ${#238a5b} !important;
-    background-color: ${#238a5b} !important;
+    fill: ${#238a3b} !important;
+    background-color: ${#238a3b} !important;
 }
 .day[fill="#196127"], .legend li[style*="background-color: rgb(25, 97, 39)"] {
-    fill: ${#196137} !important;
-    background-color: ${#196137} !important;
+    fill: ${#196127} !important;
+    background-color: ${#196127} !important;
 }
 
 ================================


### PR DESCRIPTION
This PR also changes the legend at the bottom of the contribution grids to match. The means by which this is done is VERY hacky, but it preserves the use of Github's own logic to determine which calendar cells get which colors.

As for why grayscale,
* It looks better on dark mode than the original colors do.
* It translates to light mode very well.
* It's (arguably) less-opinionated about what the color scheme should be than most other choices.