### PR TITLE
Editor color fix in practice.geeksforgeeks.org

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1613,6 +1613,13 @@ img
 
 ================================
 
+practice.geeksforgeeks.org
+
+INVERT
+.ace_dark
+
+================================
+
 prntscr.com
 prnt.sc
 


### PR DESCRIPTION
In the Dark Reader's _Filter_ and _Filter+_ mode, the editor became dull white when it was already in dark mode. I inverted it so it always remain dark.