### PR TITLE
Exclude grayscale from selection

### DIFF
--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -93,8 +93,8 @@ export function getSelectionColor(theme: Theme) {
     let backgroundColorSelection: string;
     let foregroundColorSelection: string;
     if (theme.selectionColor === 'auto') {
-        backgroundColorSelection = modifyBackgroundColor({r: 0, g: 96, b: 212}, theme);
-        foregroundColorSelection = modifyForegroundColor({r: 255, g: 255, b: 255}, theme);
+        backgroundColorSelection = modifyBackgroundColor({r: 0, g: 96, b: 212}, {...theme, grayscale: 0});
+        foregroundColorSelection = modifyForegroundColor({r: 255, g: 255, b: 255}, {...theme, grayscale: 0});
     } else {
         const rgb = parse(theme.selectionColor);
         const hsl = rgbToHSL(rgb);


### PR DESCRIPTION
- Do not consider grayscale as option in selection as it would make it less visible.
- Resolves #1020