### PR TITLE
All ::placeholder brightness reduce.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,6 +9,9 @@ CSS
     border-color: ${#c59d00} !important;
     color: ${#302505} !important;
 }
+::placeholder {
+    filter: brightness(50%) !important;
+}
 
 ================================
 


### PR DESCRIPTION
As I found many pages with placeholder having color almost the same as entered text and invert can make some pages ugly then I propose brightness reduction.
It seems to be best solution. No color changes for dynamic theme and making it a little bit darker to see it's not text already entered in the text field.