### PR TITLE
Inverting Mixmax dropdown in Gmail

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4716,6 +4716,7 @@ img[src$="profile_mask2.png"]
 .buh
 .qj.qr::before
 .qj.qr::after
+.mixmax-flyout__wrapper
 
 CSS
 @media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {


### PR DESCRIPTION
Added Mixmax dropdown to mail.google.com invert list.

https://www.mixmax.com/ is a Gmail addon that adds extra features, however, their snooze dropdown menu doesn't look very good in Dark Mode (as both the text and the background is black).

This small tweak INVERTs their dropdown class (returning it to Light mode), so that it is readable.