### PR TITLE
facebook.com - background pic messages fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -412,6 +412,10 @@ CSS
 .jewelItemNew ._33e {
     background-color: ${#d0d1d3} !important;
 }
+._5qxm {
+    background-color: rgba(0, 0, 0, 0.25);
+    background-blend-mode: color;
+}
 
 ================================
 


### PR DESCRIPTION
reduce brightness for background to 75% as we can end with original black text inverted to white.
Fixed when I saw this: https://www.facebook.com/groups/1033949366617599/permalink/2861080970571087/
compare light / dark/ dark with fix

do not add !important or you break solid background-color messages ;)