### PR TITLE
Force fallback to be opacity: 1

### DIFF
--- a/src/inject/fallback.ts
+++ b/src/inject/fallback.ts
@@ -3,7 +3,7 @@ if (
     matchMedia('(prefers-color-scheme: dark)').matches &&
     !document.querySelector('.darkreader--fallback')
 ) {
-    const css = 'html, body, body :not(iframe) { background-color: #181a1b !important; border-color: #776e62 !important; color: #e8e6e3 !important; opacity: 1 !important; }';
+    const css = 'html, body, body :not(iframe) { background-color: #181a1b !important; border-color: #776e62 !important; color: #e8e6e3 !important; } html, body { opacity: 1 !important; }';
     const fallback = document.createElement('style');
     fallback.classList.add('darkreader');
     fallback.classList.add('darkreader--fallback');

--- a/src/inject/fallback.ts
+++ b/src/inject/fallback.ts
@@ -3,7 +3,7 @@ if (
     matchMedia('(prefers-color-scheme: dark)').matches &&
     !document.querySelector('.darkreader--fallback')
 ) {
-    const css = 'html, body, body :not(iframe) { background-color: #181a1b !important; border-color: #776e62 !important; color: #e8e6e3 !important; }';
+    const css = 'html, body, body :not(iframe) { background-color: #181a1b !important; border-color: #776e62 !important; color: #e8e6e3 !important; opacity: 1 !important; }';
     const fallback = document.createElement('style');
     fallback.classList.add('darkreader');
     fallback.classList.add('darkreader--fallback');


### PR DESCRIPTION
- This bypasses the bypass of #3884.
- Force `opacity: 1` and therefore the html/body will be visible for rendering and return a dark color in order to still prevent the white-flash.
- Resolves #3884