### PR TITLE
Fix for quora.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4477,6 +4477,15 @@ td.cell, td.label {
 
 ================================
 
+quora.com
+
+CSS
+.logo_fill {
+    fill: rgb(219, 87, 83) !important;
+}
+
+================================
+
 rachel53461.wordpress.com
 
 CSS


### PR DESCRIPTION
- Makes logo visible due to dark reader set it's `fill` value to `none` property.
- Resolves #3526