### PR TITLE
Fix for launchpad.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3200,6 +3200,14 @@ INVERT
 
 ================================
 
+launchpad.net
+
+INVERT
+.edit-controls
+#launchpad-logo-and-name
+
+================================
+
 leetcode.com
 leetcode-cn.com
 


### PR DESCRIPTION
- Invert logo
- Invert edit tab (bright on dark theme)