### PR TITLE
amp-what.com is dark.

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -13,6 +13,7 @@ adventofcode.com
 agent-stats.com
 agfy.co
 ameliorated.info
+amp-what.com
 amplifi.com
 andrewleguay.com
 animencodes.com


### PR DESCRIPTION
I’m not sure whether adding `amp-what.com` or `www.amp-what.com` would be more appropriate. [This is the website.](https://amp-what.com)