### PR TITLE
app.grammarly.com - fix highlights for Firefox

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -160,7 +160,7 @@ svg text.time_cursor {
 app.grammarly.com
 
 CSS
-[class*="-alerts-markSelectedHigh"] {
+[class*="-alerts-markSelectedHigh"], span[class*="markSelectedFocused"] {
     color: rgb(14, 16, 26) !important;
 }
 


### PR DESCRIPTION
Firefox have another classes IDK why.. But heres a fix

Related Issue #1901 
PR that was for Chrome #2118 

# Before
![](https://i.imgur.com/peS5Vrk.png)
![](https://i.imgur.com/VGTKJ6y.png)

# After
![](https://i.imgur.com/bjuA3NY.png)
![](https://i.imgur.com/o69WJ4Z.png)

