### PR TITLE
Update dynamic-theme-fixes.config for coursera.org fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1355,6 +1355,24 @@ a {
 
 ================================
 
+coursera.org
+
+INVERT
+.rc-VideoMiniPlayer
+
+CSS
+.jfk-bubble.gtx-bubble, embed[type="application/pdf"], .rc-VideoMiniPlayer {
+    filter: invert(0%) hue-rotate(0deg) contrast(90%) !important;
+}
+
+html, body, body :not(iframe) {
+    background-color: none !important;
+    border-color: none !important;
+    color: none !important;
+}
+
+===============================
+
 cplusplus.com
 
 CSS


### PR DESCRIPTION
CSS element was blocking video, different element was inverting colors on it. Both of those bugs have been eliminated and I added .rc-VideoMiniPlayer CSS Selector to the inversion list for posterity. Works in light and dark on each page I have tested it on.