### PR TITLE
Delete inbox.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -794,16 +794,6 @@ CSS
     background: ${#e3e2dd} !important;
 }
 
-================================
-
-inbox.google.com
-
-INVERT
-.actionIcon
-nav li img
-
-================================
-
 instagram.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -794,6 +794,8 @@ CSS
     background: ${#e3e2dd} !important;
 }
 
+================================
+
 instagram.com
 
 INVERT


### PR DESCRIPTION
Inbox discontinued. https://www.xda-developers.com/inbox-by-gmail-discontinued-march-2019/

And now when entering inbox.google.com, an automatic redirect to mail.google.com/mail occurs, so this rule is no longer needed.