### PR TITLE
 Remove manger when Style becomes disabled

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -40,7 +40,7 @@ export interface StyleManager {
 
 export const STYLE_SELECTOR = 'style, link[rel*="stylesheet" i]:not([disabled])';
 
-export function shouldManageStyle(element: Node) {
+export function shouldManageStyle(element: Node, options?: {disableDisabled: boolean}) {
     return (
         (
             (element instanceof HTMLStyleElement) ||
@@ -49,7 +49,10 @@ export function shouldManageStyle(element: Node) {
                 element instanceof HTMLLinkElement &&
                 element.rel &&
                 element.rel.toLowerCase().includes('stylesheet') &&
-                !element.disabled
+                (
+                    (options && options.disableDisabled) ||
+                    !element.disabled
+                )
             )
         ) &&
         !element.classList.contains('darkreader') &&

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -40,7 +40,7 @@ export interface StyleManager {
 
 export const STYLE_SELECTOR = 'style, link[rel*="stylesheet" i]:not([disabled])';
 
-export function shouldManageStyle(element: Node, options?: {disableDisabled: boolean}) {
+export function shouldManageStyle(element: Node) {
     return (
         (
             (element instanceof HTMLStyleElement) ||
@@ -49,10 +49,7 @@ export function shouldManageStyle(element: Node, options?: {disableDisabled: boo
                 element instanceof HTMLLinkElement &&
                 element.rel &&
                 element.rel.toLowerCase().includes('stylesheet') &&
-                (
-                    (options && options.disableDisabled) ||
-                    !element.disabled
-                )
+                !element.disabled
             )
         ) &&
         !element.classList.contains('darkreader') &&

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -166,7 +166,7 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
             if (m.target.isConnected) {
                 if (shouldManageStyle(m.target)) {
                     updatedStyles.add(m.target as StyleElement);
-                } else if (shouldManageStyle(m.target, {disableDisabled: true})) {
+                } else if ((m.target as HTMLLinkElement).disabled && shouldManageStyle(m.target, {disableDisabled: true})) {
                     removedStyles.add(m.target as StyleElement);
                 }
             }

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -163,11 +163,12 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
         const updatedStyles = new Set<StyleElement>();
         const removedStyles = new Set<StyleElement>();
         mutations.forEach((m) => {
-            if (m.target.isConnected) {
-                if (shouldManageStyle(m.target)) {
-                    updatedStyles.add(m.target as StyleElement);
-                } else if ((m.target as HTMLLinkElement).disabled && shouldManageStyle(m.target, {disableDisabled: true})) {
-                    removedStyles.add(m.target as StyleElement);
+            const {target} = m;
+            if (target.isConnected) {
+                if (shouldManageStyle(target)) {
+                    updatedStyles.add(target as StyleElement);
+                } else if (target instanceof HTMLLinkElement && target.disabled) {
+                    removedStyles.add(target as StyleElement);
                 }
             }
         });

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -161,16 +161,21 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
 
     function handleAttributeMutations(mutations: MutationRecord[]) {
         const updatedStyles = new Set<StyleElement>();
+        const removedStyles = new Set<StyleElement>();
         mutations.forEach((m) => {
-            if (shouldManageStyle(m.target) && m.target.isConnected) {
-                updatedStyles.add(m.target as StyleElement);
+            if (m.target.isConnected) {
+                if (shouldManageStyle(m.target)) {
+                    updatedStyles.add(m.target as StyleElement);
+                } else if (shouldManageStyle(m.target, {disableDisabled: true})) {
+                    removedStyles.add(m.target as StyleElement);
+                }
             }
         });
-        if (updatedStyles.size > 0) {
+        if (updatedStyles.size + removedStyles.size > 0) {
             update({
                 updated: Array.from(updatedStyles),
                 created: [],
-                removed: [],
+                removed: Array.from(removedStyles),
                 moved: [],
             });
         }

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -13,8 +13,10 @@ const links: HTMLLinkElement[] = [];
 function createStyleLink(href) {
     const link = document.createElement('link');
     link.rel = 'stylesheet';
+    link.classList.add('testcase--link');
     link.href = href;
     document.head.append(link);
+    links.push(link);
     return link;
 }
 
@@ -41,9 +43,34 @@ describe('Link override', () => {
             '<h1>Link <strong>override</strong>!</h1>',
         );
         createOrUpdateDynamicTheme(theme, null, false);
+
         await timeout(100);
+
         expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
     });
+
+    it('should not remove manager from disabled link ', async () => {
+        const link = createStyleLink(`data:text/css;utf8,${encodeURIComponent(multiline(
+            'h1 { background: gray; }',
+            'h1 strong { color: red; }',
+        ))}`);
+        container.innerHTML = multiline(
+            '<h1>Link <strong>disabled</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(100);
+
+        expect(document.querySelector('.testcase--link').nextElementSibling.classList.contains('darkreader--sync')).toBe(true);
+        link.disabled = true;
+        
+        await timeout(100);
+
+        expect(document.querySelector('.testcase--link').nextElementSibling.classList.contains('darkreader--sync')).toBe(false);
+
+    });
+
 });
+

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -65,7 +65,7 @@ describe('Link override', () => {
 
         expect(document.querySelector('.testcase--link').nextElementSibling.classList.contains('darkreader--sync')).toBe(true);
         link.disabled = true;
-        
+
         await timeout(100);
 
         expect(document.querySelector('.testcase--link').nextElementSibling.classList.contains('darkreader--sync')).toBe(false);

--- a/tests/inject/dynamic/media-query.tests.ts
+++ b/tests/inject/dynamic/media-query.tests.ts
@@ -36,7 +36,7 @@ describe('Handle Media Queries', () => {
 
         createOrUpdateDynamicTheme(theme, null, false);
         await timeout(100);
-        
+
         expect(getComputedStyle(document.querySelector('h1')).backgroundColor).toBe('rgb(0, 102, 0)');
         expect(getComputedStyle(document.querySelector('h1 strong')).color).toBe('rgb(255, 174, 26)');
         expect(document.querySelector('.testcase-style-2').nextElementSibling.classList.contains('darkreader--sync')).toBe(false);
@@ -53,7 +53,7 @@ describe('Handle Media Queries', () => {
 
         createOrUpdateDynamicTheme(theme, null, false);
         await timeout(100);
-        
+
         expect(getComputedStyle(document.querySelector('h1')).backgroundColor).toBe('rgb(0, 102, 0)');
         expect(getComputedStyle(document.querySelector('h1 strong')).color).toBe('rgb(255, 174, 26)');
         expect(document.querySelector('.testcase-style').nextElementSibling.classList.contains('darkreader--sync')).toBe(true);
@@ -77,10 +77,10 @@ describe('Handle Media Queries', () => {
 
         createOrUpdateDynamicTheme(theme, null, false);
         await timeout(100);
-        
+
         expect(getComputedStyle(document.querySelector('h1')).backgroundColor).toBe('rgb(0, 102, 0)');
         expect(getComputedStyle(document.querySelector('h1 strong')).color).toBe('rgb(255, 174, 26)');
         expect(getComputedStyle(document.body).backgroundColor).toBe('rgb(0, 0, 0)');
     });
-    
+
 });

--- a/tests/inject/dynamic/style-override.tests.ts
+++ b/tests/inject/dynamic/style-override.tests.ts
@@ -104,7 +104,8 @@ describe('Style override', () => {
         );
         createOrUpdateDynamicTheme(theme, null, false);
         const style = document.querySelector('.testcase-style');
-        document.head.append(style);
+        container.append(style);
+
         await timeout(100);
         expect((style.nextSibling as HTMLStyleElement).classList.contains('darkreader--sync')).toBe(true);
     });


### PR DESCRIPTION
- Remove the manager of an StyleElement when the disabled attribute is being set.
- Add test cases to not handle disabled StyleElements.
- Fixes bug where the previous link wasn't removed.
- `document.head` -> `container` in `should move override` test.
- Resolves #3841
