### PR TITLE
Remove discord sites from dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -127,8 +127,6 @@ digital.fashion
 disasm.pro
 disboard.org
 discord.bots.gg
-discord.com
-discordapp.com
 discordtemplates.com
 discourse.automationgame.com
 discourse.cataclysmdda.org


### PR DESCRIPTION
Because on some sites it is not actually dark
For example:
https://blog.discord.com
https://status.discord.com/
https://support.discord.com/hc/en-us

and more