### PR TITLE
Adjust issue with AWS CloudWatch Dashboards

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -227,6 +227,11 @@ img[alt^="WEB_FreeTier"]
 .lb-is-lazyloaded
 .lb-none-v-margin.lb-img
 
+CSS
+.header-background {
+  fill: none !important;
+}
+
 ================================
 
 baike.baidu.com


### PR DESCRIPTION
## Problem

I spend a ton of time in my AWS console. When I'm viewing a dashboard on a page with a URL *similar* to:

```
https://AWS-REGION.console.aws.amazon.com/cloudwatch/home?region=AWS-REGION#dashboards:name=DASHBOARD-NAME-HERE
```

Dashboards ended up having this large white bar:

<img width="836" alt="before_fix" src="https://user-images.githubusercontent.com/1648492/76139678-6bedb700-6007-11ea-8cfc-acc81700c75d.png">

**So I fixed it:**

<img width="829" alt="after_fix" src="https://user-images.githubusercontent.com/1648492/76139677-6abc8a00-6007-11ea-9163-564038a9074a.png">

Let me know if you have any questions.
