### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1494,19 +1494,19 @@ INVERT
 
 CSS
 .css-oylsik, .css-nhjhh0 svg, .css-1q2j1fr svg {
-  fill: rgb(226, 223, 219) !important;
+    fill: ${black} !important;
 }
 
 .headline-link div {
-  color: rgb(226, 223, 219) !important;
+    color: ${black} !important;
 }
 
 .headline-link div:hover {
-  color: rgb(186, 183, 179) !important;
+    color: ${#555} !important;
 }
 
 .svelte-15nnlbj {
-  font-weight: bold !important;
+    font-weight: bold !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1487,6 +1487,30 @@ CSS
 
 ================================
 
+nytimes.com
+
+INVERT
+.svelte-1v1dl99
+
+CSS
+.css-oylsik, .css-nhjhh0 svg, .css-1q2j1fr svg {
+  fill: rgb(226, 223, 219) !important;
+}
+
+.headline-link div {
+  color: rgb(226, 223, 219) !important;
+}
+
+.headline-link div:hover {
+  color: rgb(186, 183, 179) !important;
+}
+
+.svelte-15nnlbj {
+  font-weight: bold !important;
+}
+
+================================
+
 nzbget.*
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1493,7 +1493,10 @@ INVERT
 .svelte-1v1dl99
 
 CSS
-.css-oylsik, .css-nhjhh0 svg, .css-1q2j1fr svg {
+.css-oylsik,
+.css-nhjhh0 svg,
+.css-18z7m18 svg,
+.css-1q2j1fr svg {
     fill: ${black} !important;
 }
 


### PR DESCRIPTION
color fix for nytimes.com logo and diagrams