### PR TITLE
Add keyframe support

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3840,22 +3840,6 @@ a[href$=".svg"]:hover > img {
 .diff-deletedline .diffchange {
     background-color: ${#feeec8} !important;
 }
-@keyframes unseen-fadeout-to-unread {
-    from {
-        background-color: ${#dce8ff} !important;
-    }
-    to {
-        background-color: ${#ffffff} !important;
-    }
-}
-@keyframes unseen-fadeout-to-read {
-    from {
-        background-color: ${#dce8ff} !important;
-    }
-    to {
-        background-color: ${#eaecf0} !important;
-    }
-}
 
 IGNORE INLINE STYLE
 .legend-color

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -2,14 +2,13 @@ import {forEach} from '../../utils/array';
 import {parseURL, getAbsoluteURL} from './url';
 import {logWarn} from '../utils/log';
 
-export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule) => void) {
+export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule | CSSKeyframeRule) => void) {
     forEach(rules, (rule) => {
         if (rule instanceof CSSMediaRule) {
             const media = Array.from(rule.media);
-            if (media.includes('screen') || media.includes('all') || !(media.includes('print') || media.includes('speech'))) {
                 iterateCSSRules(rule.cssRules, iterate);
             }
-        } else if (rule instanceof CSSStyleRule) {
+        } else if (rule instanceof CSSStyleRule || rule instanceof CSSKeyframeRule) {
             iterate(rule);
         } else if (rule instanceof CSSImportRule) {
             try {
@@ -17,6 +16,8 @@ export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule
             } catch (err) {
                 logWarn(err);
             }
+        } else if (rule instanceof CSSKeyframesRule) {
+            iterateCSSRules(rule.cssRules, iterate);
         } else {
             logWarn(`CSSRule type not supported`, rule);
         }

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -6,6 +6,7 @@ export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule
     forEach(rules, (rule) => {
         if (rule instanceof CSSMediaRule) {
             const media = Array.from(rule.media);
+            if (media.includes('screen') || media.includes('all') || !(media.includes('print') || media.includes('speech'))) {
                 iterateCSSRules(rule.cssRules, iterate);
             }
         } else if (rule instanceof CSSStyleRule || rule instanceof CSSKeyframeRule) {

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -340,6 +340,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
                 declarations.forEach(({property, value, important, sourceValue, keyText}) => {
                     text += `${keyText} {${property}: ${value == null ? sourceValue : value} ${important ? 'important' : ''}}`
                 });
+                text += '}';
                 target.insertRule(`${text}`, index);
             } else {
                 target.insertRule(`${selector} {}`, index);


### PR DESCRIPTION
1. It's being more used in the wild.

Would solve #2101 But was manual with `@keyframes` they are now also dropped.
Resolve #2590

https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes < Documentation I followed to get everything worked of how the CSS should look like.

The example will show it will infinty fade in the `block`.
It works with Dakreader Off and with this Patch. Without it, it will just fade out as we don't target the colors.

Example I used
[n.zip](https://github.com/darkreader/darkreader/files/4671882/n.zip)
