### PR TITLE
More label color fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2395,6 +2395,9 @@ IGNORE INLINE STYLE
 .qj
 .hU.hM
 .hV.hM
+.ajZ-Jt
+.aH5
+.JA-Kn-Jr-Kw-Jt
 
 ================================
 


### PR DESCRIPTION
Forgot to change a few more places.
Related to this (https://github.com/darkreader/darkreader/pull/2888).

`.ajZ-Jt` is for custom color choice:
![image](https://user-images.githubusercontent.com/65984816/85203060-9db72f00-b313-11ea-8522-c0243e26a1e1.png)
`.aH5` is this:
![image](https://user-images.githubusercontent.com/65984816/85203074-b58eb300-b313-11ea-8cd6-3213c08a15fe.png)
and `.JA-Kn-Jr-Kw-Jt` is for choosing presets:
![image](https://user-images.githubusercontent.com/65984816/85203087-ca6b4680-b313-11ea-9358-d0d85f2c00e8.png)
