### PR TITLE
dynamic-theme-fixes.config: Fix dark-on-dark math formulas on wikisource.org (invert .mwe-math-element)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7092,6 +7092,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+wikisource.org
+
+INVERT
+.mwe-math-element
+
+================================
+
 wikiversity.org
 
 INVERT


### PR DESCRIPTION
See for example: https://en.wikisource.org/wiki/On_the_Electrodynamics_of_Moving_Bodies_(1920_edition)