### PR TITLE
Removed spellcheck

### DIFF
--- a/src/ui/devtools/components/body.tsx
+++ b/src/ui/devtools/components/body.tsx
@@ -90,6 +90,7 @@ function Body({data, tab, actions}: BodyProps) {
             <textarea
                 id="editor"
                 onrender={onTextRender}
+                spellcheck="false"
             />
             <label id="error-text">{state.errorText}</label>
             <div id="buttons">


### PR DESCRIPTION
Added in the spellcheck attribute to prevent spellcheck in devtools. Currently:
![Screenshot from 2020-09-24 19-53-51](https://user-images.githubusercontent.com/53054099/94221316-b51c3000-fe9f-11ea-9f27-32462860dc13.png)
With this attribute, the red lines will be removed and the browsers won't check the spelling.