### PR TITLE
fix for last.fm

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2507,7 +2507,6 @@ div#publisherDetails.logo
 last.fm
 
 INVERT
-.header-new-love-button::before
 .resource-external-link--homepage::before
 
 CSS


### PR DESCRIPTION
Remove invest for heart icon.
Now it works back without invert needed.
![obraz](https://user-images.githubusercontent.com/56877029/88285839-12550300-ccf0-11ea-8e90-ddebc4d9e201.png)
