### PR TITLE
Fix for filmweb.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2444,6 +2444,19 @@ div[class*="modal--modalShadow"] div
 
 filmweb.pl
 
+INVERT
+.ribbonLbl
+.isInit.ribbon[data-state="1"]::after
+.isInit.ribbon[data-state="2"]::after
+.isInit.ribbon[data-state="3"]::after
+.isInit.ribbon[data-state="4"]::after
+.isInit.ribbon[data-state="5"]::after
+.isInit.ribbon[data-state="6"]::after
+.isInit.ribbon[data-state="7"]::after
+.isInit.ribbon[data-state="8"]::after
+.isInit.ribbon[data-state="9"]::after
+.isInit.ribbon[data-state="10"]::after
+
 CSS
 .filmInfo__info {
     color: var(--darkreader-neutral-text) !important;


### PR DESCRIPTION
Makes the text inside ribbons visible.

Before and after:
![image](https://user-images.githubusercontent.com/7274290/97967626-c4a36880-1dbd-11eb-8495-285ada871f8f.png)

It requires being logged in to see.

In some places .ribbonLbl is empty and serves no purpose. It's just a part of the template code that creates the ribbon. The text is in .isInit.ribbon::after. But in other places, like on the profile page, it is actually used and the text is there.

You can't invert the whole .isInit.ribbon::after because other states look properly not inverted.