### PR TITLE
Update Rules for theatlantic.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2528,6 +2528,11 @@ theatlantic.com
 INVERT
 .c-nav__icon--lacroix
 
+CSS
+.hamburger-inner, .hamburger-inner::after, .hamburger-inner::before {
+  background-color: #fff !important;
+}
+
 ================================
 
 theguardian.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2523,6 +2523,13 @@ div.content table tr td h1.entry-title a{
 
 ================================
 
+theatlantic.com
+
+INVERT
+.c-nav__icon--lacroix
+
+================================
+
 theguardian.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2530,7 +2530,7 @@ INVERT
 
 CSS
 .hamburger-inner, .hamburger-inner::after, .hamburger-inner::before {
-  background-color: #fff !important;
+    background-color: ${black} !important;
 }
 
 ================================


### PR DESCRIPTION
On theatlantic.com their SVG logo and some nav icons were black, which looked weird in dark mode. This adds a rule to Invert the svg based on its class property and set those black icons to white. 

Before
<img width="1301" alt="Screen Shot 2020-03-13 at 1 57 48 PM" src="https://user-images.githubusercontent.com/2746773/76647195-afc64c00-6532-11ea-9d80-e90d47ddd4bc.png">

After
<img width="1304" alt="Screen Shot 2020-03-13 at 1 57 29 PM" src="https://user-images.githubusercontent.com/2746773/76647205-b5239680-6532-11ea-975c-fe07a0b2de1e.png">


