### PR TITLE
[NO-JIRA] Exclude github.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -269,6 +269,7 @@ gifrun.com
 gifyourgame.com
 gikken.co
 giphy.com
+github.com
 githubuniverse.com
 gitkraken.com
 gitmoji.kaki87.net


### PR DESCRIPTION
[Github.com now supports native dark mode](https://github.com/settings/appearance). We should therefore encourage use of this setting instead of applying custom styling.

Let me know if there's a better way to do this, or if you want to wait until the GitHub feature is out of beta.