### PR TITLE
Fixed wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4288,6 +4288,8 @@ INVERT
 .svg-Wikimedia-logo_black
 .header .branding-box > a > span > img
 .main-footer-menuToggle
+div.post-content.footer-content > h2 > img
+img[src*="Loudspeaker.svg"]
 
 CSS
 div .thumbimage[src$=".png"],


### PR DESCRIPTION
- Inverted loudspeaker thumbnail.
- Wikipedia logo in the footer of mobile version.