### PR TITLE
Fix Styling for virustotal

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4847,6 +4847,15 @@ body {
 
 ================================
 
+virustotal.com
+
+CSS
+vt-ui-file-card{
+    background-color: {black} !important;
+}
+
+================================
+
 vrt.be/vrtnws
 
 INVERT


### PR DESCRIPTION
There was an issue with dark mode of Virustotal where all the cards were shown as white. This change will take care of that issue. 