### PR TITLE
Fix for bbs.chinauos.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -575,6 +575,18 @@ INVERT
 
 ================================
 
+bbs.chinauos.com
+
+INVERT
+.post_tip
+
+CSS
+div[style="all: initial;"] {
+    all: unset !important;
+}
+
+================================
+
 bbs.thinkpad.com
 club.lenovo.com.cn
 


### PR DESCRIPTION
- Invert topic tag icon (weird dark-white combination without the change)
- Fix main forum post text color (example page: https://bbs.chinauos.com/post/1930?id=1930&type_id=0)