### PR TITLE
Fixed "Verified Icon" on Google Translate

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3525,6 +3525,13 @@ a[href*="about/products"]
 
 ================================
 
+google.com/search?q=translate*
+
+INVERT
+.XrZwB
+
+================================
+
 goplay.anontpp.com
 
 INVERT


### PR DESCRIPTION
On searching 'translate', google provides mini translator in search results, which has a verified icon (Shield and a Right Tick mark) for some basic phrases or words. Which was black so I added an inversion fix.

Before: 
![ub9o2EW](https://user-images.githubusercontent.com/48391649/102492579-e6b82800-4097-11eb-867a-f1f6e725f229.jpeg)

After:
![cxa5tDM](https://user-images.githubusercontent.com/48391649/102492619-f46dad80-4097-11eb-9d92-182bc536564b.jpeg)
