### PR TITLE
polskatimes.pl - fixes for articles

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1544,6 +1544,38 @@ INVERT
 
 ================================
 
+polskatimes.pl
+
+INVERT
+.atomsNavigationFooterLegal
+.componentsSiteHeader
+.atomsNavigationFooterAccordion
+.atomsNavigationFooterSocialmedia__link
+.atomsNavigationFooterSocialmedia__button
+.atomsArticlePollVoting__pulseDescription
+.atomsArticlePollVoting__form
+.atomsArticlePollVoting__voteTitle
+.componentsArticleGallery__captionDescription
+.componentsPromotionsVideo__title
+.layoutsGrid
+article .atomsArticleTile__tileImg
+.layoutsGrid--last .atomsArticleTile__tileImg
+.componentsArticleGallery__img
+.componentsArticleGallery__thumbnail
+.atomsArticleFootTools__button
+.componentsPromotionsOffers__fakeImg
+.atomsNavigationFooterLinks__logoImg
+.ytp-cued-thumbnail-overlay
+.componentsRecommendationsSelected__photo
+.componentsPromotionsSubjectCategoryPromoted__image
+p.nieprzeczytane
+p.przeczytane
+article iframe
+.atomsPromotionsQuiz__imageWrapper
+.atomsPromotionsLink__imageWrapper
+
+================================
+
 praca.money.pl
 
 CSS


### PR DESCRIPTION
Clone of fixes from gazetawroclawska.pl
Same body used.