### PR TITLE
emma.cline.engineer already implements a dark mode

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -210,6 +210,7 @@ ellie-app.com
 elybeatmaker.com
 emanuelemilella.com
 emeraldchat.com/app
+emma.cline.engineer
 emuparadise.me
 energized.pro
 enlightenment.org


### PR DESCRIPTION
I added a dark mode that supports the prefers-color-scheme and will soon have a toggleable switch in the top right corner to also control it. The dark mode is a similar color scheme to darkreader so thanks! 

This should maintain alphabetical order.