### PR TITLE
Logo fix for Swedish state-TV website svt.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6825,6 +6825,15 @@ div.sumo-nav--logo
 
 ================================
 
+svt.se
+
+CSS
+#__nh > div > header > div.nyh_header__container.lp_header > nav > a.nyh_navigation__nyh_logo > img {
+    filter: invert(1);
+}
+
+================================
+
 tagesschau.de
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6827,10 +6827,8 @@ div.sumo-nav--logo
 
 svt.se
 
-CSS
-#__nh > div > header > div.nyh_header__container.lp_header > nav > a.nyh_navigation__nyh_logo > img {
-    filter: invert(1);
-}
+INVERT
+.nyh_navigation__nyh_logo-img
 
 ================================
 


### PR DESCRIPTION
Inverted the logo which was unreadable because of the black image on the dark background.