### PR TITLE
Fix for syncsetting error

### DIFF
--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -23,6 +23,7 @@ export default class UserStorage {
     private loadSettingsFromStorage() {
         return new Promise<UserSettings>((resolve) => {
             chrome.storage.local.get(DEFAULT_SETTINGS, (local: UserSettings) => {
+                local.syncSettings = local.syncSettings || DEFAULT_SETTINGS.syncSettings;
                 if (!local.syncSettings) {
                     local.theme = {...DEFAULT_SETTINGS.theme, ...local.theme};
                     local.time = {...DEFAULT_SETTINGS.time, ...local.time};


### PR DESCRIPTION
- Make sure to have a boolean in syncsettings. If local hasn't the setting, the default setting would be chosen.
- Resolves #3424