### PR TITLE
Fix for translate.google.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3122,6 +3122,15 @@ INVERT
 .clear
 .swap > .jfk-button-img
 .morebutton
+.close-button
+.ita-kd-icon-button
+.ita-kd-menuitem-inputtool-icon
+.ita-kd-checkbox
+.vk-t-btn
+.vk-sf-b
+.ita-hwt-backspace-img
+.ita-hwt-enter-img
+.ita-hwt-grip
 
 CSS
 .copybutton .jfk-button-img {


### PR DESCRIPTION
Fixes:
- close button for history and saved
- icon of the selected input method
- input tool icons
- checkbox next to the input method enabled
- virtual keyboard close button
- virtual keyboard keys
- delete, enter and move icon in handwrite