### PR TITLE
Added more selectors for svt.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7482,7 +7482,20 @@ div.sumo-nav--logo
 svt.se
 
 INVERT
-.nyh_navigation__nyh_logo-img
+header img[src*=svt]
+.nyh_navigation__menu-toggle
+.VideoPlayerTheme__play-pause-button-simple___vsG6v::before
+
+CSS
+.VideoPlayerTheme__live__splash___LA0AL, .nyh_breaking__top-prefix {
+    color: var(--darkreader-neutral-background) !important;
+}
+._Post__contentVisitor___2d3Si::after {
+    border-right-color: #262a2b !important;
+}
+.nyh_navigation .nyh_submenu::before {
+    border-bottom-color: black;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7484,13 +7484,14 @@ svt.se
 INVERT
 header img[src*=svt]
 .nyh_navigation__menu-toggle
-.VideoPlayerTheme__play-pause-button-simple___vsG6v::before
+[class^="VideoPlayerTheme__play-pause-button-simple"]::before
 
 CSS
-.VideoPlayerTheme__live__splash___LA0AL, .nyh_breaking__top-prefix {
+[class^="VideoPlayerTheme__live__splash"],
+.nyh_breaking__top-prefix {
     color: var(--darkreader-neutral-background) !important;
 }
-._Post__contentVisitor___2d3Si::after {
+[class^="_Post__contentVisitor"]::after {
     border-right-color: #262a2b !important;
 }
 .nyh_navigation .nyh_submenu::before {


### PR DESCRIPTION
Improved the code for svt.se that was added in #4309.

## Noteworthy things

Inverted the triangle icon of the play button.

|Before|After|
|-|-|
| ![svt off 1](https://user-images.githubusercontent.com/17113053/104104922-352da080-52ab-11eb-939d-e607e56d6afb.png) | ![svt on 1](https://user-images.githubusercontent.com/17113053/104104921-34950a00-52ab-11eb-8e2d-8840e6c965f2.png) |

The logo is now also inverted on the "About" page.

|Before|After|
|-|-|
| ![svt off 2](https://user-images.githubusercontent.com/17113053/104104964-7a51d280-52ab-11eb-9beb-d809adaafbe4.png) | ![svt on 2](https://user-images.githubusercontent.com/17113053/104104963-79b93c00-52ab-11eb-957a-0a3ce0a21749.png) |

Inverted the hamburger menu icon for mobile/tablet view.

|Before|After|
|-|-|
| ![svt off 3](https://user-images.githubusercontent.com/17113053/104105045-e3d1e100-52ab-11eb-8ba8-859b1d03dee7.png) | ![svt on 3](https://user-images.githubusercontent.com/17113053/104105046-e46a7780-52ab-11eb-87d8-81fd91962d53.png) |

Made the tail of the viewer questions the same color as the bubble itself.

|Before|After|
|-|-|
| ![svt off 5](https://user-images.githubusercontent.com/17113053/104105168-ade12c80-52ac-11eb-98bc-3b4f3de22a82.png) | ![svt on 5](https://user-images.githubusercontent.com/17113053/104105169-ae79c300-52ac-11eb-9f6b-ac5a7f766a32.png) |

Made the tail of the header navigation popup black, just like the popup background.

|Before|After|
|-|-|
| ![svt off 4](https://user-images.githubusercontent.com/17113053/104105081-17147000-52ac-11eb-80be-9aa7145b17cb.png) | ![svt on 4](https://user-images.githubusercontent.com/17113053/104105082-17ad0680-52ac-11eb-8318-e0d62eaa107d.png) |

## Detailed explanation

<details> 
<summary>Click me to expand/collapse</summary>

The website logotype in the header. This selector works for both the main site as well as the About page.

```css
header img[src*=svt]
```

Hamburger menu icon for mobile/tablet view.

```css
.nyh_navigation__menu-toggle
```

The icon of the play button for in-article videos.

```css
.VideoPlayerTheme__play-pause-button-simple___vsG6v::before
```

The LIVE badge for live streams.

```css
.VideoPlayerTheme__live__splash___LA0AL
.nyh_breaking__top-prefix
```

The tail of the speech bubbles in the chat sections.

```css
._Post__contentVisitor___2d3Si::after
```

The tail of the header popup.

```css
.nyh_navigation .nyh_submenu::before
```
</details>
