### PR TITLE
Dark theme fix for forum.p300.it

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2403,41 +2403,21 @@ forum.p300.it
 CSS
 .ipsReact_reactCount > a {
     background-color: var(--darkreader-neutral-background);
-    border-color : white;
+    border-color: var(--darkreader-neutral-text); !important;
 }
 
 .ipsType_normal {
-    background : none;
     border-color: rgb(48,52,54);
-    border-width: 3px;
 }
 
-.ipsMenu_headerBar {
-    background-color: var(--darkreader-neutral-background);
-}
-
-.ipsMenu_footerBar {
-    background-color: var(--darkreader-neutral-background);
-}
-
-.ipsEmoticons_category {
-    background-color: var(--darkreader-neutral-background);
-}
-
-.ipsMenu_innerContent {
-    background-color: var(--darkreader-neutral-background);
-}
-
-ul.ipsMenu, .ipsMenu > ul {
-    background-color : var(--darkreader-neutral-background);
-}
-
-a[data-mentionid]{
-    background-color : var(--darkreader-neutral-background);
-}
-
-.cUserHovercard{
-    background-color : var(--darkreader-neutral-background); 
+.ipsMenu_headerBar,
+.ipsMenu_footerBar,
+.ipsEmoticons_category,
+.ipsMenu_innerContent,
+ul.ipsMenu, .ipsMenu > ul,
+a[data-mentionid],
+.cUserHovercard {
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2398,6 +2398,50 @@ CSS
 
 ================================
 
+forum.p300.it
+
+CSS
+.ipsReact_reactCount > a {
+    background-color: var(--darkreader-neutral-background);
+    border-color : white;
+}
+
+.ipsType_normal {
+    background : none;
+    border-color: rgb(48,52,54);
+    border-width: 3px;
+}
+
+.ipsMenu_headerBar {
+    background-color: var(--darkreader-neutral-background);
+}
+
+.ipsMenu_footerBar {
+    background-color: var(--darkreader-neutral-background);
+}
+
+.ipsEmoticons_category {
+    background-color: var(--darkreader-neutral-background);
+}
+
+.ipsMenu_innerContent {
+    background-color: var(--darkreader-neutral-background);
+}
+
+ul.ipsMenu, .ipsMenu > ul {
+    background-color : var(--darkreader-neutral-background);
+}
+
+a[data-mentionid]{
+    background-color : var(--darkreader-neutral-background);
+}
+
+.cUserHovercard{
+    background-color : var(--darkreader-neutral-background); 
+}
+
+================================
+
 forums.tomshardware.com
 
 INVERT


### PR DESCRIPTION
Fixed white parts of the page using variables:
- fixed white border on new post editor (hardcoded color to match other elements)
- fixed emoticon insertion menu to match dark color
- fixed user options menu to match dark color
- fixed user badge on quote to match dark color
- fixed like counter to match dark color. White border inserted to improve readability.