### PR TITLE
fix for google maps timeline

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2145,7 +2145,7 @@ button.section-directions-details-action-button
 div.section-loading-spinner
 a.gb_b > div
 a.gb_xc
-.gm-style img[role="presentation"]:not([src*="v=840"])
+.gm-style img[role="presentation"]:not([src*="v="])
 .i4ewOd-xl07Ob
 .i4ewOd-LQLjdd li::before
 .un1lmc-j4gsHd


### PR DESCRIPTION
fix for inverted satellite view in timeline
![obraz](https://user-images.githubusercontent.com/56877029/89224701-36aabc80-d5d9-11ea-9c63-529fbcb32489.png)
