### PR TITLE
Add gitmoji.kaki87.net to already dark websites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -268,6 +268,7 @@ gikken.co
 giphy.com
 githubuniverse.com
 gitkraken.com
+gitmoji.kaki87.net
 gload.cc
 glowing-bear.org
 glslsandbox.com


### PR DESCRIPTION
![screenshot-gitmoji kaki87 net-2020 11 28-23_34_06-min](https://user-images.githubusercontent.com/21284089/100527399-76259600-31d2-11eb-8997-021e107ed9a1.png)
