### PR TITLE
Added youtube.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -688,6 +688,7 @@ yande.re
 yandexdataschool.ru/$
 yasio.pl
 you.dj
+youtube.com
 yt.is.nota.live
 yts.*
 yuzu-emu.org


### PR DESCRIPTION
Added youtube.com as it was mentioned in readme.md.
youtube.com now has its own dark mode so as mentioned in readme.md this website should be added to the exception list.