### PR TITLE
Avoid slow Array operations in Firefox

### DIFF
--- a/src/generators/utils/format.ts
+++ b/src/generators/utils/format.ts
@@ -1,3 +1,5 @@
+import {push} from '../../utils/array';
+
 interface SiteFix {
     url: string[];
     [prop: string]: any;
@@ -14,7 +16,7 @@ export function formatSitesFixesConfig(fixes: SiteFix[], options: SitesFixesForm
     const lines: string[] = [];
 
     fixes.forEach((fix, i) => {
-        lines.push(...fix.url);
+        push(lines, fix.url);
         options.props.forEach((prop) => {
             const command = options.getPropCommandName(prop);
             const value = fix[prop];
@@ -30,7 +32,7 @@ export function formatSitesFixesConfig(fixes: SiteFix[], options: SitesFixesForm
         });
         if (i < fixes.length - 1) {
             lines.push('');
-            lines.push(Array.from({length: 32}).fill('=').join(''));
+            lines.push('='.repeat(32));
             lines.push('');
         }
     });

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -1,30 +1,30 @@
+import {forEach} from '../../utils/array';
 import {parseURL, getAbsoluteURL} from './url';
 import {logWarn} from '../utils/log';
 
 export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule) => void) {
-    Array.from(rules)
-        .forEach((rule) => {
-            if (rule instanceof CSSMediaRule) {
-                const media = Array.from(rule.media);
-                if (media.includes('screen') || media.includes('all') || !(media.includes('print') || media.includes('speech'))) {
-                    iterateCSSRules(rule.cssRules, iterate);
-                }
-            } else if (rule instanceof CSSStyleRule) {
-                iterate(rule);
-            } else if (rule instanceof CSSImportRule) {
-                try {
-                    iterateCSSRules(rule.styleSheet.cssRules, iterate);
-                } catch (err) {
-                    logWarn(err);
-                }
-            } else {
-                logWarn(`CSSRule type not supported`, rule);
+    forEach(rules, (rule) => {
+        if (rule instanceof CSSMediaRule) {
+            const media = Array.from(rule.media);
+            if (media.includes('screen') || media.includes('all') || !(media.includes('print') || media.includes('speech'))) {
+                iterateCSSRules(rule.cssRules, iterate);
             }
-        });
+        } else if (rule instanceof CSSStyleRule) {
+            iterate(rule);
+        } else if (rule instanceof CSSImportRule) {
+            try {
+                iterateCSSRules(rule.styleSheet.cssRules, iterate);
+            } catch (err) {
+                logWarn(err);
+            }
+        } else {
+            logWarn(`CSSRule type not supported`, rule);
+        }
+    });
 }
 
 export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (property: string, value: string) => void) {
-    Array.from(style).forEach((property) => {
+    forEach(style, (property) => {
         const value = style.getPropertyValue(property).trim();
         if (!value) {
             return;

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -4,7 +4,7 @@ import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-t
 import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache} from './modify-css';
 import {manageStyle, shouldManageStyle, STYLE_SELECTOR, StyleManager} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
-import {push} from '../../utils/array';
+import {forEach, push, toArray} from '../../utils/array';
 import {removeNode, watchForNodePosition, iterateShadowNodes} from '../utils/dom';
 import {logWarn} from '../utils/log';
 import {throttle} from '../utils/throttle';
@@ -40,7 +40,7 @@ function setupStylePositionWatcher(node: Node, alias: string) {
 }
 
 function stopStylePositionWatchers() {
-    Array.from(stylePositionWatchers.values()).forEach((watcher) => watcher.stop());
+    forEach(stylePositionWatchers.values(), (watcher) => watcher.stop());
     stylePositionWatchers.clear();
 }
 
@@ -124,7 +124,7 @@ function createDynamicStyleOverrides() {
 
     updateVariables(getElementCSSVariables(document.documentElement));
 
-    const allStyles = Array.from(document.querySelectorAll(STYLE_SELECTOR)) as (HTMLLinkElement | HTMLStyleElement)[];
+    const allStyles = toArray(document.querySelectorAll(STYLE_SELECTOR)) as (HTMLLinkElement | HTMLStyleElement)[];
     iterateShadowNodes(document.documentElement, (node) => {
         const shadowStyles = node.shadowRoot.querySelectorAll(STYLE_SELECTOR);
         if (shadowStyles.length > 0) {
@@ -132,7 +132,7 @@ function createDynamicStyleOverrides() {
         }
     });
 
-    const newManagers = Array.from<HTMLLinkElement | HTMLStyleElement>(allStyles)
+    const newManagers = toArray<HTMLLinkElement | HTMLStyleElement>(allStyles)
         .filter((style) => !styleManagers.has(style) && shouldManageStyle(style))
         .map((style) => createManager(style));
     const newVariables = newManagers
@@ -154,7 +154,7 @@ function createDynamicStyleOverrides() {
     }
     newManagers.forEach((manager) => manager.watch());
 
-    const inlineStyleElements = Array.from(document.querySelectorAll(INLINE_STYLE_SELECTOR));
+    const inlineStyleElements = toArray(document.querySelectorAll(INLINE_STYLE_SELECTOR));
     iterateShadowNodes(document.documentElement, (node) => {
         const elements = node.shadowRoot.querySelectorAll(INLINE_STYLE_SELECTOR);
         if (elements.length > 0) {
@@ -379,8 +379,8 @@ export function removeDynamicTheme() {
         removeNode(root.querySelector('.darkreader--inline'));
     });
     shadowRootsWithOverrides.clear();
-    Array.from(styleManagers.keys()).forEach((el) => removeManager(el));
-    Array.from(document.querySelectorAll('.darkreader')).forEach(removeNode);
+    forEach(styleManagers.keys(), (el) => removeManager(el));
+    document.querySelectorAll('.darkreader').forEach(removeNode);
 }
 
 export function cleanDynamicThemeCache() {

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -4,6 +4,7 @@ import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-t
 import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache} from './modify-css';
 import {manageStyle, shouldManageStyle, STYLE_SELECTOR, StyleManager} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
+import {push} from '../../utils/array';
 import {removeNode, watchForNodePosition, iterateShadowNodes} from '../utils/dom';
 import {logWarn} from '../utils/log';
 import {throttle} from '../utils/throttle';
@@ -127,7 +128,7 @@ function createDynamicStyleOverrides() {
     iterateShadowNodes(document.documentElement, (node) => {
         const shadowStyles = node.shadowRoot.querySelectorAll(STYLE_SELECTOR);
         if (shadowStyles.length > 0) {
-            allStyles.push(...Array.from(shadowStyles as NodeListOf<HTMLLinkElement | HTMLStyleElement>));
+            push(allStyles, shadowStyles);
         }
     });
 
@@ -158,7 +159,7 @@ function createDynamicStyleOverrides() {
         const elements = node.shadowRoot.querySelectorAll(INLINE_STYLE_SELECTOR);
         if (elements.length > 0) {
             createShadowStaticStyleOverrides(node.shadowRoot);
-            inlineStyleElements.push(...Array.from(elements as NodeListOf<HTMLLinkElement | HTMLStyleElement>));
+            push(inlineStyleElements, elements);
         }
     });
     inlineStyleElements.forEach((el) => overrideInlineStyle(el as HTMLElement, filter, fixes.ignoreInlineStyle));

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -1,3 +1,4 @@
+import {forEach, push} from '../../utils/array';
 import {iterateShadowNodes} from '../utils/dom';
 import {iterateCSSDeclarations} from './css-rules';
 import {getModifiableCSSDeclaration} from './modify-css';
@@ -102,14 +103,14 @@ export function getInlineOverrideStyle() {
     }).join('\n');
 }
 
-function expand(nodes: Node[], selector: string) {
+function expand(nodes: ArrayLike<Node>, selector: string) {
     const results: Node[] = [];
-    nodes.forEach((n) => {
+    forEach(nodes, (n) => {
         if (n instanceof Element) {
             if (n.matches(selector)) {
                 results.push(n);
             }
-            results.push(...Array.from(n.querySelectorAll(selector)));
+            push(results, n.querySelectorAll(selector));
         }
     });
     return results;
@@ -186,7 +187,8 @@ function getInlineStyleCacheKey(el: HTMLElement, theme: FilterConfig) {
 }
 
 function shouldIgnoreInlineStyle(element: HTMLElement, selectors: string[]) {
-    for (const ingnoredSelector of selectors) {
+    for (let i = 0; i < selectors.length; i++) {
+        const ingnoredSelector = selectors[i];
         if (element.matches(ingnoredSelector)) {
             return true;
         }

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -138,7 +138,7 @@ export function deepWatchForInlineStyles(
     }
     const observer = new MutationObserver((mutations) => {
         mutations.forEach((m) => {
-            const createdInlineStyles = expand(Array.from(m.addedNodes), INLINE_STYLE_SELECTOR);
+            const createdInlineStyles = expand(m.addedNodes, INLINE_STYLE_SELECTOR);
             if (createdInlineStyles.length > 0) {
                 createdInlineStyles.forEach((el: HTMLElement) => elementStyleDidChange(el));
             }
@@ -276,7 +276,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
         setCustomProp('fill', 'color', element.style.getPropertyValue('fill'));
     }
 
-    Array.from(unsetProps).forEach((cssProp) => {
+    forEach(unsetProps, (cssProp) => {
         const {store, dataAttr} = overrides[cssProp];
         store.delete(element);
         element.removeAttribute(dataAttr);

--- a/src/inject/dynamic-theme/meta-theme-color.ts
+++ b/src/inject/dynamic-theme/meta-theme-color.ts
@@ -27,8 +27,10 @@ export function changeMetaThemeColorWhenAvailable(theme: FilterConfig) {
             observer.disconnect();
         }
         observer = new MutationObserver((mutations) => {
-            loop: for (const m of mutations) {
-                for (const node of Array.from(m.addedNodes)) {
+            loop: for (let i = 0; i < mutations.length; i++) {
+                const {addedNodes} = mutations[i];
+                for (let j = 0; j < addedNodes.length; j++) {
+                    const node = addedNodes[j];
                     if (node instanceof HTMLMetaElement && node.name === metaThemeColorName) {
                         observer.disconnect();
                         observer = null;

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -1,4 +1,5 @@
 import {iterateShadowNodes} from '../utils/dom';
+import {forEach, push} from '../../utils/array';
 import {isDefinedSelectorSupported} from '../../utils/platform';
 import {shouldManageStyle, STYLE_SELECTOR} from './style-manager';
 
@@ -13,18 +14,19 @@ interface ChangedStyles {
 
 function getAllManageableStyles(nodes: Iterable<Node> | ArrayLike<Node>) {
     const results: (HTMLLinkElement | HTMLStyleElement)[] = [];
-    Array.from(nodes).forEach((node) => {
+    forEach(nodes, (node) => {
         if (node instanceof Element) {
             if (shouldManageStyle(node)) {
                 results.push(node as HTMLLinkElement | HTMLStyleElement);
             }
         }
         if (node instanceof Element || node instanceof ShadowRoot) {
-            results.push(
-                ...Array.from<HTMLLinkElement | HTMLStyleElement>(
-                    node.querySelectorAll(STYLE_SELECTOR)
-                ).filter(shouldManageStyle)
-            );
+            node.querySelectorAll(STYLE_SELECTOR)
+                .forEach((style: HTMLLinkElement | HTMLStyleElement) => {
+                    if (shouldManageStyle(style)) {
+                        results.push(style);
+                    }
+                });
         }
     });
     return results;
@@ -124,7 +126,7 @@ export function watchForStyleChanges(update: (styles: ChangedStyles) => void) {
             iterateShadowNodes(n, (host) => {
                 const shadowStyles = getAllManageableStyles(host.shadowRoot.children);
                 if (shadowStyles.length > 0) {
-                    styleAdditions.push(...shadowStyles);
+                    push(styleAdditions, shadowStyles);
                 }
             });
         });
@@ -132,7 +134,7 @@ export function watchForStyleChanges(update: (styles: ChangedStyles) => void) {
             iterateShadowNodes(n, (host) => {
                 const shadowStyles = getAllManageableStyles(host.shadowRoot.children);
                 if (shadowStyles.length > 0) {
-                    styleDeletions.push(...shadowStyles);
+                    push(styleDeletions, shadowStyles);
                 }
             });
         });

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,23 @@
+function isArrayLike<T>(items: Iterable<T> | ArrayLike<T>): items is ArrayLike<T> {
+    return (items as ArrayLike<T>).length != null;
+}
+
+// NOTE: Iterating Array-like items using `for .. of` is 3x slower in Firefox
+// https://jsben.ch/kidOp
+export function forEach<T>(items: Iterable<T> | ArrayLike<T>, iterator: (item: T) => void) {
+    if (isArrayLike(items)) {
+        for (let i = 0; i < items.length; i++) {
+            iterator(items[i]);
+        }
+    } else {
+        for (const item of items) {
+            iterator(item);
+        }
+    }
+}
+
+// NOTE: Pushing items like `arr.push(...items)` is 3x slower in Firefox
+// https://jsben.ch/nr9OF
+export function push<T>(array: Array<T>, addition: Iterable<T> | ArrayLike<T>) {
+    forEach(addition, (a) => array.push(a));
+}

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -21,3 +21,14 @@ export function forEach<T>(items: Iterable<T> | ArrayLike<T>, iterator: (item: T
 export function push<T>(array: Array<T>, addition: Iterable<T> | ArrayLike<T>) {
     forEach(addition, (a) => array.push(a));
 }
+
+// NOTE: Using `Array.from()` is 2x (FF) — 5x (Chrome) slower for ArrayLike (not for Iterable)
+// https://jsben.ch/FJ1mO
+// https://jsben.ch/ZmViL
+export function toArray<T>(items: ArrayLike<T>) {
+    const results = [] as Array<T>;
+    for (let i = 0; i < items.length; i++) {
+        results.push(items[i]);
+    }
+    return results;
+}


### PR DESCRIPTION
- Using `for .. of` is 3x times slower https://jsben.ch/kidOp
- Using `push(...items)` is 3x times slower https://jsben.ch/nr9OF
- Converting Array-likes to Arrays using `Array.from` is 2x slower https://jsben.ch/FJ1mO