### PR TITLE
server.pro - Invert Logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2223,6 +2223,13 @@ CSS
 
 ================================
 
+server.pro
+
+INVERT
+svg.server-pro-logo
+
+================================
+
 share.dmhy.org
 
 CSS


### PR DESCRIPTION
Inverts the logo of Server.pro It get pretty hidden on a dark website when not inverted

# Before

![](https://i.imgur.com/MJvhSAe.png)

# After

![](https://i.imgur.com/jXa27dR.png)