### PR TITLE
fix for olx.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3259,6 +3259,18 @@ CSS
 
 ================================
 
+olx.pl
+
+CSS
+.cat-icon-628 {
+    background-image: url(https://static.olx.pl/static/olxpl/packed/img/2f828dab38aaebec334f341d5246c125a2.png) !important;
+}
+.cat-icon-87 {
+    background-image: url(https://static.olx.pl/static/olxpl/packed/img/2fe929a474b25c02ed8d46f6b4191f56c2.png) !important;
+}
+
+================================
+
 omnicalculator.com
 
 INVERT


### PR DESCRIPTION
Fix for 2 category icons not shown.

Before:
![obraz](https://user-images.githubusercontent.com/56877029/87705118-b34a3800-c79d-11ea-82fd-c92491c51f57.png)

After:
![obraz](https://user-images.githubusercontent.com/56877029/87705158-c52bdb00-c79d-11ea-8784-e5923483dc93.png)
