### PR TITLE
Fix for *.herzen.spb.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -357,6 +357,21 @@ CSS
 
 ================================
 
+atlas.herzen.spb.ru
+guide.herzen.spb.ru
+job.herzen.spb.ru
+
+INVERT
+img[src="/images/logo.png"]
+hr
+
+CSS
+body, .body, table, tbody, tr, td, .corner_bottom {
+    background: none !important;
+}
+
+================================
+
 atlassian.net
 
 CSS


### PR DESCRIPTION
Examples: https://atlas.herzen.spb.ru/, https://guide.herzen.spb.ru/, https://job.herzen.spb.ru/