### PR TITLE
Bugfix for IS_SHADOW_DOM_SUPPORTED

### DIFF
--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -71,7 +71,7 @@ export function isDefinedSelectorSupported() {
     }
 }
 
-export const IS_SHADOW_DOM_SUPPORTED = typeof ShadowRoot !== 'function';
+export const IS_SHADOW_DOM_SUPPORTED = typeof ShadowRoot === 'function';
 
 export function isCSSStyleSheetConstructorSupported() {
     try {


### PR DESCRIPTION
`IS_SHADOW_DOM_SUPPORTED` should return true when ShadowDOM is supported, false otherwise. This was previously backwards.