### PR TITLE
Fix for dota2.gamepedia.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1254,6 +1254,20 @@ CSS
 
 ================================
 
+dota2.gamepedia.com
+
+CSS
+div.vectorTabs li:not(.selected) span,
+div.vectorMenu,
+#p-search {
+    background-color: var(--darkreader-neutral-background) !important
+}
+#right-navigation {
+    background-image: none !important;
+}
+
+================================
+
 downloads.khinsider.com
 
 CSS


### PR DESCRIPTION
- Set right background color to menu.
- Remove white background-image in order to give search the good background-color
- Resolves #3308