### PR TITLE
Mutation Observer performance

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -2,7 +2,7 @@ import {replaceCSSVariables, getElementCSSVariables} from './css-rules';
 import {overrideInlineStyle, getInlineOverrideStyle, watchForInlineStyles, stopWatchingForInlineStyles, INLINE_STYLE_SELECTOR} from './inline-style';
 import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-theme-color';
 import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache} from './modify-css';
-import {manageStyle, shouldManageStyle, STYLE_SELECTOR, StyleManager} from './style-manager';
+import {manageStyle, getManageableStyles, StyleElement, StyleManager} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
 import {forEach, push, toArray} from '../../utils/array';
 import {removeNode, watchForNodePosition, iterateShadowNodes} from '../utils/dom';
@@ -15,7 +15,7 @@ import {modifyColor} from '../../generators/modify-colors';
 import {createTextStyle} from '../../generators/text-style';
 import {FilterConfig, DynamicThemeFix} from '../../definitions';
 
-const styleManagers = new Map<HTMLLinkElement | HTMLStyleElement, StyleManager>();
+const styleManagers = new Map<StyleElement, StyleManager>();
 const variables = new Map<string, string>();
 let filter: FilterConfig = null;
 let fixes: DynamicThemeFix = null;
@@ -124,16 +124,10 @@ function createDynamicStyleOverrides() {
 
     updateVariables(getElementCSSVariables(document.documentElement));
 
-    const allStyles = toArray(document.querySelectorAll(STYLE_SELECTOR)) as (HTMLLinkElement | HTMLStyleElement)[];
-    iterateShadowNodes(document.documentElement, (node) => {
-        const shadowStyles = node.shadowRoot.querySelectorAll(STYLE_SELECTOR);
-        if (shadowStyles.length > 0) {
-            push(allStyles, shadowStyles);
-        }
-    });
+    const allStyles = getManageableStyles(document);
 
-    const newManagers = toArray<HTMLLinkElement | HTMLStyleElement>(allStyles)
-        .filter((style) => !styleManagers.has(style) && shouldManageStyle(style))
+    const newManagers = allStyles
+        .filter((style) => !styleManagers.has(style))
         .map((style) => createManager(style));
     const newVariables = newManagers
         .map((manager) => manager.details())
@@ -168,7 +162,7 @@ function createDynamicStyleOverrides() {
 let loadingStylesCounter = 0;
 const loadingStyles = new Set();
 
-function createManager(element: HTMLLinkElement | HTMLStyleElement) {
+function createManager(element: StyleElement) {
     if (styleManagers.has(element)) {
         return;
     }
@@ -220,7 +214,7 @@ function updateVariables(newVars: Map<string, string>) {
     variables.forEach((value, key) => variables.set(key, replaceCSSVariables(value, variables)));
 }
 
-function removeManager(element: HTMLLinkElement | HTMLStyleElement) {
+function removeManager(element: StyleElement) {
     const manager = styleManagers.get(element);
     if (manager) {
         manager.destroy();
@@ -290,7 +284,8 @@ function createThemeAndWatchForUpdates() {
 }
 
 function watchForUpdates() {
-    watchForStyleChanges(({created, updated, removed, moved}) => {
+    const managedStyles = Array.from(styleManagers.keys());
+    watchForStyleChanges(managedStyles, ({created, updated, removed, moved}) => {
         const stylesToRemove = removed;
         const stylesToManage = created.concat(updated).concat(moved)
             .filter((style) => !styleManagers.has(style));

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -4,7 +4,6 @@ import {bgFetch} from './network';
 import {watchForNodePosition, removeNode, iterateShadowNodes} from '../utils/dom';
 import {logWarn} from '../utils/log';
 import {createAsyncTasksQueue} from '../utils/throttle';
-import {isDeepSelectorSupported, isHostSelectorSupported} from '../../utils/platform';
 import {getMatches} from '../../utils/text';
 import {FilterConfig} from '../../definitions';
 import {getAbsoluteURL} from './url';
@@ -32,21 +31,7 @@ export interface StyleManager {
     restore(): void;
 }
 
-export const STYLE_SELECTOR = (() => {
-    let selectors = [
-        'html /deep/ link[rel*="stylesheet" i]:not([disabled])',
-        'html /deep/ style',
-        ':host /deep/ link[rel*="stylesheet" i]:not([disabled])',
-        ':host /deep/ style',
-    ];
-    if (!isDeepSelectorSupported()) {
-        selectors = selectors.map((s) => s.replace('/deep/ ', ''));
-    }
-    if (!isHostSelectorSupported()) {
-        selectors = selectors.filter((s) => !s.startsWith(':host'));
-    }
-    return selectors.join(', ');
-})();
+export const STYLE_SELECTOR = 'style, link[rel*="stylesheet" i]:not([disabled])';
 
 export function shouldManageStyle(element: Node) {
     return (

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -70,6 +70,22 @@ function unsubscribeFromDefineCustomElements() {
     undefinedGroups.clear();
 }
 
+function isHugeMutation(mutations: MutationRecord[]) {
+    if (mutations.length > HUGE_MUTATIONS_COUNT) {
+        return true;
+    }
+
+    let addedNodesCount = 0;
+    for (let i = 0; i < mutations.length; i++) {
+        addedNodesCount += mutations[i].addedNodes.length;
+        if (addedNodesCount > HUGE_MUTATIONS_COUNT) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 export function watchForStyleChanges(currentStyles: StyleElement[], update: (styles: ChangedStyles) => void) {
     resetObservers();
 
@@ -204,8 +220,7 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
     }
 
     function handleTreeMutations(root: Document | ShadowRoot, mutations: MutationRecord[]) {
-        const addedNodesCount = mutations.reduce((sum, m) => sum + m.addedNodes.length, 0);
-        if (addedNodesCount > HUGE_MUTATIONS_COUNT) {
+        if (isHugeMutation(mutations)) {
             handleHugeTreeMutations(root);
         } else {
             handleMinorTreeMutations(mutations);

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -170,10 +170,8 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
         handleStyleOperations({createdStyles, removedStyles, movedStyles});
 
         additions.forEach((n) => {
-            if (n.isConnected) {
-                iterateShadowNodes(n, subscribeForShadowRootChanges);
-                collectUndefinedElements(n);
-            }
+            iterateShadowNodes(n, subscribeForShadowRootChanges);
+            collectUndefinedElements(n);
         });
     }
 

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -251,8 +251,8 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
 
         handleStyleOperations({createdStyles, removedStyles, movedStyles});
 
-        iterateShadowNodes(document, subscribeForShadowRootChanges);
-        collectUndefinedElements(document);
+        iterateShadowNodes(root, subscribeForShadowRootChanges);
+        collectUndefinedElements(root);
     }
 
     function handleTreeMutations(root: Document | ShadowRoot, mutations: MutationRecord[]) {

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -145,3 +145,152 @@ export function iterateShadowNodes(root: Node, iterator: (node: Element) => void
         iterateShadowNodes(node.shadowRoot, iterator);
     }
 }
+
+export function isDOMReady() {
+    return document.readyState === 'complete' || document.readyState === 'interactive';
+}
+
+const readyStateListeners = new Set<() => void>();
+
+export function addDOMReadyListener(listener: () => void) {
+    readyStateListeners.add(listener);
+}
+
+export function removeDOMReadyListener(listener: () => void) {
+    readyStateListeners.delete(listener);
+}
+
+if (!isDOMReady()) {
+    const onReadyStateChange = () => {
+        if (isDOMReady()) {
+            document.removeEventListener('readystatechange', onReadyStateChange);
+            readyStateListeners.forEach((listener) => listener());
+            readyStateListeners.clear();
+        }
+    };
+    document.addEventListener('readystatechange', onReadyStateChange);
+}
+
+const HUGE_MUTATIONS_COUNT = 1000;
+
+function isHugeMutation(mutations: MutationRecord[]) {
+    if (mutations.length > HUGE_MUTATIONS_COUNT) {
+        return true;
+    }
+
+    let addedNodesCount = 0;
+    for (let i = 0; i < mutations.length; i++) {
+        addedNodesCount += mutations[i].addedNodes.length;
+        if (addedNodesCount > HUGE_MUTATIONS_COUNT) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export interface ElementsTreeOperations {
+    additions: Set<Element>;
+    moves: Set<Element>;
+    deletions: Set<Element>;
+}
+
+function getElementsTreeOperations(mutations: MutationRecord[]): ElementsTreeOperations {
+    const additions = new Set<Element>();
+    const deletions = new Set<Element>();
+    const moves = new Set<Element>();
+    mutations.forEach((m) => {
+        m.addedNodes.forEach((n) => {
+            if (n instanceof Element && n.isConnected) {
+                additions.add(n);
+            }
+        });
+        m.removedNodes.forEach((n) => {
+            if (n instanceof Element) {
+                if (n.isConnected) {
+                    moves.add(n);
+                } else {
+                    deletions.add(n);
+                }
+            }
+        });
+    });
+    moves.forEach((n) => additions.delete(n));
+
+    const duplicateAdditions = [] as Element[];
+    const duplicateDeletions = [] as Element[];
+    additions.forEach((node) => {
+        if (additions.has(node.parentElement)) {
+            duplicateAdditions.push(node);
+        }
+    });
+    deletions.forEach((node) => {
+        if (deletions.has(node.parentElement)) {
+            duplicateDeletions.push(node);
+        }
+    });
+    duplicateAdditions.forEach((node) => additions.delete(node));
+    duplicateDeletions.forEach((node) => deletions.delete(node));
+
+    return {additions, moves, deletions};
+}
+
+interface OptimizedTreeObserverCallbacks {
+    onMinorMutations: (operations: ElementsTreeOperations) => void;
+    onHugeMutations: (root: Document | ShadowRoot) => void;
+}
+
+const optimizedTreeObservers = new Map<Node, MutationObserver>();
+const optimizedTreeCallbacks = new WeakMap<MutationObserver, Set<OptimizedTreeObserverCallbacks>>();
+
+export function createOptimizedTreeObserver(root: Document | ShadowRoot, callbacks: OptimizedTreeObserverCallbacks) {
+    let observer: MutationObserver;
+    let observerCallbacks: Set<OptimizedTreeObserverCallbacks>;
+    let domReadyListener: () => void;
+
+    if (optimizedTreeObservers.has(root)) {
+        observer = optimizedTreeObservers.get(root);
+        observerCallbacks = optimizedTreeCallbacks.get(observer);
+    } else {
+        let hadHugeMutationsBefore = false;
+        let subscribedForReadyState = false;
+
+        observer = new MutationObserver((mutations: MutationRecord[]) => {
+            if (isHugeMutation(mutations)) {
+                if (!hadHugeMutationsBefore || isDOMReady()) {
+                    observerCallbacks.forEach(({onHugeMutations}) => onHugeMutations(root));
+                } else {
+                    if (!subscribedForReadyState) {
+                        domReadyListener = () => observerCallbacks.forEach(({onHugeMutations}) => onHugeMutations(root));
+                        addDOMReadyListener(domReadyListener);
+                        subscribedForReadyState = true;
+                    }
+                }
+                hadHugeMutationsBefore = true;
+            } else {
+                const elementsOperations = getElementsTreeOperations(mutations);
+                observerCallbacks.forEach(({onMinorMutations}) => onMinorMutations(elementsOperations));
+            }
+        });
+        observer.observe(root, {childList: true, subtree: true});
+        optimizedTreeObservers.set(root, observer);
+        observerCallbacks = new Set();
+        optimizedTreeCallbacks.set(observer, observerCallbacks);
+    }
+
+    observerCallbacks.add(callbacks);
+
+    return {
+        disconnect() {
+            observerCallbacks.delete(callbacks);
+            if (domReadyListener) {
+                removeDOMReadyListener(domReadyListener);
+            }
+            if (observerCallbacks.size === 0) {
+                observer.disconnect();
+                optimizedTreeCallbacks.delete(observer);
+                optimizedTreeObservers.delete(root);
+            }
+        },
+    };
+}

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -243,6 +243,7 @@ interface OptimizedTreeObserverCallbacks {
 const optimizedTreeObservers = new Map<Node, MutationObserver>();
 const optimizedTreeCallbacks = new WeakMap<MutationObserver, Set<OptimizedTreeObserverCallbacks>>();
 
+// TODO: Use a single function to observe all shadow roots.
 export function createOptimizedTreeObserver(root: Document | ShadowRoot, callbacks: OptimizedTreeObserverCallbacks) {
     let observer: MutationObserver;
     let observerCallbacks: Set<OptimizedTreeObserverCallbacks>;

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -62,24 +62,6 @@ export function compareChromeVersions($a: string, $b: string) {
     return 0;
 }
 
-export function isDeepSelectorSupported() {
-    try {
-        document.querySelector('x /deep/ x');
-        return true;
-    } catch (err) {
-        return false;
-    }
-}
-
-export function isHostSelectorSupported() {
-    try {
-        document.querySelector(':host x');
-        return true;
-    } catch (err) {
-        return false;
-    }
-}
-
 export function isDefinedSelectorSupported() {
     try {
         document.querySelector(':defined');


### PR DESCRIPTION
- Scan the whole DOM tree for changes when there's too large count of mutations.
- Don't handle unnecessary mutations.
- Another attempt for #535.