### PR TITLE
pyszne.pl - more fixes for dark background logos

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1306,8 +1306,8 @@ INVERT
 .css-13azwyo
 
 CSS
-.cover {
-    background-color: rgba(255, 255, 255, 0.20);
+.cover, .logowrapper, .restaurant-logo__inner, .orderoverview__restaurant-image-container-inner {
+    background-color: rgba(255, 255, 255, 0.5) !important;
     background-blend-mode: color;
 }
 


### PR DESCRIPTION
addes some more logos darkground
made background lighter - still not forcing it to full white.