### PR TITLE
Add an INVERT for bestbuy.com Compare

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -183,6 +183,13 @@ div.orb-nav-section.orb-nav-blocks > a > img
 
 ================================
 
+bestbuy.com
+
+INVERT
+#None > div > section > div.comparison-container.comparison-container-l.legacy-variant
+
+================================
+
 betterexplained.com
 
 NO INVERT


### PR DESCRIPTION
The default is a blinding bright white.  A simple INVERT makes it tolerable.  The default darker color choice was fine for me.