### PR TITLE
Google Translate Verified Translation button fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6254,6 +6254,11 @@ INVERT
 .ita-hwt-grip
 .gt-ex-quote
 
+CSS
+.trans-verified-button {
+    background-size: cover;
+}
+
 IGNORE IMAGE ANALYSIS
 .copybutton .jfk-button-img
 .speech-button .jfk-button-img


### PR DESCRIPTION
If the page is zoomed in, the verified translation button would be zoomed in but the right color. This fixes it.