### PR TITLE
discordapp.com - subdomains fix 

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,4 +1,3 @@
-^discordapp.com
 2600.com
 5stardata.info
 adventofcode.com
@@ -69,6 +68,7 @@ diablo3.com
 diablo3ladder.com
 discord.bots.gg
 discord.com
+discordapp.com
 discuss.noisebridge.info
 disneyplus.com
 dlive.tv

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,3 +1,4 @@
+^discordapp.com
 2600.com
 5stardata.info
 adventofcode.com
@@ -68,7 +69,6 @@ diablo3.com
 diablo3ladder.com
 discord.bots.gg
 discord.com
-discordapp.com
 discuss.noisebridge.info
 disneyplus.com
 dlive.tv

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2393,6 +2393,14 @@ CSS
 
 ================================
 
+support.discordapp.com
+
+INVERT
+.logo img
+ol.breadcrumbs li:first-child:before
+
+================================
+
 teamtrees.org
 
 CSS


### PR DESCRIPTION
# Discordapp.com - Subdomain fix
Add fix for discordapp.com to exclude subdomains like support.discordapp.com and blog.discordapp.com and a little fix for support.discordapp.com

# Related Issues about discord and dark list
#773 
#1689 

# Images it is working
discordapp.com - main domain who is dark and supposed be in dark list
![](https://i.imgur.com/MvabIQ0.jpg)
blog.discordapp.com - subdomain and is white normal and is not longe in dark list
![](https://i.imgur.com/Du2EexW.jpg)
support.discordapp.com - subdomain and is white normal and is not longe in dark list
![](https://i.imgur.com/o0OIUib.jpg)