### PR TITLE
Fixes import replacement

### DIFF
--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -64,7 +64,7 @@ export function getElementCSSVariables(element: HTMLElement) {
 }
 
 export const cssURLRegex = /url\((('.+?')|(".+?")|([^\)]*?))\)/g;
-export const cssImportRegex = /@import (url\()?(('.+?')|(".+?")|([^\)]*?))\)?;?/g;
+export const cssImportRegex = /@import\s*(url\()?(('.+?')|(".+?")|([^\)]*?))\)?;?/g;
 
 export function getCSSURLValue(cssURL: string) {
     return cssURL.replace(/^url\((.*)\)$/, '$1').replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');


### PR DESCRIPTION
- Fixes a rare bug where the space between `@import` and `(url)` isn't their and Dark Reader won't replaced the import.
- Resolves #3837

Credits to @alexanderby!