### PR TITLE
fix for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3228,7 +3228,7 @@ div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;
 }
-.mw-mmv-image .svg, , .fullImageLink [src*=".svg"] {
+.mw-mmv-image .svg, .fullImageLink [src*=".svg"] {
     background-color: rgba(255, 255, 255, 0.75) !important;
     background-blend-mode: color;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3228,7 +3228,7 @@ div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;
 }
-.mw-mmv-image .svg {
+.mw-mmv-image .svg, , .fullImageLink [src*=".svg"] {
     background-color: rgba(255, 255, 255, 0.75) !important;
     background-blend-mode: color;
 }
@@ -3249,7 +3249,7 @@ li.menu-tooltip:not(.lang_btn)
 wiktionary.org
 
 CSS
-div.NavFrame div.NavHead, .fullImageLink [src*=".svg"] {
+div.NavFrame div.NavHead {
     background-image: none !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3228,6 +3228,10 @@ div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;
 }
+.mw-mmv-image .svg {
+    background-color: rgba(255, 255, 255, 0.40) !important;
+    background-blend-mode: color;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3229,7 +3229,7 @@ div .thumbimage img[src$=".png"] {
     background-color: white;
 }
 .mw-mmv-image .svg {
-    background-color: rgba(255, 255, 255, 0.40) !important;
+    background-color: rgba(255, 255, 255, 0.75) !important;
     background-blend-mode: color;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3228,7 +3228,9 @@ div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;
 }
-.mw-mmv-image .svg, .fullImageLink [src*=".svg"] {
+.mw-mmv-image .svg,
+.fullImageLink [src*=".svg"],
+a[href$=".svg"]:hover > img {
     background-color: rgba(255, 255, 255, 0.75) !important;
     background-blend-mode: color;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3249,7 +3249,7 @@ li.menu-tooltip:not(.lang_btn)
 wiktionary.org
 
 CSS
-div.NavFrame div.NavHead {
+div.NavFrame div.NavHead, .fullImageLink [src*=".svg"] {
     background-image: none !important;
 }
 


### PR DESCRIPTION
Added CSS fix for transparent svg files on zoom mentioned in #1963

URL to check:  https://en.wikipedia.org/wiki/HIV#

Before:
![image](https://user-images.githubusercontent.com/56877029/79638543-34396980-8186-11ea-8739-3f874082e1ef.png)

After:
![image](https://user-images.githubusercontent.com/56877029/79638590-7a8ec880-8186-11ea-9e2c-f2abc92be74d.png)

Checked with other pics on this page and seems to work fine when checker is set as background. :)

