### PR TITLE
Add fixes for decathon.in

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1764,6 +1764,18 @@ INVERT
 
 ================================
 
+decathlon.in
+
+CSS
+.media, .swiper-slide {
+    background-color: silver !important;
+}
+.media-body {
+    color: black;
+}
+
+================================
+
 decathlon.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1767,11 +1767,8 @@ INVERT
 decathlon.in
 
 CSS
-.media, .swiper-slide {
-    background-color: silver !important;
-}
-.media-body {
-    color: black;
+img {
+    mix-blend-mode: normal !important;
 }
 
 ================================


### PR DESCRIPTION
This fixes an issue with all (as far as I can see) product images and many other images on the Decathlon India website. Those elements, when in dark mode, have a dark tint over them, which affects visibility and makes them look greyed out. This fix sets the background color of certain parent elements of those images.
Examples of these images can be seen on the search results at [https://www.decathlon.in/search?query=brake%20pad](https://www.decathlon.in/search?query=brake%20pad)

Different colors ranging from HTML Grey to HTML White were tried, and HTML Silver seemed to be a good middle ground between the still tinted look of Grey and the potentially unappealing contrast of White. There, however, still persists a very slight tint when using Silver. The only way I could get rid of the tint completely was to use White.

Additionally, some text elements on the elements affected by this needed correction, as they were light and could not be read on the HTML Silver backgrounds. An example of these can be seen in the "Advantages" section at [https://www.decathlon.in/p/8325111/bikes-brakes-and-brake-pads/disc-brake-pads-compatible-with-shimano-deore-tektro](https://www.decathlon.in/p/8325111/bikes-brakes-and-brake-pads/disc-brake-pads-compatible-with-shimano-deore-tektro) (for example, the "Compatibility" heading under the "Advantages" section; the image on the left needed correction because of the tinting earlier mentioned, and the text on the right needed correction because of the fix for the images).