### PR TITLE
Fixed developer.mozilla.org documentation pages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1917,9 +1917,17 @@ developer.mozilla.org
 INVERT
 mark
 .icon-thumbs-down-alt
-span[class*="bc-head-icon"]::before
+.bc-head-icon-edge::before
 .last-modified::before
 .newsletter-hide > svg
+a.logo
+button.top-level-entry::before
+a.breadcrumb::after
+a.breadcrumb-penultimate::after
+a.external::before
+th.bc-platform-desktop::before
+th.bc-platform-mobile::before
+span.bc-head-txt-label::before
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1915,19 +1915,21 @@ mark, pre b {
 developer.mozilla.org
 
 INVERT
+body:not(#home) header a.logo
 mark
 .icon-thumbs-down-alt
-.bc-head-icon-edge::before
 .last-modified::before
 .newsletter-hide > svg
-a.logo
 button.top-level-entry::before
 a.breadcrumb::after
 a.breadcrumb-penultimate::after
 a.external::before
 th.bc-platform-desktop::before
 th.bc-platform-mobile::before
-span.bc-head-txt-label::before
+span[class*="bc-head-icon"]::before
+abbr.only-icon::before
+abbr.only-icon i::before
+button.only-icon::before
 
 ================================
 


### PR DESCRIPTION
I fixed many icons on the docs, that didnt invert, but there may have been some I haven's seen and fixed yet.
Also I couln't fix the seach icon in the top right, maybe someone else knows how to best fix that.

![mdn](https://user-images.githubusercontent.com/22528516/103218291-e5e68800-491a-11eb-827a-c8b34fb62c42.jpg)
