### PR TITLE
Fix for developer.mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1652,6 +1652,10 @@ developer.mozilla.org
 
 INVERT
 mark
+.icon-thumbs-down-alt
+.bc-head-icon-edge::before
+.last-modified::before
+.newsletter-hide > svg
 
 ================================
 


### PR DESCRIPTION
Example: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class