### PR TITLE
Inverted Pytorch logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3035,6 +3035,14 @@ img[src^="/static/glyphicons/"]
 
 ================================
 
+pytorch.org
+
+INVERT
+#site-logo
+.header-holder:not(.homepage-header)>*>*>.header-logo
+
+================================
+
 quickbase.com
 
 CSS


### PR DESCRIPTION
Inverts the Pytorch logo, specifically on pytorch.org and discuss.pytorch.org

The first selector is for the logo on discuss.pytorch.org
The second selector is a bit convoluted since I had to ignore the logo on the Pytorch homepage, since the logo on that page is already inverted.

Test URLs:
https://discuss.pytorch.org/ (Logo is inverted)
https://pytorch.org/ (Logo NOT inverted)
https://pytorch.org/blog/updates-improvements-to-pytorch-tutorials/ (Logo inverted)
https://pytorch.org/features/ (Logo inverted)