### PR TITLE
Add tirto.id to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -355,6 +355,7 @@ tilde.team
 tildeverse.org
 tinyzonetv.to
 tio.run
+tirto.id
 toneden.io
 totalwarwarhammer.gamepedia.com
 tracr.co


### PR DESCRIPTION
tirto.id has a toggle-able mode and with it a dark mode.

![image](https://user-images.githubusercontent.com/10338703/83332588-3420a380-a2c6-11ea-8283-a4e7fdaed5a9.png)


