### PR TITLE
rust.facepunch.com is dark by default

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -452,6 +452,7 @@ reveddit.com
 robofight.io
 rtbyte.xyz
 runicgames.com
+rust.facepunch.com
 sa-mp.com
 sabato.studio
 sanctum.geek.nz/arabesque


### PR DESCRIPTION
Adding "rust.facepunch.com" to global darklist