### PR TITLE
Add rule for my.bible.com navigation title

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3459,6 +3459,15 @@ CSS
 
 ================================
 
+my.bible.com
+
+CSS
+.nav-title {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 my.nextdns.io
 
 INVERT


### PR DESCRIPTION
This properly inverts the navigation title when reading from a plan on my.bible.com