### PR TITLE
Add feedly.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -199,6 +199,7 @@ etlegacy.com
 f.vision
 faceit.com
 factorio.com
+feedly.com
 femto.dev
 femto.pw
 filterblade.xyz


### PR DESCRIPTION
Feedly.com natively supports a dark theme.