### PR TITLE
Fix for exchanges website

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1821,16 +1821,16 @@ stackapps.com
 stackoverflow.com
 superuser.com
 
-CSS
-#hlogo a {
-    text-indent: -256em !important;
-}
-
 INVERT
 .top-bar
 
 NO INVERT
 .bar-sm
+
+CSS
+#hlogo a {
+    text-indent: -256em !important;
+}
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1826,6 +1826,12 @@ CSS
     text-indent: -256em !important;
 }
 
+INVERT
+.top-bar
+
+NO INVERT
+.bar-sm
+
 ================================
 
 statlect.com


### PR DESCRIPTION
Fixing the top bar inversion:
<img width="256" alt="Screenshot 2020-04-11 at 8 24 19 PM" src="https://user-images.githubusercontent.com/17037785/79047130-6f8de280-7c32-11ea-81d0-124834ab5a1c.png">
<img css="float:right" width="256" alt="Screenshot 2020-04-11 at 8 24 45 PM" src="https://user-images.githubusercontent.com/17037785/79047140-7e749500-7c32-11ea-8130-f5c122891e67.png">
