### PR TITLE
Fix Tenor.com Share Buttons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2523,6 +2523,14 @@ div.content table tr td h1.entry-title a{
 
 ================================
 
+tenor.com
+
+INVERT
+.FlagIcon
+.ShareIcon
+
+================================
+
 theguardian.com
 
 INVERT


### PR DESCRIPTION
The share buttons on Tenor.com, specifically the "Copy to Clipboard", "Copy embed to Clipboard", "Report" were hard to see with the default DarkReader settings. This PR inverts the colors of the ShareIcons and the FlagIcon to make them easier to see. 

Before
<img width="856" alt="Screen Shot 2020-03-25 at 10 06 44 AM" src="https://user-images.githubusercontent.com/2746773/77545351-aae19080-6e80-11ea-8893-0fd54291690c.png">

After
<img width="860" alt="Screen Shot 2020-03-25 at 10 06 31 AM" src="https://user-images.githubusercontent.com/2746773/77545342-a87f3680-6e80-11ea-99aa-6cfb23d0803d.png">