### PR TITLE
added fix for bitwit.tech into dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -528,6 +528,54 @@ a[href="/product"]
 
 ================================
 
+bitwit.tech
+
+CSS
+.svg-primary {
+    fill: #375D69 !important;
+}
+.svg-primary-light {
+    fill: #4A7F8F !important;
+}
+.svg-primary-dark {
+    fill: #28444D !important;
+}
+.svg-secondary {
+    fill: #B88399 !important;
+}
+.svg-secondary-light {
+    fill: #E8A9C4 !important;
+}
+.svg-secondary-dark {
+    fill: #825F6E !important;
+}
+.svg-light {
+    fill: #ADCED9 !important;
+}
+.svg-outline {
+    fill: none !important;
+    stroke: #000000 !important;
+}
+.svg-primary-outline {
+    fill: none !important;
+    stroke: #ADCED9 !important;
+}
+.svg-secondary-outline {
+    fill: none !important;
+    stroke: #375D69 !important;
+}
+.theme-light {
+    display: none !important;
+}
+.theme-dark {
+    display: none !important;
+}
+.theme-darkreader {
+    display: block !important;
+}
+
+================================
+
 blog.cloudflare.com
 
 CSS


### PR DESCRIPTION
Added some CSS to fix the SVG illustrations on the site.  The site does have global CSS variables for colors but Dark Reader's default colors override them even when I use !important in the Dev tools. However, Dark Reader does a good enough job that this really isn't an issue.