### PR TITLE
🧮 Adds a CSS rule to invert Wikipedia math

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1997,6 +1997,9 @@ div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;
 }
+.mwe-math-element {
+    filter: invert(1);
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1990,15 +1990,11 @@ INVERT
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black
-li::marker
 
 CSS
 div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;
-}
-.mwe-math-element {
-    filter: invert(1);
 }
 
 ================================


### PR DESCRIPTION
As described in https://github.com/darkreader/darkreader/issues/1273, there is currently an issue with the Dynamic theme that causes math rendered in a specific way (particularly on Wikipedia) to be near-invisible.

These changes invert such elements specifically for Wikipedia, though a larger fix addressing the root cause of the issue may eventually be necessary.

I've checked in Chrome that, after the change is applied, the math elements are visible (white-on-black) on the page [cited in the issue](https://en.wikipedia.org/wiki/Invertible_matrix) and [another page](https://en.wikipedia.org/wiki/Binary_search_algorithm) in Dark Mode, and checked that the elements are still visible (black-on-white) when switching to Light Mode.