### PR TITLE
Fix for discord.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1288,6 +1288,9 @@ nav[aria-label="Servers sidebar"] foreignObject {
 nav[aria-label="Servers sidebar"] foreignObject:hover {
     border-radius: 30% !important;
 }
+path[class^="wavePath"] {
+    fill: ${rgb(226, 224, 220)} !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Give the wavePath svg the right color in order to blend in.