### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -991,6 +991,7 @@ img[src$="googlelogo_dark_clr_74x24px.svg"]
 .exportUnderline
 .freebirdMaterialIconIconEl
 .quantumWizTogglePapercheckboxCheckMark
+.docs-gm #docs-titlebar-share-client-button .jfk-button .scb-button-icon
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
- Invert share button on google presentations