### PR TITLE
fixes for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1012,6 +1012,12 @@ div[role=article] div.k4urcfbm[aria-hidden="true"] {
 .esnais5j, ._8bb_ img, ._8bb_ i {
     filter: none;
 }
+.sp_Jc8OKpJq5NW {
+    background-image: url(/rsrc.php/v3/yV/r/RO526ka7f9m.png) !important;
+}
+.sp_C8jQ3Z1xUrS {
+    background-image: url(/rsrc.php/v3/yC/r/XFTwSywolOp.png) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Two icons fix for not using black inverted blobs.
.sp_Jc8OKpJq5NW .sp_C8jQ3Z1xUrS
![image](https://user-images.githubusercontent.com/56877029/80923176-330d5c80-8d82-11ea-99ef-225b43d58f13.png)
