### PR TITLE
Fix cssFilterStyleheetTemplate spelling mistake

### DIFF
--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -27,13 +27,13 @@ export function hasChromiumIssue501582() {
     );
 }
 
-export default function createCSSFilterStyleheet(config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
+export default function createCSSFilterStyleSheet(config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
     const filterValue = getCSSFilterValue(config);
     const reverseFilterValue = 'invert(100%) hue-rotate(180deg)';
-    return cssFilterStyleheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, inversionFixes);
+    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, inversionFixes);
 }
 
-export function cssFilterStyleheetTemplate(filterValue: string, reverseFilterValue: string, config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
+export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterValue: string, config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
     const fix = getInversionFixesFor(frameURL || url, inversionFixes);
 
     const lines: string[] = [];

--- a/src/generators/svg-filter.ts
+++ b/src/generators/svg-filter.ts
@@ -1,6 +1,6 @@
 import {createFilterMatrix, Matrix} from './utils/matrix';
 import {isFirefox} from '../utils/platform';
-import {cssFilterStyleheetTemplate} from './css-filter';
+import {cssFilterStyleSheetTemplate} from './css-filter';
 import {FilterConfig, InversionFix} from '../definitions';
 
 export function createSVGFilterStylesheet(config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
@@ -14,7 +14,7 @@ export function createSVGFilterStylesheet(config: FilterConfig, url: string, fra
         filterValue = 'url(#dark-reader-filter)';
         reverseFilterValue = 'url(#dark-reader-reverse-filter)';
     }
-    return cssFilterStyleheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, inversionFixes);
+    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, inversionFixes);
 }
 
 function getEmbeddedSVGFilterValue(matrixValue: string) {


### PR DESCRIPTION
I think the word ```cssFilterStyleheetTemplate```  in ``` src/generators/css-filter.ts``` is a spelling mistake so i created a PR to fix it