### PR TITLE
mapa-turystyczna.pl - fix for showing dark route

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1168,6 +1168,13 @@ img.Ha
 
 ================================
 
+mapa-turystyczna.pl
+
+INVERT
+.ts-map svg
+
+================================
+
 marginalrevolution.com
 
 INVERT


### PR DESCRIPTION
INVERT .ts-map svg - to show dark route points which are not visible at all in dark mode without fix

Check: https://mapa-turystyczna.pl/route?q=50.9028840,15.7517010;50.8708830,15.8269430;50.8631440,15.8726320;50.8519520,15.8937890;50.8448170,15.9051590;50.8476070,15.9332070;50.8220550,15.9220000;50.8083520,15.9004580;50.8265480,15.8217290;50.8382980,15.7848640;50.9028840,15.7517010#50.90280/15.89310/12