### PR TITLE
Add .vis-network class to global INVERT list

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2,6 +2,7 @@
 
 INVERT
 .jfk-bubble.gtx-bubble
+.vis-network
 
 CSS
 .vimvixen-hint {


### PR DESCRIPTION
This fixes vis-js [vis-network](https://visjs.github.io/vis-network/docs/network/) renders (In [[x]](https://visjs.github.io/vis-network/examples/network/edgeStyles/colors.html) many [[x]](https://visjs.github.io/vis-network/examples/network/data/scalingCustom.html) cases [[x]](https://visjs.github.io/vis-network/examples/network/edgeStyles/selfReference.html) ) such that text inverts correctly. I haven't examined all the edge cases, but this appears to improve readability in all cases I've seen, and not detract in any instance so far.

Examples:

- [graph with colours](https://visjs.github.io/vis-network/examples/network/edgeStyles/colors.html)
  - vanilla: 
   ![vanilla graph with colours](https://user-images.githubusercontent.com/39424834/86703019-d4e94800-c056-11ea-9d61-1cd6cf74f56e.png)
  - no invert:
    ![old dark mode graph with colours](https://user-images.githubusercontent.com/39424834/86703356-242f7880-c057-11ea-97e2-218d98017bcf.png)
  - invert:
    ![inverted graph with colours](https://user-images.githubusercontent.com/39424834/86703535-517c2680-c057-11ea-9369-5c6f83c34fa8.png)

  
