### PR TITLE
wikipedia.org - bullets showing

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3056,6 +3056,9 @@ INVERT
 .svg-Wikimedia-logo_black
 
 CSS
+div .mw-parser-output ul {
+    list-style-image: none !important;
+}
 div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;


### PR DESCRIPTION
Okay so after remove the list-style-image It's actually shows the image.... It's weird but okay

Could not make a fix for Static Thema NO CSS and NO BG wouldn't work because it's not actual background

Related Issue: #1631 

# Before

![](https://i.imgur.com/ltoHKKb.png)

# After

![](https://i.imgur.com/e46o9oE.png)