### PR TITLE
Fix progress bar color on github PRs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1189,6 +1189,12 @@ CSS
 .jfk-bubble, .octotree-sidebar, .cc-pr__logo, .cc-octicon, #network canvas, img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
 }
+.progress-bar {
+    background-color: rgba(196, 191, 183, 0.25) !important;
+}
+.progress{
+    background-color: green !important; 
+}
 
 ================================
 


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/4290846/80560716-e519e280-8996-11ea-9160-784a49fb6c63.png)


After: ![image](https://user-images.githubusercontent.com/4290846/80560696-ca476e00-8996-11ea-9d9d-824adb91716e.png)

More examples:
![image](https://user-images.githubusercontent.com/4290846/80560745-067ace80-8997-11ea-818a-a845abf3729d.png)

