### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -743,6 +743,9 @@ CSS
 .docs-gm .docs-revisions-switch.apps-ui-material-slide-toggle-container-checked .apps-ui-material-slide-toggle-thumb {
     background-color: rgb(9, 64, 155) !important;
 }
+.docs-linkbubble-bubble {
+    filter: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Do not invert bubble when adding a link into text (ctrl + k)


Before
![image](https://user-images.githubusercontent.com/25481501/81569368-788fe200-939f-11ea-92e6-2885e2cb5f52.png)

After
![image](https://user-images.githubusercontent.com/25481501/81569292-6150f480-939f-11ea-8230-c4a73b3c5192.png)
