### PR TITLE
Add iq.com to the dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -337,6 +337,7 @@ inker.co
 intactphone.com
 intothetrenches.1917.movie
 iptorrents.com
+iq.com
 isthereanydeal.com
 iwanttoeat.app
 ixirc.com


### PR DESCRIPTION
I searched for ```prefers-color-scheme``` and I didn't find it. However, after switching my Windows app mode to light. The website didn't change. So it must be dark by default. Please inform me if I'm wrong, thanks