### PR TITLE
Add stillu.cc to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -603,6 +603,7 @@ steamcommunity.com
 steamdb.info
 steamstat.us
 steamtimeidler.com
+stillu.cc
 stitches.dev
 stonestyle.co.th
 store.steampowered.com


### PR DESCRIPTION
The website already has a dark theme applied.