### PR TITLE
Logo inversion for designobserver.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -752,6 +752,13 @@ INVERT
 
 ================================
 
+designobserver.com
+
+INVERT
+.dologo
+
+================================
+
 dev.to
 
 INVERT


### PR DESCRIPTION
![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83627881-d344e400-a5c1-11ea-9bf8-b4a688dede8c.png)
![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83627916-e35cc380-a5c1-11ea-9425-a357128b5c17.png)

```
designobserver.com

INVERT
.dologo
```