### PR TITLE
Throttle Inline attribute

### DIFF
--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -4,6 +4,8 @@ import {iterateCSSDeclarations} from './css-rules';
 import {getModifiableCSSDeclaration} from './modify-css';
 import {FilterConfig} from '../../definitions';
 import {IS_SHADOW_DOM_SUPPORTED} from '../../utils/platform';
+import {getDuration} from '../../utils/time';
+import {throttle} from '../utils/throttle';
 
 interface Overrides {
     [cssProp: string]: {
@@ -168,7 +170,14 @@ function deepWatchForInlineStyles(
     });
     treeObservers.set(root, treeObserver);
 
-    const attrObserver = new MutationObserver((mutations) => {
+    let attributecount = 0;
+    let start = null;
+    const ATTEMPTS_INTERVAL = getDuration({seconds: 10});
+    const MAX_ATTEMPTS_COUNT = 50;
+    let cache: MutationRecord[];
+    let timeoutId: number = null;
+
+    const handleAttributionMutations = throttle((mutations: MutationRecord[]) => {
         mutations.forEach((m) => {
             if (INLINE_STYLE_ATTRS.includes(m.attributeName)) {
                 elementStyleDidChange(m.target as HTMLElement);
@@ -177,6 +186,31 @@ function deepWatchForInlineStyles(
                 .filter(({store, dataAttr}) => store.has(m.target) && !(m.target as HTMLElement).hasAttribute(dataAttr))
                 .forEach(({dataAttr}) => (m.target as HTMLElement).setAttribute(dataAttr, ''));
         });
+    });
+    const attrObserver = new MutationObserver((mutations) => {
+        if (timeoutId) {
+            cache.push(...mutations);
+            return;
+        }
+        attributecount++;
+        const now = Date.now();
+        if (start == null) {
+            start = now;
+        } else if (attributecount >= MAX_ATTEMPTS_COUNT) {
+            if (now - start < ATTEMPTS_INTERVAL) {
+                timeoutId = setTimeout(() => {
+                    start = null;
+                    attributecount = 0;
+                    timeoutId = null;
+                    handleAttributionMutations(cache);
+                }, 2000);
+                cache.push(...mutations);
+                return;
+            }
+            start = now;
+            attributecount = 1;
+        }
+        handleAttributionMutations(mutations);
     });
     attrObserver.observe(root, {
         attributes: true,

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -170,9 +170,10 @@ function deepWatchForInlineStyles(
     });
     treeObservers.set(root, treeObserver);
 
-    let attributecount = 0;
+    let attemptCount = 0;
     let start = null;
     const ATTEMPTS_INTERVAL = getDuration({seconds: 10});
+    const RETRY_TIMEOUT = getDuration({seconds: 2});
     const MAX_ATTEMPTS_COUNT = 50;
     let cache: MutationRecord[];
     let timeoutId: number = null;
@@ -192,23 +193,23 @@ function deepWatchForInlineStyles(
             cache.push(...mutations);
             return;
         }
-        attributecount++;
+        attemptCount++;
         const now = Date.now();
         if (start == null) {
             start = now;
-        } else if (attributecount >= MAX_ATTEMPTS_COUNT) {
+        } else if (attemptCount >= MAX_ATTEMPTS_COUNT) {
             if (now - start < ATTEMPTS_INTERVAL) {
                 timeoutId = setTimeout(() => {
                     start = null;
-                    attributecount = 0;
+                    attemptCount = 0;
                     timeoutId = null;
                     handleAttributionMutations(cache);
-                }, 2000);
+                }, RETRY_TIMEOUT);
                 cache.push(...mutations);
                 return;
             }
             start = now;
-            attributecount = 1;
+            attemptCount = 1;
         }
         handleAttributionMutations(mutations);
     });


### PR DESCRIPTION
- Max trottle the inline attribute changer to 50 attributes in 10 seconds.
- Should partially resolve conflicts with certain elements that intend to revert our changes to a element.
- Resolves #3864
- Resolves #1222