### PR TITLE
Fix dark mode for *.ethol.pens.ac.id

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17,6 +17,15 @@ CSS
 
 ================================
 
+*.ethol.pens.ac.id
+
+CSS
+.scrollableList--Z2s6Her{
+background: none !important;
+}
+
+================================
+
 *.stackexchange.com
 askubuntu.com
 mathoverflow.net

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17,15 +17,6 @@ CSS
 
 ================================
 
-*.ethol.pens.ac.id
-
-CSS
-.scrollableList--Z2s6Her{
-background: none !important;
-}
-
-================================
-
 *.stackexchange.com
 askubuntu.com
 mathoverflow.net
@@ -731,6 +722,7 @@ INVERT
 
 bbb*.
 demo*.bigbluebutton.org
+*.ethol.pens.ac.id
 
 CSS
 div[class*="scrollableList"] {


### PR DESCRIPTION
There is an unnecessary shadow that appears on the left panel that looks weird on dark mode. Now it disappears and looks better than before.