### PR TITLE
Fix a few icons not displaying correctly

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1871,6 +1871,18 @@ INVERT
 
 dndbeyond.com
 
+INVERT
+.i-ritual
+.i-concentration
+.ddbc-damage-type-icon
+.ddbc-combat-attack__icon-img--spell-school-conjuration
+.ddbc-combat-attack__icon-img--spell-school-necromancy
+.ddbc-combat-attack__icon-img--spell-school-evocation
+.ddbc-combat-attack__icon-img--spell-school-abjuration
+.ddbc-combat-attack__icon-img--spell-school-transmutation
+.ddbc-combat-attack__icon-img--spell-school-enchantment
+.ddbc-combat-attack__icon-img--spell-school-illusion
+
 CSS
 .mon-stat-block,
 .mon-stat-block::before,
@@ -1881,6 +1893,9 @@ body {
 .more-info::after,
 .details-container::after {
      border-image: none !important;
+}
+.i-type-bludgeoning {
+     background-image: url(https://www.dndbeyond.com/content/1-0-1337-0/skins/waterdeep/images/icons/damage_types/bludgeoning.svg);
 }
 
 ================================


### PR DESCRIPTION
Inverts a couple of icons in the character sheets that were black-on-black.

For some reason, when activating dark mode, a specific icon's source URL gets scrambled. (.i-type-bludgeoning)
So I forced the correct URL to be loaded.