### PR TITLE
CSS variables fixes and tests

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -478,6 +478,7 @@ export function removeDynamicTheme() {
 }
 
 export function cleanDynamicThemeCache() {
+    variables.clear();
     stopWatchingForDocumentVisibility();
     cancelRendering();
     stopWatchingForUpdates();

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -100,7 +100,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
     const observer = new MutationObserver(() => {
         update();
     });
-    const observerOptions: MutationObserverInit = {attributes: true, childList: true, characterData: true};
+    const observerOptions: MutationObserverInit = {attributes: true, childList: true, subtree: true, characterData: true};
 
     function containsCSSImport() {
         return element instanceof HTMLStyleElement && element.textContent.trim().match(cssImportRegex);

--- a/tests/inject/dynamic/style-override.tests.ts
+++ b/tests/inject/dynamic/style-override.tests.ts
@@ -163,6 +163,22 @@ describe('Style override', () => {
 
     });
 
+    it('should react on style text change', async () => {
+        container.innerHTML = multiline(
+            '<style class="testcase-style">',
+            '    h1 strong { color: red; }',
+            '</style>',
+            '<h1>Style <strong>text change</strong></h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(document.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
+
+        document.querySelector('.testcase-style').textContent = 'h1 strong { color: green; }';
+        await timeout(100);
+        expect(getComputedStyle(document.querySelector('h1 strong')).color).toBe('rgb(140, 255, 140)');
+
+    });
+
     it('should react to a new style', async () => {
         container.innerHTML = multiline(
             '<h1>Some test foor...... <strong>Oh uhm what?</strong>!</h1>',

--- a/tests/inject/dynamic/variables.tests.ts
+++ b/tests/inject/dynamic/variables.tests.ts
@@ -1,0 +1,193 @@
+import '../polyfills';
+import {DEFAULT_THEME} from '../../../src/defaults';
+import {createOrUpdateDynamicTheme, removeDynamicTheme} from '../../../src/inject/dynamic-theme';
+import {multiline, timeout} from '../../test-utils';
+
+const theme = {
+    ...DEFAULT_THEME,
+    darkSchemeBackgroundColor: 'black',
+    darkSchemeTextColor: 'white',
+};
+let container: HTMLElement;
+
+beforeEach(() => {
+    container = document.body;
+    container.innerHTML = '';
+});
+
+afterEach(() => {
+    removeDynamicTheme();
+    container.innerHTML = '';
+});
+
+describe('CSS Variables Override', () => {
+    it('should override style with variables', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --bg: gray;',
+            '        --text: red;',
+            '    }',
+            '    h1 { background: var(--bg); }',
+            '    h1 strong { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container).backgroundColor).toBe('rgb(0, 0, 0)');
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
+    });
+
+    it('should override style with variables (reverse order)', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 { background: var(--bg); }',
+            '    h1 strong { color: var(--text); }',
+            '</style>',
+            '<style>',
+            '    :root {',
+            '        --bg: gray;',
+            '        --text: green;',
+            '    }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container).backgroundColor).toBe('rgb(0, 0, 0)');
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(140, 255, 140)');
+    });
+
+    it('should skip undefined variables', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 { background: var(--bg); }',
+            '    h1 strong { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container).backgroundColor).toBe('rgb(0, 0, 0)');
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 255, 255)');
+    });
+
+    it('should use fallback variable value', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 { color: var(--text, red); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 26, 26)');
+    });
+
+    it('should not use fallback variable value', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --text: green;',
+            '    }',
+            '    h1 { color: var(--text, red); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(140, 255, 140)');
+    });
+
+    it('should handle variables referencing other variables', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --alert: red;',
+            '        --text: var(--alert);',
+            '    }',
+            '    h1 { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 26, 26)');
+    });
+
+    it('should handle variables referencing other variables (reverse order)', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --text: var(--alert);',
+            '        --alert: red;',
+            '    }',
+            '    h1 { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 26, 26)');
+    });
+
+    it('should use fallback when nested variables are missing', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 { color: var(--text, var(--alert, green)); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(140, 255, 140)');
+    });
+
+    it('should not freeze on cyclic references', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --text: var(--text);',
+            '    }',
+            '    h1 { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+    });
+
+    it('should not freeze on nested cyclic references', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --alert: var(--text);',
+            '        --text: var(--alert);',
+            '    }',
+            '    h1 { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+    });
+    it('should react on variable change', async () => {
+        container.innerHTML = multiline(
+            '<style id="variables">',
+            '    :root {',
+            '        --text: red;',
+            '    }',
+            '</style>',
+            '<style>',
+            '    h1 { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 26, 26)');
+
+        const styleElement = document.getElementById('variables') as HTMLStyleElement;
+        styleElement.textContent = ':root { --text: green; }';
+        await timeout(100);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(140, 255, 140)');
+    });
+});

--- a/tests/inject/dynamic/variables.tests.ts
+++ b/tests/inject/dynamic/variables.tests.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 afterEach(() => {
     removeDynamicTheme();
     container.innerHTML = '';
+    document.documentElement.removeAttribute('style');
 });
 
 describe('CSS Variables Override', () => {
@@ -187,6 +188,22 @@ describe('CSS Variables Override', () => {
 
         const styleElement = document.getElementById('variables') as HTMLStyleElement;
         styleElement.textContent = ':root { --text: green; }';
+        await timeout(100);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(140, 255, 140)');
+    });
+
+    it('should use <html> element variables', async () => {
+        document.documentElement.setAttribute('style', '--text: red;');
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 { color: var(--text); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 26, 26)');
+
+        document.documentElement.setAttribute('style', '--text: green;');
         await timeout(100);
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(140, 255, 140)');
     });


### PR DESCRIPTION
- Tests for old CSS variables handling implementation.
- Fixed not reacting on `<style>` element `textContent` changes in Firefox.
- Clear CSS variables cache when removing dynamic theme.