### PR TITLE
last.fm - white stroke in charts tag timeline

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -801,6 +801,9 @@ CSS
 .masthead-logo {
     filter: saturate(25); 
 }
+.highcharts-text-outline {
+    stroke: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
You can compare dark mode with this link:
https://www.last.fm/user/Myshor/listening-report/week