### PR TITLE
Add obsidian.md to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -392,6 +392,7 @@ noisebridge.net
 notebooks.quantumstat.com
 null.media
 nulledbb.com
+obsidian.md
 obsproject.com
 offshorecorptalk.com
 ogusers.com


### PR DESCRIPTION
[obsidian.md](https://obsidian.md) is already a dark page. So I added it onto the dark sites list.