### PR TITLE
circleci.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -251,6 +251,14 @@ NO INVERT
 
 ================================
 
+circleci.com
+
+INVERT
+.css-1ibtrcs
+.css-1lflngw
+
+================================
+
 cloud-catcher.squiddev.cc
 
 INVERT


### PR DESCRIPTION
The build log output is already dark (not the whole webpage though), these lines should keep the build output dark while inverting the rest of the page.