### PR TITLE
telerik.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3482,6 +3482,25 @@ div.content table tr td h1.entry-title a{
 
 ================================
 
+telerik.com
+
+INVERT
+a.TK-Aside-Menu-Link
+a.TK-Aside-Menu-Button
+
+CSS
+a.TK-TLRK-Logo svg path[fill="#7c878e"] {
+    --darkreader-inline-fill: ${black} !important;
+}
+a.TK-TLRK-Logo svg path[fill="#4b4e52"] {
+    --darkreader-inline-fill: ${black} !important;
+}
+a.TK-PRGS-Logo-Footer svg path[fill="#4b4e52"] {
+    --darkreader-inline-fill: ${black} !important;
+}
+
+================================
+
 tenor.com
 
 INVERT


### PR DESCRIPTION
Inverted logo in header(text only), footer, and header buttons. Example url: https://www.telerik.com/blogs.
 
Dark Reader doesn't apply on some elements on the main page: telerik.com/$