### PR TITLE
Removed spellcheck from TextBox

### DIFF
--- a/src/ui/controls/textbox/index.tsx
+++ b/src/ui/controls/textbox/index.tsx
@@ -11,6 +11,6 @@ export default function TextBox(props: TextBoxProps) {
     const attrs = omitAttrs(['class', 'type'], props);
 
     return (
-        <input class={cls} type="text" {...attrs} />
+        <input class={cls} type="text" spellcheck="false" {...attrs} />
     );
 }


### PR DESCRIPTION
Fixes this:
![Screenshot from 2020-11-29 12-21-10](https://user-images.githubusercontent.com/53054099/100552679-773fdd00-323d-11eb-9d8d-002ebf05f33c.png)
The `mysite.com` has squiggly lines