### PR TITLE
Add more dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -606,3 +606,14 @@ zerodayinitiative.com
 zerotier.com
 zoomquilt.org
 zoomquilt2.com
+learn.netdata.cloud
+macrumors.com
+gridcoin.us
+dslreports.com
+nyaa.si
+docs.microsoft.com
+deviantart.com
+*.slack.com
+thebestmotherfucking.website
+duckduckgo.com
+southxchange.com/

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,3 +1,4 @@
+*.slack.com
 0x00sec.org
 12bytes.org
 1337x.to
@@ -128,6 +129,7 @@ dev.lemmy.ml
 devanbuggay.com
 devart.withgoogle.com
 developerinsider.co
+deviantart.com
 di.fm
 diablo3.com
 diablo3ladder.com
@@ -151,6 +153,7 @@ discuss.noisebridge.info
 disneyplus.com
 dlive.tv
 docs.docker.com
+docs.microsoft.com
 dodi-repacks.site
 donationalerts.com
 dota2.com
@@ -163,6 +166,8 @@ draculatheme.com
 draftkings.com
 drakewars.com
 drunkenslug.com
+dslreports.com
+duckduckgo.com
 duckychannel.com.tw
 duelingnexus.com
 ecobee.com/consumerportal
@@ -242,6 +247,7 @@ graydon2.dreamwidth.org
 grc.arikado.ru
 greatview.video
 greenmangaming.com
+gridcoin.us
 groovy.bot
 gtaforums.com
 gunshipmusic.com
@@ -312,6 +318,7 @@ kulbachny.com
 lainchan.org
 leakedsource.ru
 leakth.is
+learn.netdata.cloud
 lecantiche.com
 letterboxd.com
 lightweightpdf.com
@@ -323,6 +330,7 @@ lordofthemanor.io
 m2v.ru
 m4rtyr.github.io
 macbb.org
+macrumors.com
 magnetoo.io
 magoware.tv
 marte.dev
@@ -370,6 +378,7 @@ noisebridge.net
 notebooks.quantumstat.com
 null.media
 nulledbb.com
+nyaa.si
 obsproject.com
 offshorecorptalk.com
 ogusers.com
@@ -481,6 +490,7 @@ skyblocknetwork.com
 slay.one
 slider.kz
 snazzah.com
+southxchange.com
 spacebattles.com
 spacespacespaaace.space
 speedtest.net
@@ -523,6 +533,7 @@ textfiles.com
 tf2mart.net
 the-eye.eu
 thealiendrew.github.io
+thebestmotherfucking.website
 thetatoken.org
 thiscatdoesnotexist.com
 thispersondoesnotexist.com
@@ -606,14 +617,3 @@ zerodayinitiative.com
 zerotier.com
 zoomquilt.org
 zoomquilt2.com
-learn.netdata.cloud
-macrumors.com
-gridcoin.us
-dslreports.com
-nyaa.si
-docs.microsoft.com
-deviantart.com
-*.slack.com
-thebestmotherfucking.website
-duckduckgo.com
-southxchange.com/


### PR DESCRIPTION
Natively Dark:
* gridcoin.us
* deviantart.com

Use prefers-color-scheme:
* learn.netdata.cloud
* macrumors.com
* docs.microsoft.com
* thebestmotherfucking.website
* duckduckgo.com

Have dark theme as an option:
* dslreports.com
* nyaa.si
* *.slack.com
* southxchange.com