### PR TITLE
*.factorio.com is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -98,6 +98,7 @@ erai-raws.info
 esportal.com
 eternal.abimon.org
 faceit.com
+factorio.com
 femto.pw
 filterblade.xyz
 flooxer.com
@@ -257,7 +258,6 @@ w0rp.com
 w41k3r.com
 warcraftdaily.com
 weboas.is
-wiki.factorio.com
 wowhead.com
 wowinterface.com
 www.directvnow.com


### PR DESCRIPTION
wiki.factorio.com and mods.factorio.com and factorio.com are dark, so I think simply adding the base url should work, right?