### PR TITLE
Added angrymetalguy.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -57,6 +57,21 @@ CSS
 
 ================================
 
+angrymetalguy.com
+
+INVERT
+.plbrand
+
+CSS
+.thepage {
+    background-color: ${white} !important;
+}
+.content-pad {
+    background-color: ${white} !important;
+}
+
+================================
+
 anilist.co
 
 CSS


### PR DESCRIPTION
Invert the site's logo which appeared as a black graphic on a white background otherwise. Invert text in the main messages and user comments which appeared as light gray text on a white background on Dynamic theme.