### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -991,7 +991,7 @@ img[src$="googlelogo_dark_clr_74x24px.svg"]
 .exportUnderline
 .freebirdMaterialIconIconEl
 .quantumWizTogglePapercheckboxCheckMark
-.docs-gm #docs-titlebar-share-client-button .jfk-button .scb-button-icon
+.docs-gm #docs-titlebar-share-client-button .jfk-button .scb-button-icon:not(.scb-private-icon-white)
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
- Do not target already white icons. (Google documents's share icon is white by default however Google's presentation is not) They hold the `CSS Selector`