### PR TITLE
Fix Deezer seek bar color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1520,6 +1520,15 @@ body {
 
 ================================
 
+deezer.com
+
+CSS
+.slider-track .gradient-default {
+    background-image: linear-gradient(1deg, var(--color-dark-grey-800) 13%, var(--color-coral-500));
+}
+
+================================
+
 dennisbareis.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1524,7 +1524,7 @@ deezer.com
 
 CSS
 .slider-track .gradient-default {
-    background-image: linear-gradient(1deg, var(--color-dark-grey-800) 13%, var(--color-coral-500));
+    background-image: linear-gradient(1deg, var(--color-dark-grey-800) 13%, var(--color-white));
 }
 
 ================================


### PR DESCRIPTION
The seek bar in Deezer sometimes takes the average color of the playlist. This was designed with the assumption that the background is white, so in the cases when the album cover is in grayscale, the seek bar can be dark gray and appear invisible when using Dark Reader.

This fix uses Deezer's default theme colors to make the seek bar have a gray-to-red gradient all the time.
The colors are referenced using variables, so in case Deezer changes its theme Dark Reader will use the new colors.

Current:
![image](https://user-images.githubusercontent.com/10130438/96654290-39e15900-133b-11eb-9867-b170d632b975.png)

Fixed:
![image](https://user-images.githubusercontent.com/10130438/96654301-406fd080-133b-11eb-9982-975aa485ee95.png)
