### PR TITLE
Improve quality of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-website.md
+++ b/.github/ISSUE_TEMPLATE/broken-website.md
@@ -7,8 +7,10 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
-<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
+<!-- 
+  ⚠⚠ Do not delete this issue template! ⚠⚠ 
+  Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. 
+-->
 
 <!--
 Thank you for taking the time to report a broken website.
@@ -16,24 +18,24 @@ Please make sure there is no existing issue with this broken website.
 -->
 
 **Website**
-The link to the broken website
+<!-- The link of the website where you can observe the issue. -->
 
 **How to Reproduce**
+<!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
 Steps to reproduce the behavior:
 An example of this is
->
-> 1. Go to x site
-> 2. Hover over x button
-> 3. See that when hovering it isn't changing colors
+- Go to x site
+- Hover over x button
+- See that when hovering it isn't changing colors
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Actual behavior**
-A clear and concise description of what happened.
+<!-- A clear and concise description of what actually happened. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 <!--
 Please add a version of the browser you are using. 
@@ -41,9 +43,9 @@ If you don't know how to get your browser/darkreader version please search it up
 -->
 **System info:**
 
-- OS: [e.g. Windows, MacOS, Linux]
-- Browser: [e.g. chrome, safari]
-- Darkreader Version: [e.g. 4.9.9]
+- OS: <!-- [e.g. Windows, MacOS, Linux] -->
+- Browser: <!-- [e.g. Chrome, Safari] -->
+- Darkreader Version: <!-- [e.g. 4.9.26] -->
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/broken-website.md
+++ b/.github/ISSUE_TEMPLATE/broken-website.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
-<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
+<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
 
 <!--
 Thank you for taking the time to report a broken website.

--- a/.github/ISSUE_TEMPLATE/broken-website.md
+++ b/.github/ISSUE_TEMPLATE/broken-website.md
@@ -17,35 +17,39 @@ Thank you for taking the time to report a broken website.
 Please make sure there is no existing issue with this broken website.
 -->
 
-**Website**
+# Broken Website
+
+## Website
 <!-- The link of the website where you can observe the issue. -->
 
-**How to Reproduce**
+## How to Reproduce
 <!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
 Steps to reproduce the behavior:
-An example of this is
+An example of this is:
+
 - Go to x site
 - Hover over x button
 - See that when hovering it isn't changing colors
 
-**Expected behavior**
+## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Actual behavior**
+## Actual behavior
 <!-- A clear and concise description of what actually happened. -->
 
-**Screenshots**
+## Screenshots
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 <!--
 Please add a version of the browser you are using. 
 If you don't know how to get your browser/darkreader version please search it up online.
 -->
-**System info:**
+
+## System Information
 
 - OS: <!-- [e.g. Windows, MacOS, Linux] -->
 - Browser: <!-- [e.g. Chrome, Safari] -->
 - Darkreader Version: <!-- [e.g. 4.9.26] -->
 
-**Additional context**
+## Additional context
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/broken-website.md
+++ b/.github/ISSUE_TEMPLATE/broken-website.md
@@ -1,6 +1,6 @@
 ---
 name: Broken website
-about: Creates a broken website report about Darkreader
+about: Creates a broken website report about Dark Reader
 title: "[Broken Website] Insert title here"
 labels: Broken Website
 assignees: ''
@@ -24,12 +24,13 @@ Please make sure there is no existing issue with this broken website.
 
 ## How to Reproduce
 <!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
-Steps to reproduce the behavior:
-An example of this is:
-
-- Go to x site
-- Hover over x button
-- See that when hovering it isn't changing colors
+<!--
+  Steps to reproduce the behavior:
+  An example of this is:
+  - Go to x site
+  - Hover over x button
+  - See that when hovering it isn't changing colors
+-->
 
 ## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
@@ -42,14 +43,14 @@ An example of this is:
 
 <!--
 Please add a version of the browser you are using. 
-If you don't know how to get your browser/darkreader version please search it up online.
+If you don't know how to get your browser/Dark Reader version please search it up online.
 -->
 
 ## System Information
 
 - OS: <!-- [e.g. Windows, MacOS, Linux] -->
 - Browser: <!-- [e.g. Chrome, Safari] -->
