### PR TITLE
Some tweaks to Jupyter notebook inverting

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12,10 +12,6 @@ CSS
 ::placeholder {
     opacity: 0.5 !important;
 }
-.CodeMirror-selected {
-    color: &{selectionForeground} !important;
-    background-color: &{selectionBackground} !important;
-}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2082,7 +2082,8 @@ CSS
     background-color: ${black} !important;
 }
 .CodeMirror-selected {
-    background-color: #1d558f !important;
+    color: &{selectionForeground} !important;
+    background-color: &{selectionBackground} !important;
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12,6 +12,10 @@ CSS
 ::placeholder {
     opacity: 0.5 !important;
 }
+.CodeMirror-selected {
+    color: &{selectionForeground} !important;
+    background-color: &{selectionBackground} !important;
+}
 
 ================================
 
@@ -2080,10 +2084,6 @@ INVERT
 CSS
 .output_area img, .text_cell_render img {
     background-color: ${black} !important;
-}
-.CodeMirror-selected {
-    color: &{selectionForeground} !important;
-    background-color: &{selectionBackground} !important;
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2079,9 +2079,9 @@ INVERT
 
 CSS
 .output_area img, .text_cell_render img {
-    background-color: white !important;
+    background-color: ${black} !important;
 }
-.CodeMirror-selectedtext {
+.CodeMirror-selected {
     background-color: #1d558f !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2072,6 +2072,25 @@ td.c {
 
 ================================
 
+localhost:88*
+
+INVERT
+#ipython_notebook
+
+CSS
+.output_area img, .text_cell_render img {
+    background-color: white !important;
+}
+.CodeMirror-selectedtext {
+    background-color: #1d558f !important;
+}
+
+IGNORE INLINE STYLE
+.output_area img
+.text_cell_render img
+
+================================
+
 magazynbieganie.pl
 
 INVERT


### PR DESCRIPTION
These changes are helpful for me to work with Jupyter notebook with dark reader ON.

* The INVERT is for the Jupyter notebook logo
* CSS is for PNG images (matplotlib axes are black by default) and selected text highlighting
* Ignore output images

I'm not sure whether we are allowed to add localhost links, but the 88XX are the most common ports for local Jupyter notebooks.