### PR TITLE
All ::placeholder opacity reduce.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,6 +9,9 @@ CSS
     border-color: ${#c59d00} !important;
     color: ${#302505} !important;
 }
+::placeholder {
+    opacity: 0.5 !important;
+}
 
 ================================
 
@@ -547,18 +550,6 @@ INVERT
 
 ================================
 
-gazeta.pl
-
-INVERT
-.column
-
-CSS
-.top_section_bg, .bottom_section_bg {
-    background-color: ${#e5e5e5} !important;
-}
-
-================================
-
 gazetawroclawska.pl
 
 INVERT
@@ -1039,18 +1030,6 @@ CSS
 }
 .title, h3, .line-bottom, .line-top, a, .one-line-ellipsis {
   color: ${#4b4e50} !important;
-}
-
-================================
-
-moto.pl
-
-INVERT
-img[src="https://bi.im-g.pl/im/0/24525/m24525630.png"]
-
-CSS
-.main_wrapper {
-    background-color: ${#e5e5e5} !important;
 }
 
 ================================


### PR DESCRIPTION
This fixes totally white placeholder text when black background is used,
Comparing to my previous fix with filter: brightness. It's not darkening every placeholder. Just setting transparency which can reduce brightness or not.