### PR TITLE
Fix for my.nintendo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3582,8 +3582,11 @@ a.d-none.d-md-inline
 
 my.nintendo.com
 
-IGNORE IMAGE ANALYSIS
-.Layout-app
+CSS
+.Layout-app,
+.signUpButton {
+    background-image: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Remove background

The fix in #3157 doesn't really work here, and the text is hard to read. So I am trying to fix it again here.

Before:
![2020-08-19-213104-b4a4a0](https://user-images.githubusercontent.com/1006477/90641242-93f26f00-e263-11ea-87e0-55e48e9ad11a.png)

After:
![2020-08-19-213032-f63f35](https://user-images.githubusercontent.com/1006477/90641258-994fb980-e263-11ea-890a-a76df6251c94.png)
