### PR TITLE
discordapp.com is not dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -138,7 +138,6 @@ discord.com/developers
 discord.com/invite
 discord.com/login
 discord.com/register
-discordapp.com
 discordtemplates.com
 discourse.automationgame.com
 discourse.cataclysmdda.org


### PR DESCRIPTION
- Discord has grown up and moved permantly to discord.com