### PR TITLE
Fix for thecode.media

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6385,6 +6385,13 @@ CSS
 
 ================================
 
+thecode.media
+
+INVERT
+img[src$="/logo.svg"]
+
+================================
+
 theguardian.com
 
 INVERT


### PR DESCRIPTION
- Invert logo.

Example: https://thecode.media/ai/