### PR TITLE
translate.google.com - Zoomed button fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2589,9 +2589,27 @@ translate.google.*
 translate.google.*.*
 
 INVERT
-div.jfk-button-img
+.ttsbutton
 .tlid-copy-translation-button
 .starbutton
+.speech-button
+.clear
+.swap > .jfk-button-img
+.morebutton
+
+CSS
+.copybutton .jfk-button-img {
+    background-image: -webkit-image-set(url(https://ssl.gstatic.com/images/icons/material/system_gm/1x/content_copy_black_24dp.png) 1x,url(https://ssl.gstatic.com/images/icons/material/system_gm/2x/content_copy_black_24dp.png) 2x) !important;
+}
+.speech-button .jfk-button-img {
+    background-image: -webkit-image-set(url(https://ssl.gstatic.com/images/icons/material/system_gm/1x/mic_black_24dp.png) 1x,url(https://ssl.gstatic.com/images/icons/material/system_gm/2x/mic_black_24dp.png) 2x) !important;
+}
+.result .unstarred > .jfk-button-img {
+    background-image: -webkit-image-set(url(https://ssl.gstatic.com/images/icons/material/system_gm/1x/star_border_black_24dp.png) 1x,url(https://ssl.gstatic.com/images/icons/material/system_gm/2x/star_border_black_24dp.png) 2x) !important;
+}
+.morebutton .jfk-button-img {
+    background-image: -webkit-image-set(url(https://ssl.gstatic.com/images/icons/material/system_gm/1x/more_vert_black_24dp.png) 1x,url(https://ssl.gstatic.com/images/icons/material/system_gm/2x/more_vert_black_24dp.png) 2x) !important;
+}
 
 ================================
 


### PR DESCRIPTION
When zooming out or in. The buttons will be not be the correct colour for dark mode and make it obviously big in his 'canvas' size

Related Issue: #2111

*Note: This another issue that darkreader changed some property's of the image Maybe look into this and make sure dark reader copy the property on the correct way @alexanderby*

# Zoomed Button
BEFORE Zoom 125%
![](https://i.imgur.com/PZyT5Hi.jpg)

AFTER Zoom 125%
![](https://i.imgur.com/qBQLLpt.jpg)

In light mode Zoom 125%
![](https://i.imgur.com/mwxJhtI.jpg)


# Favourite star better color
Before (Not inverted)
![](https://i.imgur.com/ukzGvbR.png)

After (Inverted)
![](https://i.imgur.com/DbNwUv2.png)