### PR TITLE
facebook.com - X icon in theatre mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -404,6 +404,7 @@ INVERT
 .sx_a4a936
 .sx_4d607f
 .snowliftPager
+._xlt
 
 CSS
 .fbNubButton {


### PR DESCRIPTION
Invert of invisible X icon in upper right corner when Theatre Mode is enabled. (after click on image)