### PR TITLE
Fix resolving absolute paths for non-index pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "debug": "node tasks/debug.js",
     "prepublishOnly": "npm test && npm run api",
     "release": "npm test && node tasks/release.js",
-    "test": "jest --config=tests/jest.config.js"
+    "test": "jest --config=tests/jest.config.js",
+    "test:inject": "jest --config=tests/inject/jest.config.js"
   },
   "main": "darkreader.js",
   "repository": {

--- a/src/inject/dynamic-theme/url.ts
+++ b/src/inject/dynamic-theme/url.ts
@@ -17,6 +17,16 @@ export function getAbsoluteURL($base: string, $relative: string) {
         return u.href;
     }
     const pathParts = b.pathname.split('/').concat($relative.split('/')).filter((p) => p);
+    let lastRealURLPath: string;
+    if (pathParts[pathParts.length - 2] == "..") { // Check if the path isn't backward
+        lastRealURLPath = pathParts[pathParts.indexOf('..') - 1]; // Get the first occurence of backwards than -1 as it's used in array
+    }else {
+        lastRealURLPath = pathParts[pathParts.length - 2];
+    }
+    if(lastRealURLPath.endsWith('.html') || lastRealURLPath.endsWith('.php') || lastRealURLPath.endsWith('.htm')  ) {
+        let index = pathParts.indexOf(lastRealURLPath);
+        pathParts.splice(index, 1);
+    }
     let backwardIndex: number;
     while ((backwardIndex = pathParts.indexOf('..')) > 0) {
         pathParts.splice(backwardIndex - 1, 2);

--- a/src/inject/dynamic-theme/url.ts
+++ b/src/inject/dynamic-theme/url.ts
@@ -16,17 +16,12 @@ export function getAbsoluteURL($base: string, $relative: string) {
         const u = parseURL(`${b.protocol}//${b.host}${$relative}`);
         return u.href;
     }
-    const pathParts = b.pathname.split('/').concat($relative.split('/')).filter((p) => p);
-    let lastRealURLPath: string;
-    if (pathParts[pathParts.length - 2] == "..") { // Check if the path isn't backward
-        lastRealURLPath = pathParts[pathParts.indexOf('..') - 1]; // Get the first occurence of backwards than -1 as it's used in array
-    }else {
-        lastRealURLPath = pathParts[pathParts.length - 2];
+    let pathParts = b.pathname.split('/');
+    const lastPathPart = pathParts[pathParts.length - 1];
+    if (lastPathPart.match(/\.[a-z]+$/i)) {
+        pathParts.pop();
     }
-    if(lastRealURLPath.endsWith('.html') || lastRealURLPath.endsWith('.php') || lastRealURLPath.endsWith('.htm')  ) {
-        let index = pathParts.indexOf(lastRealURLPath);
-        pathParts.splice(index, 1);
-    }
+    pathParts = pathParts.concat(...$relative.split('/')).filter((p) => p);
     let backwardIndex: number;
     while ((backwardIndex = pathParts.indexOf('..')) > 0) {
         pathParts.splice(backwardIndex - 1, 2);

--- a/tests/inject/dynamic.tests.ts
+++ b/tests/inject/dynamic.tests.ts
@@ -1,0 +1,10 @@
+import {getAbsoluteURL} from '../../src/inject/dynamic-theme/url';
+
+test('Absolute URL', () => {
+    expect(getAbsoluteURL('https://www.google.com', '/image.jpg')).toBe('https://www.google.com/image.jpg');
+    expect(getAbsoluteURL('https://www.google.com/path', '/image.jpg')).toBe('https://www.google.com/image.jpg');
+    expect(getAbsoluteURL('https://www.google.com/path', 'image.jpg')).toBe('https://www.google.com/path/image.jpg');
+    expect(getAbsoluteURL('https://www.google.com/long/path', '../image.jpg')).toBe('https://www.google.com/long/image.jpg');
+    expect(getAbsoluteURL('https://www.google.com/path/page.html', 'image.jpg')).toBe('https://www.google.com/path/image.jpg');
+    expect(getAbsoluteURL('https://www.google.com/path/page.html', '../image.jpg')).toBe('https://www.google.com/image.jpg');
+});

--- a/tests/inject/jest.config.js
+++ b/tests/inject/jest.config.js
@@ -1,10 +1,10 @@
 module.exports = {
     verbose: true,
-    testEnvironment: 'node',
+    testEnvironment: 'jsdom',
     transform: {
         '^.+\\.ts(x?)$': 'ts-jest'
     },
-    testRegex: 'tests/[^/]*\\.tests\\.ts(x?)$',
+    testRegex: 'tests/inject/.*\\.tests\\.ts(x?)$',
     moduleFileExtensions: [
         'ts',
         'tsx',
@@ -20,7 +20,7 @@ module.exports = {
     ],
     globals: {
         'ts-jest': {
-            tsConfig: './tests/tsconfig.json'
+            tsConfig: './tests/inject/tsconfig.json'
         }
     }
 };

--- a/tests/inject/tsconfig.json
+++ b/tests/inject/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../src/tsconfig",
+    "compilerOptions": {
+        "module": "commonjs",
+        "outDir": "",
+        "types": [
+            "jest"
+        ]
+    }
+}


### PR DESCRIPTION
Related issue #1077

[Test-pages.zip](https://github.com/darkreader/darkreader/files/4497032/Test-pages.zip)
That's the test pages I've used.

As you know mostly if not all modern website don't have .html .htm .php after their pages as they use index.html or similar so when you request the url it was automaticly grab index.html for you etc.

But as for older websites they sometimes still use .html and .php for their sub domains sites. That can causes issues with loading images. As of like [this site](https://www.musl-libc.org/how.html) It's loads an image on ![](https://i.imgur.com/1cUELyY.png) on the .listpanel (This screenshot was been made with this fix as you can see the background image).
As in the css of this sites it's sets the background-image to `    background-image: url(puzzle-a2.svg);` An incorrect way for modern browsers and HTML5 but back than an very normal way to load images. 

So darkreader will come to the image and spit back out that it absoluteURL is at `https://www.musl-libc.org/how.html` While this will be correct if how.html wasn't a file but a folder. 

With this Patch it will check if the last pathPart(not the image ofc) ends with .html .htm .php and splice this from the array as this isn't a real path/folder but a file. And it will check if the pottential .html .htm .php isn't a backwards indicator.

As of the test pages you will need to host it on a localhost 
That can be simply with python
`python -m http.server 1337` for Python 3 on windows
`python3 -m http.server 1337` for Python 3 on Linux distro's

You will find their some files and folders. I think you can figure yourself out to test this first without the fix and than with the fix and see that nonindex.html will as asked get the good url to load the image and in SomeFolder/FolderForBackwardsTest you will find the both files have ../ in the css to show it will detect automaticcly if the potetional is a backwards indicator.

Regards,
Your new member Gusted