-- Darkreader Version: <!-- [e.g. 4.9.26] -->
+- Dark Reader Version: <!-- [e.g. 4.9.26] -->
 
 ## Additional context
 <!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/broken-website.md
+++ b/.github/ISSUE_TEMPLATE/broken-website.md
@@ -1,7 +1,7 @@
 ---
 name: Broken website
 about: Creates a broken website report about Darkreader
-title: "[Broken Website] "
+title: "[Broken Website] Insert title here"
 labels: Broken Website
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/broken-website.md
+++ b/.github/ISSUE_TEMPLATE/broken-website.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
+<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+
 <!--
 Thank you for taking the time to report a broken website.
 Please make sure there is no existing issue with this broken website.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a bug report to help us improve
-title: "[BUG]"
+title: "[BUG] Insert title here"
 labels: bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,35 +7,33 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
-<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
+<!-- 
+  ⚠⚠ Do not delete this issue template! ⚠⚠ 
+  Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. 
+-->
 
 <!--
 Thank you for taking the time to report a bug.
 Please make sure there is no existing issue with this kind of bug.
 -->
 
-### **Describe the bug**
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
 
-A clear and concise description of what the bug is.
-
-### **Steps to reproduce**
-
+**Steps to reproduce**
+<!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
 - Go to '...'
 - Click on '...'
 - Scroll down to '...'
 
-### **Expected behavior**
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
 
-A clear and concise description of what you expected to happen.
+**Actual behavior**
+<!-- A clear and concise description of what actually happened. -->
 
-### **Actual behavior**
-
-A clear and concise description of what actually happened.
-
-### **Screenshots**
-
-If applicable, add screenshots to help explain your problem.
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 <!--
 Please add a version of the browser you are using. 
@@ -44,9 +42,9 @@ If you don't know how to get your browser/darkreader version please search it up
 
 ### **System Information:**
 
-- OS: [e.g. iOS 11]
-- Browser: [e.g. Chrome 73, Safari 13]
-- Dark Reader version: [e.g. 4.9.9]
+- OS: <!-- [e.g. Windows, MacOS, Linux] -->
+- Browser: <!-- [e.g. Chrome 84, Safari 13] -->
+- Darkreader Version: <!-- [e.g. 4.9.26] -->
 
 ### **Additional context**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,12 +24,13 @@ Please make sure there is no existing issue with this kind of bug.
 
 ## Steps to reproduce
 <!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
-Steps to reproduce the behavior:
-An example of this is:
-
-- Go to '...'
-- Click on '...'
-- Scroll down to '...'
+<!--
+  Steps to reproduce the behavior:
+  An example of this is:
+  - Go to x site
+  - Hover over x button
+  - See that when hovering it isn't changing colors
+-->
 
 ## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
@@ -42,14 +43,14 @@ An example of this is:
 
 <!--
 Please add a version of the browser you are using. 
-If you don't know how to get your browser/darkreader version please search it up online.
+If you don't know how to get your browser/Dark Reader version please search it up online.
 -->
 
 ## System Information
 
 - OS: <!-- [e.g. Windows, MacOS, Linux] -->
 - Browser: <!-- [e.g. Chrome 84, Safari 13] -->
-- Darkreader Version: <!-- [e.g. 4.9.26] -->
+- Dark Reader Version: <!-- [e.g. 4.9.26] -->
 
 ## Additional context
 <!--Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
-<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
+<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
 
 <!--
 Thank you for taking the time to report a bug.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,22 +17,27 @@ Thank you for taking the time to report a bug.
 Please make sure there is no existing issue with this kind of bug.
 -->
 
-**Describe the bug**
+# Bug Report
+
+## Describe the bug
 <!-- A clear and concise description of what the bug is. -->
 
-**Steps to reproduce**
+## Steps to reproduce
 <!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
+Steps to reproduce the behavior:
+An example of this is:
+
 - Go to '...'
 - Click on '...'
 - Scroll down to '...'
 
