### PR TITLE
Fix for app.grammarly.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -175,6 +175,13 @@ CSS
 [class*="-alerts-markSelectedHigh"], span[class*="markSelectedFocused"] {
     color: rgb(14, 16, 26) !important;
 }
+._c4058cde-editor-toolbarTitleContainer {
+    background: linear-gradient(-180deg, #181A1B 78%,hsla(0,0%,100%,0)) !important;
+}
+._4745ce5f-template-fullCard {
+    box-shadow: none !important
+}
+
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -182,7 +182,6 @@ CSS
     box-shadow: none !important
 }
 
-
 ================================
 
 app.mysms.com


### PR DESCRIPTION
Box-shadow is none because I couldn't get something working for a gray tint :/
# Before
![](https://i.imgur.com/5Na4lxQ.png)
![](https://i.imgur.com/IlNqti0.png)
# After
![](https://i.imgur.com/Sbqb6JZ.png)
![](https://i.imgur.com/paaXYxt.png)