### PR TITLE
Another fix for mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2830,6 +2830,7 @@ img.Ha
 .gb_df
 img[src$="google_gsuite"]
 img[src$="profile_mask2.png"]
+img[src$="logo_gmail_lockup_default_1x.png"]
 .rY>.sa
 .buh
 .qj.qr::before


### PR DESCRIPTION
Upper-left corner, invert gmail logo (I think it's more consistent that way)

Before:
![immagine](https://user-images.githubusercontent.com/12186181/89175217-98dad180-d587-11ea-9201-7f2614f53c2d.png)

After:
![immagine](https://user-images.githubusercontent.com/12186181/89175264-b445dc80-d587-11ea-8f88-54694adc1255.png)
