### PR TITLE
Fix postmarketos.org

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -511,7 +511,6 @@ poe.trade
 poeapp.com
 poelab.com
 pony.tube
-^postmarketos.org
 postwoman.io
 powercord.dev
 pr0gramm.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -511,7 +511,7 @@ poe.trade
 poeapp.com
 poelab.com
 pony.tube
-postmarketos.org
+^postmarketos.org
 postwoman.io
 powercord.dev
 pr0gramm.com


### PR DESCRIPTION
[wiki.postmarketos.org](https://wiki.postmarketos.org/wiki/Main_Page) doesn't have a dark mode.