### PR TITLE
Add invert for easypost images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -587,6 +587,13 @@ INVERT
 
 ================================
 
+easypost.com
+
+INVERT
+img
+
+================================
+
 education.github.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -590,7 +590,8 @@ INVERT
 easypost.com
 
 INVERT
-img
+.logo
+.progress-bar
 
 ================================
 


### PR DESCRIPTION
Add Invert rule for images on easypost. 

Before
<img width="1298" alt="Screen Shot 2020-03-16 at 11 04 43 AM" src="https://user-images.githubusercontent.com/2746773/76771640-05d70180-6776-11ea-98b4-5e3f9590e3eb.png">

After
<img width="566" alt="Screen Shot 2020-03-25 at 9 39 59 AM" src="https://user-images.githubusercontent.com/2746773/77542493-a1562980-6e7c-11ea-9030-99f65fc514e3.png">
