### PR TITLE
Reddit.com fix --commentswrapper-gradient-color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2624,6 +2624,9 @@ CSS
 [style^="--pseudo-before-background"] {
     --pseudo-before-background: ${#DAE0E6} !important;
 }
+[style^="--commentswrapper-gradient-color"] {
+    --commentswrapper-gradient-color: ${#ccc} !important;
+}
 
 ================================
 


### PR DESCRIPTION
In a desktop browser, when visiting any subreddit post that has multiple comments, most of the comments are hidden and the blue "View Entire Discussion" button must be clicked to expand more comments.  Directly above this button is a white gradient.  You can see an example of this here:

https://www.reddit.com/r/ProtonVPN/comments/gh5fxd/ip_leak/

My fix is to set --commentswrapper-gradient-color to #ccc.