### PR TITLE
Add the official github dependabot implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "wednesday"
     labels:
       - "dependencies"
+    reviewers:
+      - "Gusted"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
       - "dependencies"
     reviewers:
       - "Gusted"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This will add dependabot - that updates dependencies. A pr label will need to be made called `dependencies` in order for it to function correctly.