### PR TITLE
Add hanime.tv to list of sites that are already dark-mode.  It is dar…

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -116,6 +116,7 @@ hackaday.io
 hackersforcharity.org
 hackertyper.com
 hackforums.net
+hanime.tv
 hardcoregaming101.net
 heapmedia.com
 heavybit.com


### PR DESCRIPTION
Please add hanime.tv to list of sites that are already dark-mode.  This site is dark-by-default with no option for light mode of any kind.

Currently, site's functionality will break if user has darkreader installed and activated.

darkreader should not perform any operation for this site since this site is already dark mode by default.

New users that recently installed darkreader, by default, will have it on if they visit this site.  Consequently, since the site will break if darkreader is on, the new user will think the site does not work and submit bug reports to the wrong place.

Therefore, darkreader should be disabled/turned-off by default for hanime.tv
