### PR TITLE
Text inversion for printmag.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2733,6 +2733,15 @@ svg
 
 ================================
 
+printmag.com
+
+CSS
+body {
+    color: ${black} !important;
+}
+
+================================
+
 pro-run.pl
 
 INVERT


### PR DESCRIPTION
![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83343723-429fa700-a328-11ea-996f-94bec42c44d5.png)
![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83343727-47645b00-a328-11ea-8b41-7b2d5e64e052.png)

```
printmag.com

CSS
body {
    color: ${black} !important;
}
```