### PR TITLE
changed color for tiles

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3732,10 +3732,12 @@ CSS
 .slds-brand-band:after,
 .slds-brand-band_cover,
 .slds-brand-band_medium,
-.slds-card,
 .slds-page-header,
 .slds-clearfix {
     background-color: var(--darkreader-neutral-background) !important;
+}
+.slds-card {
+    background-color: #333333 !important;
 }
 .slds-button_neutral,
 .slds-button--neutral {


### PR DESCRIPTION
.slds-card is a tile on a page with black text. The default color made the tile's blend into the dark background and made the text in them unreadable.

Moved .slds-card and changed it's background color so that text in the panels can be read and differentiated from the rest of the page as intended.