### PR TITLE
Add fix for diagrams in the Free Pascal manual

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7457,6 +7457,13 @@ html, body {
 
 ================================
 
+www.freepascal.org/docs-html
+
+INVERT
+img
+
+================================
+
 www.gamer.com.tw
 forum.gamer.com.tw
 


### PR DESCRIPTION
The diagrams used throughout the manual are transparent pngs with black figures:
https://www.freepascal.org/docs-html/current/ref/refli5.html