### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1668,7 +1668,6 @@ docs.google.com
 
 INVERT
 .docs-icon
-.punch-filmstrip-controls-icon
 #docs-editor canvas
 .docs-homescreen-icon
 .kix-equation-toolbar-icon


### PR DESCRIPTION
- Remove inverted selector as it's now gray/white-ish by default.
- Partially reverts #449