### PR TITLE
Fix Deezer seek bar color

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -315,6 +315,11 @@ deezer.com
 INVERT
 .page-sidebar
 
+CSS
+.slider-track .gradient-default {
+    background-image: linear-gradient(1deg, var(--color-dark-grey-800) 13%, var(--color-coral-500));
+}
+
 NO INVERT
 .player-cover *
 


### PR DESCRIPTION
The seek bar had a dark gray color and was invisible.
This fix uses Deezer's default theme colors to make the seek bar have a gray-to-red gradient.
The colors are referenced using variables, so in case Deezer changes its theme Dark Reader will use the new colors.

Current:
![image](https://user-images.githubusercontent.com/10130438/96653183-cc342d80-1338-11eb-9acc-51ac8c96e806.png)

Fixed:
![image](https://user-images.githubusercontent.com/10130438/96653288-000f5300-1339-11eb-9961-f1ae7392a99c.png)

