### PR TITLE
Fix for linkedin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1505,7 +1505,8 @@ CSS
     background-blend-mode: color;
 }
 .global-footer-compact__linkedin-logo,
-li-icon[type="linkedin-logo"] {
+li-icon[type="linkedin-logo"],
+.bug-text-color {
     fill: ${black} !important;
 }
 


### PR DESCRIPTION
This makes "in" main linkedin logo white like in rest logos included in CSS.
![image](https://user-images.githubusercontent.com/56877029/78491461-e6b20b00-7748-11ea-81a6-279a321845ab.png)
