### PR TITLE
facebook.com - remove  invert for gallery icons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -593,8 +593,6 @@ INVERT
 .repliedLast
 .hu5pjgll.eb18blue
 .sx_0f440a
-.snowliftPager
-.fbPhotoSnowliftFullScreen
 .sx_73ef60
 .sx_f77c61
 


### PR DESCRIPTION
Removed:
.snowliftPager
.fbPhotoSnowliftFullScreen
as it started to invert into black ones.