### PR TITLE
Add arewewaylandyet.com to dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -26,6 +26,7 @@ app.keeweb.info
 app.plex.tv
 app.pluralsight.com
 application.security
+arewewaylandyet.com
 argoto.snaz.in
 arisuchan.jp
 arkadia.xyz


### PR DESCRIPTION
[arewewaylandyet.com](https://arewewaylandyet.com/) has a dark mode enabled by default when `prefers-color-scheme` is set to dark.