### PR TITLE
wego.here.com - icons on the recommendet routes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1753,6 +1753,13 @@ CSS
 
 ================================
 
+wego.here.com
+
+INVERT
+.route_card_left
+
+================================
+
 what-if.xkcd.com
 
 INVERT


### PR DESCRIPTION
Black recommended routes icons invert.