### PR TITLE
Fix for nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3495,7 +3495,8 @@ CSS
 .css-oylsik,
 .css-nhjhh0 svg,
 .css-18z7m18 svg,
-.css-1q2j1fr svg {
+.css-1q2j1fr svg,
+a[data-testid] > svg {
     fill: ${black} !important;
 }
 


### PR DESCRIPTION
- Add selector to select Logo in articles.
- Resolves #3343