### PR TITLE
Fix #1621: Fix the Duplication of text for all shortcuts

### DIFF
--- a/src/ui/controls/shortcut/index.tsx
+++ b/src/ui/controls/shortcut/index.tsx
@@ -89,8 +89,8 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
         });
     }
 
-    function onUpdate(props) {
-        props.textContent = shortcutMessage;
+    function onRender(node) {
+        node.textContent = shortcutMessage;
     }
 
     return (
@@ -98,7 +98,7 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
             class={cls}
             href="#"
             onclick={onClick}
-            updated={onUpdate}
-        >{props.textTemplate(shortcut)}</a>
+            attached={onRender}
+        ></a>
     );
 }

--- a/src/ui/controls/shortcut/index.tsx
+++ b/src/ui/controls/shortcut/index.tsx
@@ -18,18 +18,7 @@ interface ShortcutLinkProps {
 export default function ShortcutLink(props: ShortcutLinkProps) {
     const cls = mergeClass('shortcut', props.class);
     const shortcut = props.shortcuts[props.commandName];
-    const shortcutClass = document.getElementsByClassName("shortcut");
-    const toggleCurrent = document.getElementsByClassName("shortcut").item(0);
-    const toggleExtension = document.getElementsByClassName("shortcut").item(1);
-
-    if (shortcutClass.length == 3) {
-        if (toggleCurrent.innerHTML.lastIndexOf("Toggle") > 5) {
-            toggleCurrent.innerHTML = toggleCurrent.innerHTML.slice(0,toggleCurrent.innerHTML.indexOf("Toggle",1));
-        }
-        if (toggleExtension.innerHTML.lastIndexOf("Toggle") > 5) {
-            toggleExtension.innerHTML = toggleExtension.innerHTML.slice(0,toggleExtension.innerHTML.indexOf("Toggle",1));
-        }
-    }
+    const shortcutMessage = props.textTemplate(shortcut);
 
     let enteringShortcutInProgress = false;
 
@@ -100,11 +89,16 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
         });
     }
 
+    function onUpdate(props) {
+        props.textContent = shortcutMessage;
+    }
+
     return (
         <a
             class={cls}
             href="#"
             onclick={onClick}
+            updated={onUpdate}
         >{props.textTemplate(shortcut)}</a>
     );
 }

--- a/src/ui/controls/shortcut/index.tsx
+++ b/src/ui/controls/shortcut/index.tsx
@@ -18,6 +18,18 @@ interface ShortcutLinkProps {
 export default function ShortcutLink(props: ShortcutLinkProps) {
     const cls = mergeClass('shortcut', props.class);
     const shortcut = props.shortcuts[props.commandName];
+    const shortcutClass = document.getElementsByClassName("shortcut");
+    const toggleCurrent = document.getElementsByClassName("shortcut").item(0);
+    const toggleExtension = document.getElementsByClassName("shortcut").item(1);
+
+    if (shortcutClass.length == 3) {
+        if (toggleCurrent.innerHTML.lastIndexOf("Toggle") > 5) {
+            toggleCurrent.innerHTML = toggleCurrent.innerHTML.slice(0,toggleCurrent.innerHTML.indexOf("Toggle",1));
+        }
+        if (toggleExtension.innerHTML.lastIndexOf("Toggle") > 5) {
+            toggleExtension.innerHTML = toggleExtension.innerHTML.slice(0,toggleExtension.innerHTML.indexOf("Toggle",1));
+        }
+    }
 
     let enteringShortcutInProgress = false;
 

--- a/src/ui/controls/shortcut/index.tsx
+++ b/src/ui/controls/shortcut/index.tsx
@@ -89,7 +89,7 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
         });
     }
 
-    function onRender(node) {
+    function onRender(node: HTMLAnchorElement) {
         node.textContent = shortcutMessage;
     }
 


### PR DESCRIPTION
Steps to solving this issue 

When another button is clicked it 
In this function listed below it matches the parents/siblings 
![image](https://user-images.githubusercontent.com/49354833/68886796-d8097f80-06e5-11ea-9eae-36bc3b2151a6.png)
It then calls the insertNode function and inserts the shortcut message again 
![image](https://user-images.githubusercontent.com/49354833/68886834-e8215f00-06e5-11ea-8803-894a86710e17.png)
When its sets the shortcut it goes into this function
![image](https://user-images.githubusercontent.com/49354833/68887682-65999f00-06e7-11ea-910f-6edcb59eadfa.png)

The code I added does the following
    //create variables for both the toggle switches
    const shortcutClass = document.getElementsByClassName("shortcut");
    const toggleCurrent = document.getElementsByClassName("shortcut").item(0);
    const toggleExtension = document.getElementsByClassName("shortcut").item(1);

    //If all the toggles come back in the class, it means that the shortcuts exist and its not the 
    creation
    if (shortcutClass.length == 3) {
        //Check to see if there is any repeats of Toggle 
        if (toggleCurrent.innerHTML.lastIndexOf("Toggle") > 5) {
            //if there is repeats then take the first instance of the string (Example of what the string 
            looks like "Toggle extension\nAlt+Shift+DToggle extension\nAlt+Shift+D")
            toggleCurrent.innerHTML = 
            toggleCurrent.innerHTML.slice(0,toggleCurrent.innerHTML.indexOf("Toggle",1));
        }
        //Same logic for the extension button 
        if (toggleExtension.innerHTML.lastIndexOf("Toggle") > 5) {
            toggleExtension.innerHTML = 
            toggleExtension.innerHTML.slice(0,toggleExtension.innerHTML.indexOf("Toggle",1));
        }
    }

