### PR TITLE
Fix Google Maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -731,13 +731,14 @@ label.kd-checkbox-label:before
 label.kd-checkbox-label:after
 button.section-directions-details-action-button
 div.section-loading-spinner
-a[title="Google Apps"]
 a.gb_b > div
 a.gb_xc
 .gm-style img[role="presentation"]:not([src*="v=840"])
 .i4ewOd-xl07Ob
 .i4ewOd-LQLjdd li::before
 .un1lmc-j4gsHd
+.maps-sprite-settings-languages
+.gb_D.gb_oc
 
 ================================
 


### PR DESCRIPTION
Fixed invert Google Apps to work for all languages. And added invert for the icon next to Language.