### PR TITLE
Fixed genshin-impact-map.appsample.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3284,6 +3284,7 @@ genshin-impact-map.appsample.com
 INVERT
 .bg-secondary.px-1.py-0.input-group-text > .icon
 .border-top2.text-center.w-100.sidebar-footer
+.gm-ui-hover-effect
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3279,6 +3279,14 @@ INVERT
 
 ================================
 
+genshin-impact-map.appsample.com
+
+INVERT
+.bg-secondary.px-1.py-0.input-group-text > .icon
+.border-top2.text-center.w-100.sidebar-footer
+
+================================
+
 geogebra.org
 
 INVERT


### PR DESCRIPTION
- Inverted global icon 
- Inverted images back to normal because they look creepy as sh*t