### PR TITLE
Added sverigesradio.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7497,15 +7497,15 @@ button.reset
 
 CSS
 .local-weather-item__weather-icon {
-  filter: invert(1) hue-rotate(180deg) !important;
+    filter: invert(1) hue-rotate(180deg) !important;
 }
 
 .live-marker .dot, .live-label::before {
-  background-color: #fff !important;
+    background-color: var(--darkreader-neutral-text) !important;
 }
 
 .search-page em, .search-result em {
-  color: #000 !important;
+    color: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7472,6 +7472,44 @@ div.sumo-nav--logo
 
 ================================
 
+sverigesradio.se
+
+INVERT
+.cross
+.default
+.details-button__icon
+.external-link-with-icon__icon
+.gallery-button svg g
+.info-teaser-container__title h2
+.link-icon .icon
+.local-weather-item__wind-icon
+.logo
+.menu-icon.icon
+.play-icon--white
+.program-footer__link-item:nth-of-type(2) svg
+.progress.queue-progress .bar
+.support-info__icon svg
+input[type="range"]::-webkit-slider-thumb
+input[type="range"]::-moz-range-thumb
+input[type="range"]::-webkit-slider-runnable-track
+input[type="range"]::-moz-range-track
+button.reset
+
+CSS
+.local-weather-item__weather-icon {
+  filter: invert(1) hue-rotate(180deg) !important;
+}
+
+.live-marker .dot, .live-label::before {
+  background-color: #fff !important;
+}
+
+.search-page em, .search-result em {
+  color: #000 !important;
+}
+
+================================
+
 svt.se
 
 INVERT


### PR DESCRIPTION
Added code for the website of Sweden's national publicly funded radio broadcaster _Sveriges Radio_ (https://en.wikipedia.org/wiki/Sveriges_Radio).

## Noteworthy things

Inverted the header logo and the play/pause buttons.

|Before|After|
|-|-|
| ![sr off 1](https://user-images.githubusercontent.com/17113053/103947005-b6642680-5137-11eb-8518-af3ee9421e89.png) | ![sr on 1](https://user-images.githubusercontent.com/17113053/103947006-b6fcbd00-5137-11eb-8334-306bdd54eabd.png) |

Inverted the weather icons so rain and snow is displayed properly.

|Before|After|
|-|-|
| ![sr off 2](https://user-images.githubusercontent.com/17113053/103946180-a1d35e80-5136-11eb-8d83-93100ca48dce.png) | ![sr on 2](https://user-images.githubusercontent.com/17113053/103946177-a13ac800-5136-11eb-8e0d-be18b302aea3.png) |

Inverted the highlighted text in the search results to improve contrast.

|Before|After|
|-|-|
| ![sr off 5](https://user-images.githubusercontent.com/17113053/103944630-3f795e80-5134-11eb-8962-51ff9c43a2bc.png) | ![sr on 5](https://user-images.githubusercontent.com/17113053/103944635-4011f500-5134-11eb-91e1-cf98fbed87cf.png) |

Inverted various icons in the footer.

|Before|After|
|-|-|
| ![sr off 3](https://user-images.githubusercontent.com/17113053/103947174-f5927780-5137-11eb-8a88-757d6a5da05d.png) | ![sr on 3](https://user-images.githubusercontent.com/17113053/103947175-f62b0e00-5137-11eb-864f-5cb9dcd8840f.png) |

## Detailed explanation
<details> 
<summary>Click me to expand/collapse</summary>
Icon of the close button to the dialog for choosing a regional radio channel.

```css
.cross
```

The vote percentage bars in the poll results.

```css
.default
```

Icons next to the "Download", "Share" and "Add to my list" links in the sidebar and inside articles.

```css
.details-button__icon
```

Icon next to external links.

```css
.external-link-with-icon__icon,
.link-icon .icon
```

The icon to enlarge images in articles.

```css
.gallery-button svg g
```

The header of any public service announcement.

```css
.info-teaser-container__title h2
```

The wind direction icons in the sidebar.

```css
.local-weather-item__wind-icon
```

The website logotype in the header.

```css
.logo
```

The dropdown icon in the header.

```css
.menu-icon.icon
```

The play/pause icon inside the play button next to the headlines.

```css
.play-icon--white
```

The social media icons in the footer.

```css
.program-footer__link-item:nth-of-type(2) svg
```

The progress bar for live broadcasts.

```css
.progress.queue-progress .bar
```

Question mark icon at the bottom of the page.

```css
.support-info__icon svg
```

The volume range handle inside the player at the bottom of the screen.

```css
input[type=range]::-webkit-slider-thumb,
input[type=range]::-moz-range-thumb
```

The volume range background inside the player at the bottom of the screen.

```css
input[type=range]::-webkit-slider-runnable-track,
input[type=range]::-moz-range-track
```

The button to clear the search box input.

```css
button.reset
```

The weather icons in the sidebar. `hue-rotate()` is used here to retain the color of the icons.

```css
.local-weather-item__weather-icon
```

The icon inside the "track" of the player at the bottom of the screen that displays the current position of a live broadcast.

```css
.live-marker .dot
```

The icon inside the "LIVE" badge.

```css
.live-label::before
```

The highlighted text inside the search results. Used to make the text distinguishable against the yellow background.

```css
.search-page em,
.search-result em
```
</details>

