### PR TITLE
Fix Stack Exchange upvotes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -59,7 +59,7 @@ body {
     background-image: repeating-linear-gradient(0deg, transparent, transparent 13px, ${#e4e6e8} -13px, ${#e4e6e8} 21px) !important;
 }
 .c-pointer {
-    color: grey !important;
+    color: grey;
 }
 .js-accepted-answer-indicator.fc-green-500 {
     color: var(--green) !important;


### PR DESCRIPTION
Remove !important that was overriding native color of up/down-voted arrows and selected checks.

- Resolves #2602 
- Resolves #3478