### PR TITLE
Fixes for Jumia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3934,6 +3934,7 @@ div.-fw-w:nth-child(1) > a.-fs0 > img
 article.-df > svg > use
 svg.ic.xprss
 svg.ic[alt*="Express"]
+svg.ic[aria-label*="Express"]
 
 ================================
 justhost.ru

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3932,6 +3932,7 @@ svg.ic[alt*="Express"]
 svg.ic[aria-label*="Express"]
 
 ================================
+
 justhost.ru
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3902,13 +3902,8 @@ INVERT
 
 ================================
 
-jumia.com
-jumia.co
-jumia.ma
-jumia.ci
-jumia.dz
-jumia.ug
-jumia.sn
+jumia.*
+jumia.*.*
 zando.co.za
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3902,6 +3902,38 @@ INVERT
 
 ================================
 
+jumia.com
+jumia.co
+jumia.ma
+jumia.ci
+jumia.dz
+jumia.ug
+jumia.sn
+zando.co.za
+
+INVERT
+svg.ic[role="img"]:not([aria-label="Zando logo"])
+.logo > a > img
+.inbox > a:not(:nth-of-type(1)) > svg
+img[src*="jumia-group-logo.png"]
+img[src*="jumia_logo_small_checkout.png"]
+img[src*="/Jumia-Pay"]
+li.logo:nth-child(1) > .-i-jumia-logo
+img[src*="empty-cart.png"]
+.-header > img:nth-child(1)
+.-gy5 > .-fs0 > .vent-link[title*="Rewards"]
+.-gy5 > .-fs0 > .vent-link[title*="Pay"]
+.-gy5 > .-fs0 > .vent-link[title*="Food"]
+.-gy5 > .-fs0 > .vent-link[title*="Party"]
+.-gy5 > .-fs0 > .vent-link[title*="Now"]
+nav.s-menu > a.m-itm:nth-child(2) > svg
+nav.s-menu > a.m-itm:nth-child(3) > svg
+nav.s-menu > a.m-itm:nth-child(4) > svg
+nav.s-menu > a.m-itm:nth-child(5) > svg
+div.-fw-w:nth-child(1) > a.-fs0 > img
+article.-df > svg > use
+
+================================
 justhost.ru
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3932,6 +3932,8 @@ nav.s-menu > a.m-itm:nth-child(4) > svg
 nav.s-menu > a.m-itm:nth-child(5) > svg
 div.-fw-w:nth-child(1) > a.-fs0 > img
 article.-df > svg > use
+svg.ic.xprss
+svg.ic[alt*="Express"]
 
 ================================
 justhost.ru


### PR DESCRIPTION
Jumia is one of the most popular e-commerce websites in Africa.

It has 11 different domains for different countries, but they all look almost exactly the same. I tried my best to test all of them:
jumia.com.ng
jumia.com.eg
jumia.com.tn
jumia.com.gh
jumia.co.ke
jumia.ma
jumia.ci
jumia.dz
jumia.sn
jumia.ug
zando.co.za