### PR TITLE
fix for allegro.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -142,7 +142,7 @@ CSS
 allegro.pl
 
 CSS
-._88e3e06 {
+#opbox-listing--base i {
     background-size: 100% 100% !important;
 }
 


### PR DESCRIPTION
fixed size for smart icon on offers
Removed old class and used ID related path

![image](https://user-images.githubusercontent.com/56877029/79637632-62687a80-8181-11ea-9bda-e8020767fc05.png)

URL to fast check:
https://allegro.pl/listing?string=maseczka&bmatch=baseline-al-product-eyesa2-dict43-hea-1-5-0318