### PR TITLE
Fix for google.*/maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3600,7 +3600,6 @@ div.maps-sprite-common-chevron-left
 span.maps-sprite-common-chevron-right
 span.section-destination-via-line-icon
 div.section-directions-trip-travel-mode-icon
-div.goog-menu-button-dropdown
 button.searchbox-hamburger.white-foreground
 label.kd-radio-label:before
 label.kd-checkbox-label:before
@@ -3621,6 +3620,8 @@ a[href*="about/products"]
 .section-review-interaction-button
 .section-directions-trip-travel-mode-icon
 .renderable-component-icon
+.cards-rating-star
+.maps-sprite-common-chevron-right
 
 ================================
 


### PR DESCRIPTION
- Remove rule for incorrectly inverting dropdown icon in div with section-subheader class.
- Invert empty raring icons in search.
- Invert right arrow in div with section-editorial-container class.

Example of site pages: https://www.google.com/maps/search/kfc/@51.510671,-0.1306647,14z, https://www.google.com/maps/place/Mercato+Metropolitano/@51.5101876,-0.1324672,14z/data=!4m5!3m4!1s0x487604a1478398d3:0x21dbf63818cd65e3!8m2!3d51.4984612!4d-0.0984102 