### PR TITLE
Try handle @import link errors

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -148,12 +148,14 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             if (element.sheet == null) {
                 try {
                     await linkLoading(element);
-                    if (cancelAsyncOperations) {
-                        return null;
-                    }
                 } catch (err) {
+                    // NOTE: Some @import resources can fail,
+                    // bug the style sheet can still be valid.
+                    // There's no way to get the actual error.
                     logWarn(err);
                     wasLoadingError = true;
+                }
+                if (cancelAsyncOperations) {
                     return null;
                 }
             }

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -150,7 +150,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
                     await linkLoading(element);
                 } catch (err) {
                     // NOTE: Some @import resources can fail,
-                    // bug the style sheet can still be valid.
+                    // but the style sheet can still be valid.
                     // There's no way to get the actual error.
                     logWarn(err);
                     wasLoadingError = true;


### PR DESCRIPTION
- Some @import resources can fail, but the style sheet can still be valid.
- Fix for https://fivethirtyeight.com/
- Fix for some websites from #2065