### PR TITLE
Update *.stackexchange.com to stop inverting .math

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -173,9 +173,6 @@ CSS
 askubuntu.com
 *.stackexchange.com
 
-INVERT
-.math
-
 CSS
 body {
   background-image: none !important;


### PR DESCRIPTION
StackExchange sites that use MathJax are barely legible now when math is inverted, so this removes the lines causing the inversion.