### PR TITLE
fix for plotek.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1222,6 +1222,7 @@ INVERT
 ================================
 
 gazeta.pl
+plotek.pl
 
 INVERT
 .column


### PR DESCRIPTION
added as gazeta.pl alternative

URL to check:
https://www.plotek.pl/plotek/7,154063,25966011,andrzej-chyra-skomentowal-wykorzystanie-jego-wizerunku-w-filmie.html#s=amtpc_FB_Gazeta