### PR TITLE
Opt out disboard.org, add small fix for brainly.com, add large fix for omnivox.ca

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -96,6 +96,7 @@ developerinsider.co
 di.fm
 diablo3.com
 diablo3ladder.com
+disboard.org
 discord.bots.gg
 discord.com
 discordapp.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -481,6 +481,12 @@ article, article section, article footer, .css-1fzo8jw, .css-efdc07, article .cs
 
 ================================
 
+brainly.com
+
+INVERT
+.brn-rich-content > p > img
+
+================================
 cheapshark.com
 
 CSS
@@ -2485,6 +2491,39 @@ omnicalculator.com
 
 INVERT
 .GenericText
+
+================================
+
+omnivox.ca
+
+INVERT
+td[style*="/cvir/UI"]
+img[src^="/cvir/UI/Theme/Lea_Defaut/Images/Accueil_LEA"]
+img[src="/cvir/UI/Theme/Lea_Defaut/Images/mesclasses_cg_subtop.jpg"]
+img[src^="/cvir/UI/Theme/Lea_Defaut/Images/accueil_"]
+img[src$="/bas_du_menu.jpg"]
+img[src$="tile.jpg"]
+.cgSelect
+.mioLinks
+.calendrier
+.servLinks
+.descSection
+
+CSS
+.cgSelect > table > tbody > tr > td:nth-child(1) > a > font {
+    color: green !important;
+}
+.calendrier > table > tbody > tr,
+.calendrier > table > tbody > tr > td > img,
+.calendrier > table > tbody > tr > td > table > tbody > tr > td > img
+{
+    filter: invert(100%) hue-rotate(180deg) contrast(100%) !important;
+}
+
+table[style*="/cvir/UI"]
+{
+    background-image: none !important
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -487,6 +487,7 @@ INVERT
 .brn-rich-content > p > img
 
 ================================
+
 cheapshark.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2521,7 +2521,8 @@ CSS
     filter: invert(100%) hue-rotate(180deg) contrast(100%) !important;
 }
 
-table[style*="/cvir/UI"]
+table[style*="/cvir/UI"],
+.cgBg
 {
     background-image: none !important
 }


### PR DESCRIPTION
Note: *.omnivox.ca is for my province's college intranet, so unfortunately there are no public pages to test them, but it works... This is just to address the outdated static-image pages.

![screencapture-www-mpo-ovx-omnivox-ca-cvir-doce-Default-aspx-2020-05-30-17_34_26](https://user-images.githubusercontent.com/16656689/83339462-19d1d000-a29c-11ea-8885-fe99b7bbbceb.png)

For brainly I think it was the math formulas