### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5457,7 +5457,7 @@ theguardian.com
 
 INVERT
 .inline-the-guardian-logo__svg
-.css-t7dp8u
+a[data-link-name^="logo"] > svg
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5457,6 +5457,7 @@ theguardian.com
 
 INVERT
 .inline-the-guardian-logo__svg
+.css-t7dp8u
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5457,7 +5457,7 @@ theguardian.com
 
 INVERT
 .inline-the-guardian-logo__svg
-a[data-link-name$^="logo"] > svg
+a[data-link-name$="logo"] > svg
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5457,7 +5457,7 @@ theguardian.com
 
 INVERT
 .inline-the-guardian-logo__svg
-a[data-link-name^="logo"] > svg
+a[data-link-name$^="logo"] > svg
 
 ================================
 


### PR DESCRIPTION
Fix for theguardian.com where certain news articles (mainly comment/opinion) didn't have logo inverted. Example:
https://www.theguardian.com/commentisfree/2020/aug/31/the-rights-culture-war-politics-rightwing-fantasy-elections