### PR TITLE
yagpdb.xyz

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,5 +1,6 @@
 2600.com
 5stardata.info
+^yagpdb.xyz
 adventofcode.com
 animeonline.su
 app.keeweb.info

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,6 +1,6 @@
+^yagpdb.xyz
 2600.com
 5stardata.info
-^yagpdb.xyz
 adventofcode.com
 animeonline.su
 app.keeweb.info


### PR DESCRIPTION
Adds the main domain to the dark site list but the subdomain `docs.` not to it
#2055 for more info
main domain
![](https://i.imgur.com/UW6kHNR.jpg)
subdomain docs.yagpdb.xyz
![](https://i.imgur.com/prrylwq.jpg)