### PR TITLE
Fixes for meituan.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3569,6 +3569,15 @@ CSS
 
 ================================
 
+meituan.com
+
+INVERT
+.dpLogo
+.header-title
+.site-logo
+
+================================
+
 messages.android.com
 
 INVERT


### PR DESCRIPTION
- Invert logos

They are present on main page (meituan.com), accounts page (accounts.meituan.com) and dianping's verify page (verify.meituan.com, need some parameters to access, though).