### PR TITLE
Fix for notebook equations in GitHub preview

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3086,6 +3086,14 @@ regex101.com
 INVERT
 canvas
 
+
+================================
+
+render.githubusercontent.com/view/ipynb
+
+INVERT
+img.math
+
 ================================
 
 repl.it


### PR DESCRIPTION
LaTeX equations could not be seen in GitHub notebook previews before due to them being images. This inverts them to be visible again.
The domain filter is set to the default domain GitHub uses to serve their notebook preview from a linked iframe.

Test URL: https://github.com/bentrevett/pytorch-pos-tagging/blob/master/1%20-%20BiLSTM%20for%20PoS%20Tagging.ipynb

Before:
![image](https://user-images.githubusercontent.com/17806916/84242131-40221780-aab5-11ea-9a0f-63d6ef66fbed.png)

After:
![image](https://user-images.githubusercontent.com/17806916/84242207-5a5bf580-aab5-11ea-8418-8591cce88cc2.png)
