### PR TITLE
Add editor.freepik.com to dark sites config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -87,6 +87,7 @@ dpreview.com
 draculatheme.com
 draftkings.com
 ecobee.com/consumerportal
+editor.freepik.com
 editor.method.ac
 egee.io
 eggsy.codes


### PR DESCRIPTION
[https://editor.freepik.com/](https://editor.freepik.com/) is dark.