### PR TITLE
Add jsitor.com to already dark websites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -342,6 +342,7 @@ jonah.pw
 jqbx.fm
 jsben.ch
 jsfiddle.net
+jsitor.com
 kadantiscam.netlify.app
 kaoskrew.org
 killabee-gaming.com


### PR DESCRIPTION
![2020-11-23 17_10_43-Greenshot](https://user-images.githubusercontent.com/21284089/99986281-43813500-2daf-11eb-94cc-7c8dd186bad9.png)
