### PR TITLE
Add gitmoji.carloscuesta.me to already dark websites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -269,6 +269,7 @@ gikken.co
 giphy.com
 githubuniverse.com
 gitkraken.com
+gitmoji.carloscuesta.me
 gload.cc
 glowing-bear.org
 glslsandbox.com


### PR DESCRIPTION
As per carloscuesta/gitmoji@050a616

![screenshot-gitmoji carloscuesta me-2020 11 24-11_32_07](https://user-images.githubusercontent.com/21284089/100083346-a0312e00-2e49-11eb-912d-0d4a963dce99.png)