### PR TITLE
Fix for github.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2168,7 +2168,8 @@ CSS
 }
 
 IGNORE INLINE STYLE
-a[href^="https://apps.apple.com/app/"] *
+a[href^="https://apps.apple.com/app/"] g
+a[href^="https://apps.apple.com/app/"] path
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2167,6 +2167,9 @@ CSS
     fill: ${black} !important;
 }
 
+IGNORE INLINE STYLE
+a[href^="https://apps.apple.com/app/"] *
+
 ================================
 
 github.myshopify.com


### PR DESCRIPTION
- Ignore styling the button to install github mobile trough App store.

Before:
![](https://i.imgur.com/RjRZBHT.png)

After:
![](https://i.imgur.com/aWIHnGE.png)