### PR TITLE
Fix for map.baidu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1608,6 +1608,7 @@ path[class^="wavePath"] {
 ================================
 
 ditu.baidu.com
+map.baidu.com
 
 INVERT
 .BMap_contextMenu
@@ -3729,19 +3730,6 @@ manjaro.org
 CSS
 .page-header-image {
     z-index: 0 !important;
-}
-
-================================
-
-map.baidu.com
-
-INVERT
-#MapHolder > canvas
-#map-operate > :nth-child(2)
-
-CSS
-#map-operate > :nth-child(2) > button {
-    background-color: white !important;
 }
 
 ================================


### PR DESCRIPTION
The fix in #3452 seems broken now. Since map.baidu.com and ditu.baidu.com are actually the same site, using ditu.baidu.com's fix here works fine.