### PR TITLE
Improvements to dropbox.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1786,6 +1786,91 @@ dropbox.com
 
 INVERT
 .dl-dropbox
+.home__suggest_card .brws-file-name-cell-icon
+.mc-icon-template-content--folder-large
+.drops-empty-page-header-image
+.restorations-education__df-help__image
+.search__view--empty img
+.plan-status-section__icon img
+
+CSS
+html, 
+.maestro-app,
+.embedded-app,
+.page-header, 
+.lasso-footer,
+.embedded-app table tbody, 
+.embedded-app table tr td, 
+.embedded-app table .mc-table-head *,
+.mc-media-actions,
+.mc-button-secondary,
+.home-access-section__header,
+.home-access .starred-item,
+.home-access .recents-item,
+.restorations-education__other-options-container,
+.app-directory-navigation-sidebar,
+.dig-Tabs-group {
+    background-color: rgb(24, 26, 27) !important;
+}
+
+.mc-button-secondary:hover {
+    border-color: #8ac3ef !important;
+    color: #8ac3ef !important;
+}
+
+.button-primary,
+.mc-button-primary,
+.dig-Button--primary,
+.dig-Button--primary .dig-Button-content,
+.dig-Button--primary .dig-UIIcon {
+    background-color: #72b6ec !important;
+    color: #1d2737 !important;
+}
+
+.button-primary:hover,
+.mc-button-primary:hover,
+.dig-Button--primary:hover,
+.dig-Button--outline:hover,
+.dig-Button--primary .dig-Button-content:hover,
+.dig-Button--outline .dig-Button-content:hover {
+    background-color: #8ac3ef !important;
+    background-image: none !important;
+}
+
+.dig-Button--outline:hover {
+    color: #1d2737 !important;
+}
+
+.dig-Button--primary:before,
+.dig-Button--outline:before,
+.dig-Button--primary .dig-Button-content .dig-UIIcon {
+    background-color: transparent !important;
+}
+
+.brws-files-view-list .brws-file-row {
+    background-color: #171b21  !important;
+    border-bottom-color: rgba(255, 255, 255, 0.1) !important;
+}
+
+.dig-Toggle-input:checked + .dig-Toggle-track,
+.dig-Checkbox-input:checked ~ .dig-Checkbox-styles, 
+.dig-Checkbox-input:indeterminate ~ .dig-Checkbox-styles,
+.account-plan-tab-quota-usage.is-within-quota .normal-color {
+    background-color: #72b6ec !important;
+    border-color: #8ac3ef !important;
+}
+
+.account-plan-tab-quota-usage.is-within-quota .shared-color {
+    border-color: #8ac3ef !important;
+}
+
+.restorations-education__explanation-container {
+    border-color: rgb(24, 26, 27) !important;
+}
+
+.maestro-nav__container {
+    background-color: rgb(18, 18, 18) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Dropbox doesn't look terrible with Dark Reader enabled, but it could look better:

![Old Dropbox Homepage](https://i.imgur.com/c6KZxMN.png)
![Old Dropbox All Files](https://i.imgur.com/gTYPzrB.png)
---

This PR makes quite a few tweaks to Dropbox's CSS since their web offering styles different elements inconsistently.

The most obvious changes are for SVG icons, tables and buttons as seen below:

![New Dropbox Homepage](https://i.imgur.com/4VzaFg0.png)
![New Dropbox All Files](https://i.imgur.com/nwawQkt.png)

Besides the changes seen in the images, here is a list of all significant stylings:
- Graphics with poor contrast were inverted
- Toggles, checkboxes, and buttons use light blue
- The side navigation is darker
- Table backgrounds are lighter
- Tab backgrounds are lighter
- Footer matches the background

Please let me know if there is anything I should change. Thank you.

