### PR TITLE
Fix render bug for protected sites

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -364,7 +364,7 @@ export class Extension {
     private getURLInfo(url: string): TabInfo {
         const {DARK_SITES} = this.config;
         const isInDarkList = isURLInList(url, DARK_SITES);
-        const isProtected = canInjectScript(url);
+        const isProtected = !canInjectScript(url);
         return {
             url,
             isInDarkList,

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -364,7 +364,7 @@ export class Extension {
     private getURLInfo(url: string): TabInfo {
         const {DARK_SITES} = this.config;
         const isInDarkList = isURLInList(url, DARK_SITES);
-        const isProtected = !(this.user.settings.enableForProtectedPages || canInjectScript(url));
+        const isProtected = canInjectScript(url);
         return {
             url,
             isInDarkList,

--- a/src/ui/popup/components/site-toggle/index.tsx
+++ b/src/ui/popup/components/site-toggle/index.tsx
@@ -13,8 +13,10 @@ export default function SiteToggleButton({data, tab, actions}: ExtWrapper & {tab
             actions.toggleURL(tab.url);
         }
     }
-    const isProtected = data.settings.enableForProtectedPages ? false : !tab.isProtected;
-    const toggleHasEffect = data.isEnabled && !isProtected;
+    const toggleHasEffect = (
+        data.isEnabled &&
+        data.settings.enableForProtectedPages ? true : !tab.isProtected
+    );
     const pdf = isPDF(tab.url);
     const isSiteEnabled = isURLEnabled(tab.url, data.settings, tab);
     const host = getURLHostOrProtocol(tab.url);

--- a/src/ui/popup/components/site-toggle/index.tsx
+++ b/src/ui/popup/components/site-toggle/index.tsx
@@ -13,10 +13,8 @@ export default function SiteToggleButton({data, tab, actions}: ExtWrapper & {tab
             actions.toggleURL(tab.url);
         }
     }
-    const toggleHasEffect = (
-        data.isEnabled &&
-        !tab.isProtected
-    );
+    const isProtected = data.settings.enableForProtectedPages ? false : !tab.isProtected;
+    const toggleHasEffect = data.isEnabled && !isProtected;
     const pdf = isPDF(tab.url);
     const isSiteEnabled = isURLEnabled(tab.url, data.settings, tab);
     const host = getURLHostOrProtocol(tab.url);

--- a/src/ui/popup/components/site-toggle/index.tsx
+++ b/src/ui/popup/components/site-toggle/index.tsx
@@ -14,8 +14,8 @@ export default function SiteToggleButton({data, tab, actions}: ExtWrapper & {tab
         }
     }
     const toggleHasEffect = (
-        data.isEnabled &&
-        data.settings.enableForProtectedPages ? true : !tab.isProtected
+        data.settings.enableForProtectedPages || 
+        !tab.isProtected
     );
     const pdf = isPDF(tab.url);
     const isSiteEnabled = isURLEnabled(tab.url, data.settings, tab);

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -137,7 +137,7 @@ export function isPDF(url: string) {
 }
 
 export function isURLEnabled(url: string, userSettings: UserSettings, {isProtected, isInDarkList}) {
-    if (isProtected && userSettings.enableForProtectedPages) {
+    if (isProtected && !userSettings.enableForProtectedPages) {
         return false;
     }
     if (isPDF(url) && userSettings.enableForPDF) {

--- a/tests/utils/url.tests.ts
+++ b/tests/utils/url.tests.ts
@@ -66,12 +66,12 @@ test('URL is enabled', () => {
         'https://chrome.google.com/webstore',
         {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
-    )).toBe(false);
+    )).toBe(true);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
         {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
         {isProtected: true, isInDarkList: false},
-    )).toBe(true);
+    )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
         {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
@@ -86,7 +86,7 @@ test('URL is enabled', () => {
         'https://microsoftedge.microsoft.com/addons',
         {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true} as UserSettings,
         {isProtected: true, isInDarkList: false},
-    )).toBe(false);
+    )).toBe(true);
     expect(isURLEnabled(
         'https://duckduckgo.com',
         {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,


### PR DESCRIPTION
- tab.isProtected should not use `enableForProtectedPages` option as it doesn't get up-to-date data and will return the old value.
- Real-time site-toggle disable according isProtected logic and `enableForProtectedPages` option.
- Make test according to the good visa-versa logic(Forgot to update in previous PR)
- Resolves #3548