### PR TITLE
Remove defanor.uberspace.net from dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -127,7 +127,6 @@ darkmodelist.com
 darkreader.org
 dcards.snaz.in
 deepweblinks.net
-defanor.uberspace.net
 del.dog
 deltarune.com
 demonforums.net


### PR DESCRIPTION
The site removed all traces of CSS is no longer dark. Author's justification on his personal blog: gopher://uberspace.net/0/~defanor/phlog/no-more-css.rst