### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1074,7 +1074,7 @@ div[aria-label="Change Position"] .ha302278,
     fill: none !important;
 }
 .s1i5eluu {
-    background-color: var(--primary-button-background);
+    background-color: var(--primary-button-background) !important;
 }
 .q66pz984 {
     color: var(--accent);


### PR DESCRIPTION
Added !important in .s1i5eluu to have always original button color in groups.
Group with other color had blue.
![image](https://user-images.githubusercontent.com/56877029/81935108-6193fe80-95f0-11ea-90a2-a8f591e0d3fb.png)
