### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1439,6 +1439,14 @@ CSS
 
 ================================
 
+*.ethol.pens.ac.id
+
+CSS
+.scrollableList--Z2s6Her{
+background: none !important;
+}
+
+================================
 cookiepedia.co.uk
 
 INVERT


### PR DESCRIPTION
Add *.ethol.pens.ac.id to the list. (That is my school's page for online classrooms)
There is an unnecessary shadow that appears on the left panel that looks weird on dark mode. Now it disappears and looks better than before.