### PR TITLE
Add exception to Stylus CSS

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -61,7 +61,8 @@ export function shouldManageStyle(element: Node) {
             )
         ) &&
         !element.classList.contains('darkreader') &&
-        element.media !== 'print'
+        element.media !== 'print' &&
+        !element.classList.contains('stylus')
     );
 }
 


### PR DESCRIPTION
So as Dynamic thema watch for new Doms and override them Stylus CSS is just being overwritten with a darker thema. Even the user wanted it to be that specific color.

Related Request: #2141 

# The CSS
![](https://i.imgur.com/jaIiehK.png)

# Page with JUST darkreader on
![](https://i.imgur.com/HloD16y.png)

# Page with Current darkreader and the CSS
![](https://i.imgur.com/tWk7uxh.png)

# Page with Modified darkreader and the CSS (How it susspose to be)
![](https://i.imgur.com/DzZYtd1.png)