### PR TITLE
Lighter background for devblogs.microsoft.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -308,6 +308,15 @@ video#vjs_video_3_html5_api.vjs-tech {
 
 ================================
 
+devblogs.microsoft.com
+
+CSS
+.postcontent, #single-wrapper{
+    background-color: #282828 !important;
+}
+
+================================
+
 developer.mozilla.org
 
 INVERT


### PR DESCRIPTION
Black is too black everywhere, set lighter background for devblogs.microsoft.com:

.postcontent, #single-wrapper{
    background-color: #282828 !important;
}