### PR TITLE
Use sRGB to determine `pixel lightness`

### DIFF
--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -88,9 +88,8 @@ function analyzeImage(image: HTMLImageElement) {
             if (a < TRANSPARENT_ALPHA_THRESHOLD) {
                 transparentPixelsCount++;
             } else {
-                // Use HSP to determine the `pixel Lightness`
-                // http://alienryderflex.com/hsp.html & https://stackoverflow.com/a/24213274/13569411
-                p = Math.sqrt(0.299 * r^2 + 0.587 * g^2 + 0.114 * b^2)
+                // Use sRGB to determine the `pixel Lightness`
+                p = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
                 if (p < DARK_LIGHTNESS_THRESHOLD) {
                     darkPixelsCount++;
                 }

--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -89,6 +89,7 @@ function analyzeImage(image: HTMLImageElement) {
                 transparentPixelsCount++;
             } else {
                 // Use sRGB to determine the `pixel Lightness`
+                // https://en.wikipedia.org/wiki/Relative_luminance
                 p = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
                 if (p < DARK_LIGHTNESS_THRESHOLD) {
                     darkPixelsCount++;

--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -76,7 +76,7 @@ function analyzeImage(image: HTMLImageElement) {
 
     let i: number, x: number, y: number;
     let r: number, g: number, b: number, a: number;
-    let l: number, min: number, max: number;
+    let p: number;
     for (y = 0; y < height; y++) {
         for (x = 0; x < width; x++) {
             i = 4 * (y * width + x);
@@ -88,13 +88,13 @@ function analyzeImage(image: HTMLImageElement) {
             if (a < TRANSPARENT_ALPHA_THRESHOLD) {
                 transparentPixelsCount++;
             } else {
-                min = Math.min(r, g, b);
-                max = Math.max(r, g, b);
-                l = (max + min) / 2;
-                if (l < DARK_LIGHTNESS_THRESHOLD) {
+                // Use HSP to determine the `pixel Lightness`
+                // http://alienryderflex.com/hsp.html & https://stackoverflow.com/a/24213274/13569411
+                p = Math.sqrt(0.299 * r^2 + 0.587 * g^2 + 0.114 * b^2)
+                if (p < DARK_LIGHTNESS_THRESHOLD) {
                     darkPixelsCount++;
                 }
-                if (l > LIGHT_LIGHTNESS_THRESHOLD) {
+                if (p > LIGHT_LIGHTNESS_THRESHOLD) {
                     lightPixelsCount++;
                 }
             }

--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -76,7 +76,7 @@ function analyzeImage(image: HTMLImageElement) {
 
     let i: number, x: number, y: number;
     let r: number, g: number, b: number, a: number;
-    let p: number;
+    let l: number;
     for (y = 0; y < height; y++) {
         for (x = 0; x < width; x++) {
             i = 4 * (y * width + x);
@@ -90,11 +90,11 @@ function analyzeImage(image: HTMLImageElement) {
             } else {
                 // Use sRGB to determine the `pixel Lightness`
                 // https://en.wikipedia.org/wiki/Relative_luminance
-                p = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
-                if (p < DARK_LIGHTNESS_THRESHOLD) {
+                l = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+                if (l < DARK_LIGHTNESS_THRESHOLD) {
                     darkPixelsCount++;
                 }
-                if (p > LIGHT_LIGHTNESS_THRESHOLD) {
+                if (l > LIGHT_LIGHTNESS_THRESHOLD) {
                     lightPixelsCount++;
                 }
             }


### PR DESCRIPTION
We also can use HSP instead of HSL in rest of our code :eyes: < If that is possible in every section of the code that use HSL at the moment.

Resolves #704