### PR TITLE
Fixed breaking in TypeScript 4.1

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -112,13 +112,13 @@ export class Extension {
         return {
             collect: async () => {
                 if (!this.ready) {
-                    await new Promise((resolve) => this.awaiting.push(resolve));
+                    await new Promise<void>((resolve) => this.awaiting.push(resolve));
                 }
                 return await this.collectData();
             },
             getActiveTabInfo: async () => {
                 if (!this.ready) {
-                    await new Promise((resolve) => this.awaiting.push(resolve));
+                    await new Promise<void>((resolve) => this.awaiting.push(resolve));
                 }
                 const url = await this.tabs.getActiveTabURL();
                 return this.getURLInfo(url);
@@ -214,7 +214,7 @@ export class Extension {
         if (this.ready) {
             return this.getTabMessage(url, frameURL);
         } else {
-            return new Promise((resolve) => {
+            return new Promise<{type: string; data?: any}>((resolve) => {
                 this.awaiting.push(() => {
                     resolve(this.getTabMessage(url, frameURL));
                 });

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -55,7 +55,7 @@ function handleIsDefined(e: CustomEvent<{tag: string}>) {
 }
 
 async function customElementsWhenDefined(tag: string) {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
         // `customElements.whenDefined` is not available in extensions
         // https://bugs.chromium.org/p/chromium/issues/detail?id=390807
         if (window.customElements && typeof customElements.whenDefined === 'function') {


### PR DESCRIPTION
Promise resolve arguments are no longer optional https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#resolves-parameters-are-no-longer-optional-in-promises