### PR TITLE
Fix for forums.tomshardware.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1348,6 +1348,14 @@ CSS
 
 ================================
 
+forums.tomshardware.com
+
+INVERT
+img[src="/styles/tomshardware/tomshardware/toms-hardware-logo.png"]
+div.trophyShowcase.trophyShowcase--postbit
+
+================================
+
 garmin.com
 
 INVERT


### PR DESCRIPTION
Logo and trophies inversion.

Example page: https://forums.tomshardware.com/threads/meltdown-and-spectre-vulnerabilities-information.3209119/