### PR TITLE
Remove rules for metacritic.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1949,13 +1949,6 @@ CSS
 
 ================================
 
-metacritic.com
-
-INVERT
-img[src="/images/icons/dark_logo.png"]
-
-================================
-
 midkar.com
 
 CSS


### PR DESCRIPTION
Since they changed the site design, this rule is obsolete.

[metacritic.com](https://www.metacritic.com/)