### PR TITLE
Recognize DevTools to be restricted

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -28,6 +28,7 @@ export function canInjectScript(url: string) {
     return (url
         && !url.startsWith('chrome')
         && !url.startsWith('https://chrome.google.com/webstore')
+        && !url.startsWith('devtools')
     );
 }
 


### PR DESCRIPTION
Currently `devtools://*` URLs are considered as non-restricted sites:
![Screenshot from 2020-11-17 16-26-18](https://user-images.githubusercontent.com/53054099/99466698-ba22bc00-28f1-11eb-89c2-ba102f14e7f1.png)
This PR adds in the fact that the `devtools` protocol is restricted.