### PR TITLE
Fix for beta.protonmail.com labels

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -775,7 +775,7 @@ body {
 beta.protonmail.com
 
 CSS
-.label-stack-item-button {
+.label-stack-item {
     background-color: var(--color,currentColor) !important;
 }
 .items-column-list-inner {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4278123/99483295-e65b2e80-292b-11eb-8454-e1ea85895119.png)

After:
![image](https://user-images.githubusercontent.com/4278123/99483317-f246f080-292b-11eb-8994-7a9a8d7a2d4f.png)