### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2429,9 +2429,6 @@ img[src*="map.php"], ._8bb_ img[src*="map.php"],
 img[src*="www.traseo.pl%2Froute"], ._8bb_ img[src*="www.traseo.pl%2Froute"] {
     filter: invert(100%) hue-rotate(180deg) !important;
 }
-.q2y6ezfg, .mkbloq8g {
-    background-color: var(--always-white) !important;
-}
 .j7vl6m33 {
     fill: var(--always-white) !important;
 }


### PR DESCRIPTION
Removed .q2y6ezfg, .mkbloq8g {
    background-color: var(--always-white) !important;
} from CSS

as it was breaking some buttons in messenger tab opened from facebook.com