### PR TITLE
Fix for incorrect background image

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3440,10 +3440,8 @@ IGNORE IMAGE ANALYSIS
 
 global.gotomeeting.com/join/*
 
-CSS
-body{
-    background-image: url(https://join.gotomeeting.com/background-daisy.svg) !important;
-}
+IGNORE IMAGE ANALYSIS
+body
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3438,6 +3438,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+global.gotomeeting.com/join/*
+
+CSS
+body{
+    background-image: url(https://join.gotomeeting.com/background-daisy.svg) !important;
+}
+
+================================
+
 gls-pakete.de
 
 CSS


### PR DESCRIPTION
There are two background images assigned to body in css. One is assigned by DarkReader(format unknown), and other is in normal style file(a svg file). DarkReader loads a bright image in dark mode. So I aasigned the svg file, which works perfectly fine in both, Dark and Light modes.

Steps to Repeat Behavior: Go to [this Link](https://global.gotomeeting.com/join/600000)

You would be able to see a bright white background image.

Before:
![Screenshot (236)](https://user-images.githubusercontent.com/48391649/102491448-3695ef80-4096-11eb-863c-ab82589c7581.jpg)

After:
![Screenshot (296)](https://user-images.githubusercontent.com/48391649/102491469-40b7ee00-4096-11eb-86ca-aefceca80ead.jpg)
