### PR TITLE
cleantechnica.com BODY background fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -486,6 +486,16 @@ img[src$="dark_create_class_arrow.svg"]
 
 ================================
 
+cleantechnica.com
+
+CSS
+body {
+    background-image: none !important; 
+	background-color: #1d1e1f !important; 
+}
+
+================================
+
 cloud.databricks.com
 *.azuredatabricks.net
 


### PR DESCRIPTION
BODY element has a light background image applied.

background-image: url("https://cleantechnica.com/wp-content/themes/gonzo/images/backgrounds/Light_wool.png"

Background image is approx. 2% darker than the white interior background color of their fixed width website.

Fix is to remove the background image and set the background color to rgb 29,30,31, which is approx. 2% darker than the default background color that Dark Reader sets (rgb 30,31,32) for the interior background color of their fixed width website.