### PR TITLE
fixes for gazetawroclawska.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1218,6 +1218,38 @@ CSS
 
 ================================
 
+gazetawroclawska.pl
+
+INVERT
+.atomsNavigationFooterLegal
+.componentsSiteHeader
+.atomsNavigationFooterAccordion
+.atomsNavigationFooterSocialmedia__link
+.atomsNavigationFooterSocialmedia__button
+.atomsArticlePollVoting__pulseDescription
+.atomsArticlePollVoting__form
+.atomsArticlePollVoting__voteTitle
+.componentsArticleGallery__captionDescription
+.componentsPromotionsVideo__title
+.layoutsGrid
+article .atomsArticleTile__tileImg
+.layoutsGrid--last .atomsArticleTile__tileImg
+.componentsArticleGallery__img
+.componentsArticleGallery__thumbnail
+.atomsArticleFootTools__button
+.componentsPromotionsOffers__fakeImg
+.atomsNavigationFooterLinks__logoImg
+.ytp-cued-thumbnail-overlay
+.componentsRecommendationsSelected__photo
+.componentsPromotionsSubjectCategoryPromoted__image
+p.nieprzeczytane
+p.przeczytane
+article iframe
+.atomsPromotionsQuiz__imageWrapper
+.atomsPromotionsLink__imageWrapper
+
+================================
+
 geizhals.at
 geizhals.de
 


### PR DESCRIPTION
White articles comes back.
Reverted old fixes for this site.

![image](https://user-images.githubusercontent.com/56877029/81933257-60150700-95ed-11ea-94e9-cb6c3bb6c0fc.png)

Example URL:
https://gazetawroclawska.pl/wroclaw-akcja-policji-na-moscie-milenijnym-uzyto-granatow-zatrzymany-syn-znanego-gangstera/ar/c1-14966038