### PR TITLE
rythmbot.co is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -548,6 +548,7 @@ romefrontend.dev
 rtbyte.xyz
 runicgames.com
 rust.facepunch.com
+rythmbot.co
 sa-mp.com
 sabato.studio
 sanctum.geek.nz/arabesque


### PR DESCRIPTION
link: [rythmbot.co](https://rythmbot.co/)