### PR TITLE
Fix for Karamel extension (youtube.com)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5749,6 +5749,9 @@ INVERT
 
 youtube.com
 
+INVERT
+#tube-mount .b img
+
 CSS
 html[hide-scrollbar] ::-webkit-scrollbar {
     display: none !important;


### PR DESCRIPTION
[Karamel](https://chrome.google.com/webstore/detail/karamel-view-reddit-comme/halllmdjninjohpckldgkaolbhgkfnpe?hl=en) is an extension that shows reddit comments in YouTube.

The button to activate the extension isn't visible, so this fixes that.

Before:
![msedge_7k8FqtPh0L](https://user-images.githubusercontent.com/46883293/88753143-1f735700-d121-11ea-8987-a8b3a1b4f048.png)
After:
![msedge_EIEKY8kXKy](https://user-images.githubusercontent.com/46883293/88753149-2306de00-d121-11ea-8dd1-2717b58d96cb.png)
