### PR TITLE
Fixed NASA JPL logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2486,6 +2486,15 @@ INVERT
 
 ================================
 
+jpl.nasa.gov
+
+CSS
+.brand_area {
+   background-image: url("https://www.jpl.nasa.gov/assets/images/logo_nasa_trio_white@2x.png") !important;
+}
+
+================================
+
 jsdelivr.com
 
 INVERT


### PR DESCRIPTION
Instead of inverting the black image to white and mess up the colors, force it to use the provided white image