### PR TITLE
Added 5 websites which have a dark mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Dark Reader for Google Chrome and Mozilla Firefox
+# Dark Reader for Google Chrome, Microsoft Edge and Mozilla Firefox
 
 ![Dark Reader screenshot](https://i.imgur.com/DyBlYwU.png)
 
 This extension **inverts brightness** of web pages and aims to **reduce eyestrain** while you browse the web.  
-Visit [Chrome Web Store](https://chrome.google.com/webstore/detail/dark-reader/eimadpbcbfnmbkopoojfekhnkhdbieeh)
+Visit [Edge Addons](https://microsoftedge.microsoft.com/addons/detail/dark-reader/ifoakfbpdcdoeenechcleahebpibofpc), [Chrome Web Store](https://chrome.google.com/webstore/detail/dark-reader/eimadpbcbfnmbkopoojfekhnkhdbieeh)
 and [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/darkreader/)
 for more info.
 
@@ -155,7 +155,7 @@ To build and debug the extension **install the [Node.js](https://nodejs.org/)** 
 Install development dependencies by running `npm install` in the project root folder.  
 Then execute `npm run debug`.
 
-#### Chrome
+#### Chrome and Edge
 - Open the `chrome://extensions` page.
 - Disable the official Dark Reader version.
 - Enable the **Developer mode**.

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -108,7 +108,6 @@ coolmathgames.com
 corepacks.com
 coriolis.io
 countermail.com
-courses.codestackr.com
 cracked.to
 crackingking.com
 crackwatch.com
@@ -271,7 +270,6 @@ hackersforcharity.org
 hackertyper.com
 hackforums.net
 hackthebox.eu
-hacktoberfest.digitalocean.com
 hardcoregaming101.net
 hardforum.com
 hastebin.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -97,6 +97,7 @@ clashofstats.com
 clt.gg
 codepen.io
 codesandbox.io
+codestackr.com
 codingame.com
 coinpot.co
 color.adobe.com
@@ -107,6 +108,7 @@ coolmathgames.com
 corepacks.com
 coriolis.io
 countermail.com
+courses.codestackr.com
 cracked.to
 crackingking.com
 crackwatch.com
@@ -119,6 +121,7 @@ cybercrime-tracker.net
 cyberpunk.net
 cybersole.io
 cytu.be
+daily.dev
 danidev.net
 darckrepacks.com
 daringfireball.net
@@ -250,6 +253,7 @@ gitkraken.com
 gload.cc
 glowing-bear.org
 glslsandbox.com
+go.dailynow.co
 goaudio.cc
 god.freevar.com
 gogalaxy.com
@@ -267,6 +271,7 @@ hackersforcharity.org
 hackertyper.com
 hackforums.net
 hackthebox.eu
+hacktoberfest.digitalocean.com
 hardcoregaming101.net
 hardforum.com
 hastebin.com


### PR DESCRIPTION
I added 5 websites which have dark mode. But one of them, [Hacktoberfest](hacktoberfest.digitalocean.com), determines dark mode by checking the system theme. If the system is dark, the site is dark, else light. But with dark reader, it looks like this
With the default light mode
![image](https://user-images.githubusercontent.com/51731966/94982580-469f3800-0559-11eb-96cb-146640ff6d22.png)
