### PR TITLE
Correct some image elements on artofproblemsolving.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -494,6 +494,7 @@ CSS
 .article-single figure img {
     mix-blend-mode: initial !important;
 }
+
 ================================
 
 artofproblemsolving.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -494,6 +494,13 @@ CSS
 .article-single figure img {
     mix-blend-mode: initial !important;
 }
+================================
+
+artofproblemsolving.com
+
+INVERT
+.latex
+.latexcenter
 
 ================================
 


### PR DESCRIPTION
The site uses images mixed in with text for some special characters. The images have transparent backgrounds and black symbols on them. When rendered on the inverted webpage, they are nearly the same color as the background, and are hence unreadable This change makes those inversions.
The example page I visited: https://artofproblemsolving.com/wiki/index.php/2010_AMC_10A_Problems