### PR TITLE
Fix for flow.polar.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -905,28 +905,10 @@ INVERT
 .detail-data-panel__icon
 .sleep-chart-yaxis.end
 .supergraph-canvas
+.leaflet-pane.leaflet-map-pane img:not([src*="satellite"])
+.zone1desc
 
 CSS
-.highlight {
-    color: ${#ffffff} !important;
-}
-.altitudetitle {
-    color: ${#ffffff} !important;
-}
-.altdescmax {
-    color: ${#ffffff} !important;
-}
-.altdescmin {
-    color: ${#ffffff} !important;
-}
-.zonedesctitle {
-    color: ${#ffffff} !important;
-}
-.zonedescmax {
-    color: ${#ffffff} !important;
-}
-.zonedesclight {
-    color: ${#ffffff} !important;
 }
 .highcharts-container svg {
     fill: ${#3f3f3f} !important;
@@ -934,6 +916,9 @@ CSS
 .card__item-icon--rounded img {
     background-color: rgba(255, 255, 255, 0.15) !important;
     background-blend-mode: color;
+}
+.zone1desc {
+    color: ${#ffffff} !important; 
 }
 
 ================================


### PR DESCRIPTION
Training maps dark mode enabled (excluding satellite type)
Relive maps dark mode enabled.
Removed old CSS texts force to black. :)

Results after fixes to see live (all trainings public):
https://flow.polar.com/training/analysis/4500340188
https://flow.polar.com/training/analysis/4500936293
https://flow.polar.com/training/relive/4500340188
https://flow.polar.com/training/relive/4500936293

Screens after improvement:
Road Map:
![image](https://user-images.githubusercontent.com/56877029/78825086-aae4a300-79df-11ea-9058-a48bb9046164.png)
Terrain Map:
![image](https://user-images.githubusercontent.com/56877029/78825153-c51e8100-79df-11ea-98ab-39448f4b36bc.png)
Satellite map:
![image](https://user-images.githubusercontent.com/56877029/78825225-e2534f80-79df-11ea-8ae0-9a9787bf9ab8.png)

Same maps used in relive - so sattelite is showing uninverted photos, terrain/road map is in dark mod. ;)
Screen from Relive:
![image](https://user-images.githubusercontent.com/56877029/78825523-6e657700-79e0-11ea-905d-bb450ce8c4a1.png)


