### PR TITLE
Fix for desmos.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1525,6 +1525,13 @@ INVERT
 
 ================================
 
+desmos.com
+
+INVERT
+.dcg-grapher
+
+================================
+
 dev.dota2.com
 
 CSS


### PR DESCRIPTION
Axis, grid and axis' labels are now correctly inverted