### PR TITLE
rooms.ryanair.com - invert for some images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1236,6 +1236,15 @@ CSS
 
 ================================
 
+rooms.ryanair.com
+???-rooms.ryanair.com
+
+INVERT
+.form__verisign-img
+.provider-logo
+
+================================
+
 runkit.com
 
 INVERT


### PR DESCRIPTION
One image during login fix.
All providers invert to be more readable.

???- in adress added for the Ryanair Labs people having access to testing environments.  (like me)