### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1375,6 +1375,9 @@ img[src*="map"], [style*="map"],
 .sp_ENb4WaRga4J {
     background-image: url(/rsrc.php/v3/yy/r/8OUMcyHbiu8.png) !important;
 }
+.sp_zT9aHJDYI11 {
+    background-image: url(/rsrc.php/v3/yB/r/99Zvs7cEY2d.png) !important;
+}
 
 IGNORE INLINE STYLE
 [role="button"] svg


### PR DESCRIPTION
Fix for closing picture gallery "X". Force to not use inverted blob.
![obraz](https://user-images.githubusercontent.com/56877029/85407098-0ba56580-b563-11ea-8509-d5af2ac78258.png)


