### PR TITLE
support.mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3394,6 +3394,7 @@ INVERT
 div.sumo-nav--logo
 
 ================================
+
 tagesschau.de
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3386,6 +3386,14 @@ ol.breadcrumbs li:first-child:before
 
 ================================
 
+support.mozilla.org
+
+INVERT
+.card--topic .card--icon
+.card--icon-sm
+div.sumo-nav--logo
+
+================================
 tagesschau.de
 
 CSS


### PR DESCRIPTION
Inverted logo and card icons on urls such as: https://support.mozilla.org/en-US/products/firefox