### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -901,8 +901,8 @@ CSS
 
 chess.com
 
-INVERT
-div[class^='piece b']
+IGNORE IMAGE ANALYSIS
+.piece
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -899,6 +899,13 @@ CSS
 
 ================================
 
+chess.com
+
+INVERT
+div[class^='piece b']
+
+================================
+
 chilkatsoft.com
 
 CSS


### PR DESCRIPTION
Fix for chess.com where black pieces would be inverted by darkreader making them extremely white (only broken on daily matches for some reason)

View: https://www.chess.com/daily/game/274666002

Before fix:
![image](https://user-images.githubusercontent.com/64779344/91835022-bb244580-ec40-11ea-8e9a-33b23c40d3ac.png)

After fix:
![image](https://user-images.githubusercontent.com/64779344/91835205-faeb2d00-ec40-11ea-9e98-e56776abbbc5.png)


