### PR TITLE
Fixes for youtube.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5776,6 +5776,9 @@ html[hide-scrollbar] ::-webkit-scrollbar {
 #like-bar {
     background-color: ${rgb(144, 144, 144)} !important;
 }
+#search-icon-legacy.ytd-searchbox {
+    border: 1px solid var(--ytd-searchbox-legacy-border-color);
+}
 yt-formatted-string.ytd-video-primary-info-renderer {
     color: ${black} !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5777,7 +5777,7 @@ html[hide-scrollbar] ::-webkit-scrollbar {
     background-color: ${rgb(144, 144, 144)} !important;
 }
 #search-icon-legacy.ytd-searchbox {
-    border: 1px solid var(--ytd-searchbox-legacy-border-color);
+    border: 1px solid var(--ytd-searchbox-legacy-border-color) !important;
 }
 yt-formatted-string.ytd-video-primary-info-renderer {
     color: ${black} !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5948,6 +5948,12 @@ html:not(.style-scope) {
     --yt-spec-general-background-b: ${#f1f1f1} !important;
     --yt-spec-general-background-c: ${#e9e9e9} !important;
 }
+.ytp-hover-progress-light {
+    background-color: rgba(255,255,255,.5) !important;
+}
+.ytp-progress-list {
+    background-color: rgba(255,255,255,.2) !important;
+}
 .ytp-volume-slider-handle {
     background-color: white !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6009,6 +6009,12 @@ paper-button.ytd-subscribe-button-renderer[subscribed] {
 .ytp-load-progress {
     background: rgba(255,255,255,0.3) !important;
 }
+yt-chip-cloud-chip-renderer {
+    background-color: rgba(255,255,255,0.05) !important;
+}
+yt-chip-cloud-chip-renderer.iron-selected {
+    background-color: rgba(255,255,255,0.2) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6015,6 +6015,9 @@ yt-chip-cloud-chip-renderer {
 yt-chip-cloud-chip-renderer.iron-selected {
     background-color: rgba(255,255,255,0.2) !important;
 }
+paper-item[aria-selected="true"] {
+    background-color: rgba(255,255,255,0.2) !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Keep the same progress bar colors from light mode.

This makes it more visible, especially for videos with multiple chapters.

> Before
> ![msedge_UNWigpD2BP](https://user-images.githubusercontent.com/46883293/88876995-1e5a2c80-d1ea-11ea-8802-b56784cc5292.png)

> After
> ![msedge_rghmMRV23U](https://user-images.githubusercontent.com/46883293/88877001-20bc8680-d1ea-11ea-85d9-384c55603300.png)

---

- Make search button border same as the search box so it doesn't stick out.

> Before
> ![msedge_AwHGTXYaWo](https://user-images.githubusercontent.com/46883293/88879068-ff11ce00-d1ee-11ea-8285-4d2b2121012f.png)

> After
> ![msedge_LcvYJAj7tI](https://user-images.githubusercontent.com/46883293/88879100-0933cc80-d1ef-11ea-854e-379c3cf1f54f.png)

---

- Fix homepage chip selectors.

> Before
> ![msedge_ZaJXmT4FqL](https://user-images.githubusercontent.com/46883293/88893219-a4d33600-d20b-11ea-8132-94b8be01def3.png)

> After
> ![msedge_vGeBQmsFys](https://user-images.githubusercontent.com/46883293/88893232-a997ea00-d20b-11ea-966c-8d05c3a54f0d.png)

---

- Fix sidebar selection highlight

> Before
> ![msedge_mLHp4k8YpR](https://user-images.githubusercontent.com/46883293/88897027-46f51d00-d210-11ea-819b-2cf5f9130a1b.png)

> After
> ![msedge_OLYHRjeHCu](https://user-images.githubusercontent.com/46883293/88897052-4eb4c180-d210-11ea-8dfa-da1e461c6205.png)



