### PR TITLE
fix for flow.polar.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2155,6 +2155,9 @@ CSS
 .zone1desc {
     color: ${#ffffff} !important;
 }
+rect[class=" highcharts-background"] {
+    --darkreader-inline-fill: #282b36 !important;
+}
 
 ================================
 


### PR DESCRIPTION
Some of changeable highcharts had white background in after change to other - forced darkreader-inline-fill.

1st OK:
![obraz](https://user-images.githubusercontent.com/56877029/91664053-e1d16780-eaec-11ea-9dad-cca27e8cd36f.png)

Change to next:
Before:
![obraz](https://user-images.githubusercontent.com/56877029/91664064-f281dd80-eaec-11ea-8b12-cc25e3ef6bc5.png)

After:
![obraz](https://user-images.githubusercontent.com/56877029/91664090-29f08a00-eaed-11ea-8c98-d2e055fdc06e.png)
