### PR TITLE
Fix version label on Mobile

### DIFF
--- a/src/ui/popup/body/style.less
+++ b/src/ui/popup/body/style.less
@@ -132,6 +132,12 @@
     }
 }
 
+.mobile {
+    .darkreader-version {
+        position: relative;
+    }
+}
+
 .preview .dev-tools-button {
     overflow: visible;
     position: relative;


### PR DESCRIPTION
- Fix position of current version label in Mobile to be relative so it won't overlap with other text.
- Resolve #3374

![](https://i.imgur.com/2n3mgsV.png) Should do it