### PR TITLE
Fix for drive.google.com/file

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2177,6 +2177,7 @@ drive.google.com/file
 INVERT
 div[role="menu"] > div[role="menuitem"] > div > div > div
 div[role="menu"] > div[role="menuitem"] > div > div
+div[role="document"]
 
 CSS
 div[role="toolbar"] div[role="button"] > div[class*='-']:not([onclick]):not(:link):not(:visited):not([style*="background-image"]):first-child,


### PR DESCRIPTION
- Invert file contents.

And if the user is not satisfied with the quality of the inversion, then he can simply disable DarkReader for this site, and his site will remain dark in color, and the document will look like the original.