### PR TITLE
Delete donationalerts.com from dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -186,7 +186,6 @@ discuss.noisebridge.info
 disneyplus.com
 dlive.tv
 dodi-repacks.site
-donationalerts.com
 dota2.ru
 dotabuff.com
 dotapicker.com


### PR DESCRIPTION
- There is not always a dark theme on the donation page.

Example of site page: https://www.donationalerts.com/r/libertalia