### PR TITLE
::placeholder opacity change

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,6 +9,9 @@ CSS
     border-color: ${#c59d00} !important;
     color: ${#302505} !important;
 }
+::placeholder {
+    opacity: 0.5 !important;
+}
 
 ================================
 


### PR DESCRIPTION
Fix for almost white placeholder text when background is black in darkmode.

See https://myrooms.ryanair.com/account/register-info/independent as example.