### PR TITLE
Fix logo and button for startpage

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4628,8 +4628,14 @@ html {
 
 startpage.com
 
+INVERT
+.hamburger-menu .hamburger-button
+
 IGNORE IMAGE ANALYSIS
 .home__section__search-logo
+.header__logo
+.header-settings__logo
+.hamburger-menu .hamburger-button
 
 ================================
 


### PR DESCRIPTION
More fixes for startpage. Fix menu button. Fix logo on search result page and [setting page](https://startpage.com/do/settings).