### PR TITLE
Fix for duckduckgo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -835,6 +835,14 @@ mark
 
 ================================
 
+duckduckgo.com
+
+IGNORE INLINE STYLE
+#color_picker_container .sample
+.zci--color_codes .circle
+
+================================
+
 duo.google.com
 
 INVERT


### PR DESCRIPTION
- Ignore color pickers.

Example
https://duckduckgo.com/?q=color+picker+%23ffffff
https://duckduckgo.com/?q=%23000