### PR TITLE
Add carbon.now.sh to the list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -90,6 +90,7 @@ byte.co
 caniuse.com
 captaindisillusion.com
 caracal.club
+carbon.now.sh
 cardsity.app
 carl.gg
 cascadr.co


### PR DESCRIPTION
Pretty surprised that it wasn't on the list. So I decided to add it.

By the way, GitHub now has a built-in dark theme. But it's still in beta. Looks pretty slick though. Should we add it to the list? Thanks

![image](https://user-images.githubusercontent.com/67551202/101623176-a1b64500-3a4a-11eb-9aa9-40347b2fd8ae.png)
