### PR TITLE
cdkeys.com and lospec.com are dark websites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -99,6 +99,7 @@ carbon.now.sh
 cardsity.app
 carl.gg
 cascadr.co
+cdkeys.com
 cdnnow.pro
 cheat.sh
 checkra.in
@@ -386,6 +387,7 @@ lollilol.cf
 lollilol.ml
 lookmovie.ag
 lordofthemanor.io
+lospec.com
 m2v.ru
 m4rtyr.github.io
 macbb.org


### PR DESCRIPTION
The title already says it all.
I hope it is okay if I do one pull request for multiple dark-sites edits at once :)