### PR TITLE
Fix for slashnet.wordpress.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5560,6 +5560,17 @@ INVERT
 
 ================================
 
+slashnet.wordpress.com
+
+CSS
+#container,
+.entry,
+body {
+    background-image: none !important;
+}
+
+================================
+
 smap.uthm.edu.my
 
 CSS


### PR DESCRIPTION
- Remove white-ish background-images which overriden background-color.
- Resolves #3866