### PR TITLE
Remove avatar icon border on gitlab

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1697,10 +1697,10 @@ INVERT
 
 CSS
 :root {
-  --svg-status-bg: #181a1b;
+    --svg-status-bg: #181a1b;
 }
 .avatar, .avatar-container {
-    border: none;
+    border: none !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1699,6 +1699,9 @@ CSS
 :root {
   --svg-status-bg: #181a1b;
 }
+.avatar, .avatar-container {
+    border: none;
+}
 
 ================================
 


### PR DESCRIPTION
In dark mode, the border of avatar icons is visible (gray color). Removing it improves dark mode and has no effect on normal/light mode.