### PR TITLE
Added inversion fixes to outlook.live.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1457,6 +1457,9 @@ outlook.live.com
 
 INVERT
 #O365_NavHeader
+span.ms-Pivot-text
+span.ms-Pivot-icon
+.ms-FocusZone.ms-CommandBar
 
 ================================
 


### PR DESCRIPTION
The two black buttons are now inverted and the bar above it is inverted.