### PR TITLE
Add MeWe.com custom CSS

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5261,6 +5261,16 @@ g > rect
 
 ================================
 
+mewe.com
+
+CSS
+html,
+body {
+    height: auto !important;
+}
+
+================================
+
 midkar.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5265,7 +5265,7 @@ mewe.com
 
 CSS
 body > .ember-view {
-    background-color: #2c2d2d !important;
+    background-color: ${#ebf0f3} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5264,9 +5264,8 @@ g > rect
 mewe.com
 
 CSS
-html,
-body {
-    height: auto !important;
+body > .ember-view {
+    background-color: #2c2d2d !important;
 }
 
 ================================


### PR DESCRIPTION
By default MeWe.com social network `body` and `html` are `100%` height. That makes DarkReader applied styles look good only on the very top of the page, but if you scroll just a bit, there's a black bar and then you can't separate other elements from the background. Setting height to `auto`, fixes this

![Untitled](https://user-images.githubusercontent.com/3602819/103805393-2ef5b500-505c-11eb-9d91-944e5482c548.png)