### PR TITLE
Inversion for theregister.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3412,23 +3412,8 @@ div.sc-2d8w30-1.bRnfTk svg g path
 
 ================================
 
-theregister.co.uk
-
-INVERT
-.row_label.title_rhs_line
-
-CSS
-article {
-  background-color: ${white} !important;
-}
-
-body {
-  color: ${black} !important;
-}
-
-================================
-
-theregister.com
+theregister.*
+theregister.*.*
 
 INVERT
 .row_label.title_rhs_line

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3422,6 +3422,26 @@ article {
   background-color: ${white} !important;
 }
 
+body {
+  color: ${black} !important;
+}
+
+================================
+
+theregister.com
+
+INVERT
+.row_label.title_rhs_line
+
+CSS
+article {
+  background-color: ${white} !important;
+}
+
+body {
+  color: ${black} !important;
+}
+
 ================================
 
 theverge.com


### PR DESCRIPTION
`theregister.co.uk` has been redirected to `theregister.com` since yesterday and some inversion adjustment.

![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83343878-682db000-a32a-11ea-9f97-a22e21ca268b.png)
![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83343879-6d8afa80-a32a-11ea-809b-fa645742979d.png)

```
theregister.com

INVERT
.row_label.title_rhs_line

CSS
article {
  background-color: ${white} !important;
}

body {
  color: ${black} !important;
}
```