### PR TITLE
Fix for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6004,7 +6004,6 @@ img[src="images/black.png"]
 wikipedia.org
 
 INVERT
-.mwe-math-element
 .mw-ext-score
 .mw-wiki-logo
 .central-textlogo__image


### PR DESCRIPTION
Deleting `.mwe-math-element` as inverting it would actually make math elements become completely black on a dark background.
[This page](https://en.wikipedia.org/wiki/Lattice_(group)) can be used as a reference to this issue, look for the color of _R^n_ in the first line.