### PR TITLE
Fix for zdic.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7200,9 +7200,15 @@ CSS
 
 zdic.net
 
+INVERT
+li a img
+.kxtimg
+.zipic img
+.zx img
+
 CSS
-.zisong img {
-    background-color: ${black} !important;
+.nr-box-header {
+    background-image: none !important;
 }
 
 ================================


### PR DESCRIPTION
The fix in #3565 is not complete and removes the matts behind a character. This one tries to fix it in a better way and also fix other issues.

Example URLs:

https://www.zdic.net/zd/bs/ (And click one of the characters to expand the list)
https://www.zdic.net/hans/%E4%B8%AC
https://www.zdic.net/hans/%F0%A0%86%AA