### PR TITLE
Fix for netlify.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5165,6 +5165,15 @@ CSS
 
 ================================
 
+netlify.com
+
+CSS
+[data-darkreader-inline-fill] {
+    fill: var(--scrim-icon-color) !important;
+}
+
+================================
+
 netzpolitik.org
 
 INVERT


### PR DESCRIPTION
- Due to some `!important;` overrides and inline-styling which have for no logical reason `none` the original value of fill should be fixed.
- Resolves #4317