### PR TITLE
Fixes to BBC Weather icons and text

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -375,9 +375,33 @@ INVERT
 
 ================================
 
+bbc.co.uk/weather
+bbc.com/weather
+
+INVERT
+.orb-nav-section.orb-nav-blocks
+.orb-icon.orb-icon-arrow
+
+CSS
+.wr-icon-weather-type__svg-background, 
+.wr-icon-rain__svg-background,
+.wr-icon-wind-direction__svg-background,
+.wr-icon-gel__svg-background {
+    opacity: 0% !important;
+}
+
+.wr-value--windspeed {
+    color: ${#dad7d2} !important;
+}
+
+.wr-c-environmental-data__icon-text {
+    color: ${#dcd9d4} !important;
+}
+
+================================
+
 bbc.com/news
 bbc.com/sport
-bbc.com/weather
 bbc.com/travel
 bbc.com/capital
 bbc.com/autos


### PR DESCRIPTION
Made it so that the BBC weather (for bbc.co.uk/weather) icons don't have white backgrounds any more, and made the text in the wind speed and pollen, uv, pollution icons dark text so it's readable.

(There's also a tiny fix that makes the results in Detexify inverted)