### PR TITLE
Logo inversion for linotype.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1918,6 +1918,13 @@ li-icon[type="linkedin-logo"],
 
 ================================
 
+linotype.com
+
+INVERT
+#logo
+
+================================
+
 lirc.org
 
 CSS


### PR DESCRIPTION
Before ![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83229700-a3a56e80-a1b2-11ea-9ca6-619b14311df7.png)

After ![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83229697-a1dbab00-a1b2-11ea-87c0-1b80a9481c05.png)

```
linotype.com

INVERT
#logo
```