### PR TITLE
Revert #3739 (Firefox CORS issue for images)

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -244,6 +244,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             }
 
             syncStylePositionWatcher && syncStylePositionWatcher.stop();
+            insertStyle();
 
             // Firefox issue: Some websites get CSP warning,
             // when `textContent` is not set (e.g. pypi.org).
@@ -253,8 +254,6 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             if (syncStyle.sheet == null) {
                 syncStyle.textContent = '';
             }
-
-            insertStyle();
 
             const sheet = syncStyle.sheet;
             for (let i = sheet.cssRules.length - 1; i >= 0; i--) {


### PR DESCRIPTION
- Reverts commit https://github.com/darkreader/darkreader/pull/3739/commits/750441ab868b215afe7d311445e7fb8fcb6062c3
- Reverting as it's causing issues with Firefox's CORS to load 'blob:' URLS.
- Resolves #3936