### PR TITLE
Added emeraldchat.com/app

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -158,6 +158,7 @@ egee.io
 eggsy.codes
 eleaks.to
 elybeatmaker.com
+emeraldchat.com/app
 emuparadise.me
 energized.pro
 enlightenment.org


### PR DESCRIPTION
You need to either press start or login (after captcha) to see that the /app link is fully dark.