-**Expected behavior**
+## Expected behavior
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Actual behavior**
+## Actual behavior
 <!-- A clear and concise description of what actually happened. -->
 
-**Screenshots**
+## Screenshots
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 <!--
@@ -40,12 +45,11 @@ Please add a version of the browser you are using.
 If you don't know how to get your browser/darkreader version please search it up online.
 -->
 
-### **System Information:**
+## System Information
 
 - OS: <!-- [e.g. Windows, MacOS, Linux] -->
 - Browser: <!-- [e.g. Chrome 84, Safari 13] -->
 - Darkreader Version: <!-- [e.g. 4.9.26] -->
 
-### **Additional context**
-
-Add any other context about the problem here.
+## Additional context
+<!--Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,9 @@ assignees: ''
 
 ---
 
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
+<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+
 <!--
 Thank you for taking the time to report a bug.
 Please make sure there is no existing issue with this kind of bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,8 +7,10 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
-<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
+<!-- 
+  ⚠⚠ Do not delete this issue template! ⚠⚠ 
+  Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. 
+-->
 
 <!--
 Thank you for taking the time to suggest a feature request.
@@ -16,10 +18,10 @@ Please make sure there is no existing issue about this kind of feature.
 -->
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest a new Feature for Darkreader
+about: Suggest a new Feature for Dark Reader
 title: "[Feature Request] Insert title here"
 labels: enhancement
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
-<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
+<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
 
 <!--
 Thank you for taking the time to suggest a feature request.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest a new Feature for Darkreader
-title: "[Feature Request]"
+title: "[Feature Request] Insert title here"
 labels: enhancement
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,10 @@ labels: enhancement
 assignees: ''
 
 ---
+
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
+<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+
 <!--
 Thank you for taking the time to suggest a feature request.
 Please make sure there is no existing issue about this kind of feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,11 +17,13 @@ Thank you for taking the time to suggest a feature request.
 Please make sure there is no existing issue about this kind of feature.
 -->
 
-**Is your feature request related to a problem? Please describe.**
+# Feature Request
+
+## Is your feature request related to a problem? Please describe
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 <!-- A clear and concise description of what you want to happen. -->
 
-**Additional context**
+## Additional context
 <!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/performance_issue.md
@@ -7,8 +7,11 @@ assignees: ''
 
 ---
 
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
+<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+
 <!--
-  Thank you for taking the time to a performance issue
+  Thank you for taking the time to a performance issue.
   Please make sure there is no existing issue about this issue.
   And make sure it's a actually performance issue, e.g. a extra 1 second to loading the website isn't a performance issue.
 -->

--- a/.github/ISSUE_TEMPLATE/performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/performance_issue.md
@@ -25,26 +25,27 @@ assignees: ''
 
 ## How to Reproduce
 <!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
-Steps to reproduce the behavior:
-An example of this is:
-
-- Go to '...'
-- Click on '...'
-- Notice spikes in CPU Usage
+<!--
+  Steps to reproduce the behavior:
+  An example of this is:
+    - Go to '...'
+    - Click on '...'
+    - Notice spikes in CPU Usage
+-->
 
 ## Performance Profiler
 <!-- A link to either profile.zip *Chromium only* or a firefox profiler *Firefox only*. -->
 
 <!--
   Please add a version of the browser you are using. 
-  If you don't know how to get your browser/darkreader version please search it up online.
+  If you don't know how to get your browser/Dark Reader version please search it up online.
 -->
 
 ## System Information
 
 - OS: <!-- [e.g. Windows, MacOS, Linux] -->
 - Browser: <!-- [e.g. Chrome 84, Safari 13] -->
-- Darkreader Version: <!-- [e.g. 4.9.26] -->
+- Dark Reader Version: <!-- [e.g. 4.9.26] -->
 
 <!--
   Do you have this performance issue with Dark Reader disabled?

--- a/.github/ISSUE_TEMPLATE/performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/performance_issue.md
@@ -18,23 +18,29 @@ assignees: ''
   And make sure it's a actually performance issue, e.g. a extra 1 second to loading the website isn't a performance issue.
 -->
 
-**Website**
+# Performance Issue
+
+## Website
 <!-- If applicable, the link of the website where the performance issue is noticed. -->
 
