### PR TITLE
Use tabs.create for Firefox popup links (#2464)

### DIFF
--- a/src/ui/popup/utils/issues.ts
+++ b/src/ui/popup/utils/issues.ts
@@ -36,7 +36,9 @@ export function fixNotClosingPopupOnNavigation() {
             target = target.parentElement;
         }
         if (target && target.hasAttribute('href')) {
-            requestAnimationFrame(() => window.close());
+            chrome.tabs.create({ url: target.getAttribute('href') });
+            e.preventDefault();
+            window.close();
         }
     });
 }


### PR DESCRIPTION
Using `requestAnimationFrame` ends up closing the window too soon, so we use
tabs.create instead.

Tested this on Firefox Desktop and Fenix Android (didn't test on Chrome because this is a Firefox-specific path.)