### PR TITLE
Background for Kaggle notebook images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1957,6 +1957,18 @@ INVERT
 
 ================================
 
+kaggle*
+
+CSS
+div.output_png img {
+    background-color: ${black} !important;
+}
+
+IGNORE INLINE STYLE
+div.output_png img
+
+================================
+
 keep.google.com
 
 INVERT


### PR DESCRIPTION
I added a white background (in dark mode) so that I can see the graph axes.

I used `kaggle*` instead of `kaggle.com` because kaggle loads notebooks in an iframe with URL something like `kaggleusercontent.com`  

Before: 
![image](https://user-images.githubusercontent.com/17806916/84100100-03282900-a9c0-11ea-8386-df380e4b2eae.png)


After: 
![image](https://user-images.githubusercontent.com/17806916/84100044-e5f35a80-a9bf-11ea-9281-ac07da919bc2.png)
