### PR TITLE
github.com - Refined Github Better darkmode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -891,6 +891,9 @@ CSS
 .refined-github .dashboard-rollup-items .body {
     border-top-color: ${#bbc1c9} !important;
 }
+.refined-github .reaction-summary-item a {
+    box-shadow: 0 0 0 2px rgb(24, 26, 27) !important;
+}
 .js-site-search-form {
     background-color: #ffffff1a !important;
     border-radius: 2pt !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -892,7 +892,7 @@ CSS
     border-top-color: ${#bbc1c9} !important;
 }
 .refined-github .reaction-summary-item a {
-    box-shadow: 0 0 0 2px rgb(24, 26, 27) !important;
+    box-shadow: 0 0 0 2px ${white} !important;
 }
 .js-site-search-form {
     background-color: #ffffff1a !important;


### PR DESCRIPTION
The boxes around the reaction are white now it's the same as background

Before
![](https://i.imgur.com/EcxzJIx.png)

After
![](https://i.imgur.com/IJF2pqM.png)