### PR TITLE
invert bright home page image for wikidata.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4597,10 +4597,8 @@ INVERT
 
 wikidata.org
 
-CSS
-.wd-mp-headerimage {
-    filter: invert(100%);
-}
+INVERT
+.wd-mp-headerimage
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4595,6 +4595,15 @@ INVERT
 
 ================================
 
+wikidata.org
+
+CSS
+.wd-mp-headerimage {
+    filter: invert(100%);
+}
+
+================================
+
 wikimapia.org
 
 INVERT


### PR DESCRIPTION
dark mode for wikidata.org is quite good but the bright big header image of the homepage needs to be inverted