### PR TITLE
Fix a bright icon and a bright label

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2780,7 +2780,6 @@ body {
 mail.google.com
 
 INVERT
-tr.hR
 img.Hl
 img.Hk
 img.Ha

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2781,7 +2781,6 @@ mail.google.com
 
 INVERT
 tr.hR
-div.aCi
 img.Hl
 img.Hk
 img.Ha
@@ -2795,6 +2794,7 @@ img.Ha
 .d-Na-N-M7-JX.d-Na-J3
 .gb_df
 img[src$="google_gsuite"]
+img[src$="profile_mask2.png"]
 .rY>.sa
 .buh
 .qj.qr::before

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2780,6 +2780,8 @@ body {
 mail.google.com
 
 INVERT
+tr.hR
+div.aCi
 img.Hl
 img.Hk
 img.Ha


### PR DESCRIPTION
That two simple additions will fix the bright upper left icon (the people icon) that you see when opening an e-mail plus it fixes the label that you see right in front of the title of the conversation

Before:
![immagine](https://user-images.githubusercontent.com/12186181/89124464-70939a00-d4d7-11ea-972b-c56c7b4c3f50.png)

After:
![immagine](https://user-images.githubusercontent.com/12186181/89124484-9882fd80-d4d7-11ea-8307-957696b1dd05.png)

It'll work on every language of course (I made sure to verify that since it's my first commit of my life)