### PR TITLE
fix for messenger.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2064,6 +2064,7 @@ messenger.com
 INVERT
 ._4rv6
 a._4ce_
+.j7vl6m33
 
 CSS
 ._8rsr {


### PR DESCRIPTION
fix for dark camera icon
![image](https://user-images.githubusercontent.com/56877029/82183068-97cdc880-98e5-11ea-94ad-132e18150b30.png)
