### PR TITLE
fix for pomorska.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1247,6 +1247,7 @@ CSS
 
 gazetawroclawska.pl
 dziennikzachodni.pl
+pomorska.pl
 
 INVERT
 .atomsNavigationFooterLegal


### PR DESCRIPTION
Another sibling of gazetawroclawska.pl