### PR TITLE
youtube.com - upload day color fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3189,6 +3189,10 @@ ytd-toggle-button-renderer.style-default-active[is-icon-button] {
     color: var(--yt-spec-call-to-action) !important;
 }
 
+#date yt-formatted-string.ytd-video-primary-info-renderer {
+    color: var(--yt-spec-text-secondary) !important;
+}
+
 ================================
 
 yuque.com


### PR DESCRIPTION
The upload date is white? It was set to #fffff with a !important property IDK why but this will make it gray.
I'm using the same variable that the views color is using
Issue: #2082 
Before
![](https://i.imgur.com/TGmaffV.png)
After
![](https://i.imgur.com/JXWgT3C.png)