### PR TITLE
Fixes for cloud-catcher.squiddev.cc

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2385,3 +2385,15 @@ CSS
 #player-theater-container {
     background: none !important;
 }
+
+================================
+
+cloud-catcher.squiddev.cc
+
+INVERT
+button[class*="styles_action-button"]
+
+CSS
+button[title*="computer off"] svg path {
+  fill: green !important;
+}

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -236,6 +236,18 @@ NO INVERT
 
 ================================
 
+cloud-catcher.squiddev.cc
+
+INVERT
+button[class*="styles_action-button"]
+
+CSS
+button[title*="computer off"] svg path {
+  fill: green !important;
+}
+
+================================
+
 cloud.digitalocean.com
 
 INVERT
@@ -2384,16 +2396,4 @@ CSS
 }
 #player-theater-container {
     background: none !important;
-}
-
-================================
-
-cloud-catcher.squiddev.cc
-
-INVERT
-button[class*="styles_action-button"]
-
-CSS
-button[title*="computer off"] svg path {
-  fill: green !important;
 }


### PR DESCRIPTION
Fixes the buttons on https://cloud-catcher.squiddev.cc

Note 1: Turn on the dark mode setting on the website to fix the editor
Note 2: You can use Cloud Catcher with https://emux.cc (select CC-Tweaked on startup of CCEmuX)
Note 3: View at `https://cloud-catcher.squiddev.cc/?id=[your ID]`

I don't know if I am doing this correctly or not.