### PR TITLE
Logo inversion for pressgazette.co.uk

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2810,6 +2810,13 @@ svg
 
 ================================
 
+pressgazette.co.uk
+
+INVERT
+.site-logo
+
+================================
+
 pro-run.pl
 
 INVERT


### PR DESCRIPTION
![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83612763-0761da00-a5ad-11ea-894a-c22eefba83df.png)
![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83612772-0e88e800-a5ad-11ea-9fc4-ca5850d08ef1.png)

```
pressgazette.co.uk

INVERT
.site-logo
```