### PR TITLE
fix for mp.weixin.qq.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4185,6 +4185,14 @@ div.mzp-c-navigation-logo {
 
 ================================
 
+mp.weixin.qq.com
+
+INVERT
+.audio_card_progress
+.audio_card_progress_handle
+
+================================
+
 msmgtoolkit.in
 
 CSS


### PR DESCRIPTION
E.g. https://mp.weixin.qq.com/s?__biz=MzIxMTMzNTc5OA==&mid=2247492960&idx=1&sn=3eb1b1c7ccea5e37ecde404687e02fbe

![sshot-003](https://user-images.githubusercontent.com/36977733/95862451-78cb4980-0d52-11eb-969e-a187271465ec.png)
![sshot-002](https://user-images.githubusercontent.com/36977733/95862453-79fc7680-0d52-11eb-8898-bd89f456e3cd.png)
