### PR TITLE
Fix for google maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1319,6 +1319,8 @@ google.*.*/maps
 
 INVERT
 #app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) .widget-scene-canvas
+#app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) .canvas-container > canvas
+
 .widget-settings-button-icon
 .searchbox-hamburger::before
 .searchbox-searchbutton::before

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1320,7 +1320,6 @@ google.*.*/maps
 INVERT
 #app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) .widget-scene-canvas
 #app-container.vasquette:not(.app-imagery-mode):not(.app-globe-mode) .canvas-container > canvas
-
 .widget-settings-button-icon
 .searchbox-hamburger::before
 .searchbox-searchbutton::before


### PR DESCRIPTION
- Invert the other canvas when the other is disabled.

It doesn't interfere with satelite mode etc etc. 
Why I have the other canvas and the `main` one is display: none. I don't know.