### PR TITLE
Fixed google translate verified icon

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8620,6 +8620,7 @@ a[href*="about/products"][title]
 .yPHXsc div
 .mn-dwn-arw
 img.act-icon-dark-gray
+#dimg_15
 
 CSS
 .RNNXgb {


### PR DESCRIPTION
Fixed google translate verified icon

1. Search up how to translate box in Spanish
2. Notice verified icon is black

Before:
![Screenshot from 2020-12-06 19-28-58](https://user-images.githubusercontent.com/53054099/101306326-72f56000-37f9-11eb-995f-12b54d98cfc6.png)
After:
![Screenshot from 2020-12-06 19-29-07](https://user-images.githubusercontent.com/53054099/101306334-77ba1400-37f9-11eb-9876-a46a57abd95f.png)
