### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -48,6 +48,7 @@ bbc.co.uk/iplayer
 beastskills.com
 bedrocklinux.org
 ben-herila.webflow.io
+benfoster.dev
 benleggiero.blog
 benleggiero.me
 bequiet.com


### PR DESCRIPTION
My website "benfoster.dev", along with the in-progress version already bares a full dark design without the ability to modify to a light version dynamically. When dark reader is enabled, the extension improperly modifies the logo constructed via HTML and CSS. Observe the brackets on the left and right becoming black, along with the backdrop-filter blur properties being disabled.