### PR TITLE
Added movistar streaming service to the list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -261,6 +261,7 @@ undertale.com
 v7player.wostreaming.net
 vakhtangov.ru
 vanced.app
+ver.movistarplus.es
 verify.bots.gg
 viduro.xyz
 vinesauce.com


### PR DESCRIPTION
Added ver.movistarplus.es to the list. The website has a dark theme for default, so the extension dont have to change anything.