### PR TITLE
Add techgaun.github.io/active-forks to already dark websites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -612,6 +612,7 @@ tautulli.com
 teambeyond.net
 teamos-hkrg.com
 teaspeak.de
+techgaun.github.io/active-forks
 telecineplay.com.br
 telugucz.com
 terminal.sexy


### PR DESCRIPTION
As per techgaun/active-forks@7ae4090

![screenshot-techgaun github io-2020 11 20-16_23_25](https://user-images.githubusercontent.com/21284089/99817075-c060a480-2b4c-11eb-8e06-7afa1a4c0e07.png)
