### PR TITLE
Fixes for wikitonary.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3210,6 +3210,15 @@ li.menu-tooltip:not(.lang_btn)
 
 ================================
 
+wiktionary.org
+
+CSS
+div.NavFrame div.NavHead {
+    background-image: none !important;
+}
+
+================================
+
 www.bing.com
 
 CSS


### PR DESCRIPTION
The background-Image is holding the box white so let's don't display it

Explain:
![](https://i.imgur.com/c0xlGoL.png)

# BEFORE
![](https://i.imgur.com/aiERccF.png)
![](https://i.imgur.com/mbZLQQQ.jpg)

# After
![](https://i.imgur.com/GtsgwJe.png)
![](https://i.imgur.com/3gzk6HT.jpg)

# Darkreader off
![](https://i.imgur.com/zhnt3ku.png)