### PR TITLE
Removed css-tricks.com from dark list, added a fix

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -129,7 +129,6 @@ crackwatch.com
 crazygames.com
 cryptowat.ch
 cs.rin.ru
-css-tricks.com
 cswarzone.com
 ctr-electronics.com
 cxsecurity.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1660,6 +1660,15 @@ table#calendar td {
 
 ================================
 
+css-tricks.com
+
+CSS
+.article-article {
+    background: ${white} !important;
+}
+
+================================
+
 cynkra.com
 
 INVERT


### PR DESCRIPTION
If you open any actual article, the background of the actual article text is white. But after removing it from the dark list, it required a fix for the image overlapping the article preview on the front page.