### PR TITLE
Update dynamic-theme-fixes.config - orf.at/corona/stories/daten - invisible tooltips

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4431,6 +4431,13 @@ INVERT
 
 ================================
 
+orf.at/corona/stories/daten
+
+INVERT
+.bg
+
+================================
+
 overleaf.com
 
 INVERT


### PR DESCRIPTION
orf.at/corona/stories/daten - tooltips of diagram were not readable because the background was bright and the text color was white