### PR TITLE
Fix for wired.co.uk

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7564,6 +7564,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+wired.co.uk
+
+INVERT
+body a svg
+.c-nav__open-icon
+.c-nav__close-icon
+
+================================
+
 wired.com
 
 INVERT


### PR DESCRIPTION
- Invert logo.
- Invert search icon.
- Invert search close icon.

Examples: https://www.wired.co.uk/, https://www.wired.co.uk/article/android-11-best-features-how-to-download