### PR TITLE
Fix for discord.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -970,6 +970,10 @@ CSS
 nav[aria-label="Servers sidebar"] foreignObject {
     mask: none !important;
     border-radius: 100% !important;
+    transition: all .5s;
+}
+nav[aria-label="Servers sidebar"] foreignObject:hover {
+    border-radius: 30% !important;                                                                                                                                                                                                                                       
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -964,6 +964,16 @@ CSS
 
 ================================
 
+discord.com
+
+CSS
+nav[aria-label="Servers sidebar"] foreignObject {
+    mask: none !important;
+    border-radius: 100% !important;
+}
+
+================================
+
 dnslytics.com
 
 INVERT


### PR DESCRIPTION
- Makes icons in server sidebar visible due to a `dimming` mask 
- Resolves #2925