### PR TITLE
Add option to run on protected pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5477,7 +5477,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -91,7 +91,7 @@ export class Extension {
         this.registerCommands();
 
         this.ready = true;
-        this.tabs.updateContentScript();
+        this.tabs.updateContentScript(this.user.settings.disableProtectedCheck);
 
         this.awaiting.forEach((ready) => ready());
         this.awaiting = null;
@@ -364,7 +364,7 @@ export class Extension {
     private getURLInfo(url: string): TabInfo {
         const {DARK_SITES} = this.config;
         const isInDarkList = isURLInList(url, DARK_SITES);
-        const isProtected = !canInjectScript(url);
+        const isProtected = this.user.settings.disableProtectedCheck ? false : !canInjectScript(url);
         return {
             url,
             isInDarkList,

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -91,7 +91,7 @@ export class Extension {
         this.registerCommands();
 
         this.ready = true;
-        this.tabs.updateContentScript(this.user.settings.enableForProtectedPages);
+        this.tabs.updateContentScript({runOnProtectedPages: this.user.settings.enableForProtectedPages});
 
         this.awaiting.forEach((ready) => ready());
         this.awaiting = null;
@@ -364,7 +364,7 @@ export class Extension {
     private getURLInfo(url: string): TabInfo {
         const {DARK_SITES} = this.config;
         const isInDarkList = isURLInList(url, DARK_SITES);
-        const isProtected = this.user.settings.enableForProtectedPages ? !canInjectScript(url) : false ;
+        const isProtected = !(this.user.settings.enableForProtectedPages || canInjectScript(url));
         return {
             url,
             isInDarkList,

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -364,7 +364,7 @@ export class Extension {
     private getURLInfo(url: string): TabInfo {
         const {DARK_SITES} = this.config;
         const isInDarkList = isURLInList(url, DARK_SITES);
-        const isProtected = this.user.settings.enableForProtectedPages ? !canInjectScript(url) : false;
+        const isProtected = this.user.settings.enableForProtectedPages ? !canInjectScript(url) : false ;
         return {
             url,
             isInDarkList,

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -91,7 +91,7 @@ export class Extension {
         this.registerCommands();
 
         this.ready = true;
-        this.tabs.updateContentScript(this.user.settings.disableProtectedCheck);
+        this.tabs.updateContentScript(this.user.settings.enableForProtectedPages);
 
         this.awaiting.forEach((ready) => ready());
         this.awaiting = null;
@@ -364,7 +364,7 @@ export class Extension {
     private getURLInfo(url: string): TabInfo {
         const {DARK_SITES} = this.config;
         const isInDarkList = isURLInList(url, DARK_SITES);
-        const isProtected = this.user.settings.disableProtectedCheck ? false : !canInjectScript(url);
+        const isProtected = this.user.settings.enableForProtectedPages ? !canInjectScript(url) : false;
         return {
             url,
             isInDarkList,

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -91,7 +91,7 @@ export default class TabManager {
 
     async updateContentScript(disableCheck: boolean) {
         (await queryTabs({}))
-            .filter((tab) => disableCheck ? true : canInjectScript(tab.url))
+            .filter((tab) => disableCheck ? canInjectScript(tab.url) : true )
             .filter((tab) => !this.ports.has(tab.id))
             .forEach((tab) => !tab.discarded && chrome.tabs.executeScript(tab.id, {
                 runAt: 'document_start',

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -89,9 +89,9 @@ export default class TabManager {
         });
     }
 
-    async updateContentScript(disableCheck: boolean) {
+    async updateContentScript(options: {runOnProtectedPages: boolean}) {
         (await queryTabs({}))
-            .filter((tab) => disableCheck ? canInjectScript(tab.url) : true )
+            .filter((tab) => options.runOnProtectedPages || canInjectScript(tab.url))
             .filter((tab) => !this.ports.has(tab.id))
             .forEach((tab) => !tab.discarded && chrome.tabs.executeScript(tab.id, {
                 runAt: 'document_start',

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -89,9 +89,9 @@ export default class TabManager {
         });
     }
 
-    async updateContentScript() {
+    async updateContentScript(disableCheck: boolean) {
         (await queryTabs({}))
-            .filter((tab) => canInjectScript(tab.url))
+            .filter((tab) => disableCheck ? true : canInjectScript(tab.url))
             .filter((tab) => !this.ports.has(tab.id))
             .forEach((tab) => !tab.discarded && chrome.tabs.executeScript(tab.id, {
                 runAt: 'document_start',

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -55,5 +55,5 @@ export const DEFAULT_SETTINGS: UserSettings = {
     },
     previewNewDesign: false,
     enableForPDF: true,
-    disableProtectedCheck: false,
+    enableForProtectedPages: true,
 };

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -55,5 +55,5 @@ export const DEFAULT_SETTINGS: UserSettings = {
     },
     previewNewDesign: false,
     enableForPDF: true,
-    enableForProtectedPages: true,
+    enableForProtectedPages: false,
 };

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -55,4 +55,5 @@ export const DEFAULT_SETTINGS: UserSettings = {
     },
     previewNewDesign: false,
     enableForPDF: true,
+    disableProtectedCheck: false,
 };

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -87,6 +87,7 @@ export interface UserSettings {
     location: LocationSettings;
     previewNewDesign: boolean;
     enableForPDF: boolean;
+    disableProtectedCheck: boolean;
 }
 
 export interface TimeSettings {

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -87,7 +87,7 @@ export interface UserSettings {
     location: LocationSettings;
     previewNewDesign: boolean;
     enableForPDF: boolean;
-    disableProtectedCheck: boolean;
+    enableForProtectedPages: boolean;
 }
 
 export interface TimeSettings {

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -27,7 +27,7 @@ export function getMockData(override = {} as Partial<ExtensionData>): ExtensionD
             applyToListedOnly: false,
             changeBrowserTheme: false,
             enableForPDF: true,
-            enableForProtectedPages: true,
+            enableForProtectedPages: false,
             notifyOfNews: false,
             syncSettings: true,
             automation: '',

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -27,6 +27,7 @@ export function getMockData(override = {} as Partial<ExtensionData>): ExtensionD
             applyToListedOnly: false,
             changeBrowserTheme: false,
             enableForPDF: true,
+            disableProtectedCheck: false,
             notifyOfNews: false,
             syncSettings: true,
             automation: '',

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -27,7 +27,7 @@ export function getMockData(override = {} as Partial<ExtensionData>): ExtensionD
             applyToListedOnly: false,
             changeBrowserTheme: false,
             enableForPDF: true,
-            disableProtectedCheck: false,
+            enableForProtectedPages: true,
             notifyOfNews: false,
             syncSettings: true,
             automation: '',

--- a/src/ui/popup/site-list-page/index.tsx
+++ b/src/ui/popup/site-list-page/index.tsx
@@ -1,10 +1,14 @@
 import {m} from 'malevic';
 import {ViewProps} from '../types';
 import SiteList from './site-list';
+import CheckButton from '../check-button';
 
 export default function SiteListPage(props: ViewProps) {
     function onSiteListChange(sites: string[]) {
         props.actions.changeSettings({siteList: sites});
+    }
+    function onDisableProtectedCheck(value: boolean) {
+        props.actions.changeSettings({disableProtectedCheck: value});
     }
 
     const label = props.data.settings.applyToListedOnly ?
@@ -18,6 +22,14 @@ export default function SiteListPage(props: ViewProps) {
                 onChange={onSiteListChange}
             />
             <label class="site-list-page__description">Enter website name and press Enter</label>
+            <CheckButton
+                checked={props.data.settings.disableProtectedCheck}
+                onChange={onDisableProtectedCheck}
+                label={'Disable protected check'}
+                description={props.data.settings.disableProtectedCheck ?
+                    'Disabled to check if a site is protected' :
+                    'Enabled to check if a site is protected'}
+            />
         </div>
     );
 }

--- a/src/ui/popup/site-list-page/index.tsx
+++ b/src/ui/popup/site-list-page/index.tsx
@@ -25,10 +25,10 @@ export default function SiteListPage(props: ViewProps) {
             <CheckButton
                 checked={props.data.settings.enableForProtectedPages}
                 onChange={onEnableForProtectedPages}
-                label={'Enable protected check'}
+                label={'Enable on protected pages'}
                 description={props.data.settings.enableForProtectedPages ?
-                    'Enabled to check if a site is protected' :
-                    'Disabled to check if a site is protected'}
+                    'Will try running on protected pages (browser settings etc)' :
+                    'Will not try running on protected pages (browser settings etc)'}
             />
         </div>
     );

--- a/src/ui/popup/site-list-page/index.tsx
+++ b/src/ui/popup/site-list-page/index.tsx
@@ -7,8 +7,8 @@ export default function SiteListPage(props: ViewProps) {
     function onSiteListChange(sites: string[]) {
         props.actions.changeSettings({siteList: sites});
     }
-    function onDisableProtectedCheck(value: boolean) {
-        props.actions.changeSettings({disableProtectedCheck: value});
+    function onEnableForProtectedPages(value: boolean) {
+        props.actions.changeSettings({enableForProtectedPages: value});
     }
 
     const label = props.data.settings.applyToListedOnly ?
@@ -23,12 +23,12 @@ export default function SiteListPage(props: ViewProps) {
             />
             <label class="site-list-page__description">Enter website name and press Enter</label>
             <CheckButton
-                checked={props.data.settings.disableProtectedCheck}
-                onChange={onDisableProtectedCheck}
-                label={'Disable protected check'}
-                description={props.data.settings.disableProtectedCheck ?
-                    'Disabled to check if a site is protected' :
-                    'Enabled to check if a site is protected'}
+                checked={props.data.settings.enableForProtectedPages}
+                onChange={onEnableForProtectedPages}
+                label={'Enable protected check'}
+                description={props.data.settings.enableForProtectedPages ?
+                    'Enabled to check if a site is protected' :
+                    'Disabled to check if a site is protected'}
             />
         </div>
     );

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -137,7 +137,7 @@ export function isPDF(url: string) {
 }
 
 export function isURLEnabled(url: string, userSettings: UserSettings, {isProtected, isInDarkList}) {
-    if (isProtected) {
+    if (isProtected && !userSettings.disableProtectedCheck) {
         return false;
     }
     if (isPDF(url) && userSettings.enableForPDF) {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -137,7 +137,7 @@ export function isPDF(url: string) {
 }
 
 export function isURLEnabled(url: string, userSettings: UserSettings, {isProtected, isInDarkList}) {
-    if (isProtected && !userSettings.disableProtectedCheck) {
+    if (isProtected && userSettings.enableForProtectedPages) {
         return false;
     }
     if (isPDF(url) && userSettings.enableForPDF) {

--- a/tests/utils/url.tests.ts
+++ b/tests/utils/url.tests.ts
@@ -69,12 +69,12 @@ test('URL is enabled', () => {
     )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, disableProtectedCheck: true} as UserSettings,
+        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, disableProtectedCheck: true} as UserSettings,
+        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(

--- a/tests/utils/url.tests.ts
+++ b/tests/utils/url.tests.ts
@@ -59,34 +59,39 @@ test('URL is enabled', () => {
     // Special URLs
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
+        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: false} as UserSettings,
+        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
+        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
+        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://microsoftedge.microsoft.com/addons',
-        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
+        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://microsoftedge.microsoft.com/addons',
-        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: false} as UserSettings,
+        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
+    expect(isURLEnabled(
+        'https://duckduckgo.com',
+        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
+        {isProtected: false, isInDarkList: false},
+    )).toBe(true);
     expect(isURLEnabled(
         'https://darkreader.org/',
         {siteList: [], siteListEnabled: [], applyToListedOnly: false} as UserSettings,

--- a/tests/utils/url.tests.ts
+++ b/tests/utils/url.tests.ts
@@ -59,17 +59,17 @@ test('URL is enabled', () => {
     // Special URLs
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
+        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
@@ -79,12 +79,12 @@ test('URL is enabled', () => {
     )).toBe(false);
     expect(isURLEnabled(
         'https://microsoftedge.microsoft.com/addons',
-        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://microsoftedge.microsoft.com/addons',
-        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(

--- a/tests/utils/url.tests.ts
+++ b/tests/utils/url.tests.ts
@@ -68,6 +68,16 @@ test('URL is enabled', () => {
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
+        'https://chrome.google.com/webstore',
+        {siteList: [], siteListEnabled: [], applyToListedOnly: false, disableProtectedCheck: true} as UserSettings,
+        {isProtected: true, isInDarkList: false},
+    )).toBe(true);
+    expect(isURLEnabled(
+        'https://chrome.google.com/webstore',
+        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, disableProtectedCheck: true} as UserSettings,
+        {isProtected: true, isInDarkList: false},
+    )).toBe(false);
+    expect(isURLEnabled(
         'https://microsoftedge.microsoft.com/addons',
         {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
         {isProtected: true, isInDarkList: false},


### PR DESCRIPTION
- Add a option under sitelist to allow people to disable the check if a site is protected
- Let users allow to darken sites that aren't protected in there Environment(Firefox about:config)
- Resolves #912
- Resolves #1254

Possible bug with render of UI that when toggling the option and staying in the same pop-up(so not closing it after toggling) that the Toggle site button is still rendering the `old option` so 

Disabled -> Enabled. Toggle site still shows the protected CSS.
Enabled -> Disabled. Toggle site still let you toggle the site.