### PR TITLE
Fix for app.getpocket.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2837,6 +2837,13 @@ CSS
 
 ================================
 
+app.getpocket.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
 gg.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -510,6 +510,13 @@ svg text.time_cursor {
 
 ================================
 
+app.getpocket.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
 app.grammarly.com
 
 CSS
@@ -2834,13 +2841,6 @@ CSS
 .dth-page-body.dth-bg-contain.dth-bg-top-center.dth-bg-repeat-x {
     background-image: none !important;
 }
-
-================================
-
-app.getpocket.com
-
-IGNORE IMAGE ANALYSIS
-*
 
 ================================
 


### PR DESCRIPTION
- Ignore image analysis for images on a page with all articles.

For some reason, Dark Reader inverts the image for some articles, but not for others. Although these images shouldn't be inverted at all.

Here are the articles for which Dark Reader somehow inverts the image in the article list: https://senrigan.io/blog/everything-i-know-strategies-tips-and-tricks-for-spaced-repetition-anki/, https://journal.tinkoff.ru/read-first/, https://thecode.media/hurry/, https://medfront.org/2019/12/13/vaping/ (you need to save these articles and open My List).

I also checked other sections on this site and did not find any problems with this rule. Although I also tried to make a more precise rule for these images, but I failed.