### PR TITLE
github.com - 'transparent' labels make more sense

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1092,6 +1092,9 @@ CSS
     background-color: rgb(28, 30, 31) !important;
     color: darkgrey !important;
 }
+a[style*="--darkreader-inline-bgcolor:#181a1b"] {
+    --darkreader-inline-bgcolor: #2b2b2b !important;
+}
 
 ================================
 


### PR DESCRIPTION
For info #2204 

# Before
![](https://i.imgur.com/ilTUSr7.png)
![](https://i.imgur.com/U8G2wE4.png)

# After
![](https://i.imgur.com/X6rXqKm.png)
![](https://i.imgur.com/wcjHtaG.png)