### PR TITLE
fix for booking.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -813,6 +813,13 @@ INVERT
 .-iconset-review_great
 .-iconset-review_poor
 .-iconset-chat_bubbles
+.location_section_icon
+.hp-date-picker-icon
+.-streamline-info_sign
+.-streamline-person
+.-streamline-chat_bubbles
+.hp-policies-calendar-icon
+.-iconset-moon_crescent
 
 ================================
 


### PR DESCRIPTION
Invert for some black icons on offer page.

Page to check: https://www.booking.com/hotel/gr/mykonos-secret-spot.pl.html