### PR TITLE
spacebattles.com, sufficientvelocity.com are dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -197,6 +197,7 @@ shutov.by
 sites.google.com/site/igotdemthingsyoulike/
 skidrowreloaded.com
 snazzah.com
+spacebattles.com
 spacespacespaaace.space
 speedtest.net
 staszic.waw.pl
@@ -208,6 +209,7 @@ steamstat.us
 store.steampowered.com
 streamelements.com
 streamlabs.com
+sufficientvelocity.com
 svtplay.se
 takethewalk.net
 tallguysfree.com


### PR DESCRIPTION
spacebattles.com, sufficientvelocity.com are dark by default