### PR TITLE
COVID-19 Map is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -110,6 +110,7 @@ ggapp.io
 giantbomb.com
 gidonline.in
 giphy.com
+gisanddata.maps.arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6
 gitkraken.com
 glowing-bear.org
 gogoanime.se


### PR DESCRIPTION
The COVID-19 Incidents map is already dark by default 

![](https://i.imgur.com/hZX9snb.jpg)