### PR TITLE
Fixes for  journal.tinkoff.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1436,6 +1436,21 @@ h1.logo
 
 ================================
 
+journal.tinkoff.ru
+
+INVERT
+.g2tvv
+._3aEco
+._1Dhxk
+.uVy35.V6dif::before
+._38Vkx.FrrKu::after
+._3LO60._4GqdT::after
+.PwECA
+.best-authors__arrow.best-authors__arrow--active
+.best-authors__arrow
+
+================================
+
 keep.google.com
 
 INVERT


### PR DESCRIPTION
Fix pages like journal.tinkoff.ru/list/the-fastest-cars, journal.tinkoff.ru/about, journal.tinkoff.ru/user* (requires login to your account)