### PR TITLE
Fix for heritage.org/index

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2704,6 +2704,18 @@ INVERT
 
 ================================
 
+heritage.org/index
+
+INVERT
+.bar
+
+CSS
+.content-container {
+    background-image: none !important;
+}
+
+================================
+
 hh.ru
 
 CSS


### PR DESCRIPTION
- Invert chart title bar
- Remove background of right sidebar

Example URL: https://www.heritage.org/index/ranking