### PR TITLE
fix for docs.google.com (#2707 fix)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -862,6 +862,9 @@ CSS
 .docs-linkbubble-bubble {
     filter: none !important;
 }
+.docs-text-ui-cursor-blink {
+    fill: ${black} !important;
+}
 
 ================================
 


### PR DESCRIPTION
Fix for black cursor.
![image](https://user-images.githubusercontent.com/56877029/83672023-e95c9f80-a5d5-11ea-8a03-3590df720983.png)
