### PR TITLE
Fix for todoist.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6779,6 +6779,13 @@ img[src="/img/logout-black.png"]
 
 ================================
 
+todoist.com
+
+INVERT
+.ist_button_apple > img
+
+================================
+
 tokfm.pl
 
 CSS


### PR DESCRIPTION
- Invert Apple icon.

Example: https://todoist.com/users/showlogin