### PR TITLE
Fixed compass.pressekompass.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -964,6 +964,13 @@ INVERT
 
 ================================
 
+community.ntppool.org
+
+INVERT
+#site-logo
+
+================================
+
 compass.pressekompass.net
 
 INVERT
@@ -971,13 +978,6 @@ INVERT
 
 IGNORE INLINE STYLE
 text
-
-================================
-
-community.ntppool.org
-
-INVERT
-#site-logo
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -964,6 +964,16 @@ INVERT
 
 ================================
 
+compass.pressekompass.net
+
+INVERT
+.logo-holder .brand-logo
+
+IGNORE INLINE STYLE
+text
+
+================================
+
 community.ntppool.org
 
 INVERT


### PR DESCRIPTION
`compass.pressekompass.net` is a tool to let visitors of (mainly german) news websites vote for their opinion. The voting gets via an Iframe embedded into the website. This fix corrects the wrong invertation of the media outlet's logo and fixes the shown percentage after voting.
Example URL: [heise.de](https://www.heise.de/news/Trump-will-Begnadigung-von-Whistleblower-Snowden-pruefen-4871768.html)

Before:
![grafik](https://user-images.githubusercontent.com/12871113/90418373-57811080-e0b5-11ea-9c17-e1605eff4e63.png)

After: 
![grafik](https://user-images.githubusercontent.com/12871113/90418271-328c9d80-e0b5-11ea-99f3-89c09250e236.png)