### PR TITLE
polskatimes.pl - remove old fix + add logo invert

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1611,32 +1611,7 @@ INVERT
 polskatimes.pl
 
 INVERT
-.atomsNavigationFooterLegal
-.componentsSiteHeader
-.atomsNavigationFooterAccordion
-.atomsNavigationFooterSocialmedia__link
-.atomsNavigationFooterSocialmedia__button
-.atomsArticlePollVoting__pulseDescription
-.atomsArticlePollVoting__form
-.atomsArticlePollVoting__voteTitle
-.componentsArticleGallery__captionDescription
-.componentsPromotionsVideo__title
-.layoutsGrid
-article .atomsArticleTile__tileImg
-.layoutsGrid--last .atomsArticleTile__tileImg
-.componentsArticleGallery__img
-.componentsArticleGallery__thumbnail
-.atomsArticleFootTools__button
-.componentsPromotionsOffers__fakeImg
-.atomsNavigationFooterLinks__logoImg
-.ytp-cued-thumbnail-overlay
-.componentsRecommendationsSelected__photo
-.componentsPromotionsSubjectCategoryPromoted__image
-p.nieprzeczytane
-p.przeczytane
-article iframe
-.atomsPromotionsQuiz__imageWrapper
-.atomsPromotionsLink__imageWrapper
+.componentsNavigationNavbar__logo
 
 ================================
 


### PR DESCRIPTION
Removed old fix as it works without it since 20/Feb/2020.
Added invert for main logo.