### PR TITLE
Fix background of thinkpad/lenovo bbs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -566,7 +566,7 @@ club.lenovo.com.cn
 
 CSS
 body[style] {
-    box-shadow: inset 0px 0px 0px 9999px var(--darkreader-neutral-background); }
+    box-shadow: inset 0px 0px 0px 9999px var(--darkreader-neutral-background);
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -561,6 +561,16 @@ INVERT
 
 ================================
 
+bbs.thinkpad.com
+club.lenovo.com.cn
+
+CSS
+body[style] {
+    box-shadow: inset 0px 0px 0px 9999px var(--darkreader-neutral-background); }
+}
+
+================================
+
 bfi.org.uk
 
 INVERT


### PR DESCRIPTION
There is a `!important` style to set background on `<body>` tag, so I managed to workaround it in an ugly way.