### PR TITLE
background fix for express.js documentation

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1373,6 +1373,15 @@ canvas
 
 ================================
 
+expressjs.com
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
 facebook.com
 
 INVERT


### PR DESCRIPTION
The express.js documentation has a looping background image that gets inverted and makes text harder to read, this disables the background image entirely since it also doesn't make a difference in light mode.