### PR TITLE
Fix for dotaunderlords.gamepedia.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1731,17 +1731,16 @@ CSS
 
 ================================
 
+dotaunderlords.gamepedia.com
 dota2.gamepedia.com
 
 CSS
-div.vectorTabs li:not(.selected) span,
-div.vectorMenu,
-#p-search {
-    background-color: var(--darkreader-neutral-background) !important
-}
 #right-navigation {
     background-image: none !important;
 }
+
+IGNORE IMAGE ANALYSIS
+#left-navigation
 
 ================================
 


### PR DESCRIPTION
- Cleaner and better fix than current one.
- Exposes `dota2.gamepedia.com` to the fix as well
- Resolves #3809