### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -784,6 +784,7 @@ INVERT
 .vs-icon
 .vpc-icon
 .docs-analytics-img
+.apps-share-sprite
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
- Invert clipboard icon

#Before
![](https://i.imgur.com/85ibkM3.png)
#After
![](https://i.imgur.com/fTIlzFR.png)