### PR TITLE
Improve wuffs.org dark mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7103,6 +7103,9 @@ CSS
 .wday-6 .mWeekday {
     color: ${#000059} !important;
 }
+select:focus {
+    color: var(--darkreader-selection-text) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7090,10 +7090,19 @@ span.name a
 wuffs.org
 
 CSS
-.heavyShower { background-color: #660; }
-.lightShower { background-color: #990; }
-.wday-0, .wday-6 { background: #333; }
-.wday-0 .mWeekday, .wday-6 .mWeekday { color: #CCF; }
+.heavyShower {
+    background-color: ${#e4b849} !important;
+}
+.lightShower {
+    background-color: ${#ff9} !important;
+}
+.wday-0, .wday-6 {
+    background: ${#ccc} !important;
+}
+.wday-0 .mWeekday,
+.wday-6 .mWeekday {
+    color: ${#000059} !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7087,6 +7087,16 @@ span.name a
 
 ================================
 
+wuffs.org
+
+CSS
+.heavyShower { background-color: #660; }
+.lightShower { background-color: #990; }
+.wday-0, .wday-6 { background: #333; }
+.wday-0 .mWeekday, .wday-6 .mWeekday { color: #CCF; }
+
+================================
+
 wunderground.com
 
 CSS


### PR DESCRIPTION
This website has a tool called MeteoNook. One of the pages of it shows a monthly summary with highlights on certain days (namely weekends and days with meteor showers). I found the text on the bright-yellow highlighted rows to be very unreadable for me. This may be due in part to my colorblindness, which is why I labeled this an "improvement" instead of a "fix" (please feel free to give feedback on the changes I'm making).

I lowered the brightness of both yellow highlightcolors so that the light text is more visible. I also increased the brightness of both the background and day label for the weekends to make them a bit more visible.

**Before:**
![Before](https://user-images.githubusercontent.com/607715/94753840-1be49200-0355-11eb-8b45-07c352ac7c40.png)

**After:**
![After](https://user-images.githubusercontent.com/607715/94753850-22730980-0355-11eb-9a56-2b66d966aa0a.png)
