### PR TITLE
fix for naszemiasto.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2109,6 +2109,38 @@ CSS
 
 ================================
 
+naszemiasto.pl
+
+INVERT
+.componentsNavigationNavbar
+.atomsNavigationFooterLegal
+.componentsSiteHeader
+.atomsNavigationFooterAccordion
+.atomsNavigationFooterSocialmedia__link
+.atomsNavigationFooterSocialmedia__button
+.atomsArticlePollVoting__pulseDescription
+.atomsArticlePollVoting__form
+.atomsArticlePollVoting__voteTitle
+.componentsArticleGallery__captionDescription
+.componentsPromotionsVideo__title
+.layoutsGrid
+aside .atomsArticleTile__tileImg
+.componentsArticleGallery__img
+.componentsArticleGallery__thumbnail
+.atomsArticleFootTools__button
+.componentsPromotionsOffers__fakeImg
+.atomsNavigationFooterLinks__logoImg
+.ytp-cued-thumbnail-overlay
+.componentsPromotionsSubjectCategoryPromoted__image
+.componentsRecommendationsSelected__photo
+p.nieprzeczytane
+p.przeczytane
+article iframe
+.atomsPromotionsQuiz__imageWrapper
+.atomsPromotionsLink__imageWrapper
+
+================================
+
 natemat.pl
 
 INVERT


### PR DESCRIPTION
Articles page started back to load as white.
Putting back old fixes into config.
![image](https://user-images.githubusercontent.com/56877029/81932747-87b79f80-95ec-11ea-9d6d-69a371f2a81d.png)

some example URL:
https://wroclaw.naszemiasto.pl/sa-wstepne-wyniki-sekcji-zwlok-35-letniego-kacpra-z/ar/c1-7697947