### PR TITLE
Added several restricted schemes in Chrome and Edge

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -19,10 +19,14 @@ export function canInjectScript(url: string) {
     }
     if (isEdge) {
         return (url
+            && !url.startsWith('about')
             && !url.startsWith('chrome')
+            && !url.startsWith('data')
+            && !url.startsWith('devtools')
             && !url.startsWith('edge')
             && !url.startsWith('https://chrome.google.com/webstore')
             && !url.startsWith('https://microsoftedge.microsoft.com/addons')
+            && !url.startsWith('view-source')
         );
     }
     return (url

--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -26,9 +26,12 @@ export function canInjectScript(url: string) {
         );
     }
     return (url
+        && !url.startsWith('about')
         && !url.startsWith('chrome')
         && !url.startsWith('https://chrome.google.com/webstore')
+        && !url.startsWith('data')
         && !url.startsWith('devtools')
+        && !url.startsWith('view-source')
     );
 }
 

--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -19,7 +19,6 @@ export function canInjectScript(url: string) {
     }
     if (isEdge) {
         return (url
-            && !url.startsWith('about')
             && !url.startsWith('chrome')
             && !url.startsWith('data')
             && !url.startsWith('devtools')
@@ -30,7 +29,6 @@ export function canInjectScript(url: string) {
         );
     }
     return (url
-        && !url.startsWith('about')
         && !url.startsWith('chrome')
         && !url.startsWith('https://chrome.google.com/webstore')
         && !url.startsWith('data')


### PR DESCRIPTION
**Chrome**
- `about:blank` is restricted and maybe others starting with `about`
- `data:*` can't be edited, but can be edited into dark mode in `firefox`
- `view-source:*` is restricted in chrome and edge

**Edge**
- `about:blank` is restricted and maybe others starting with `about`
- `data:*` can't be edited, but can be edited into dark mode in `firefox`
- `view-source:*` is restricted in chrome and edge
- `devtools:*` is restricted in chrome and edge