### PR TITLE
fix for flow.polar.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2247,6 +2247,7 @@ INVERT
 .sleep-chart-yaxis.end
 .supergraph-canvas
 .leaflet-pane.leaflet-map-pane img:not([src*="satellite"])
+.mapboxgl-canvas
 .zone1desc
 
 CSS


### PR DESCRIPTION
Added fix for new map canvas in training page.
Makes map dakr but inverts sattelite in it if manually changed. I could not find how to exclude satellite maps. :(
![obraz](https://user-images.githubusercontent.com/56877029/93886722-13051800-fce6-11ea-97ea-0f7a38e4fcc4.png)
![obraz](https://user-images.githubusercontent.com/56877029/93886803-287a4200-fce6-11ea-815b-5f9cbdea90d5.png)
