### PR TITLE
wired.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3964,6 +3964,14 @@ div.NavFrame div.NavHead {
 
 ================================
 
+wired.com
+
+INVERT
+i.logo.icon.icon--logo--150
+picture.standard-navigation__logo-image.responsive-image
+
+================================
+
 wunderground.com
 
 CSS


### PR DESCRIPTION
Inverted logo in the header of articles and the bottom of the main page.