### PR TITLE
Improve 10fastfingers.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -86,7 +86,12 @@ CSS
     background: var(--darkreader-neutral-background) !important;
     color: var(--darkreader-neutral-text) !important;
 }
-body, .container-modified > .row, #practice-main, #top1000-index-container, #text-practice, #content-bg {
+body, 
+.container-modified > .row, 
+#practice-main, 
+#top1000-index-container, 
+#text-practice, 
+#content-bg {
     background: var(--darkreader-neutral-background) !important;
 }
 #main-content-trenner {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -79,14 +79,19 @@ html, body {
 10fastfingers.com
 
 CSS
-body {
-    background-image: none;
-}
 #speedtest-main .hide-time {
     color: transparent !important;
 }
 #inputfield {
-    color: #333 !important;
+    background: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+body, .container-modified > .row, #practice-main, #top1000-index-container, #text-practice, #content-bg {
+    background: var(--darkreader-neutral-background) !important;
+}
+#main-content-trenner {
+    background: var(--darkreader-neutral-background) !important;
+    border-bottom: 1px solid rgb(151, 141, 127) !important;
 }
 
 ================================


### PR DESCRIPTION
1. make text input field dark
1. make all backgrounds dark

I made the backgrounds darker than in #2189 because I find it uncomfortable when the important parts are darker than the background. If this is not something we want to do here, I'm open for discussion.\
These changes also fix the backgrounds of the `text-practice` and `top1000` modes.

### Top 1000 changes (Practice is similar)
![top1000_old](https://user-images.githubusercontent.com/28599611/89640314-9b9f3480-d8af-11ea-8889-4d853e94647d.PNG)
old

![top1000_new](https://user-images.githubusercontent.com/28599611/89640329-a35ed900-d8af-11ea-8863-8f5601e1b80b.PNG)
new

### Typing and general background changes
The missing time is due to another personal customization which has nothing to do with these changes.

![typing_old](https://user-images.githubusercontent.com/28599611/89640335-a659c980-d8af-11ea-8002-3a913d3a1ea8.PNG)
old

![typing_new](https://user-images.githubusercontent.com/28599611/89640337-a78af680-d8af-11ea-9427-827d01584882.PNG)
new