### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1443,6 +1443,9 @@ img[src*="map"], [style*="map"],
 .sp_zT9aHJDYI11 {
     background-image: url(/rsrc.php/v3/yB/r/99Zvs7cEY2d.png) !important;
 }
+.sp_58eJ3V9_er3 {
+    background-image: url(/rsrc.php/v3/yd/r/jUiHkRoni5c.png) !important;
+}
 
 IGNORE INLINE STYLE
 [role="button"] svg


### PR DESCRIPTION
Fix to not use blob on maximize movie icon.
![obraz](https://user-images.githubusercontent.com/56877029/86520572-44d4b400-be46-11ea-965e-3e63bf912aa6.png)
