### PR TITLE
google.* - Invert Fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3135,6 +3135,7 @@ INVERT
 .gb_x.gb_Vb
 .gb_x.gb_Ub
 .gb_0b
+#dictionary-modules img[src*="png"]
 a.gb_b > div
 .gb_D.gb_pc
 .gb_C

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3135,10 +3135,10 @@ INVERT
 .gb_x.gb_Vb
 .gb_x.gb_Ub
 .gb_0b
-#dictionary-modules img
 a.gb_b > div
 .gb_D.gb_pc
 .gb_C
+.gb_sa svg 
 
 CSS
 .RNNXgb {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3138,7 +3138,7 @@ INVERT
 a.gb_b > div
 .gb_D.gb_pc
 .gb_C
-.gb_sa svg 
+.gb_sa svg
 
 CSS
 .RNNXgb {


### PR DESCRIPTION
Hmm The images for dictonary are inverted Why? IDK because for certain they would look something that is just not useable. 
Added a Invert for the 9 dots Looks better :)

Related Issue: #1843

# Before
![](https://i.imgur.com/i4e9KBX.png)
![](https://i.imgur.com/4Z1i40Q.jpg)
# After
![](https://i.imgur.com/igbGD1b.png)
![](https://i.imgur.com/7Hv5uEg.jpg)