### PR TITLE
Fixes for worldcubeassociation.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8364,6 +8364,37 @@ picture.standard-navigation__logo-image.responsive-image
 
 ================================
 
+worldcubeassociation.org
+
+CSS
+.flag-icon-pl{background-image: url(/packs/media/4x3/pl-7ea4b5b2.svg);}
+.flag-icon-kr{background-image: url(/packs/media/4x3/kr-939387c3.svg);}
+.flag-icon-fi{background-image: url(/packs/media/4x3/fi-3b522e7f.svg);}
+.flag-icon-jp{background-image: url(/packs/media/4x3/jp-19c631c1.svg);}
+.flag-icon-ru{background-image: url(/packs/media/4x3/ru-f1c2ba49.svg);}
+.flag-icon-si{background-image: url(/packs/media/4x3/si-7f576d87.svg);}
+.flag-icon-co{background-image: url(/packs/media/4x3/co-59ec93f7.svg);}
+.flag-icon-lt{background-image: url(/packs/media/4x3/lt-4c19d3a9.svg);}
+.flag-icon-sk{background-image: url(/packs/media/4x3/sk-be58e557.svg);}
+.flag-icon-bg{background-image: url(/packs/media/4x3/bg-c9c13073.svg);}
+.flag-icon-ve{background-image: url(/packs/media/4x3/ve-b8bb0477.svg);}
+.flag-icon-ge{background-image: url(/packs/media/4x3/ge-98cf9dc1.svg);}
+.flag-icon-ec{background-image: url(/packs/media/4x3/ec-3ea7f906.svg);}
+.flag-icon-pk{background-image: url(/packs/media/4x3/pk-8f9276eb.svg);}
+.flag-icon-uy{background-image: url(/packs/media/4x3/uy-4c3f85c5.svg);}
+.flag-icon-mg{background-image: url(/packs/media/4x3/mg-f9101073.svg);}
+.flag-icon-pa{background-image: url(/packs/media/4x3/pa-8788ab50.svg);}
+.flag-icon-cy{background-image: url(/packs/media/4x3/cy-70de54e6.svg);}
+.flag-icon-bh{background-image: url(/packs/media/4x3/bh-ec61516d.svg);}
+.flag-icon-mt{background-image: url(/packs/media/4x3/mt-c91049a1.svg);}
+.flag-icon-bt{background-image: url(/packs/media/4x3/bt-eed19cbf.svg);}
+.flag-icon-jm{background-image: url(/packs/media/4x3/jm-6bb96bbc.svg);}
+.event-checkbox input[type="checkbox"] + i.cubing-icon, .event-checkbox input[type="radio"] + i.cubing-icon, .event-radio input[type="checkbox"] + i.cubing-icon, .event-radio input[type="radio"] + i.cubing-icon{
+    color: rgba(0,0,0,1);
+}
+
+================================
+
 worldometers.info
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8367,31 +8367,36 @@ picture.standard-navigation__logo-image.responsive-image
 worldcubeassociation.org
 
 CSS
-.flag-icon-pl{background-image: url(/packs/media/4x3/pl-7ea4b5b2.svg);}
-.flag-icon-kr{background-image: url(/packs/media/4x3/kr-939387c3.svg);}
-.flag-icon-fi{background-image: url(/packs/media/4x3/fi-3b522e7f.svg);}
-.flag-icon-jp{background-image: url(/packs/media/4x3/jp-19c631c1.svg);}
-.flag-icon-ru{background-image: url(/packs/media/4x3/ru-f1c2ba49.svg);}
-.flag-icon-si{background-image: url(/packs/media/4x3/si-7f576d87.svg);}
-.flag-icon-co{background-image: url(/packs/media/4x3/co-59ec93f7.svg);}
-.flag-icon-lt{background-image: url(/packs/media/4x3/lt-4c19d3a9.svg);}
-.flag-icon-sk{background-image: url(/packs/media/4x3/sk-be58e557.svg);}
-.flag-icon-bg{background-image: url(/packs/media/4x3/bg-c9c13073.svg);}
-.flag-icon-ve{background-image: url(/packs/media/4x3/ve-b8bb0477.svg);}
-.flag-icon-ge{background-image: url(/packs/media/4x3/ge-98cf9dc1.svg);}
-.flag-icon-ec{background-image: url(/packs/media/4x3/ec-3ea7f906.svg);}
-.flag-icon-pk{background-image: url(/packs/media/4x3/pk-8f9276eb.svg);}
-.flag-icon-uy{background-image: url(/packs/media/4x3/uy-4c3f85c5.svg);}
-.flag-icon-mg{background-image: url(/packs/media/4x3/mg-f9101073.svg);}
-.flag-icon-pa{background-image: url(/packs/media/4x3/pa-8788ab50.svg);}
-.flag-icon-cy{background-image: url(/packs/media/4x3/cy-70de54e6.svg);}
-.flag-icon-bh{background-image: url(/packs/media/4x3/bh-ec61516d.svg);}
-.flag-icon-mt{background-image: url(/packs/media/4x3/mt-c91049a1.svg);}
-.flag-icon-bt{background-image: url(/packs/media/4x3/bt-eed19cbf.svg);}
-.flag-icon-jm{background-image: url(/packs/media/4x3/jm-6bb96bbc.svg);}
-.event-checkbox input[type="checkbox"] + i.cubing-icon, .event-checkbox input[type="radio"] + i.cubing-icon, .event-radio input[type="checkbox"] + i.cubing-icon, .event-radio input[type="radio"] + i.cubing-icon{
-    color: rgba(0,0,0,1);
+.event-checkbox input[type="checkbox"] + i.cubing-icon, 
+.event-checkbox input[type="radio"] + i.cubing-icon, 
+.event-radio input[type="checkbox"] + i.cubing-icon, 
+.event-radio input[type="radio"] + i.cubing-icon {
+    color: rgba(0, 0, 0, 1) !important;
 }
+
+IGNORE IMAGE ANALYSIS
+.flag-icon-pl
+.flag-icon-kr
+.flag-icon-fi
+.flag-icon-jp
+.flag-icon-ru
+.flag-icon-si
+.flag-icon-co
+.flag-icon-lt
+.flag-icon-sk
+.flag-icon-bg
+.flag-icon-ve
+.flag-icon-ge
+.flag-icon-ec
+.flag-icon-pk
+.flag-icon-uy
+.flag-icon-mg
+.flag-icon-pa
+.flag-icon-cy
+.flag-icon-bh
+.flag-icon-mt
+.flag-icon-bt
+.flag-icon-jm
 
 ================================
 


### PR DESCRIPTION
22 flags were displayed incorrectly, which was fixed in a somewhat janky/hardcoded way. Example page with flags visible: https://www.worldcubeassociation.org/results/rankings/333/single?region=world&show=by+region
Fixed event selectors being indiscernible between checked and unchecked. Example: https://www.worldcubeassociation.org/profile/edit?section=preferences (I don't think it's visible anywhere that doesn't require an account).