### PR TITLE
Logo and banner inversion for news.mynavi.jp

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2415,6 +2415,15 @@ CSS
 
 ================================
 
+news.mynavi.jp
+
+INVERT
+.itsearch-head .logo
+.site-header__bnr
+.site-header__logo
+
+================================
+
 news.ycombinator.com
 
 INVERT


### PR DESCRIPTION
![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83942919-261cd680-a822-11ea-9efe-e50db00867e9.png)
![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83942922-2b7a2100-a822-11ea-9b3e-97bb96329c2d.png)

![RG_logo_before_inversion](https://user-images.githubusercontent.com/10338703/83942973-9cb9d400-a822-11ea-8ffc-c72f1bdaf41e.png)
![RG_logo_after_inversion](https://user-images.githubusercontent.com/10338703/83942976-9fb4c480-a822-11ea-9b8f-38451a16ce50.png)

```
news.mynavi.jp

INVERT
.itsearch-head .logo
.site-header__bnr
.site-header__logo
```