### PR TITLE
Fix for docs.google.com/presentation

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1978,6 +1978,7 @@ img[src$="googlelogo_dark_clr_74x24px.svg"]
 .quantumWizTogglePapercheckboxCheckMark
 #docs-titlebar-share-client-button .scb-button-icon:not([class*="white"])
 body[itemtype*="PresentationObject"] #docs-titlebar-share-client-button .scb-button-icon
+g.punch-filmstrip-indicator > image
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
- Invert animation Icon.
- Resolves #4344