### PR TITLE
fix calendar.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -515,6 +515,18 @@ INVERT
 
 ================================
 
+calendar.google.com
+
+CSS
+div[role="checkbox"] > div > div > div {
+    border: 1px solid ${black} !important;
+}
+
+IGNORE INLINE STYLE
+div[role="checkbox"]
+
+================================
+
 cheapshark.com
 
 CSS


### PR DESCRIPTION
It inverts color of checkboxes in
My calendars/Other calendars panels

With Dark Reader disabled:
![Dark Reader disabled](https://i.ibb.co/17kfdZ2/light.png)

With Dark Reader currently:
![Dark Reader currently](https://i.ibb.co/7j7bP3Y/dark-checkboxes.png)

After invert:
![After invert](https://i.ibb.co/stCXyxV/dark.png)
