### PR TITLE
Move definedElements to darkreader's proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8349,7 +8349,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },

--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -10,17 +10,17 @@ export function injectProxy() {
         Object.defineProperty(CSSStyleSheet.prototype, 'deleteRule', deleteRuleDescriptor);
         Object.defineProperty(CSSStyleSheet.prototype, 'removeRule', removeRuleDescriptor);
         document.removeEventListener('__darkreader__cleanUp', cleanUp);
-        document.removeEventListener('__darkreader__addUndefinedResolver', (e: any) => addUndefinedResolver(e.details.tag));
+        document.removeEventListener('__darkreader__addUndefinedResolver', (e: CustomEvent<{tag: string}>) => addUndefinedResolver(e));
     };
 
-    const addUndefinedResolver = ($tag: string) => {
-        customElements.whenDefined($tag).then(() => {
-            document.dispatchEvent(new CustomEvent('__darkreader__isDefined', {detail: {tag: $tag}}));
+    const addUndefinedResolver = (e: CustomEvent<{tag: string}>) => {
+        customElements.whenDefined(e.detail.tag).then(() => {
+            document.dispatchEvent(new CustomEvent('__darkreader__isDefined', {detail: {tag: e.detail.tag}}));
         });
     };
 
     document.addEventListener('__darkreader__cleanUp', cleanUp);
-    document.addEventListener('__darkreader__addUndefinedResolver', (e: any) => addUndefinedResolver(e.details.tag));
+    document.addEventListener('__darkreader__addUndefinedResolver', (e: CustomEvent<{tag: string}>) => addUndefinedResolver(e));
 
     const updateSheetEvent = new Event('__darkreader__updateSheet');
 

--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -10,6 +10,7 @@ export function injectProxy() {
         Object.defineProperty(CSSStyleSheet.prototype, 'deleteRule', deleteRuleDescriptor);
         Object.defineProperty(CSSStyleSheet.prototype, 'removeRule', removeRuleDescriptor);
         document.removeEventListener('__darkreader__cleanUp', cleanUp);
+        document.removeEventListener('__darkreader__addUndefinedResolver', (e: any) => addUndefinedResolver(e.details.tag));
     };
 
     const addUndefinedResolver = ($tag: string) => {
@@ -19,7 +20,7 @@ export function injectProxy() {
     };
 
     document.addEventListener('__darkreader__cleanUp', cleanUp);
-    document.addEventListener('__darkreader__addUndefinedResolver', (e: any) => addUndefinedResolver(e.info.tag))
+    document.addEventListener('__darkreader__addUndefinedResolver', (e: any) => addUndefinedResolver(e.details.tag));
 
     const updateSheetEvent = new Event('__darkreader__updateSheet');
 
@@ -49,7 +50,7 @@ export function injectProxy() {
 
     function proxyRemoveRule(index?: number): void {
         removeRuleDescriptor.value.call(this, index);
-        if (this.ownerNode && !this.ownerN ode.classList.contains('darkreader')) {
+        if (this.ownerNode && !this.ownerNode.classList.contains('darkreader')) {
             this.ownerNode.dispatchEvent(updateSheetEvent);
         }
     }

--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -11,7 +11,15 @@ export function injectProxy() {
         Object.defineProperty(CSSStyleSheet.prototype, 'removeRule', removeRuleDescriptor);
         document.removeEventListener('__darkreader__cleanUp', cleanUp);
     };
+
+    const addUndefinedResolver = ($tag: string) => {
+        customElements.whenDefined($tag).then(() => {
+            document.dispatchEvent(new CustomEvent('__darkreader__isDefined', {detail: {tag: $tag}}));
+        });
+    };
+
     document.addEventListener('__darkreader__cleanUp', cleanUp);
+    document.addEventListener('__darkreader__addUndefinedResolver', (e: any) => addUndefinedResolver(e.info.tag))
 
     const updateSheetEvent = new Event('__darkreader__updateSheet');
 
@@ -41,7 +49,7 @@ export function injectProxy() {
 
     function proxyRemoveRule(index?: number): void {
         removeRuleDescriptor.value.call(this, index);
-        if (this.ownerNode && !this.ownerNode.classList.contains('darkreader')) {
+        if (this.ownerNode && !this.ownerN ode.classList.contains('darkreader')) {
             this.ownerNode.dispatchEvent(updateSheetEvent);
         }
     }

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -37,24 +37,19 @@ function collectUndefinedElements(root: ParentNode) {
         });
 }
 
-function customElementsWhenDefined(tag: string) {
+function customElementsWhenDefined($tag: string) {
     return new Promise((resolve) => {
         // `customElements.whenDefined` is not available in extensions
         // https://bugs.chromium.org/p/chromium/issues/detail?id=390807
         if (window.customElements && typeof window.customElements.whenDefined === 'function') {
-            customElements.whenDefined(tag).then(resolve);
+            customElements.whenDefined($tag).then(resolve);
         } else {
-            const checkIfDefined = () => {
-                const elements = undefinedGroups.get(tag);
-                if (elements && elements.size > 0) {
-                    if (elements.values().next().value.matches(':defined')) {
-                        resolve();
-                    } else {
-                        requestAnimationFrame(checkIfDefined);
-                    }
+            document.addEventListener('__darkreader__isDefined', (e: any) => {
+                if (e.details.tag === $tag) {
+                    resolve();
                 }
-            };
-            requestAnimationFrame(checkIfDefined);
+            });
+            document.dispatchEvent(new CustomEvent('__darkreader__addUndefinedResolver', {detail: {tag: $tag}}));
         }
     });
 }

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -42,7 +42,7 @@ const resolvers = new Map<string, () => void>();
 function handleIsDefined(e: CustomEvent<{tag: string}>)  {
     if (resolvers.has(e.detail.tag)) {
         const resolve = resolvers.get(e.detail.tag);
-        resolve && resolve();
+        resolve();
     }
 }
 
@@ -54,7 +54,7 @@ function customElementsWhenDefined(tag: string) {
             customElements.whenDefined(tag).then(resolve);
         } else {
             resolvers.set(tag, resolve);
-            document.dispatchEvent(new CustomEvent('__darkreader__addUndefinedResolver', {detail: {tag: tag}}));
+            document.dispatchEvent(new CustomEvent('__darkreader__addUndefinedResolver', {detail: {tag}}));
         }
     });
 }

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -39,22 +39,22 @@ function collectUndefinedElements(root: ParentNode) {
 
 const resolvers = new Map<string, () => void>();
 
-const handleIsDefined = (e: any) => {
-    if (resolvers.has(e.details.tag)) {
-        const resolve = resolvers.get(e.details.tag);
+function handleIsDefined(e: CustomEvent<{tag: string}>)  {
+    if (resolvers.has(e.detail.tag)) {
+        const resolve = resolvers.get(e.detail.tag);
         resolve && resolve();
     }
 }
 
-function customElementsWhenDefined($tag: string) {
+function customElementsWhenDefined(tag: string) {
     return new Promise((resolve) => {
         // `customElements.whenDefined` is not available in extensions
         // https://bugs.chromium.org/p/chromium/issues/detail?id=390807
         if (window.customElements && typeof window.customElements.whenDefined === 'function') {
-            customElements.whenDefined($tag).then(resolve);
+            customElements.whenDefined(tag).then(resolve);
         } else {
-            resolvers.set($tag, resolve);
-            document.dispatchEvent(new CustomEvent('__darkreader__addUndefinedResolver', {detail: {tag: $tag}}));
+            resolvers.set(tag, resolve);
+            document.dispatchEvent(new CustomEvent('__darkreader__addUndefinedResolver', {detail: {tag: tag}}));
         }
     });
 }


### PR DESCRIPTION
- Instead of using rAF use the page's context to check when the custom element is defined and let the content script know it can be resolved.

Is their a simple test case where this is actually helpful? as I tried reading the code and understand it and wasn't able to have a simple test case to test this against.