### PR TITLE
web.whatsapp.com - fix for "intro" picture.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2786,6 +2786,9 @@ CSS
 ._2RT36 {
     outline: solid !important;
 }
+[data-asset-intro-image] {
+    background-image: url(/img/intro-connection_c98cc75f2aa905314d74375a975d2cf2.jpg) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Forced original picture to be used instead of inverted colors blob.
![image](https://user-images.githubusercontent.com/56877029/76299665-c747cf80-62bb-11ea-89b5-8f66b16127ee.png)
