### PR TITLE
facebook.com - event question mark icon invert fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -667,11 +667,11 @@ INVERT
 .editPhoto i._3-8_
 .sx_08856a
 .sx_ac12f7
-.sx_a1a9dd
 .sp_hk4DJV_EEeW
 .sp_V53xxlprDHX_1_5x
 .sp_V53xxlprDHX_2x
 #pagelet_ego_pane button img._3-8_
+#event_tabs #reaction_units span img
 
 CSS
 .fbNubButton {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -672,6 +672,7 @@ INVERT
 .sp_V53xxlprDHX_2x
 #pagelet_ego_pane button img._3-8_
 #event_tabs #reaction_units span img
+#homepage_panel_promote_footer_pagelet i
 
 CSS
 .fbNubButton {


### PR DESCRIPTION
Remove .sx_a1a9dd
Add #event_tabs #reaction_units span img
![image](https://user-images.githubusercontent.com/56877029/76645820-05621f00-655a-11ea-9435-dfd9a91fb1e2.png)
