### PR TITLE
Logo inversion for railwaygazette.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2731,6 +2731,13 @@ td.cell, td.label {
 
 ================================
 
+railwaygazette.com
+
+INVERT
+.mastheadLogo
+
+================================
+
 reddit.com
 
 INVERT


### PR DESCRIPTION
Before ![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83157790-305a1900-a12e-11ea-9ac6-fd111807c824.png)
After ![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83157783-2f28ec00-a12e-11ea-942f-d6da70e70dff.png)

```
railwaygazette.com

INVERT
.mastheadLogo
```
