### PR TITLE
Fix for binance.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -971,6 +971,15 @@ CSS
 div.qr-code > canvas {
     outline: solid 10px white !important;
 }
+div > input[type="checkbox"] + svg {
+    fill: transparent !important;
+}
+div > input[type="checkbox"]:checked + svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+label > svg circle {
+    fill: rgb(37, 40, 42) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -965,6 +965,15 @@ CSS
 
 ================================
 
+binance.com
+
+CSS
+div.qr-code > canvas {
+    outline: solid 10px white !important;
+}
+
+================================
+
 bing.com
 
 INVERT


### PR DESCRIPTION
Fixes #4702 

The page fills checkmark icons with the background color to "hide" them when they are disabled. This causes problems after dark mode inversion.
I simply made checkmarks transparent while unchecked, and it works as expected now.
Also fixed invisible radio buttons.


Original Uneditable
![image](https://user-images.githubusercontent.com/5316261/104045330-7496b700-51ef-11eb-8164-a0fdd24d00b2.png)
Original Editable
![image](https://user-images.githubusercontent.com/5316261/104045429-9a23c080-51ef-11eb-968e-87ae5d891148.png)
Current broken state
![image](https://user-images.githubusercontent.com/5316261/104045516-b9bae900-51ef-11eb-8cdb-2faa97d1e48a.png)
Fixed Uneditable
![image](https://user-images.githubusercontent.com/5316261/104045572-cfc8a980-51ef-11eb-96e4-bd5dc5462480.png)
Fixed Editable
![image](https://user-images.githubusercontent.com/5316261/104045604-da833e80-51ef-11eb-912a-2f4ee67393bb.png)


I also added a fix for QR codes on this website. Their QR codes don't include white borders, which is fine as long as it's on a white background, but they are malfunctioning on dark mode. I had to add an outline to make the mobile app recognize these codes.
| Original | Current | Fixed |
|-|-|-|
|![image](https://user-images.githubusercontent.com/5316261/104048633-9d6d7b00-51f4-11eb-9fc6-7b7f91c20544.png) | ![image](https://user-images.githubusercontent.com/5316261/104048642-a1999880-51f4-11eb-9a5d-21059fe875d1.png) | ![image](https://user-images.githubusercontent.com/5316261/104048647-a3fbf280-51f4-11eb-8323-76fff6d257e3.png) |
