### PR TITLE
Fix for web.whatsapp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3126,6 +3126,9 @@ CSS
 [data-asset-intro-image] {
     background-image: url(/img/intro-connection_c98cc75f2aa905314d74375a975d2cf2.jpg) !important;
 }
+._11ozL {
+    border: 5px solid white !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3120,9 +3120,6 @@ CSS
     border-width: 15px !important;
     border-style: solid !important;
 }
-._2RT36 {
-    outline: solid !important;
-}
 [data-asset-intro-image] {
     background-image: url(/img/intro-connection_c98cc75f2aa905314d74375a975d2cf2.jpg) !important;
 }


### PR DESCRIPTION
When activating dark mode on https://web.whatsapp.com, my mobile whatsapp scanner cant read the code.
So i added a border to separate the qrcode from the dark background, in the web.whatsapp.com block