### PR TITLE
fix buttons on www.tinkercad.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2115,6 +2115,15 @@ CSS
 
 ================================
 
+www.tinkercad.com/things
+
+CSS
+.editor-3d-container .viewcube__button {
+    background-color: white !important;
+}
+
+================================
+
 wx.qq.com
 wx2.qq.com
 


### PR DESCRIPTION
The buttons are on a canvas which always has white background.
In dynamic mode, the buttons have grey background with grey icons.
Set the buttons background to white to be unobtrusive.
Now you can see the buttons borders and the icon.
![image](https://user-images.githubusercontent.com/8471027/71698849-61236580-2dbd-11ea-81cc-6f0f81d6f29d.png)
