### PR TITLE
fix for pyszne.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3284,7 +3284,7 @@ INVERT
 .gm-style
 
 CSS
-.cover, .logowrapper, .restaurant-logo__inner, .orderoverview__restaurant-image-container-inner {
+.cover img, .logowrapper, .restaurant-logo__inner, .orderoverview__restaurant-image-container-inner {
     background-color: rgba(255, 255, 255, 0.5) !important;
     background-blend-mode: color;
 }


### PR DESCRIPTION
Fix for dark logos. Added img after .cover to work it as it should.
![obraz](https://user-images.githubusercontent.com/56877029/85403271-5d4af180-b55d-11ea-9207-de767b77b16e.png)
