### PR TITLE
Prevent targetting pre element

### DIFF
--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -2,7 +2,8 @@ import {FilterConfig} from '../definitions';
 
 export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
-    lines.push('* {');
+    // Don't target pre elements as they are preformatted element's e.g. code blocks
+    lines.push('*:not(pre) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...


### PR DESCRIPTION
- Do not target pre element's 

Resolves #1643

HTML Living standard & HTML5:
https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element & https://www.w3.org/TR/html52/grouping-content.html#the-pre-element
```
The pre element represents a block of preformatted text, in which structure is represented by 
typographic conventions rather than by elements.
```