### PR TITLE
Excluded label colors

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2388,6 +2388,14 @@ CSS
     background-color: transparent !important
 }
 
+IGNORE INLINE STYLE
+.at
+.au
+.av
+.qj
+.hU.hM
+.hV.hM
+
 ================================
 
 mapa-turystyczna.pl


### PR DESCRIPTION
Label colors are chosen to stand out and have a meaning, and should stay the same regardless of the theme.
This change prevents the colors from being skewed.

Inbox (`.at`, `.au`, `.av` classes):
![image](https://user-images.githubusercontent.com/65984816/85186034-65760900-b29f-11ea-823f-f8d513a94883.png)
Also includes the colors in the category list (`.qj`):
![image](https://user-images.githubusercontent.com/65984816/85186083-aa01a480-b29f-11ea-9416-d5a8602ebc71.png)
And the label in mail headers (`.hU.hM`, `.hV.hM`):
![image](https://user-images.githubusercontent.com/65984816/85186125-dfa68d80-b29f-11ea-901e-4cd8c14b066c.png)
