### PR TITLE
Cache AnalyzeImage

### DIFF
--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -4,6 +4,7 @@ import {getURLHost} from '../../utils/url';
 import {loadAsDataURL} from '../../utils/network';
 import {FilterConfig} from '../../definitions';
 
+
 export interface ImageDetails {
     src: string;
     dataURL: string;
@@ -49,7 +50,12 @@ async function urlToImage(url: string) {
     });
 }
 
+const ImageCache = new Map();
+
 function analyzeImage(image: HTMLImageElement) {
+    if (ImageCache.has(image.src)) {
+        return ImageCache.get(image.src);
+    }
     const MAX_ANALIZE_PIXELS_COUNT = 32 * 32;
 
     const naturalPixelsCount = image.naturalWidth * image.naturalHeight;
@@ -108,13 +114,14 @@ function analyzeImage(image: HTMLImageElement) {
     const LIGHT_IMAGE_THRESHOLD = 0.7;
     const TRANSPARENT_IMAGE_THRESHOLD = 0.1;
     const LARGE_IMAGE_PIXELS_COUNT = 800 * 600;
-
-    return {
+    const returnObject = {
         isDark: ((darkPixelsCount / opaquePixelsCount) >= DARK_IMAGE_THRESHOLD),
         isLight: ((lightPixelsCount / opaquePixelsCount) >= LIGHT_IMAGE_THRESHOLD),
         isTransparent: ((transparentPixelsCount / totalPixelsCount) >= TRANSPARENT_IMAGE_THRESHOLD),
         isLarge: (naturalPixelsCount >= LARGE_IMAGE_PIXELS_COUNT),
     };
+    ImageCache.set(image.src, returnObject);
+    return returnObject;
 }
 
 export function getFilteredImageDataURL({dataURL, width, height}: ImageDetails, filter: FilterConfig) {


### PR DESCRIPTION
Well maybe you know AnalyzeImage is quite heavy program and caching the results would improve loading speeds and sites that request an image like 100x times *Looking at you google*
As it's 4 simple booleans it hopefully won't be heavy on memory usage.

We cache the .src as AnalyzeImage is being used at GetImageDetails that always pass an data: that reperesent the image data so if it's dynamic loaded it will pass another data:

*Linkedin improves speed on second reload and a little bit on first*