### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1137,6 +1137,9 @@ a[role="link"] > i.hu5pjgll, ._3w97 {
 .j7vl6m33 {
     fill: var(--always-white) !important;
 }
+.sp_j_D4UkXXXbu {
+    background-image: url(/rsrc.php/v3/y-/r/kQ6of4djkqp.png) !important;
+}
 
 IGNORE INLINE STYLE
 [role="button"] svg


### PR DESCRIPTION
Fix for blobbed icon in stories.
![image](https://user-images.githubusercontent.com/56877029/83291924-85a73080-a1e9-11ea-8cb0-61ab4510fd6f.png)
