### PR TITLE
Fix for goplay.anontpp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2069,6 +2069,17 @@ a[href*="about/products"]
 
 ================================
 
+goplay.anontpp.com
+
+INVERT
+img[src*="download.svg"]
+img[src*="cast.png"]
+img[src*="bookmark.png"]
+.jw-slider-container
+.jw-time-tip::after
+
+================================
+
 gorod.gov.spb.ru
 
 INVERT


### PR DESCRIPTION
- Invert download, cast, and bookmark icons.
- Invert player progress bar for visibility.

The site is only accessible via an access token, so below are screenshots of the changes.

> Before
> ![msedge_cB0X99IQYJ](https://user-images.githubusercontent.com/46883293/88881564-5ca91900-d1f5-11ea-9be0-8d3bc4d63ffd.png)

> After
> ![msedge_i66haH46t9](https://user-images.githubusercontent.com/46883293/88881590-6894db00-d1f5-11ea-8e1e-513ff2bb2369.png)
