### PR TITLE
Update deprecated functions

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -46,9 +46,9 @@ export function auto(themeOptions: Partial<Theme> | false = {}, fixes: DynamicTh
     if (themeOptions) {
         store = {themeOptions, fixes};
         handleColorScheme();
-        darkScheme.addListener(handleColorScheme);
+        darkScheme.addEventListener('change', handleColorScheme);
     } else {
-        darkScheme.removeListener(handleColorScheme);
+        darkScheme.removeEventListener('change', handleColorScheme);
         disable();
     }
 }

--- a/src/inject/utils/watch-color-scheme.ts
+++ b/src/inject/utils/watch-color-scheme.ts
@@ -1,10 +1,10 @@
 export function watchForColorSchemeChange(callback: ({isDark}) => void) {
     const query = window.matchMedia('(prefers-color-scheme: dark)');
     const onChange = () => callback({isDark: query.matches});
-    query.addListener(onChange);
+    query.addEventListener('change', onChange);
     return {
         disconnect() {
-            query.removeListener(onChange);
+            query.removeEventListener('change', onChange);
         },
     };
 }


### PR DESCRIPTION
- The general addListener/removeListener are still supported for backwards comparability, however this can change at any time and therefore update them to the updated function.

https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener
https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/onchange