### PR TITLE
docs: Update README.md for adding a new usage for the react developer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ const CSS = await collectCSS();
 const isEnabled = isDarkReaderEnabled();
 ```
 
+... or you can also use the darkreader with other modern frontend framework. Please refer to:
+
+- [react-darkreader](https://github.com/Turkyden/react-darkreader)
+
 ## Contributors
 
 This project exists thanks to all the people who contribute!


### PR DESCRIPTION
## react-darkreader

> A React hook for adding a dark / night mode to your site inspired by darkreader.

Add a new usage for the react developer. [react-darkreader &rarr;](https://react-darkreader.vercel.app/)

In adition to this, looking forward to other framework such as [Vuejs](), [Angular]() ...

@alexanderby @Gusted
