### PR TITLE
Add Raindrop app to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -5,6 +5,7 @@ animeonline.su
 app.keeweb.info
 app.plex.tv
 app.pluralsight.com
+app.raindrop.io
 argoto.snaz.in
 arisuchan.jp
 as2.aiae.ovh


### PR DESCRIPTION
The web-app for Raindrop.io defaults to dark mode.