### PR TITLE
Add 9 sites to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -67,6 +67,7 @@ blackmod.net
 blink.sh
 blizzard.com
 block.wingysam.xyz
+blox.link
 blog.aractus.com
 blog.dota2.com
 blog.ja-ke.tech
@@ -150,6 +151,7 @@ digital.fashion
 disasm.pro
 disboard.org
 discord.bio
+discord.boats
 discord.bots.gg
 discord.com/app
 discord.com/channels
@@ -178,6 +180,7 @@ draculatheme.com
 draftkings.com
 drakewars.com
 drunkenslug.com
+dsc.gg
 duckychannel.com.tw
 duelingnexus.com
 dyno.gg
@@ -214,6 +217,7 @@ find.lolpros.gg
 flixxo.com
 flooxer.com
 florr.io
+fluxpoint.dev
 flyordie.io
 fortnite-api.com
 forum.cswarzone.com
@@ -363,6 +367,7 @@ matteotiscia.com
 mcrpw.github.io
 mcskinhistory.com
 mednafen.github.io
+mee6.xyz
 melody.ml
 merklex.io
 metronom.us
@@ -506,6 +511,7 @@ restream4me.com
 reveddit.com
 robofight.io
 rocketleagueesports.com
+roleypoly.com
 romefrontend.dev
 rtbyte.xyz
 runicgames.com
@@ -579,6 +585,7 @@ symfony.com
 szmarczak.com
 t.maisputain.ovh
 tacoanon.github.io
+tacobot.app
 takethewalk.net
 tallguysfree.com
 tautulli.com
@@ -655,6 +662,7 @@ wasm.continuation-labs.com/d3demo/
 watercss.kognise.dev
 weavesilk.com
 weboas.is
+widgetbot.io
 wiki.step-project.com
 wolfy.fr
 wormate.io
@@ -670,6 +678,7 @@ www.tvnz.co.nz
 x1337x.*/$
 x64dbg.com
 xbins.org
+xela.dev
 xn--rpa.cc
 xonotic.org
 yande.re

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -67,11 +67,11 @@ blackmod.net
 blink.sh
 blizzard.com
 block.wingysam.xyz
-blox.link
 blog.aractus.com
 blog.dota2.com
 blog.ja-ke.tech
 blokada.org
+blox.link
 bogleech.com
 bonsaihd.live
 botboy.snaz.in

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -585,7 +585,6 @@ symfony.com
 szmarczak.com
 t.maisputain.ovh
 tacoanon.github.io
-tacobot.app
 takethewalk.net
 tallguysfree.com
 tautulli.com


### PR DESCRIPTION
Added 9 sites
- [blox.link](https://blox.link)
- [discord.boats](https://discord.boats)
- [dsc.gg](https://dsc.gg)
- [fluxpoint.dev](https://fluxpoint.dev)
- [mee6.xyz](https://mee6.xyz)
- [roleypoly.com](https://roleypoly.com)
- ~~[tacobot.app](https://tacobot.app)~~
- [widgetbot.io](https://widgetbot.io)
- [xela.dev](https://xela.dev)