### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -795,6 +795,7 @@ INVERT
 .vpc-icon
 .docs-analytics-img
 .share-butter-copy-icon
+.doc-previews-indicator-popover .docs-link-bubble-mime-icon
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
- Invert new Icon for preview links popup

Example ![](https://i.imgur.com/10JZJE1.png)