### PR TITLE
Add cache to parseURL

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -20,6 +20,7 @@ import {createAdoptedStyleSheetOverride} from './adopted-style-manger';
 import {isFirefox} from '../../utils/platform';
 import {injectProxy} from './stylesheet-proxy';
 import {parse} from '../../utils/color';
+import {parsedURLCache} from '../../utils/url';
 
 const variables = new Map<string, string>();
 const INSTANCE_ID = generateUID();
@@ -475,6 +476,7 @@ export function removeDynamicTheme() {
         manager.destroy();
     });
     adoptedStyleManagers.splice(0);
+    parsedURLCache.clear();
 }
 
 export function cleanDynamicThemeCache() {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -3,6 +3,8 @@ import {isIPV6, compareIPV6} from './ipv6';
 
 let anchor: HTMLAnchorElement;
 
+export const parsedURLCache = new Map<string, URL>();
+
 function fixBaseURL($url: string) {
     if (!anchor) {
         anchor = document.createElement('a');
@@ -12,12 +14,18 @@ function fixBaseURL($url: string) {
 }
 
 export function parseURL($url: string, $base: string = null) {
-    if ($base) {
-        $base = fixBaseURL($base);
-        return new URL($url, $base);
+    const key = `${$url}${$base ? ';' + $base : ''}`;
+    if (parsedURLCache.has(key)) {
+        return parsedURLCache.get(key);
     }
-    $url = fixBaseURL($url);
-    return new URL($url);
+    if ($base) {
+        const parsedURL = new URL($url, fixBaseURL($base));
+        parsedURLCache.set(key, parsedURL);
+        return parsedURL;
+    }
+    const parsedURL = new URL(fixBaseURL($url));
+    parsedURLCache.set($url, parsedURL);
+    return parsedURL;
 }
 
 export function getAbsoluteURL($base: string, $relative: string) {


### PR DESCRIPTION
- URL Constructors are expensive in time.
- Adding a cache resolve this problem, because the main $url is 95% the same one.
- Resolves #1158