### PR TITLE
endomondo.com - invert for shop logo in footer

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -573,6 +573,7 @@ endomondo.com
 
 INVERT
 .header-shop-logo
+.footer-shop-logo
 
 ================================
 


### PR DESCRIPTION
Added invert for shop logo in footer.
![image](https://user-images.githubusercontent.com/56877029/76218584-c27c1080-6214-11ea-94f8-b079771d9e14.png)
