### PR TITLE
Fixed instructure.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1771,7 +1771,6 @@ CSS
 instructure.com
 
 INVERT
-.title_3bek::after
 .equation_image
 
 ================================


### PR DESCRIPTION
Removed .title_3bek::after from inverted list on instructure.com as the dynamic theme inverts it correctly now