### PR TITLE
Changed main key to browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:utils": "jest --config=tests/utils/jest.config.js",
     "test:utils:debug": "node --inspect-brk ./node_modules/jest/bin/jest --config=tests/utils/jest.config.js --runInBand --no-cache --watch"
   },
-  "main": "darkreader.js",
+  "browser": "darkreader.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/darkreader/darkreader.git"


### PR DESCRIPTION
The `main` key inside the `package.json` is used only for server-side or non-client-side scripts. I think that `darkreader.js` runs on the client-side. According to `npm`'s documentation, use the `browser` key instead when it is a client-side script:
https://docs.npmjs.com/cli/v6/configuring-npm/package-json#browser