### PR TITLE
Fix for VRT Nieuws (Belgian news site)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3599,7 +3599,7 @@ INVERT
 
 CSS
 article:hover::before {
-    background-color: #000000 !important;
+    background-color: ${white} !important;
 }
 .vrt-site-header__container::before {
     background-color: transparent !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3592,6 +3592,21 @@ body {
 
 ================================
 
+vrt.be/vrtnws
+
+INVERT
+.vrt-site-header__home>svg
+
+CSS
+article:hover::before {
+    background-color: #000000 !important;
+}
+.vrt-site-header__container::before {
+    background-color: transparent !important;
+}
+
+================================
+
 w3.org
 
 INVERT


### PR DESCRIPTION
Add custom CSS for VRT nieuws (Belgian VRT news site). The header and some hover effects were bright white.