### PR TITLE
reddit.com: make article titles color --darkreader-neutral-text

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6111,6 +6111,9 @@ CSS
 .md p>a[href="#s"]::after, a[href="#s"]::after {
     color: #000;
 }
+.thing .title {
+    color: var(--darkreader-neutral-text);
+}
 
 ================================
 


### PR DESCRIPTION
When in dark reader mode, reddit.com article titles are a dark blue on black, a little difficult to read (for me.)  This patch changes the title to a darkreader color.