### PR TITLE
fix for relive.cc

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3902,6 +3902,16 @@ canvas
 
 ================================
 
+relive.cc
+
+INVERT
+img[src*="logo-relive"]
+
+IGNORE IMAGE ANALYSIS
+.email-button i
+
+================================
+
 render.githubusercontent.com/view/ipynb
 
 INVERT


### PR DESCRIPTION
Logo invert + mail icon blob disable.

Link if you want to check: https://www.relive.cc/view/vmqXoM3pNL6