### PR TITLE
GitHub comment box fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2750,6 +2750,9 @@ CSS
 #commit-activity-detail > svg {
     fill: ${black} !important;
 }
+tab-container, file-attachment, div.timeline-comment {
+    background: var(--darkreader-neutral-background) !important;
+}
 
 IGNORE INLINE STYLE
 a[href^="https://apps.apple.com/app/"] g


### PR DESCRIPTION
This fixes white borders when creating a new issue and when writing a new comment. I think this improves upon #3928.
Verified to work on Edge Chromium and Firefox. This *might* fix #3914.

---

**Before**

![peoblem1](https://user-images.githubusercontent.com/26112391/97147708-ef733880-178f-11eb-83cd-821bc7305498.png)
![problem2](https://user-images.githubusercontent.com/26112391/97147715-f0a46580-178f-11eb-922d-db09767a273d.png)

---

**After**

![image](https://user-images.githubusercontent.com/26112391/97147815-1cbfe680-1790-11eb-9e87-c3566bb772dd.png)
