### PR TITLE
Fix few bad CSS rules for youtube.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3218,6 +3218,18 @@ INVERT
 youtube.com
 
 CSS
+ytd-clarification-renderer.style-scope.ytd-watch-flexy {
+    background-color: #333;
+}
+ytd-browse.style-scope.ytd-page-manager {
+    background-color: black;
+}
+div#secondary.style-scope.ytd-two-column-browse-results-renderer {
+    background-color: black;
+}
+#primary.ytd-two-column-browse-results-renderer {
+    background-color: black;
+}
 html[hide-scrollbar] ::-webkit-scrollbar {
     display: none !important;
 }


### PR DESCRIPTION
Some elements in youtube.com were showing a white and compatible background-color with dark mode.