### PR TITLE
add research.protocol.ai to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2717,6 +2717,15 @@ CSS
 
 ================================
 
+research.protocol.ai
+
+CSS
+.text-black, .page-content {
+    color: ${rgb(19,19,22)};
+}
+
+================================
+
 richie-bendall.ml
 
 CSS


### PR DESCRIPTION
FIxes the main text to be inverted instead of black.