-**How to Reproduce**
+## How to Reproduce
 <!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
+Steps to reproduce the behavior:
+An example of this is:
+
 - Go to '...'
 - Click on '...'
 - Notice spikes in CPU Usage
 
-**Performance Profiler**
+## Performance Profiler
 <!-- A link to either profile.zip *Chromium only* or a firefox profiler *Firefox only*. -->
 
 <!--
   Please add a version of the browser you are using. 
   If you don't know how to get your browser/darkreader version please search it up online.
 -->
-**System info:**
+
+## System Information
 
 - OS: <!-- [e.g. Windows, MacOS, Linux] -->
 - Browser: <!-- [e.g. Chrome 84, Safari 13] -->
@@ -45,6 +51,6 @@ assignees: ''
   Does it happen in other browsers?
   Do you have hardware acceleration enabled?
 -->
-**Additional context**
-<!-- Add any other context or screenshots about the feature request here. -->
 
+## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/performance_issue.md
@@ -7,8 +7,10 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
-<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
+<!-- 
+  ⚠⚠ Do not delete this issue template! ⚠⚠ 
+  Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. 
+-->
 
 <!--
   Thank you for taking the time to a performance issue.
@@ -17,18 +19,16 @@ assignees: ''
 -->
 
 **Website**
-If applicable, the link of the website where the performance issue is noticed.
+<!-- If applicable, the link of the website where the performance issue is noticed. -->
 
 **How to Reproduce**
-Steps to reproduce the behavior:
-An example of this is
->
-> 1. Go to x site
-> 2. Go to x feature
-> 3. Notice spikes in CPU Usage
+<!-- We need to know how you encountered the bug to properly troubleshoot the issue. -->
+- Go to '...'
+- Click on '...'
+- Notice spikes in CPU Usage
 
 **Performance Profiler**
-A link to either profile.zip *Chromium only* or a firefox profiler *Firefox only*.
+<!-- A link to either profile.zip *Chromium only* or a firefox profiler *Firefox only*. -->
 
 <!--
   Please add a version of the browser you are using. 
@@ -36,9 +36,9 @@ A link to either profile.zip *Chromium only* or a firefox profiler *Firefox only
 -->
 **System info:**
 
-- OS: [e.g. Windows, MacOS, Linux]
-- Browser: [e.g. chrome, safari]
-- Dark Reader Version: [e.g. 4.9.9]
+- OS: <!-- [e.g. Windows, MacOS, Linux] -->
+- Browser: <!-- [e.g. Chrome 84, Safari 13] -->
+- Darkreader Version: <!-- [e.g. 4.9.26] -->
 
 <!--
   Do you have this performance issue with Dark Reader disabled?
@@ -46,4 +46,5 @@ A link to either profile.zip *Chromium only* or a firefox profiler *Firefox only
   Do you have hardware acceleration enabled?
 -->
 **Additional context**
-Elaborate on the problem
+<!-- Add any other context or screenshots about the feature request here. -->
+

--- a/.github/ISSUE_TEMPLATE/performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/performance_issue.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->
-<!-- Issues that do not use the issue template/don't fill out the basic info are likely to be ignored and closed. -->
+<!-- ⚠⚠ Do not delete this issue template! ⚠⚠ -->	 
+<!-- Issues that do not use the issue template/don't fill out the essential information are likely to be ignored and closed. -->
 
 <!--
   Thank you for taking the time to a performance issue.

--- a/.github/ISSUE_TEMPLATE/performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/performance_issue.md
@@ -1,7 +1,7 @@
 ---
 name: Performance issues
 about: Adress a performance issue of Dark Reader
-title: "[Performance] "
+title: "[Performance] Insert title here"
 labels:
 assignees: ''
 


### PR DESCRIPTION
- Add an warning that an issue can be closed if it don't have an issue template.
- Add an warning that the issue can be closed if it doesn't fill out basic information.
- Add descriptions.
- Default messages into comments.

Description:
Hopefully people will actually follow this else the issue can be closed without any notice, which will hopefully improve the quality in reported issues.