### PR TITLE
app.grammarly.com - fix highlight

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -149,6 +149,15 @@ svg text.time_cursor {
 
 ================================
 
+app.grammarly.com
+
+CSS
+[class*="-alerts-markSelectedHigh"] {
+    color: rgb(14, 16, 26) !important;
+}
+
+================================
+
 app.mysms.com
 
 CSS


### PR DESCRIPTION
Fixs the highlight of the words issue.
I'm using a wildcard because, they have a generated number/letters before it, but it's works on all word issues.

Related Issue: #1901 

# Before
![](https://i.imgur.com/EYsgIcu.jpg)
![](https://i.imgur.com/i6pBffJ.jpg)

# After
![](https://i.imgur.com/7VqQaVY.jpg)
![](https://i.imgur.com/hE9nwa6.jpg)