### PR TITLE
Fix dark mode for academy.dqlab.id

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -202,6 +202,13 @@ CSS
 
 ================================
 
+academy.dqlab.id
+
+INVERT
+.menu img
+
+================================
+
 accounts.google.com
 
 INVERT


### PR DESCRIPTION
A simple invert to the images in the sidebar menu. Looks perfect now.
![image](https://user-images.githubusercontent.com/67551202/101238455-f425f780-3712-11eb-9754-f507f4534a66.png)
