### PR TITLE
Fix for google.com/maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1774,6 +1774,8 @@ a.gb_xc
 .un1lmc-j4gsHd
 .maps-sprite-settings-languages
 a[href*="about/products"]
+.google-logo
+.watermark
 
 ================================
 


### PR DESCRIPTION
- Invert logo

Before
![](https://i.imgur.com/FBaBvOI.png)
![](https://i.imgur.com/OxiQLzn.png)

After
![](https://i.imgur.com/sWHFEvd.png)
![](https://i.imgur.com/JOtpjrt.png)