### PR TITLE
fix for linkedin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3739,6 +3739,8 @@ linkedin.com
 
 INVERT
 .artdeco-button
+.jobs-search-box__input-icon
+.artdeco-pill
 
 CSS
 .js-job-card-company-logo {


### PR DESCRIPTION
invert for two icons and pills buttons in jobs
![image](https://user-images.githubusercontent.com/56877029/98445408-ec753200-2117-11eb-9706-6d270e371bea.png)
