### PR TITLE
Fixed ableton.com footer logos

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -59,6 +59,14 @@ CSS
 
 ================================
 
+ableton.com
+
+INVERT
+.main-footer__basics__logo
+.main-footer__secondary__signature__logo
+
+================================
+
 akinator.com
 
 INVERT


### PR DESCRIPTION
Fixed the inversion on the logos at the footer of [ableton.com](https://ableton.com/)

![ableton](https://user-images.githubusercontent.com/22528516/76841136-a68df580-6838-11ea-8bff-e0ba199ee98d.jpg)
