### PR TITLE
last.fm - color fix for some last year report info

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -908,6 +908,9 @@ CSS
 .highcharts-text-outline {
     stroke: none !important;
 }
+.user-dashboard-scalable-content span {
+    color: ${#666666} !important;
+}
 
 ================================
 


### PR DESCRIPTION
Added CSS fix for:
.user-dashboard-scalable-content span
It is some numbers darkened for light background icons.