### PR TITLE
Update cursor color on hackerrank.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1053,6 +1053,11 @@ INVERT
 .badge-title
 .badge-star
 
+CSS
+.monaco-editor .cursor {
+    background-color: rgb(224, 221, 217);
+}
+
 ================================
 
 hdgo.cc

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1055,7 +1055,7 @@ INVERT
 
 CSS
 .monaco-editor .cursor {
-    background-color: rgb(224, 221, 217);
+    background-color: ${black} !important;
 }
 
 ================================


### PR DESCRIPTION
This fixes the cursor color on hackerrank.com. It was previously very dark and barely visible.