### PR TITLE
Add audiomass.co to already dark websites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -42,6 +42,7 @@ atelier.net/virtual-economy
 atlassurvivalshelters.com
 atresplayer.com
 audiolove.club
+audiomass.co
 audioz.download
 avengedsevenfold.com
 azeria-labs.com


### PR DESCRIPTION
![screenshot-audiomass co-2021 01 07-23_01_46-min](https://user-images.githubusercontent.com/21284089/103950176-ba467780-513c-11eb-99b8-557b7c990bd1.png)
