### PR TITLE
Add missing.csail.mit.edu to the dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -402,6 +402,7 @@ metropool.nl
 miaou.drycat.fr
 minehut.com
 miniroyale2.io
+missing.csail.mit.edu
 missions.ingress.com
 mixer.com
 mixxx.org


### PR DESCRIPTION
Can confirm that it is dark by default. A very cool website with a lot of useful sources for learning Computer Science.