### PR TITLE
Add admin.microsoft.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,6 +1,7 @@
 2600.com
 5stardata.info
 acm.sdut.edu.cn/onlinejudge3/
+admin.microsoft.com
 adventofcode.com
 animeonline.su
 app.keeweb.info


### PR DESCRIPTION
Dark Reader doesn't work properly with https://admin.microsoft.com/ 

However, https://admin.microsoft.com/ has its own Dark Mode setting which works great! 

The way to enable this is to click the "Dark Mode" button which results in a POST to https://admin.microsoft.com/admin/api/navigation/darkmode with payload 

```js
{IsDarkModeOn: true}
```

Does this qualify to be added to dark-sites.config?