### PR TITLE
Fix for whatsapp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8264,7 +8264,11 @@ span[data-icon="tail-out"] {
 }
 #hide_till_load > div > div._2y_d._2yzz._2ywk > div > div._2zs2._1hk9 > div {
     background-image: url(https://static.whatsapp.net/rsrc.php/v1/y_/r/oqWQjtJbOPM.jpg) !important;
-    background-size: 100% !important
+    background-size: 100% !important;
+}
+div#subheader._2zs9._2awa {
+    background-image: url(https://static.whatsapp.net/rsrc.php/v1/yQ/r/dPFl9fRFF9u.jpg) !important;
+    background-size: 100% !important;
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2608,6 +2608,13 @@ INVERT
 
 ================================
 
+faq.whatsapp.com
+
+INVERT
+#wafaq_search_input
+
+================================
+
 farside.ph.utexas.edu
 mathpages.com
 mathprofi.ru

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8262,7 +8262,7 @@ span[data-icon="tail-in"] {
 span[data-icon="tail-out"] {
     color: rgb(4, 57, 51) !important;
 }
-div._2zs9 {
+#hide_till_load > div > div._2y_d._2yzz._2ywk > div > div._2zs2._1hk9 > div {
     background-image: url(https://static.whatsapp.net/rsrc.php/v1/y_/r/oqWQjtJbOPM.jpg) !important;
     background-size: 100% !important
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8239,7 +8239,6 @@ INVERT
 whatsapp.com
 
 INVERT
-.selectable-text > span._3PxOr
 span[data-icon="audio-download"]
 .landing-main .invisible-space > span
 .landing-main div[data-ref] span > svg > path
@@ -8247,9 +8246,6 @@ div.landing-header > span > svg
 #wafaq_search_input
 
 CSS
-._3Ye_R {
-    color: gray !important
-}
 [data-asset-intro-image], [data-asset-intro-image-light] {
     background-image: url(/img/intro-connection_c98cc75f2aa905314d74375a975d2cf2.jpg) !important;
 }
@@ -8262,11 +8258,11 @@ span[data-icon="tail-in"] {
 span[data-icon="tail-out"] {
     color: rgb(4, 57, 51) !important;
 }
-#hide_till_load > div > div._2y_d._2yzz._2ywk > div > div._2zs2._1hk9 > div {
+body#top-of-page > div#hide_till_load > div > div:nth-child(2):not([data-testid="whatsapp_www_header"]) > div:not(#subheader) > div > div:not(h1 ~ div) {
     background-image: url(https://static.whatsapp.net/rsrc.php/v1/y_/r/oqWQjtJbOPM.jpg) !important;
     background-size: 100% !important;
 }
-div#subheader._2zs9._2awa {
+div#subheader {
     background-image: url(https://static.whatsapp.net/rsrc.php/v1/yQ/r/dPFl9fRFF9u.jpg) !important;
     background-size: 100% !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2608,13 +2608,6 @@ INVERT
 
 ================================
 
-faq.whatsapp.com
-
-INVERT
-#wafaq_search_input
-
-================================
-
 farside.ph.utexas.edu
 mathpages.com
 mathprofi.ru
@@ -8196,37 +8189,6 @@ CSS
 
 ================================
 
-web.whatsapp.com
-
-INVERT
-.selectable-text > span._3PxOr
-span[data-icon="audio-download"]
-.landing-main .invisible-space > span
-.landing-main div[data-ref] span > svg > path
-div.landing-header > span > svg
-
-CSS
-._3Ye_R {
-    color: gray !important
-}
-[data-asset-intro-image], [data-asset-intro-image-light] {
-    background-image: url(/img/intro-connection_c98cc75f2aa905314d74375a975d2cf2.jpg) !important;
-}
-html[dir] .landing-main > :first-child > :nth-child(2) > :first-child {
-    border: 5px solid white !important;
-}
-span[data-icon="tail-in"] {
-    color: rgb(30, 36, 39) !important;
-}
-span[data-icon="tail-out"] {
-    color: rgb(4, 57, 51) !important;
-}
-
-IGNORE INLINE STYLE
-path[fill="currentColor"]
-
-================================
-
 webaim.org
 
 CSS
@@ -8271,6 +8233,38 @@ INVERT
 .illustration
 .archive-image
 .logo
+
+================================
+
+whatsapp.com
+
+INVERT
+.selectable-text > span._3PxOr
+span[data-icon="audio-download"]
+.landing-main .invisible-space > span
+.landing-main div[data-ref] span > svg > path
+div.landing-header > span > svg
+#wafaq_search_input
+
+CSS
+._3Ye_R {
+    color: gray !important
+}
+[data-asset-intro-image], [data-asset-intro-image-light] {
+    background-image: url(/img/intro-connection_c98cc75f2aa905314d74375a975d2cf2.jpg) !important;
+}
+html[dir] .landing-main > :first-child > :nth-child(2) > :first-child {
+    border: 5px solid white !important;
+}
+span[data-icon="tail-in"] {
+    color: rgb(30, 36, 39) !important;
+}
+span[data-icon="tail-out"] {
+    color: rgb(4, 57, 51) !important;
+}
+
+IGNORE INLINE STYLE
+path[fill="currentColor"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8262,6 +8262,10 @@ span[data-icon="tail-in"] {
 span[data-icon="tail-out"] {
     color: rgb(4, 57, 51) !important;
 }
+div._2zs9 {
+    background-image: url(https://static.whatsapp.net/rsrc.php/v1/y_/r/oqWQjtJbOPM.jpg) !important;
+    background-size: 100% !important
+}
 
 IGNORE INLINE STYLE
 path[fill="currentColor"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8258,7 +8258,7 @@ span[data-icon="tail-in"] {
 span[data-icon="tail-out"] {
     color: rgb(4, 57, 51) !important;
 }
-body#top-of-page > div#hide_till_load > div > div:nth-child(2):not([data-testid="whatsapp_www_header"]) > div:not(#subheader) > div > div:not(h1 ~ div) {
+body#top-of-page > div#hide_till_load > div > div:nth-child(2):not([data-testid="whatsapp_www_header"]) > div:not(#subheader) > div:nth-child(1) > :nth-child(1):not(h1) {
     background-image: url(https://static.whatsapp.net/rsrc.php/v1/y_/r/oqWQjtJbOPM.jpg) !important;
     background-size: 100% !important;
 }


### PR DESCRIPTION
- Before:
![Screenshot from 2020-12-07 10-42-30](https://user-images.githubusercontent.com/53054099/101391299-f7d38e80-3878-11eb-9046-54ea918d22a2.png)
The caret color was inverted and the text was harder to read. This fixes it by inverting the input.
- Moved to `whatsapp.com` instead of `web.whatsapp.com`
- Fixed security page: https://www.whatsapp.com/security/
- Fixed the background on faq.whatsapp.com