### PR TITLE
Fix category refinement for JCrew

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -966,6 +966,18 @@ body
 
 ================================
 
+jcrew.com
+
+CSS
+.c-filters__refinement--label .refinement--label__checkbox svg path {
+    fill: transparent !important
+}
+.c-filters__refinement--label.is-selected .refinement--label__checkbox svg path {
+    fill: #fff !important
+}
+
+================================
+
 jeremykun.com
 
 NO INVERT


### PR DESCRIPTION
When refining categories on JCrew's website, all checkboxes were orange, regardless of whether or not they were selected. The only difference was that selected items had a black background, and nonselected ones had a gray background. It's nearly impossible to tell the difference.

Now, the checkboxes are invisible if they are not selected, and white if they are selected. The black vs. gray background remains untouched.