### PR TITLE
Make time in my.nextdns.io logs more visible

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4449,6 +4449,11 @@ img[src*="/static/media/samsung"]
 img[src*="/static/media/sonos"]
 a.d-none.d-md-inline
 
+CSS
+.text-right[style*="opacity: 0.3"] {
+opacity: 0.6 !important;
+}
+
 ================================
 
 my.nintendo.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4451,7 +4451,7 @@ a.d-none.d-md-inline
 
 CSS
 .text-right[style*="opacity: 0.3"] {
-opacity: 0.6 !important;
+    opacity: 0.6 !important;
 }
 
 ================================


### PR DESCRIPTION
"0.3" opacity is a little hard to see, increased to "0.6".

Time elements look like this:

`<div class="text-right" style="font-size: 0.8em; opacity: 0.3; margin-top: 2px;"><time datetime="1604283965954">9 minutes ago</time></div>`

Before:
![image](https://user-images.githubusercontent.com/14346945/97824464-aefe4800-1cc4-11eb-9ab3-0975402200a2.png)

After:
![image](https://user-images.githubusercontent.com/14346945/97824478-b7ef1980-1cc4-11eb-9129-9c9497ebe54c.png)