### PR TITLE
Added PDF Viewer Invert on PDF Viewer Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ or **[inversion-fixes.config](https://github.com/alexanderby/darkreader/blob/mas
 
 Automatically syncing the above files to every Dark Reader user was disabled because the GitHub team doesn't allow using GitHub as a CDN. Storing these files and making requests to other resources would be expensive and look suspicious. As such, changes are included with each new Dark Reader release.
 
+The URL patterns work like Regular Expressions with a few improvements specifically for URLs. Here are some examples:
+* `*.google.com`
+* `amazing.com`
+* `new.example.com/*`
+
+In Dynamic Mode, you can match PDF files with the `isPDF` pattern.
+
 ### Use Dev Tools!
 
 Dev Tools is designed to **fix minor issues** on a web page
@@ -184,8 +191,8 @@ Submit a **pull request**, and wait for **review**.
 You can install the extension from a file.  
 Install [Node.js LTS](https://nodejs.org/en/). Download the source code (or check out from git).  
 Open terminal in root folder and run:  
-- `npm install`  
-- `npm run release`  
+- `npm install`
+- `npm run release`
 
 This will generate `build.zip` for use in Chromium browsers and `build-firefox.xpi` for use in Firefox.
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ or **[inversion-fixes.config](https://github.com/alexanderby/darkreader/blob/mas
 
 Automatically syncing the above files to every Dark Reader user was disabled because the GitHub team doesn't allow using GitHub as a CDN. Storing these files and making requests to other resources would be expensive and look suspicious. As such, changes are included with each new Dark Reader release.
 
-The URL patterns work like Regular Expressions with a few improvements specifically for URLs. Here are some examples:
-* `*.google.com`
-* `amazing.com`
-* `new.example.com/*`
-
-In Dynamic Mode, you can match PDF files with the `isPDF` pattern.
-
 ### Use Dev Tools!
 
 Dev Tools is designed to **fix minor issues** on a web page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,7 +1193,7 @@
     },
     "@types/filewriter": {
       "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
+      "resolved": "http://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
       "integrity": "sha1-wFTor02d11205jq8dviFFocU1LM=",
       "dev": true
     },
@@ -5532,7 +5532,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -6000,7 +6000,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -6607,7 +6607,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -1,7 +1,7 @@
 import {formatSitesFixesConfig} from './utils/format';
 import {parseSitesFixesConfig} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
-import {compareURLPatterns, isURLInList} from '../utils/url';
+import {compareURLPatterns, isURLInList, isPDF} from '../utils/url';
 import {DynamicThemeFix} from '../definitions';
 
 const dynamicThemeFixesCommands = {
@@ -64,7 +64,7 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, fixes: Dy
         .slice(1)
         .map((theme) => {
             return {
-                specificity: isURLInList(frameURL || url, theme.url) ? theme.url[0].length : 0,
+                specificity: (isURLInList(frameURL || url, theme.url) || (isPDF(frameURL || url) && enabledForPDF && theme.url.includes('isPDF'))) ? theme.url[0].length : 0,
                 theme
             };
         })

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -50,6 +50,7 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, fixes: Dy
         return null;
     }
 
+    let urlSpecified:string = frameURL || url;
     const common = {
         url: fixes[0].url,
         invert: fixes[0].invert || [],
@@ -57,14 +58,14 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, fixes: Dy
         ignoreInlineStyle: fixes[0].ignoreInlineStyle || [],
         ignoreImageAnalysis: fixes[0].ignoreImageAnalysis || [],
     };
-    if (enabledForPDF) {
+    if (enabledForPDF && isPDF(urlSpecified)) {
         common.invert = common.invert.concat('embed[type="application/pdf"]');
     }
     const sortedBySpecificity = fixes
         .slice(1)
         .map((theme) => {
             return {
-                specificity: (isURLInList(frameURL || url, theme.url) || (isPDF(frameURL || url) && enabledForPDF && theme.url.includes('isPDF'))) ? theme.url[0].length : 0,
+                specificity: isURLInList(urlSpecified, theme.url) ? theme.url[0].length : 0,
                 theme
             };
         })


### PR DESCRIPTION
All this pull request does is the following:
Say I want to configure inside my Dynamic Configuration for only PDFs. Then inside the following:
```
mydomain.com
thisotherstuff.com

CSS
...

IGNORE IMAGE ANALYSIS
.ignore-this
#ignoreme

INVERT
.wrong-logo

```
I could add in `isPDF` in the URL Patterns section:
```
mydomain.com
thisotherstuff.com
isPDF

CSS
...

IGNORE IMAGE ANALYSIS
.ignore-this
#ignoreme

INVERT
.wrong-logo

```
And then whenever you open up a PDF, the configuration will be applied.