### PR TITLE
Revert fix for Github

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3045,6 +3045,26 @@ CSS
     background-color: #ffffff1a !important;
     border-radius: 2pt !important;
 }
+.day[fill="#ebedf0"], .legend li[style*="background-color: rgb(235, 237, 240)"] {
+    fill: ${#ebedf0} !important;
+    background-color: ${#ebedf0} !important;
+}
+.day[fill="#9be9a8"], .legend li[style*="background-color: rgb(155, 233, 168)"] {
+    fill: ${#9be9a8} !important;
+    background-color: ${#9be9a8} !important;
+}
+.day[fill="#40c463"], .legend li[style*="background-color: rgb(64, 196, 99)"] {
+    fill: ${#40c463} !important;
+    background-color: ${#40c463} !important;
+}
+.day[fill="#30a14e"], .legend li[style*="background-color: rgb(48, 161, 78)"] {
+    fill: ${#30a14e} !important;
+    background-color: ${#30a14e} !important;
+}
+.day[fill="#216e39"], .legend li[style*="background-color: rgb(33, 110, 57)"] {
+    fill: ${#216e39} !important;
+    background-color: ${#216e39} !important;
+}
 .blob-num:not(.cc-coverage-covered-border):not(.cc-coverage-missed-border) {
     border-right: 0 !important;
 }
@@ -3079,11 +3099,6 @@ CSS
 }
 :root {
     --color-previewable-comment-form-bg: var(--darkreader-neutral-background) !important;
-    --color-calendar-graph-day-bg: ${#ebedf0} !important;
-    --color-calendar-graph-day-L1-bg: ${#9be9a8} !important;
-    --color-calendar-graph-day-L2-bg: ${#40c463} !important;
-    --color-calendar-graph-day-L3-bg: ${#30a14e} !important;
-    --color-calendar-graph-day-L4-bg: ${#216e39} !important;
 }
 .Box,
 .form-select,


### PR DESCRIPTION
- Github reverted their contribution back to manual colors and not the old inline variable system.
- Reverts darkreader/darkreader#3977
- Resolves #3967