### PR TITLE
github.com - fix color for gitako

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -870,6 +870,7 @@ a[href="https://github.com"]
 github.com
 
 INVERT
+.gitako-position-wrapper
 .octotree-sidebar
 .cc-pr__logo
 .cc-octicon


### PR DESCRIPTION
fix background-color for [gitako](https://addons.mozilla.org/en-US/firefox/addon/gitako-github-file-tree/?src=search) in firefox