### PR TITLE
Fix for amazon.*.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -332,7 +332,7 @@ INVERT
 ================================
 
 amazon.*
-amazon.co.uk
+amazon.*.*
 
 INVERT
 #banner-image


### PR DESCRIPTION
- Changes amazon.co.uk -> amazon.*.* So it can match other TLD with a dot in it as well.