### PR TITLE
Add github.com in dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -270,6 +270,7 @@ gifrun.com
 gifyourgame.com
 gikken.co
 giphy.com
+github.com
 githubuniverse.com
 gitkraken.com
 gitmoji.kaki87.net


### PR DESCRIPTION
GitHub now has a dark theme feature!

https://github.com/githubevents/universe2020/discussions/17