### PR TITLE
linkedin.com - two logos invert

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -823,6 +823,14 @@ CSS
 
 ================================
 
+linkedin.com
+
+INVERT
+.global-footer-compact__linkedin-logo
+.mb3
+
+================================
+
 lirc.org
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -829,6 +829,12 @@ INVERT
 .global-footer-compact__linkedin-logo
 .mb3
 
+CSS
+.js-job-card-company-logo {
+    background-color: rgba(255, 255, 255, 0.20);
+    background-blend-mode: color;
+}
+
 ================================
 
 lirc.org


### PR DESCRIPTION
Linked text was black and unreadable.