### PR TITLE
🎨 Fixes Dynamic Google Sheets input color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -334,6 +334,17 @@ INVERT
 .docs-homescreen-icon
 .kix-equation-toolbar-icon
 .kix-equation-toolbar-palette-icon
+.cell-input
+
+CSS
+.cell-input {
+  background-color: ${black} !important;
+  color: ${white} !important;
+}
+
+.cell-input > span, .cell-input > font {
+  --darkreader-inline-color: ${white} !important;
+}
 
 ================================
 


### PR DESCRIPTION
There is currently an issue with the Dynamic theme engine where, upon text entry to a cell in Google Sheets, the input text will become a very light color that is barely visible in either Dark or Light mode.

These changes prevent that from happening for the three available modes of text entry (click on cell and type, double-click on cell and type, click on cell then click on top bar and type), and are scoped to specifically affect a cell being edited in Google Sheets.

Likely, a change to the actual code for the Dynamic theme engine is in order, but it seems to me that a workaround is in order, given how long the bug has existed.

See https://github.com/darkreader/darkreader/issues/490 for more information.