### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -813,7 +813,7 @@ INVERT
 .editPhoto i._3-8_
 .sx_08856a
 .sx_ac12f7
-.sp_NfKX-XV69KF
+.sp_hk4DJV_EEeW
 .sp_V53xxlprDHX_1_5x
 .sp_V53xxlprDHX_2x
 #pagelet_ego_pane button .img._3-8_

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -817,6 +817,7 @@ INVERT
 .sp_V53xxlprDHX_1_5x
 .sp_V53xxlprDHX_2x
 #pagelet_ego_pane button .img._3-8_
+#homepage_panel_promote_footer_pagelet button .img._3-8_
 #event_tabs #reaction_units span img
 .fbAggregatedMap
 .fbPlaceFlyoutWrap img


### PR DESCRIPTION
1. change back to old class for next/prev icons on page panel
.sp_NfKX-XV69KF => .sp_hk4DJV_EEeW
![image](https://user-images.githubusercontent.com/56877029/79609545-3bfdfd00-80f7-11ea-94f7-3d8ae7d2d047.png)
