### PR TITLE
Fix for yandex.*/maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4727,6 +4727,19 @@ img[src*=".png"]
 
 ================================
 
+yandex.*/maps
+
+INVERT
+.content-panel-header__logo
+.whats-here-preview__control-search-icon
+.close-button._color_black._circle
+.business-social-links-view__icon
+.social-share-view_discovery-small
+.social-share-view_discovery-large
+.orgpage-social-links-view__icon
+
+================================
+
 yadi.sk
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4727,6 +4727,14 @@ img[src*=".png"]
 
 ================================
 
+yadi.sk
+
+INVERT
+span.logo.burger-sidebar__logo
+span.logo.burger-sidebar__sidebar-logo
+
+================================
+
 yandex.*/maps
 
 INVERT
@@ -4737,14 +4745,7 @@ INVERT
 .social-share-view_discovery-small
 .social-share-view_discovery-large
 .orgpage-social-links-view__icon
-
-================================
-
-yadi.sk
-
-INVERT
-span.logo.burger-sidebar__logo
-span.logo.burger-sidebar__sidebar-logo
+.map-container > ymaps > ymaps > ymaps > ymaps
 
 ================================
 


### PR DESCRIPTION
Examples: https://yandex.ru/maps/discovery/peterburg-s-otkrytok/, https://yandex.ru/maps/2/saint-petersburg/?ll=30.358177%2C59.928250&mode=poi&poi%5Bpoint%5D=30.359167%2C59.927261&poi%5Buri%5D=ymapsbm1%3A%2F%2Forg%3Foid%3D1105821859&z=13, https://yandex.ru/maps/discovery/luchshie-torgovye-centry-sankt-peterburga/, https://yandex.ru/maps/org/mezhdunarodny_aeroport_pulkovo/1423973195/