### PR TITLE
Add godbolt.org to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -285,6 +285,7 @@ glslsandbox.com
 go.dailynow.co
 goaudio.cc
 god.freevar.com
+godbolt.org
 gogalaxy.com
 gogoanime.se
 goosegame.io


### PR DESCRIPTION
It has a dark theme by default.