### PR TITLE
Fix for psprices.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5625,6 +5625,18 @@ CSS
 
 ================================
 
+psprices.com
+
+INVERT
+.d-inline-block
+
+CSS
+body, footer {
+    background: var(--darkreader-neutral-background) !important; 
+}
+
+================================
+
 pyszne.pl
 
 INVERT


### PR DESCRIPTION
- Invert PS Store logo.
- Fix background.

Example: https://psprices.com/region-us/game/2947059/cyberpunk-2077