### PR TITLE
fix for confluence

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -767,6 +767,16 @@ INVERT
 
 ================================
 
+confluence.*
+
+CSS
+.geDiagramContainer rect,
+.geDiagramContainer path {
+    filter: brightness(60%);
+}
+
+================================
+
 cookiepedia.co.uk
 
 INVERT


### PR DESCRIPTION
Darkening rect and path in diagrams to be more readable.
Without fix:
![obraz](https://user-images.githubusercontent.com/56877029/86573740-199cb280-bf75-11ea-8d77-5f2bd727ecc8.png)
After fix:
![obraz](https://user-images.githubusercontent.com/56877029/86573801-2caf8280-bf75-11ea-8ba8-b488ddbc67d1.png)
