### PR TITLE
Fix for stackexchange group of sites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -69,6 +69,9 @@ body {
 #content {
     background-color: var(--darkreader-neutral-bg) !important;
 }
+#newuser-box {
+    background: ${#423C2D} !important;
+}
 
 ================================
 


### PR DESCRIPTION
Fixes color of `#newuser-box`:

### Before

![image](https://user-images.githubusercontent.com/34424160/101949270-3e174d80-3beb-11eb-906d-af5c361941b3.png)

### After

![image](https://user-images.githubusercontent.com/34424160/101949297-48d1e280-3beb-11eb-9b2e-377022932335.png)
