### PR TITLE
Allow every math in less compiler

### DIFF
--- a/tasks/bundle-css.js
+++ b/tasks/bundle-css.js
@@ -17,7 +17,7 @@ function getLessFiles({debug}) {
 async function bundleCSSEntry({src, dest}) {
     const srcDir = path.join(process.cwd(), path.dirname(src));
     const input = await fs.readFile(src, {encoding: 'utf8'});
-    const output = await less.render(input, {paths: [srcDir]});
+    const output = await less.render(input, {paths: [srcDir], math: 'always'});
     const {css} = output;
     await fs.outputFile(dest, css, {encoding: 'utf8'});
 }


### PR DESCRIPTION
- FIx an error with the current math in our `.less` files.
- Resolves #4584