### PR TITLE
Fix for Discord

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -141,6 +141,7 @@ digital.fashion
 disasm.pro
 disboard.org
 discord.bots.gg
+discord.com/app
 discord.com/channels
 discord.com/developers
 discord.com/invite


### PR DESCRIPTION
- Dark Site List ignored for Discord because of the dynamic URL change