### PR TITLE
Fix for waze.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4322,6 +4322,15 @@ img[alt~="Equation"]
 
 ================================
 
+waze.com
+
+INVERT
+.wm-map__leaflet
+.leaflet-bottom
+.leaflet-popup-content-wrapper
+
+================================
+
 web.archive.org
 
 INVERT


### PR DESCRIPTION
Example: https://www.waze.com/livemap/