### PR TITLE
Fix for forum.ivao.aero

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2798,6 +2798,41 @@ html {
 
 ================================
 
+forum.ivao.aero
+
+INVERT
+.buttonlist
+
+CSS
+.cat_bar, .cat_bar > *, .catbg > * {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+    background-image: none !important;
+}
+
+:not(a) > span, :not(a) > span > *, #footer {
+    background: none !important;
+}
+
+.buttonlist a:not(.active) {
+   color: var(--darkreader-neutral-background) !important;
+}
+
+ul.dropmenu li {
+    border: none !important;
+    background: var(--darkreader-neutral-background) !important;                                                                                                         
+}
+
+ul.dropmenu ul {
+    border: 1px solid var(--darkreader-neutral-text) !important;
+    background: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+#header
+
+================================
+
 forum.miranda-ng.org
 
 CSS


### PR DESCRIPTION
IVAO is online flight-simulation network with more than 210,000 registered members.
This PR improves the dark theme for the forum of IVAO which is not publicly accessible.
Currently, there are multiple white spots on the page, some of them are very hard to read.
![Screenshot_488](https://user-images.githubusercontent.com/24833249/100515634-d5a58680-317d-11eb-8229-f44bbac95d48.png) ![Screenshot_491](https://user-images.githubusercontent.com/24833249/100515650-f2da5500-317d-11eb-8810-36ecdd5032b1.png)
![Screenshot_490](https://user-images.githubusercontent.com/24833249/100515667-0c7b9c80-317e-11eb-952a-39f6b97fb50c.png) ![Screenshot_493](https://user-images.githubusercontent.com/24833249/100515668-0f768d00-317e-11eb-8fc5-3adce9ad71c5.png)
![Screenshot_489](https://user-images.githubusercontent.com/24833249/100515657-fec61700-317d-11eb-91d8-5b576d6dbc5b.png) ![Screenshot_492](https://user-images.githubusercontent.com/24833249/100515663-07b6e880-317e-11eb-9e5a-4192c3212807.png)






