### PR TITLE
Fix font-family for github.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1703,6 +1703,9 @@ CSS
 .jfk-bubble, .octotree-sidebar, .cc-pr__logo, .cc-octicon, #network canvas, img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
 }
+.blob-code-inner, .blob-code-inner > *, .CodeMirror pre > span, .CodeMirror-linenumber {
+    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Force font-family so font-settings won't override codeblocks.
- Resolves #2909 