### PR TITLE
Fix header on chat.stackexchange.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -50,6 +50,7 @@ INVERT
 .h-auto[alt="Unix & Linux"]
 .h-auto[alt="Web Applications"]
 a.js-gps-track::before
+img[alt="The Stack Exchange Network"]
 
 CSS
 body {
@@ -1012,7 +1013,7 @@ CSS
     background-blend-mode: color;
 }
 .zone1desc {
-    color: ${#ffffff} !important; 
+    color: ${#ffffff} !important;
 }
 
 ================================


### PR DESCRIPTION
Before Fix:
![Screenshot_2020-04-25 all rooms chat stackexchange com(1)](https://user-images.githubusercontent.com/30190448/80276136-2a72b180-8704-11ea-8b3f-adb2464003a8.png)

After Fix:
![Screenshot_2020-04-25 all rooms chat stackexchange com](https://user-images.githubusercontent.com/30190448/80276137-2ba3de80-8704-11ea-86de-10d000ed29e3.png)
