### PR TITLE
dict.cc language bar fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -731,6 +731,15 @@ mark
 
 ================================
 
+dict.cc
+
+CSS
+#langbar {
+    background-image: none !important;
+}
+
+================================
+
 dictionary.cambridge.org
 
 INVERT


### PR DESCRIPTION
On dict.cc the topmost language selection bar has a white background image which stays bright in dark mode. Removed the background image to solve.