### PR TITLE
Add jsdelivr and minified content link

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ This will generate `build.zip` for use in Chromium browsers and `build-firefox.x
 
 You can use Dark Reader to enable dark mode on your website.
 Install the package from NPM (`npm install darkreader`)
-or download from CDN like `https://unpkg.com/darkreader`.
+or include the script via a CDN such as:
+
+- [https://unpkg.com/](https://unpkg.com/) | [https://unpkg.com/darkreader/](https://unpkg.com/darkreader/) | [Direct link](https://unpkg.com/darkreader)
+- [https://www.jsdelivr.com/](https://www.jsdelivr.com/) | [https://www.jsdelivr.com/package/npm/darkreader](https://www.jsdelivr.com/package/npm/darkreader) | [Direct link](https://cdn.jsdelivr.net/npm/darkreader/darkreader.min.js)
+
 Then use the following API
 ```javascript
 DarkReader.enable({


### PR DESCRIPTION
Refactored the readme to include a link
to jsdelivr because they have minified
versions there and it looks like unpkg
does not.

I included links to the home pages
because people new to the services
may want to read about each
service before they dive in.

I included links to the pages for
each project listing so that the
choice to run current or
use a static version is
more obvious.

Please refactor as appropriate
and/or as required.