### PR TITLE
Add aspenuwu.me to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -36,6 +36,7 @@ artofkeys.com
 as2.aiae.ovh
 asherhe.com
 asoftmurmur.com
+aspenuwu.me
 ast4u.me
 atelier.net/virtual-economy
 atlassurvivalshelters.com


### PR DESCRIPTION
Hi, I own aspenuwu.me, and I always use dark color schemes where available :)

(both screenshots have DR disabled for the site)

![image](https://user-images.githubusercontent.com/65794972/103159848-44392c80-479c-11eb-994f-03288da682f0.png)
![image](https://user-images.githubusercontent.com/65794972/103159850-48fde080-479c-11eb-8422-1b6538e42631.png)
