### PR TITLE
Update KDE fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -727,10 +727,11 @@ CSS
 ================================
 
 dot.kde.org
+forum.kde.org
 
 CSS
 body {
-    background: ${white};
+    background: rgb(27,29,30);
 }
 
 ================================


### PR DESCRIPTION
background color matches correctly inverted elements better.
Apply fix to another subdomain too.