### PR TITLE
Logo inversion for thejakartapost.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3486,6 +3486,13 @@ INVERT
 
 ================================
 
+thejakartapost.com
+
+INVERT
+.logo-jakartapost
+
+================================
+
 theleagueofmoveabletype.com
 
 INVERT


### PR DESCRIPTION
![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83642741-6dfced00-a5d9-11ea-9b21-34ee242d511c.png)
![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83642762-72290a80-a5d9-11ea-99a8-657aa2865931.png)

```
thejakartapost.com

INVERT
.logo-jakartapost
```