### PR TITLE
Fix yellowy background on Basecamp

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15,6 +15,20 @@ CSS
 
 ================================
 
+3.basecamp.com
+
+CSS
+body, .nav__main {
+    background-color: rgb(0, 0, 0);
+}
+@media screen and (min-width: 768px){
+    .panel--perma, .panel--project {
+        box-shadow: rgba(0, 0, 0, 0.05) 0px -1px 10px, rgba(0, 0, 0, 0.1) 0px 1px 4px, rgb(24, 26, 27) 0px 10px 30px;
+    }
+}
+
+================================
+
 4pda.ru
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28,7 +28,7 @@ html, body {
 
 CSS
 body, .nav__main {
-    background-color: rgb(0, 0, 0);
+    background-color: ${white};
 }
 @media screen and (min-width: 768px){
     .panel--perma, .panel--project {


### PR DESCRIPTION
Dynamic theme on Basecamp chose an ugly, dusty, yellowy colour for the background by default: rgb(39, 29, 22)
Changed that to pure black, along with the navbar and fixing the shadow.