### PR TITLE
emojipedia.org is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -173,6 +173,7 @@ eleaks.to
 elybeatmaker.com
 emanuelemilella.com
 emeraldchat.com/app
+emojipedia.org
 emuparadise.me
 energized.pro
 enlightenment.org


### PR DESCRIPTION
Add `emojipedia.org` ([https://emojipedia.org](https://emojipedia.org)) to blacklist.