### PR TITLE
Fix for instructure.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1376,6 +1376,7 @@ instructure.com
 
 INVERT
 .title_3bek::after
+.equation_image
 
 ================================
 


### PR DESCRIPTION
LATEX Equations were previously black text making it impossible to read with Dark Reader turned on.    I just added 1 line to invert the color to make it readable.