### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1563,7 +1563,8 @@ a[role="link"] > i.hu5pjgll, ._3w97 {
 img[src*="/map"], [style*="map"],
 ._8bb_ img[src*="/map"], ._8bb_ [style*="map"],
 img[src*="mapy.cz"], ._8bb_ img[src*="mapy.cz"],
-img[src*="%2Fmap"], ._8bb_ img[src*="%2Fmap"] {
+img[src*="%2Fmap"], ._8bb_ img[src*="%2Fmap"],
+img[src*="map.php"], ._8bb_ img[src*="map.php"] {
     filter: invert(100%) hue-rotate(180deg) !important;
 }
 .q2y6ezfg, .mkbloq8g {


### PR DESCRIPTION
One more map to invert.
You can check https://www.facebook.com/pages/Skatepark-Bielsko-Bia%C5%82a-B%C5%82onie/190062067706569?rf=378478895952915

Map on the page not inverted 'cause previous fixes.