### PR TITLE
Don't style the scrollbar

### DIFF
--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -87,27 +87,6 @@ export function getModifiedUserAgentStyle(filter: FilterConfig, isIFrame: boolea
     lines.push(`    background-color: ${modifyBackgroundColor({r: 250, g: 255, b: 189}, filter)} !important;`);
     lines.push(`    color: ${modifyForegroundColor({r: 0, g: 0, b: 0}, filter)} !important;`);
     lines.push('}');
-    if (!isMacOS()) {
-        lines.push('::-webkit-scrollbar {');
-        lines.push(`    background-color: ${modifyBackgroundColor({r: 241, g: 241, b: 241}, filter)};`);
-        lines.push(`    color: ${modifyForegroundColor({r: 96, g: 96, b: 96}, filter)};`);
-        lines.push('}');
-        lines.push('::-webkit-scrollbar-thumb {');
-        lines.push(`    background-color: ${modifyBackgroundColor({r: 193, g: 193, b: 193}, filter)};`);
-        lines.push('}');
-        lines.push('::-webkit-scrollbar-thumb:hover {');
-        lines.push(`    background-color: ${modifyBackgroundColor({r: 166, g: 166, b: 166}, filter)};`);
-        lines.push('}');
-        lines.push('::-webkit-scrollbar-thumb:active {');;
-        lines.push(`    background-color: ${modifyBackgroundColor({r: 96, g: 96, b: 96}, filter)};`);
-        lines.push('}');
-        lines.push('::-webkit-scrollbar-corner {');
-        lines.push(`    background-color: ${modifyBackgroundColor({r: 255, g: 255, b: 255}, filter)};`);
-        lines.push('}');
-        lines.push('* {');
-        lines.push(`    scrollbar-color: ${modifyBackgroundColor({r: 193, g: 193, b: 193}, filter)} ${modifyBackgroundColor({r: 241, g: 241, b: 241}, filter)};`);
-        lines.push('}');
-    }
     return lines.join('\n');
 }
 


### PR DESCRIPTION
In many cases, applying our style to the scrollbar will override user
styles or OS theme settings, resulting in an unusuable scrollbar.
Investigated by ebbit1q.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>
Resolves: #1785
Resolves: #1592
Resolves: #1343
Resolves: #1323
Resolves: #858