### PR TITLE
Fix for amap.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -297,6 +297,18 @@ CSS
 
 ================================
 
+amap.com
+
+INVERT
+.amap-info
+.amap-menu
+.logo-img
+#subway-svg
+#themap
+.title01-logo > a > img
+
+================================
+
 amazon.*
 amazon.co.uk
 


### PR DESCRIPTION
- Invert logo, map and context menus

Locations:
amap.com
map.amap.com/subway
id.amap.com