### PR TITLE
Fix #682: Sorting the sitelist

### DIFF
--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -27,6 +27,7 @@ export default class UserStorage {
             siteList: [],
             siteListEnabled: [],
             applyToListedOnly: false,
+            filterListed: false,
             changeBrowserTheme: false,
             notifyOfNews: false,
             syncSettings: true,

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -61,6 +61,7 @@ export interface UserSettings {
     siteList: string[];
     siteListEnabled: string[];
     applyToListedOnly: boolean;
+    filterListed: boolean;
     changeBrowserTheme: boolean;
     notifyOfNews: boolean;
     syncSettings: boolean;

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -23,6 +23,7 @@ export function getMockData(override = {}): ExtensionData {
             siteList: [],
             siteListEnabled: [],
             applyToListedOnly: false,
+            filterListed: false,
             changeBrowserTheme: false,
             notifyOfNews: false,
             syncSettings: true,

--- a/src/ui/popup/components/site-list-settings/index.tsx
+++ b/src/ui/popup/components/site-list-settings/index.tsx
@@ -12,7 +12,24 @@ export default function SiteListSettings({data, actions, isFocused}: SiteListSet
     function isSiteUrlValid(value: string) {
         return /^([^\.\s]+?\.?)+$/.test(value);
     }
+    
+    function sortList(sitelist : string[], mode : boolean) {
+        sitelist = sitelist
+        .sort((a, b) => {
+            var textA = parseURL(a);
+            var textB = parseURL(b);
+            console.log(textA);
+            console.log(textB);
+            return mode ? textA.localeCompare(textB) : textB.localeCompare(textA)});
+        actions.changeSettings({siteList: data.settings.siteList});
+    }
 
+    function parseURL(text : string) {
+        return (text
+        .toLowerCase() // Make string lowercase
+        .replace(/^(https?):\/\//,'') // Remove http/https
+        .replace(/\www./g,'')); // Remove www.
+    }
     return (
         <section class="site-list-settings">
             <Toggle
@@ -42,6 +59,15 @@ export default function SiteListSettings({data, actions, isFocused}: SiteListSet
                     : getLocalMessage('setup_add_site_hotkey')
                 )}
                 onSetShortcut={(shortcut) => actions.setShortcut('addSite', shortcut)}
+            />
+            <Toggle
+                checked={data.settings.filterListed}
+                labelOn={"Ascending"}
+                labelOff={"Descending"}
+                onChange={(value) => {
+                    sortList(data.settings.siteList,value);
+                    actions.changeSettings({filterListed: value}) 
+                }}
             />
         </section>
     );

--- a/src/ui/popup/components/site-list-settings/index.tsx
+++ b/src/ui/popup/components/site-list-settings/index.tsx
@@ -18,8 +18,6 @@ export default function SiteListSettings({data, actions, isFocused}: SiteListSet
         .sort((a, b) => {
             var textA = parseURL(a);
             var textB = parseURL(b);
-            console.log(textA);
-            console.log(textB);
             return mode ? textA.localeCompare(textB) : textB.localeCompare(textA)});
         actions.changeSettings({siteList: data.settings.siteList});
     }


### PR DESCRIPTION
I added toggle button to sort the Sitelist, both ascending and descending. 
Steps I took to accomplish this.
![image](https://user-images.githubusercontent.com/49354833/69895964-5df11180-1307-11ea-817b-4ae96ef1db22.png)
The sortList function take in the sitelist data and a boolean to decide which way to sort. 
It first parses the url to exclude strings including (http, https and www.)
If the mode is true then it sorts ascending and if its false then it sorts descending.   

For the actual toggle button
![image](https://user-images.githubusercontent.com/49354833/69895998-c4762f80-1307-11ea-83fc-eb512732dbdb.png)
I hardcoded the values and will add the local messages in for the text if everything else looks good as the local messages are stored in many different languages. 

I am pretty new to adding to definition list so, I'm unsure if I did the defining of the definition properly for the Toggle button. 
In mock.ts, definitions.d.ts and user-storage.ts
I added filterListed to the list to create this toggle button. 

This is  what it looks like on dark reader
![image](https://user-images.githubusercontent.com/49354833/69896029-4403fe80-1308-11ea-97ce-afbde956d279.png)

