### PR TITLE
wego.here.com  - added invert for .route_tooltip_icon

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2284,6 +2284,7 @@ wego.here.com
 
 INVERT
 .route_card_left
+.route_tooltip_icon
 
 ================================
 


### PR DESCRIPTION
Added invert for icon presenting type of travel on the map tooltip