### PR TITLE
Fix charts for nexojornal.com.br

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2214,6 +2214,13 @@ INVERT
 
 ================================
 
+nexojornal.com.br
+
+INVERT
+.g-aiImg
+
+================================
+
 ngrok.com
 
 INVERT


### PR DESCRIPTION
Applies INVERT for charts in the brazilian newspaper Nexo.
This modifies posts located at https://www.nexojornal.com.br/grafico/