### PR TITLE
fix for strava.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6410,6 +6410,7 @@ INVERT
 .weekly-goal svg
 .week.clearfix svg
 .activity-map img
+.group-activity-map img
 img.leaflet-tile-loaded:not([src*="satellite"])
 
 CSS
@@ -6449,6 +6450,7 @@ CSS
 IGNORE IMAGE ANALYSIS
 .app-icon.icon-nav-training
 .app-icon.icon-fb
+.app-icon.icon-rowing
 
 ================================
 


### PR DESCRIPTION
Added .app-icon.icon-rowing to IGNORE IMAGE ANALYSIS
Darkened gropu activity map