### PR TITLE
Image processing performance

### DIFF
--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -56,11 +56,7 @@ let context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
 function createCanvas() {
     const maxWidth = MAX_ANALIZE_PIXELS_COUNT;
     const maxHeight = MAX_ANALIZE_PIXELS_COUNT;
-    if (typeof OffscreenCanvas === 'function') {
-        canvas = new OffscreenCanvas(maxWidth, maxHeight);
-    } else {
-        canvas = document.createElement('canvas');
-    }
+    canvas = document.createElement('canvas');
     canvas.width = maxWidth;
     canvas.height = maxHeight;
     context = canvas.getContext('2d');

--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -134,6 +134,8 @@ function analyzeImage(image: HTMLImageElement) {
     };
 }
 
+const objectURLs = new Set<string>();
+
 export function getFilteredImageDataURL({dataURL, width, height}: ImageDetails, filter: FilterConfig) {
     const matrix = getSVGFilterMatrixValue(filter);
     const svg = [
@@ -152,9 +154,12 @@ export function getFilteredImageDataURL({dataURL, width, height}: ImageDetails, 
     }
     const blob = new Blob([bytes], {type: 'image/svg+xml'});
     const objectURL = URL.createObjectURL(blob);
+    objectURLs.add(objectURL);
     return objectURL;
 }
 
 export function cleanImageProcessingCache() {
     removeCanvas();
+    objectURLs.forEach((u) => URL.revokeObjectURL(u));
+    objectURLs.clear();
 }

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -3,7 +3,7 @@ import {clamp} from '../../utils/math';
 import {getMatches} from '../../utils/text';
 import {modifyBackgroundColor, modifyBorderColor, modifyForegroundColor, modifyGradientColor, modifyShadowColor, clearColorModificationCache} from '../../generators/modify-colors';
 import {cssURLRegex, getCSSURLValue, getCSSBaseBath} from './css-rules';
-import {getImageDetails, getFilteredImageDataURL, ImageDetails} from './image';
+import {getImageDetails, getFilteredImageDataURL, ImageDetails, cleanImageProcessingCache} from './image';
 import {getAbsoluteURL} from './url';
 import {logWarn, logInfo} from '../utils/log';
 import {FilterConfig, Theme} from '../../definitions';
@@ -419,5 +419,6 @@ export function cleanModificationCache() {
     colorParseCache.clear();
     clearColorModificationCache();
     imageDetailsCache.clear();
+    cleanImageProcessingCache();
     awaitingForImageLoading.clear();
 }


### PR DESCRIPTION
- Reuse a single Canvas (5x times faster in Chrome and 20% in Firefox https://jsben.ch/ZPvNu).
- Offscreen Canvas is slow (available in Chrome only) https://jsben.ch/vc7Gm
- Clear Object URLs when necessary.