### PR TITLE
Fix filter for chrome extension "bookmark sidebar"

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -12,6 +12,7 @@ svg image
 [style*="background-image: url"]
 [background]
 twitterwidget
+iframe#blockbyte-bs-sidebar
 
 NO INVERT
 [style*="background:url"] *


### PR DESCRIPTION
Prevent invert the extension's iframe.
Target extension is https://chrome.google.com/webstore/detail/bookmark-sidebar/jdbnofccmhefkmjbkkdkfiicjkgofkdh
