### PR TITLE
List Edge Add-ons store as protected

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -20,6 +20,7 @@ export function canInjectScript(url: string) {
             && !url.startsWith('chrome')
             && !url.startsWith('edge')
             && !url.startsWith('https://chrome.google.com/webstore')
+            && !url.startsWith('https://microsoftedge.microsoft.com/addons')
         );
     }
     return (url

--- a/tests/url.tests.ts
+++ b/tests/url.tests.ts
@@ -67,6 +67,16 @@ test('URL is enabled', () => {
         {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
+        expect(isURLEnabled(
+        'https://microsoftedge.microsoft.com/addons',
+        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        {isProtected: true, isInDarkList: false},
+    )).toBe(false);
+        expect(isURLEnabled(
+        'https://microsoftedge.microsoft.com/addons',
+        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        {isProtected: true, isInDarkList: false},
+    )).toBe(false);
     expect(isURLEnabled(
         'https://darkreader.org/',
         {siteList: [], siteListEnabled: [], applyToListedOnly: false} as UserSettings,


### PR DESCRIPTION
This will make it list https://microsoftedge.microsoft.com/addons as protected in Chrome as well, but most Chrome users wouldn't ever go to that page. To make it only protected in Edge would require app changes.