### PR TITLE
praca.pl - fix for inverted pics in offers

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1988,11 +1988,15 @@ praca.pl
 
 INVERT
 .app-header__logo
+.szcont .f1top
 
 CSS
 .listing__logo {
     background-color: rgba(255, 255, 255, 0.20);
     background-blend-mode: color;
+}
+.app-offer__content {
+    background-color: rgb(25, 26, 27) !important;
 }
 
 ================================


### PR DESCRIPTION
Fix for inverted pics in offer and white background.
Before:
![image](https://user-images.githubusercontent.com/56877029/77544389-3a9b3500-6ea9-11ea-8c25-d0ad534cb1c7.png)

After:
![image](https://user-images.githubusercontent.com/56877029/77544536-69b1a680-6ea9-11ea-946c-655717b63966.png)
