### PR TITLE
fix circuit-diagram.org icons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1263,7 +1263,7 @@ INVERT
 circuit-diagram.org
 
 INVERT
-canvas[_ngcontent-ail-c19]
+.components-list .item .image
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1260,6 +1260,13 @@ INVERT
 
 ================================
 
+circuit-diagram.org
+
+INVERT
+canvas[_ngcontent-ail-c19]
+
+================================
+
 citymapper.com
 
 INVERT


### PR DESCRIPTION
Fixes black icons on circuit-diagram.org

![old](https://user-images.githubusercontent.com/5316261/101243277-11a59200-3710-11eb-8c4a-bc2203fbefb1.png) ![new](https://user-images.githubusercontent.com/5316261/101243280-18cca000-3710-11eb-950b-518a469bd136.png)

