### PR TITLE
Added a fix for Aftonbladet.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -256,6 +256,15 @@ svg.reviews__icon-topic
 
 ================================
 
+aftonbladet.se
+
+CSS
+._3KEys{
+    color: black
+}
+
+================================
+
 ai2.appinventor.mit.edu
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -259,8 +259,8 @@ svg.reviews__icon-topic
 aftonbladet.se
 
 CSS
-._3KEys{
-    color: black
+a[href$="plus_plusikon"] > :nth-child(1){
+   color: ${white}
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -259,7 +259,7 @@ svg.reviews__icon-topic
 aftonbladet.se
 
 CSS
-a[href$="plus_plusikon"] > :nth-child(1){
+a[href$="plus_plusikon"] > :nth-child(1) {
    color: ${white}
 }
 


### PR DESCRIPTION
Aftonbladet.se is one of the largest newspapers in Sweden. I added a fix for a button on the main page, which can be seen on all sub-pages. There was a contrast error, that had to do with Darkreader inverting black text to white. 

Will probably find more things to correct as I use the website more in the future.