### PR TITLE
Add an INVERT for bestbuy.com Compare Products - Take 2

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -183,6 +183,14 @@ div.orb-nav-section.orb-nav-blocks > a > img
 
 ================================
 
+bestbuy.com
+
+INVERT
+#None > div > section > div.comparison-container.comparison-container-l.legacy-variant
+.product-container
+
+================================
+
 betterexplained.com
 
 NO INVERT


### PR DESCRIPTION
I messed up the first PR #2741 by deleting the source fork/branch.

The default Compare section when comparing products on bestbuy.com by default is a blinding bright white!

Inverting the `.comparison-container` and `.product-container` makes it tolerable to view.



The default darker color choice was fine for me.