### PR TITLE
Add genshin.gg and 2 other similar sites to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -254,9 +254,12 @@ geekabit.nl
 geektyper.com
 gekri.com
 generated.photos
+genshin.gg
 geocities.restorativland.org
 gethalfmoon.com
 getsharex.com
+gfl.matsuda.tips
+gflcorner.com
 gfycat.com
 ggapp.io
 ghacksuserjs.github.io/TorZillaPrint/TorZillaPrint.html


### PR DESCRIPTION
genshin.gg, gfl.matsuda.tips and gflcorner.com are dark by default