### PR TITLE
ProMods website

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3920,6 +3920,15 @@ body {
 
 ================================
 
+promods.net
+
+CSS
+html {
+    background-image: none !important;
+}
+
+================================
+
 prostovpn.org
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -676,6 +676,15 @@ nav.pagination {
 
 ================================
 
+blog.promods.net
+
+CSS
+body.custom-background {
+    background: none !important;
+}
+
+================================
+
 blogger.com
 
 INVERT


### PR DESCRIPTION
The website is already light-on-dark, the only fix made is removing the main background image, which interferes with contrast settings.