### PR TITLE
www.tvnz.co.nz is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -250,6 +250,7 @@ www.gdax.com
 www.gotimelinr.com
 www.netflix.com
 www.razer.com
+www.tvnz.co.nz
 xn--rpa.cc
 yande.re
 yandexdataschool.ru/$


### PR DESCRIPTION
add www.tvnz.co.nz to src/config/dark-sites.config