### PR TITLE
Fixed incorrect box-shadow color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3045,6 +3045,15 @@ CSS
 
 ================================
 
+geeksforgeeks.org*
+
+CSS
+.gsc-input-box{
+    box-shadow: rgba(255, 255, 255, 0.3) 0px 0px 2px !important;
+}
+
+================================
+
 geizhals.*
 skinflint.co.uk
 cenowarka.pl

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3045,11 +3045,11 @@ CSS
 
 ================================
 
-geeksforgeeks.org*
+geeksforgeeks.org
 
 CSS
-.gsc-input-box{
-    box-shadow: rgba(255, 255, 255, 0.3) 0px 0px 2px !important;
+.gsc-input-box {
+    box-shadow: ${rgba(0, 0, 0, 0.3)} 0px 0px 2px !important;
 }
 
 ================================


### PR DESCRIPTION
Search box has shadow of black color even in dark mode, which is making the box disappear completely. So I added white colored box-shadow which is working great.

Repeat Behavior: Go to [GeeksforGeeks](https://www.geeksforgeeks.org/)
You'll be able to see the search button on top right but not the input box. (Also marked in image below)
Due to the black color box-shadow. I fixed it.

Before:
![Before](https://user-images.githubusercontent.com/48391649/102516929-6e605f80-40b5-11eb-9e08-1cbd53a7aaa4.jpg)

After:
![After](https://user-images.githubusercontent.com/48391649/102516991-7ddfa880-40b5-11eb-9e9a-93575f5d55b0.jpg)
