### PR TITLE
Fix for npmjs.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1816,6 +1816,8 @@ header a[href="/"] svg
 #customers_panel img[src*="conde-nast.full.png"]
 #customers_panel img[src*="netflix.full.png"]
 #customers_panel img[src*="visa.full.png"]
+._5532dff2
+._93bbf0b4
 
 ================================
 


### PR DESCRIPTION
Correct invert of new header icons.

Before: 
![black icons](https://i.imgur.com/Y9a5iDI.png "black icons")

After:
![white icons](https://i.imgur.com/rMKxFmN.png "black icons")