### PR TITLE
Fix for gorod.gov.spb.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1942,6 +1942,17 @@ a[href*="about/products"]
 
 ================================
 
+gorod.gov.spb.ru
+
+INVERT
+.header__logo
+.reason__icon
+.map-with-address
+.problem-details__map
+.problem-map-page__map
+
+================================
+
 gramota.ru
 
 INVERT


### PR DESCRIPTION
Examples: https://gorod.gov.spb.ru/, https://gorod.gov.spb.ru/problems/add/?reason=12&category=2&city_object=2, https://gorod.gov.spb.ru/problems/2706511/, https://gorod.gov.spb.ru/problems/2706511/map/