### PR TITLE
Add `neovim.io` to dark sites.

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -375,6 +375,7 @@ n-o-d-e.net
 namechk.com
 nanhu.ca
 neal.fun/size-of-space
+neovim.io
 neundex.com
 newgrounds.com
 nexusmods.com


### PR DESCRIPTION
The site can be found at [neovim.io](https://neovim.io/).