### PR TITLE
Add Destiny Item Manager to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -21,6 +21,7 @@ animeonline.su
 animepahe.com
 animixplay.com
 animk.info
+app.destinyitemmanager.com
 app.keeweb.info
 app.plex.tv
 app.pluralsight.com
@@ -51,6 +52,7 @@ benleggiero.blog
 benleggiero.me
 bequiet.com
 bestblackhatforum.com
+beta.destinyitemmanager.com
 betterttv.com
 bherila.net
 bin.disroot.org


### PR DESCRIPTION
DIM is already a light-on-dark theme:

![image](https://user-images.githubusercontent.com/313208/96349630-a4f20d80-1065-11eb-937e-525ba08dbed8.png)

cc @kyleshay @inexorableAce