### PR TITLE
Fix for openstreetmap.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2031,6 +2031,18 @@ CSS
 
 ================================
 
+openstreetmap.org/#map
+
+INVERT
+#map
+
+CSS
+#map {
+    background-color: ${#1b1b1b} !important;
+}
+
+================================
+
 overleaf.com
 
 INVERT


### PR DESCRIPTION
- Inverted Map(Darkens the map) 
- Doesn't Interfere with the editor's map(Is satelite)

Related Issue #628 

Thanks for https://github.com/darkreader/darkreader/issues/628#issuecomment-532433059
# Before
![](https://i.imgur.com/obqn5o6.png)
# After
![](https://i.imgur.com/t5jR2N3.png)