### PR TITLE
Partial fix for Microsoft main logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2827,11 +2827,11 @@ img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/R
 img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4pxBu"]
 img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4pkvE"]
 img[src*="/static/images/inreplyto.svg"]
-img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b"]
+.clogo .cimage
 
 CSS
 .c-logo .c-image {
-    background: ${black} !important;
+    background: transparent !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -665,8 +665,8 @@ cleantechnica.com
 
 CSS
 body {
-    background-image: none !important; 
-	background-color: #1d1e1f !important; 
+    background-image: none !important;
+	background-color: #1d1e1f !important;
 }
 
 ================================
@@ -1028,7 +1028,7 @@ nav[aria-label="Servers sidebar"] foreignObject {
     transition: all .5s;
 }
 nav[aria-label="Servers sidebar"] foreignObject:hover {
-    border-radius: 30% !important;                                                                                                                                                                                                                                       
+    border-radius: 30% !important;
 }
 
 ================================
@@ -1108,10 +1108,10 @@ downloads.khinsider.com
 
 CSS
 body {
-    background: none !important;    
+    background: none !important;
 }
 #faux {
-    background-image: none !important;    
+    background-image: none !important;
 }
 
 ================================
@@ -2828,6 +2828,7 @@ img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/R
 img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4pkvE"]
 img[src*="/static/images/inreplyto.svg"]
 .clogo .cimage
+img[src="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4pndL"]
 
 CSS
 .c-logo .c-image {
@@ -3120,7 +3121,7 @@ notion.so
 
 CSS
 .notion-divider-block div div {
-    border-bottom: 1px solid ${rgba(55, 53, 47, 0.4)} !important;      
+    border-bottom: 1px solid ${rgba(55, 53, 47, 0.4)} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2827,6 +2827,7 @@ img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/R
 img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4pxBu"]
 img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE4pkvE"]
 img[src*="/static/images/inreplyto.svg"]
+img[src*="img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b"]
 
 CSS
 .c-logo .c-image {


### PR DESCRIPTION
![Microsoft Logo](https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE1Mu3b?ver=5c31)
[microsoft.com](https://microsoft.com)
Inverting the logo kind of works, but the background is black, not gray like the rest of the page (and it is a PNG, so I don't know how to fix background with CSS).

**Also,** when using light mode the image is now broken again, but the opposite of what it was before. I don't know how to fix this, it would be nice to just remove the background.

**Also also,** it seems like people have attempted to fix the Microsoft logo at least three times before, but they keep updating the image version. This is more of a temporary fix, I might see if I can do a more complex selector later.