### PR TITLE
Placeholder for remote settings change handler

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -50,7 +50,7 @@ export class Extension {
             },
             onColorSchemeChange: this.onColorSchemeChange,
         });
-        this.user = new UserStorage({onRemoteSettingsChange: () => this.onSettingsChanged()});
+        this.user = new UserStorage({onRemoteSettingsChange: () => this.onRemoteSettingsChange()});
         this.awaiting = [];
     }
 
@@ -361,6 +361,11 @@ export class Extension {
         this.tabs.sendMessage(this.getTabMessage);
         this.saveUserSettings();
         this.reportChanges();
+    }
+
+    private onRemoteSettingsChange() {
+        // TODO: Requires proper handling and more testing
+        // to prevent cycling across instances.
     }
 
 

--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -80,7 +80,11 @@ export async function writeLocalStorage<T extends {[key: string]: any}>(values: 
 }
 
 export const subscribeToOuterSettingsChange = (callback: () => void) => {
-    !isWriting && chrome.storage.onChanged.addListener(callback);
+    chrome.storage.onChanged.addListener(() => {
+        if (!isWriting) {
+            callback();
+        }
+    });
 };
 
 export async function getFontList() {


### PR DESCRIPTION
The last implementation can cause cycling between instances, because the settings are saved into storage after receiving, which causes sending them again.

It will also make it possible to have a look if syncing works before pushing a change.