### PR TITLE
Dynamic Theme - fix Waterfox Classic compatibility

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -124,7 +124,7 @@ function createDynamicStyleOverrides() {
 
     updateVariables(getElementCSSVariables(document.documentElement));
 
-    const allStyles = getManageableStyles(document);
+    const allStyles = getManageableStyles(document.documentElement);
 
     const newManagers = allStyles
         .filter((style) => !styleManagers.has(style))


### PR DESCRIPTION
Changes the `getManageableStyles` call in `dynamic-theme/index.ts` for `allStyles` from passing `document` to instead passing `document.documentElement`.

Works around a problem with Waterfox Classic where `node === document` within `getManageableStyles` isn't returning `true` when the `document` is passed in. Relevant line in `getManageableStyles`: https://github.com/darkreader/darkreader/blob/5dec347335641eebaf6e72671e1e2fdacb16f1a3/src/inject/dynamic-theme/style-manager.ts#L57

Passing in the `documentElement` seems to work perfectly, with no adverse effects in other browsers.

Tested on Win10 in Waterfox Classic v2020.05 and it fixed the problem.
Also tested in fresh installs of Chrome v83 and Firefox v77, found no adverse effects from this change.