### PR TITLE
dark-sites.config: Add saznajnovo.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -213,6 +213,7 @@ sanctum.geek.nz/arabesque
 sandervanderburg.blogspot.com
 sapphdavis.com
 sapphdavis.me
+saznajnovo.com
 secrethitler.io
 serebii.net
 sheet.host


### PR DESCRIPTION
saznajnovo.com is blog about IT things on Serbian language and looks good in dark mode.