### PR TITLE
steamcharts.com is not dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -522,7 +522,6 @@ starmadedock.net
 staszic.waw.pl
 statbot.net
 steam.tv
-steamcharts.com
 steamcommunity.com
 steamdb.info
 steamstat.us


### PR DESCRIPTION
- Not a dark privacy setting pop-up
- Resolved #1544