### PR TITLE
Fix for Fontspring.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1552,6 +1552,12 @@ INVERT
 .fiu-header__branding
 .fiu-sample-list__item img
 .fiu-gallery-head__text img
+================================
+
+fontspring.com
+
+INVERT
+.grid6 .fullwidth
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1552,6 +1552,7 @@ INVERT
 .fiu-header__branding
 .fiu-sample-list__item img
 .fiu-gallery-head__text img
+
 ================================
 
 fontspring.com

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -615,6 +615,13 @@ img
 
 ================================
 
+fontspring.com
+
+NO INVERT
+.grid6 .fullwidth
+
+================================
+
 forum.unity.com
 
 INVERT


### PR DESCRIPTION
Includes dynamic and filter/filter+ fixes
Properly renders the font preview images as white instead of black