### PR TITLE
QUICKFIX!!! facebook.com (i) siteinfo icon

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -397,7 +397,6 @@ INVERT
 ._-op i
 ._2o7_
 ._2o89
-._34k2
 ._2q08
 .sx_af7fe0
 .sx_7ed17e


### PR DESCRIPTION
There was too many changes in my last fixes.
it seems ._34k2 was related somehow with something I removed earlier.