### PR TITLE
Fix for translate.google.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3146,6 +3146,7 @@ INVERT
 .ita-hwt-backspace-img
 .ita-hwt-enter-img
 .ita-hwt-grip
+.gt-ex-quote
 
 CSS
 .copybutton .jfk-button-img {


### PR DESCRIPTION
Fix quote sign in word usage examples