### PR TITLE
added 'fortnite-api.com' to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -79,6 +79,7 @@ faceit.com
 femto.pw
 filterblade.xyz
 flooxer.com
+fortnite-api.com
 frankerfacez.com
 geektyper.com
 getsharex.com


### PR DESCRIPTION
added [fortnite-api.com](https://fortnite-api.com) to the global dark list.