### PR TITLE
Fix for personal.vanguard.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4388,6 +4388,15 @@ body {
 
 ================================
 
+personal.vanguard.com
+
+CSS
+.hidePageIfJSdisabled {
+    display: block !important;
+}
+
+================================
+
 pgatour.com
 
 CSS


### PR DESCRIPTION
- Override the ridiculous behavior to hide the page when java script is disabled what Dark reader is somehow triggering.
- Resolves #3576