### PR TITLE
Fix for prostovpn.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3454,6 +3454,15 @@ INVERT
 
 ================================
 
+prostovpn.org
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
 pyszne.pl
 
 INVERT


### PR DESCRIPTION
Exaples: prostovpn.org, antizapret.prostovpn.org