### PR TITLE
praca.pl - added background for dark company logos

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1557,6 +1557,12 @@ praca.pl
 INVERT
 .app-header__logo
 
+CSS
+.listing__logo {
+    background-color: rgba(255, 255, 255, 0.20);
+    background-blend-mode: color;
+}
+
 ================================
 
 pro-run.pl


### PR DESCRIPTION
CSS fix adding lighter background for dark logos:
![image](https://user-images.githubusercontent.com/56877029/74589597-e7f76f00-5006-11ea-9d76-233a76ec1795.png)
