### PR TITLE
fix for leetcode-cn.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3262,12 +3262,16 @@ leetcode.com
 leetcode-cn.com
 
 INVERT
+.cursor
 .CodeMirror-cursor
 .user-story-chapter-base .companies-showcase-base .logo
 
 CSS
 [class^=question-picker-detail] {
     background: none !important;
+}
+.monaco-editor, .monaco-editor-background, .monaco-editor .margin{
+    background-color: black;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3270,8 +3270,8 @@ CSS
 [class^=question-picker-detail] {
     background: none !important;
 }
-.monaco-editor, .monaco-editor-background, .monaco-editor .margin{
-    background-color: black;
+.monaco-editor, .monaco-editor-background, .monaco-editor .margin {
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
I didn't test on leetcode.com because of the redirect.

Before

![sshot-015](https://user-images.githubusercontent.com/36977733/93328791-ba2c1000-f80b-11ea-914b-3889ddd3b0aa.png)

After

![sshot-014](https://user-images.githubusercontent.com/36977733/93328807-c1531e00-f80b-11ea-84f6-7265544a9404.png)

I can see no difference with or without `.CodeMirror-cursor`. Is it still useful?