### PR TITLE
Make lazy-loaded elements manage-able

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -53,7 +53,11 @@ export function shouldManageStyle(element: Node) {
             )
         ) &&
         !element.classList.contains('darkreader') &&
-        element.media !== 'print' &&
+        (
+            element.media !== 'print' ||
+            // Some stylesheets uses 'lazy loading' and has on initial a `print` media.
+            element.getAttribute('onload').toLowerCase().includes('this.media=')
+        ) &&
         !element.classList.contains('stylus')
     );
 }

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -53,11 +53,7 @@ export function shouldManageStyle(element: Node) {
             )
         ) &&
         !element.classList.contains('darkreader') &&
-        (
-            element.media !== 'print' ||
-            // Some stylesheets uses 'lazy loading' and has on initial a `print` media.
-            element.getAttribute('onload').toLowerCase().includes('this.media=')
-        ) &&
+        element.media !== 'print' &&
         !element.classList.contains('stylus')
     );
 }

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -182,7 +182,7 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
             onHugeMutations: handleHugeTreeMutations,
         });
         const attrObserver = new MutationObserver(handleAttributeMutations);
-        attrObserver.observe(root, {attributes: true, attributeFilter: ['rel', 'disabled'], subtree: true});
+        attrObserver.observe(root, {attributes: true, attributeFilter: ['rel', 'disabled', 'media'], subtree: true});
         observers.push(treeObserver, attrObserver);
         observedRoots.add(root);
     }


### PR DESCRIPTION
- Adds a extra attribute to watch for. `media` attribute is changed when it's finished 'lazy-loading'.
- Resolves #3649
- Resolves #2729