### PR TITLE
Fix for wiki.archlinux.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5584,6 +5584,15 @@ img[src="//cdnassets.com/ui/resellerdata/120000_149999/129394/supersite2/supersi
 
 ================================
 
+wiki.archlinux.org
+
+CSS
+.mw-body {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 wiki.mozilla.org
 
 CSS


### PR DESCRIPTION
- Fix text color.

It's unstable without this fix (often unreadable on first visit, but works correctly after a refresh, etc).