### PR TITLE
Fix bright red background on track.toggl.com.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7607,6 +7607,15 @@ body {
 
 ================================
 
+track.toggl.com
+
+CSS
+#root, .content-wrapper > * {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 translate.google.*
 translate.google.*.*
 


### PR DESCRIPTION
track.toggl.com has a very pale pink background, which dynamic mode turns into a very jarring red. This forces it to be the default Dark Reader background color.