### PR TITLE
fix button color on tincercad.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -787,6 +787,15 @@ html {
 
 ================================
 
+https://www.tinkercad.com/things
+
+CSS
+.editor-3d-container .viewcube__button {
+    background-color: white !important;
+}
+
+================================
+
 imdb.com
 
 CSS


### PR DESCRIPTION
The buttons are on a canvas which always has white background.
In dynamic mode, the buttons have grey background with grey icons. 
Set the buttons background to white to be unobtrusive. 
Now you can see the buttons borders and the icon.

![image](https://user-images.githubusercontent.com/8471027/71698216-038e1980-2dbb-11ea-8ae4-e3183537b37f.png)
