### PR TITLE
Remove blokada.org from already dark websites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -76,7 +76,6 @@ block.wingysam.xyz
 blog.aractus.com
 blog.dota2.com
 blog.ja-ke.tech
-blokada.org
 blox.link
 bogleech.com
 bondoer.fr


### PR DESCRIPTION
![screenshot-blokada org-2020 12 26-22_53_24](https://user-images.githubusercontent.com/21284089/103159765-bbd37f80-47cd-11eb-9b58-f344dd8f33e9.png)
