### PR TITLE
Expose CSS fixes to Shadow Roots

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1717,6 +1717,15 @@ CSS
 
 ================================
 
+ea.com
+
+CSS
+img[src*="white-bg-ea-bg-global-white"] {
+    display: none !important;
+}
+
+================================
+
 easypost.com
 
 INVERT

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -115,6 +115,9 @@ function createShadowStaticStyleOverrides(root: ShadowRoot) {
     const inlineStyle = createOrUpdateStyle('darkreader--inline', root);
     inlineStyle.textContent = getInlineOverrideStyle();
     root.insertBefore(inlineStyle, root.firstChild);
+    const overrideStyle = createOrUpdateStyle('darkreader--override', root);
+    overrideStyle.textContent = fixes && fixes.css ? replaceCSSTemplates(fixes.css) : '';
+    root.insertBefore(overrideStyle, inlineStyle.nextSibling);
     shadowRootsWithOverrides.add(root);
 }
 
@@ -336,6 +339,7 @@ function watchForUpdates() {
         newManagers.forEach((manager) => manager.watch());
         stylesToRestore.forEach((style) => styleManagers.get(style).restore());
     }, (shadowRoot) => {
+        createShadowStaticStyleOverrides(shadowRoot);
         handleAdoptedStyleSheets(shadowRoot);
     });
 
@@ -432,6 +436,7 @@ export function removeDynamicTheme() {
     }
     shadowRootsWithOverrides.forEach((root) => {
         removeNode(root.querySelector('.darkreader--inline'));
+        removeNode(root.querySelector('.darkreader--override'));
     });
     shadowRootsWithOverrides.clear();
     forEach(styleManagers.keys(), (el) => removeManager(el));

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -173,7 +173,6 @@ export function iterateShadowHosts(root: Node, iterator: (host: Element) => void
                 return (node as Element).shadowRoot == null ? NodeFilter.FILTER_SKIP : NodeFilter.FILTER_ACCEPT;
             }
         },
-        false,
     );
     for (
         let node = ((root as Element).shadowRoot ? walker.currentNode : walker.nextNode()) as Element;


### PR DESCRIPTION
- Expose Dynamic theme fixes to shadow-roots so it can be fixed as well.
- Removed a depcrated option in createTreeWalker
- Resolves #3652