### PR TITLE
Correct some image elements on wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7224,6 +7224,7 @@ img[src*="Loudspeaker.svg"]
 img[alt="The Signpost"]
 
 CSS
+.mwe-popups-discreet > svg,
 div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"] {
     background-color: white;


### PR DESCRIPTION
Wikipedia articles can have links to other Wikipedia pages. When one hovers over any these links, a popup appears showing an excerpt from the article the to which the link points, and sometimes, an image from the linked page. These images are what this change deals with.

If, for example, an SVG image depicting a diagram is displayed, the image is designed to be displayed with a white background--and hence the diagram is in a dark color like black, and the SVG has a transparent background. Before this change, the background was made dark by Dark Reader, while the SVG was unaltered. This lead to near invisibility of the diagram in question.
This change makes the background color of the image's container white, so that transparent-background images like diagrams are visible.

An example page: https://en.wikipedia.org/wiki/Lithium-ion_battery
The link to "LiPF6" in the "Electrolytes" section shows a popup with a transparent-background SVG