### PR TITLE
facebook.com - fix for ._3qb- icons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -562,7 +562,7 @@ canvas
 facebook.com
 
 INVERT
-._3qb- img
+._3qb- .img
 ._2o7_
 ._2o89
 ._2q08


### PR DESCRIPTION
Catched that img is not workig => fixed to .img