### PR TITLE
fix dynamic theme editor for zenn.dev

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8357,7 +8357,7 @@ CSS
 zenn.dev
 
 CSS
-:root{
+:root {
     --c-primary-bg: #393e3f;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8354,6 +8354,19 @@ CSS
 
 ================================
 
+zenn.dev
+
+CSS
+:root{
+    --c-primary-bg: #393e3f;
+}
+
+#header > div > div > a > svg > g {
+    fill: white !important;
+}
+
+================================
+
 zeptovm.com
 
 INVERT


### PR DESCRIPTION
fix zenn.dev, Japanese Common developer site.

### Before
![スクリーンショット 2020-11-15 17 04 07](https://user-images.githubusercontent.com/7910558/99179995-c67a0e00-2765-11eb-9bf5-db8fa935aadd.png)


### After
![スクリーンショット 2020-11-15 17 04 42](https://user-images.githubusercontent.com/7910558/99180004-de519200-2765-11eb-8347-f5ff0f784777.png)

https://zenn.dev/it/articles/385c9bc5f74c97dfc214