### PR TITLE
Fix for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3809,20 +3809,26 @@ a[href$=".svg"]:hover > img {
     background-color: rgba(255, 255, 255, 0.75) !important;
     background-blend-mode: color;
 }
+.diff-addedline .diffchange {
+    background-color: ${lightblue} !important;
+}
+.diff-deletedline .diffchange {
+    background-color: ${#feeec8} !important;
+}
 @keyframes unseen-fadeout-to-unread {
     from {
-        background-color: ${#dce8ff};
+        background-color: ${#dce8ff} !important;
     }
     to {
-        background-color: ${#ffffff};
+        background-color: ${#ffffff} !important;
     }
 }
 @keyframes unseen-fadeout-to-read {
     from {
-        background-color: ${#dce8ff};
+        background-color: ${#dce8ff} !important;
     }
     to {
-        background-color: ${#eaecf0};
+        background-color: ${#eaecf0} !important;
     }
 }
 


### PR DESCRIPTION
- Add !important for `@keyframes`
- Make diff changes colors to be visible colors in dark mode and light mode

Resolves: #1252 
# Before
![](https://i.imgur.com/xJqss1g.png)
![](https://i.imgur.com/bMsolvd.png)
# After
![](https://i.imgur.com/g5oHAAz.png)
![](https://i.imgur.com/5mo6ype.png)