### PR TITLE
Fix white content background on mnt.ee

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4427,12 +4427,10 @@ path[fill-rule="evenodd"]
 
 mnt.ee
 
-INVERT
-#zone-content-wrapper
-
 CSS
 #zone-content-wrapper {
-    color: ${white};
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4429,8 +4429,11 @@ mnt.ee
 
 CSS
 #zone-content-wrapper {
-    background-color: var(--darkreader-neutral-background) !important;
     color: var(--darkreader-neutral-text) !important;
+}
+
+#zone-content {
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4425,6 +4425,18 @@ path[fill-rule="evenodd"]
 
 ================================
 
+mnt.ee
+
+INVERT
+#zone-content-wrapper
+
+CSS
+#zone-content-wrapper {
+    color: ${white};
+}
+
+================================
+
 mobiel.nl
 
 INVERT


### PR DESCRIPTION
For example, the issue this fixes is visible on this page: https://www.mnt.ee/eng/vehicle/registration