### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3691,6 +3691,15 @@ CSS
 
 ================================
 
+rtlnieuws.nl
+
+CSS
+section {
+    background-image: none !important;
+}
+
+================================
+
 runkit.com
 
 INVERT


### PR DESCRIPTION
rtlnieuws.nl

CSS
section {
    background-image: none !important;
}

They placed a section in a section and colored is white. Very anoing when it is text.