### PR TITLE
Fix dynamic style bug for Github contribution display

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1903,21 +1903,21 @@ CSS
     fill: ${#ebedf0} !important;
     background-color: ${#ebedf0} !important;
 }
-.day[fill="#c6e48b"], .legend li[style*="background-color: rgb(198, 228, 139)"] {
-    fill: ${#c6d4cb} !important;
-    background-color: ${#c6d4cb} !important;
+.day[fill="#9be9a8"], .legend li[style*="background-color: rgb(155, 233, 168)"] {
+    fill: ${#9be9a8} !important;
+    background-color: ${#9be9a8} !important;
 }
-.day[fill="#7bc96f"], .legend li[style*="background-color: rgb(123, 201, 111)"] {
-    fill: ${#7bb97f} !important;
-    background-color: ${#7bb97f} !important;
+.day[fill="#40c463"], .legend li[style*="background-color: rgb(64, 196, 99)"] {
+    fill: ${#40c463} !important;
+    background-color: ${#40c463} !important;
 }
-.day[fill="#239a3b"], .legend li[style*="background-color: rgb(35, 154, 59)"] {
-    fill: ${#238a3b} !important;
-    background-color: ${#238a3b} !important;
+.day[fill="#30a14e"], .legend li[style*="background-color: rgb(48, 161, 78)"] {
+    fill: ${#30a14e} !important;
+    background-color: ${#30a14e} !important;
 }
-.day[fill="#196127"], .legend li[style*="background-color: rgb(25, 97, 39)"] {
-    fill: ${#196127} !important;
-    background-color: ${#196127} !important;
+.day[fill="#216e39"], .legend li[style*="background-color: rgb(33, 110, 57)"] {
+    fill: ${#216e39} !important;
+    background-color: ${#216e39} !important;
 }
 .blob-num:not(.cc-coverage-covered-border):not(.cc-coverage-missed-border) {
     border-right: 0 !important;


### PR DESCRIPTION
Colors of contribution icons do not seem good.

Using the latest version 4.9.15, it looks like this. Colors are hard to distinguish and are not corresponding with colors on the axis legend bar below.
![Before Fix](https://user-images.githubusercontent.com/50290471/87914917-0543d400-caa4-11ea-8f80-620124656301.png)

And I find out it's because CSS selectors are trying to catch the wrong colors in the dynamic config for github.com. (Maybe those colors were right at some time, but Github changed them later on.)
Anyway, I replaced them with colors that I found is applying to the icons. After the fix, the contribution displayer looks like the snapshot below.
![After Fix](https://user-images.githubusercontent.com/50290471/87915953-65874580-caa5-11ea-99af-29f3da166d86.png)