### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -101,6 +101,7 @@ fortnite-api.com
 forum.snahp.it
 frankerfacez.com
 gamejolt.com
+geekabit.nl
 geektyper.com
 getsharex.com
 ggapp.io
@@ -146,6 +147,7 @@ marte.dev
 mcrpw.github.io
 mcskinhistory.com
 merklex.io
+metropool.nl
 miaou.drycat.fr
 mixer.com
 mkbhd.com


### PR DESCRIPTION
added sites geekabit.nl and metropool.nl since they have a native dark theme.