### PR TITLE
Improve testing locales

### DIFF
--- a/tests/config/locales.tests.ts
+++ b/tests/config/locales.tests.ts
@@ -1,65 +1,46 @@
-import {readFile as fsReadFile, readdir as fsReadDir} from 'fs';
+import {readFileSync as fsReadFile, readdirSync as fsReadDir} from 'fs';
 import {resolve as resolvePath} from 'path';
 
-function readDir(dir) {
-    return new Promise<string[]>((resolve, reject) => {
-        fsReadDir(resolvePath(__dirname, dir), (err, files) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(files);
-        });
-    });
+function readDir(dir: string) {
+    return fsReadDir(resolvePath(__dirname, dir));
 }
 
-function readLocale(name) {
-    return new Promise<string>((resolve, reject) => {
-        fsReadFile(resolvePath(__dirname, '../../src/_locales/', name), {encoding: 'utf-8'}, (err, data) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(data);
-        });
-    });
+function readLocale(name: string) {
+    return fsReadFile(resolvePath(__dirname, '../../src/_locales/', name), {encoding: 'utf-8'});
 }
 
-test('Locales', async () => {
-    const files = await readDir('../../src/_locales');
-    const enLocale = await readLocale('en.config');
+describe('Locales', () => {
+    const files = readDir('../../src/_locales');
+    const enLocale = readLocale('en.config');
     const enLines = enLocale.split('\n');
-    const locales: string[] = [];
-    for (const file of files) {
-        const locale = await readLocale(file);
-        locales.push(locale);
-    }
 
-    function compareLinesToEnLocale(predicate: (en: string, loc: string) => boolean) {
-        return locales.every((loc, j) => {
-            const lines = loc.split('\n');
-            for (let i = 0; i < Math.min(lines.length, enLines.length); i++) {
-                if (!predicate(enLines[i], lines[i])) {
-                    console.error(`${files[j]}, line ${i + 1}`);
-                    return false;
-                }
+    function compareLinesToEnLocale(loc: string, predicate: (en: string, loc: string) => boolean) {
+        const lines = loc.split('\n');
+        for (let i = 0, len = Math.min(lines.length, enLines.length); i < len; i++) {
+            if (!predicate(enLines[i], lines[i])) {
+                console.error(`${loc}, line ${i + 1}`);
+                return false;
             }
-            return true;
-        });
+        }
+        return true;
     }
 
-    // Line count is the same
-    expect(locales.every((loc) => loc.split('\n').length === enLines.length)).toBe(true);
+    it.each(files)('%s', (file) => {
+        const locale = readLocale(file);
 
-    // Locale ends with new line
-    expect(locales.every((loc) => loc.endsWith('\n')));
+        // Line count is the same
+        expect(locale.split('\n').length).toEqual(enLines.length);
 
-    // Line spaces are the same
-    expect(compareLinesToEnLocale((en, loc) => !en === !loc)).toBe(true);
+        // Locale ends with new line
+        expect(locale.endsWith('\n')).toBe(true);
 
-    // Message codes are on the same positions
-    expect(compareLinesToEnLocale((en, loc) => !en.startsWith('@') || (en.startsWith('@') && en === loc))).toBe(true);
+        // Line spaces are the same
+        expect(compareLinesToEnLocale(locale, (en, loc) => !en === !loc)).toBe(true);
 
-    // No extra whitespace
-    expect(compareLinesToEnLocale((en, loc) => loc.trim() === loc)).toBe(true);
+        // Message codes are on the same positions
+        expect(compareLinesToEnLocale(locale, (en, loc) => !en.startsWith('@') || (en.startsWith('@') && en === loc))).toBe(true);
+
+        // No extra whitespace
+        expect(compareLinesToEnLocale(locale, (en, loc) => loc.trim() === loc)).toBe(true);
+    });
 });


### PR DESCRIPTION
Improves the feedback from locales.test.js.

Before:

Something wrong... Somewhere 🤔 

<img width="904" alt="Zrzut ekranu 2020-07-26 o 12 42 40" src="https://user-images.githubusercontent.com/5426427/88477373-b680b900-cf3f-11ea-9a7a-b8a643ff5377.png">

After:

Oh! These locales are wrong.

<img width="904" alt="Zrzut ekranu 2020-07-26 o 12 57 29" src="https://user-images.githubusercontent.com/5426427/88477379-c1d3e480-cf3f-11ea-9d99-32039b9c0f36.png">

But what precisely?

<img width="904" alt="obraz" src="https://user-images.githubusercontent.com/5426427/88477394-e334d080-cf3f-11ea-967b-0d1ddadad5d3.png">


