### PR TITLE
overleaf.com - Invert pdf pages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1913,6 +1913,13 @@ CSS
 
 ================================
 
+overleaf.com
+
+INVERT
+.pdf-page-container
+
+================================
+
 pgatour.com
 
 CSS


### PR DESCRIPTION
Currently doesn't invert the pdf preview pages on overleaf.com, so this fixes it.

## Before
![before](https://user-images.githubusercontent.com/2358149/77372227-fc383580-6d43-11ea-97be-2309d71ecdb2.png)

## After
![after](https://user-images.githubusercontent.com/2358149/77372231-ff332600-6d43-11ea-963d-b1350611c754.png)
