### PR TITLE
facebook.com - text message with background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -404,6 +404,7 @@ INVERT
 .sx_a4a936
 .sx_4d607f
 .snowliftPager
+._4a6n
 
 CSS
 .fbNubButton {


### PR DESCRIPTION
._4a6n
invert for text color for messages with background...
Now it ends almost always with white and sometimes it's hard to read.
Checked invert with some messages and seems to work nice.