### PR TITLE
Fix for linternaute.fr

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1205,6 +1205,18 @@ NO INVERT
 
 ================================
 
+linternaute.fr
+
+INVERT
+.dico_liste.grid_line > li
+
+CSS
+.dico_liste_greyandwhite .dico_liste li a {
+    color: var(--darkreader-neutral-background);
+}
+
+================================
+
 mail.live.com
 
 INVERT


### PR DESCRIPTION
Synonymes section was not inverted, see #4299