### PR TITLE
Update dynamic-theme-fixes.config for ikea.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3770,6 +3770,9 @@ CSS
 .range-revamp-ratings-bar__star--half path:first-child  {
     fill: ${rgb(246, 245, 244)} !important;
 }
+.hnf-svg-icon {
+    fill: var(--darkreader-neutral-text) !important;
+}
 
 IGNORE INLINE STYLE
 .gpr__color-dot


### PR DESCRIPTION
This CSS patch fixes the menu on https://www.ikea.com/us/en/.

**Before:**
![image](https://user-images.githubusercontent.com/7400326/102038120-6b532f80-3d94-11eb-963a-99fc87f6d3c6.png)



**After:**
![image](https://user-images.githubusercontent.com/7400326/102038138-7908b500-3d94-11eb-9f56-550034956be5.png)

