### PR TITLE
fix for praca.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5335,6 +5335,9 @@ img[alt="Praca.pl"]
 .listing__logo
 .app-offer__logo-img
 .company__img
+.employer-profile-header .logo img
+.company-job-list .logo img
+.epc-other-employers .logo img
 
 CSS
 .app-offer__content {


### PR DESCRIPTION
Added invert for logos on company profile page.

Example URL: https://www.praca.pl/780060,kubo_sp_z_o_o_spolka_komandytowa,torun,firma.html