### PR TITLE
Turkish official gazette

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4730,6 +4730,15 @@ CSS
 
 ================================
 
+resmigazete.gov.tr
+
+CSS
+img[src="/assets/img/arma.png"] {
+    filter: hue-rotate(180deg) invert(1) brightness(2);
+}
+
+================================
+
 richie-bendall.ml
 
 CSS


### PR DESCRIPTION
This fixes the logo background issue with https://resmigazete.gov.tr.