### PR TITLE
Fix code diff and terminal font on gitlab.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3441,6 +3441,10 @@ CSS
 .avatar, .avatar-container {
     border: none !important;
 }
+table.code .line_content *:not(pre),
+.job-log *:not(pre) {
+  font-family: "Menlo", "DejaVu Sans Mono", "Liberation Mono", "Consolas", "Ubuntu Mono", "Courier New", "andale mono", "lucida console", monospace !important;
+}
 
 ================================
 


### PR DESCRIPTION
As of the important flag added to the `:not(pre)` selector and because GitLab.com doesn't use pre/code elements for individual code and terminal lines, the font family in terminals and code diffs are overwritten in case the font settings in Dark Reader are changed, e.g. to the system font. Re-applying GitLab's font-stack to those elements again, with the !important flag, solves the issue.