### PR TITLE
update dynamic-theme-fixes for opencollective

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1411,10 +1411,7 @@ INVERT
 opencollective.com
 
 CSS
-.cover.COLECTIVE {
-    background-color: ${black} !important;
-}
-.backgroundCover {
+.kTvAgT {
     background-image: unset !important;
 }
 


### PR DESCRIPTION
It looks like they use obfuscated/generated class names, so they are likely to change in the future. If we can mark it with XPath, it would be more robust, because the class names could change and (as long as the order stays the same) the path would still work
`/html/body/div[1]/main/div[1]`