### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -619,6 +619,12 @@ CSS
 .ia-invite-controls-area {
     background-color: transparent !important
 }
+.docs-gm .docs-revisions-switch .apps-ui-material-slide-toggle-thumb {
+    background-color: rgb(43, 46, 48) !important;
+}
+.docs-gm .docs-revisions-switch.apps-ui-material-slide-toggle-container-checked .apps-ui-material-slide-toggle-thumb {
+    background-color: rgb(9, 64, 155) !important;
+}
 
 ================================
 


### PR DESCRIPTION
The color of the button in History of the document? is not visible 

I'm using the first CSS to make the button gray 
I'm using the Seconds CSS to make the on button blue instead of gray that caused by the first CSS

# Darkreader Turned off
![](https://i.imgur.com/2ImLfPU.png)
![](https://i.imgur.com/tYHg0a0.png)
# Before
![](https://i.imgur.com/MppYL2M.png)
![](https://i.imgur.com/mzC4md1.png)
# After
![](https://i.imgur.com/cxf7gZU.png)
![](https://i.imgur.com/SCOko2D.png)