### PR TITLE
Fix for quizlet.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4748,6 +4748,15 @@ td.cell, td.label {
 
 ================================
 
+quizlet.com
+
+CSS
+.UIKeyboardHint {
+    background-color: transparent !important;
+}
+
+================================
+
 quora.com
 
 CSS


### PR DESCRIPTION
- Make the box around the answer fully visible by removing the background-color of the Keyboard Hint.