### PR TITLE
sourceforge.net - CSS fixes for white background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1966,6 +1966,19 @@ CSS
 
 ================================
 
+sourceforge.net
+
+CSS
+#code-art-wrapper img {
+    background-color: rgba(24, 26, 27, 0.50);
+    background-blend-mode: color;
+}
+.all-facets, .m-project-search-results {
+    background-color: ${white} !important;
+}
+
+================================
+
 stackoverflow.com
 
 INVERT


### PR DESCRIPTION
1. Main page image darkened.
https://sourceforge.net/
![image](https://user-images.githubusercontent.com/56877029/75545326-4c162c00-5a26-11ea-88f9-beb869c56515.png)
2. Search results white background fix.
https://sourceforge.net/directory/os:windows/?q=test
![image](https://user-images.githubusercontent.com/56877029/75545387-79fb7080-5a26-11ea-9246-b879127ecf90.png)

