### PR TITLE
Fix dndbeyond.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1186,21 +1186,13 @@ nav[aria-label="Servers sidebar"] foreignObject:hover {
 dndbeyond.com
 
 CSS
-.mon-stat-block {
+.mon-stat-block,
+.mon-stat-block::before,
+.mon-stat-block::after,
+body {
      background-image: none !important;                                                                                                                                                                                                                                                                                                                                                                            
 }
-.mon-stat-block::before {
-     background-image: none !important;  
-}
-.mon-stat-block::after{
-     background-image: none !important;  
-}
-body {
-     background-image: none !important;
-}
-.more-info::after {
-     border-image: none !important;
-}
+.more-info::after,
 .details-container::after {
      border-image: none !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1183,6 +1183,27 @@ nav[aria-label="Servers sidebar"] foreignObject:hover {
 
 ================================
 
+dndbeyond.com
+
+CSS
+.mon-stat-block {
+     background-image: none !important;                                                                                                                                                                                                                                                                                                                                                                            
+}
+.mon-stat-block::before {
+     background-image: none !important;  
+}
+.mon-stat-block::after{
+     background-image: none !important;  
+}
+body {
+     background-image: none !important;
+}
+.more-info::after {
+     border-image: none !important;
+}
+
+================================
+
 dnslytics.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1201,6 +1201,9 @@ body {
 .more-info::after {
      border-image: none !important;
 }
+.details-container::after {
+     border-image: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
When viewing a monster of item description page, the paper text background got completely garbled. Also fixed the website background image.

Before:
![chrome_2020-08-02_04-38-50](https://user-images.githubusercontent.com/33287665/89119850-5a59ef80-d47f-11ea-9e4a-32adcc38a7d0.png)

After:
![chrome_2020-08-02_05-16-54](https://user-images.githubusercontent.com/33287665/89119858-6b0a6580-d47f-11ea-8bdd-c5b329070a25.png)

