### PR TITLE
Support For Google Sheets Add-ons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2126,6 +2126,7 @@ img[src$="googlelogo_dark_clr_74x24px.svg"]
 #docs-titlebar-share-client-button .scb-button-icon:not([class*="white"])
 body[itemtype*="PresentationObject"] #docs-titlebar-share-client-button .scb-button-icon
 g.punch-filmstrip-indicator > image
+iframe
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
Sheets add-ons run in an iframe, so simple inversion is all that's needed.