### PR TITLE
Fix for youtube.com/embed

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2481,9 +2481,11 @@ html.i-ua_swipe_yes .menu2__container
 ================================
 
 youtube-nocookie.com
+youtube.com/embed
 
 NO INVERT
 video
+div[style*="https://i.ytimg.com"]
 
 ================================
 


### PR DESCRIPTION
- Add youtube.com/embed to youtube-nocookie.com fixes.
- Do not invert the thumbnail.
- Resolves #680