### PR TITLE
Fixed geizhals.de and geizhals.at

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -870,6 +870,24 @@ CSS
 
 ================================
 
+geizhals.at
+
+CSS
+img.listview__image, img.galleryview__image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
+geizhals.de
+
+CSS
+img.listview__image, img.galleryview__image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
 get.todoist.help
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -871,14 +871,6 @@ CSS
 ================================
 
 geizhals.at
-
-CSS
-img.listview__image, img.galleryview__image {
-    mix-blend-mode: normal !important;
-}
-
-================================
-
 geizhals.de
 
 CSS


### PR DESCRIPTION
Fixed images in the search view [here](https://geizhals.at/?fs=acer) and the same problem with images [here](https://geizhals.at/?deals=1)
![geizhals](https://user-images.githubusercontent.com/22528516/76706326-e775f500-66e6-11ea-93dc-97727e61ff4b.jpg)

I fixed both geizhals.de and geizhals.at with the same code