### PR TITLE
Fix for wikimedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4711,6 +4711,7 @@ wikimedia.org
 
 INVERT
 img.graphite-graph
+img[src="images/black.png"]
 
 ================================
 


### PR DESCRIPTION
- Invert black circle so it becomes visible