### PR TITLE
Fix for fast.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1291,6 +1291,22 @@ img
 
 ================================
 
+fast.com
+
+INVERT
+div.logo
+div.powered-by
+
+CSS
+div.logo {
+    background-image: url("https://fast.com/assets/new-logo-vert-37861c.svg") !important;
+}
+div.powered-by {
+    background-image: url("https://fast.com/assets/poweredby-865a3b.svg") !important
+}
+
+================================
+
 fastmail.com/mail
 
 CSS


### PR DESCRIPTION
- Logo inversions.
- Forced to use default logos rather than blobs.