### PR TITLE
github.com - add support for any on-premises github repository

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1606,6 +1606,7 @@ a[href="https://github.com"]
 ================================
 
 github.com
+github.*.com
 
 CSS
 .markdown-body code,


### PR DESCRIPTION
when using Github Enterprise plan (i.e. on-premises installation)
the domain is github.*.com (e.g. github.my-company-domain.com)