### PR TITLE
Update dark-sites.config - deleted easttv.org

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -74,7 +74,6 @@ dplay.com
 dpreview.com
 draculatheme.com
 draftkings.com
-easttv.org
 ecobee.com/consumerportal
 editor.method.ac
 egee.io


### PR DESCRIPTION
Deleted the easttv.org website, because it is now down.