### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9970,6 +9970,6 @@ section p {
 zybooks.com
 
 CSS
-.zyimage{
-    background-color: #FFF;
+.zyimage {
+    background-color: var(--darkreader-neutral-text) !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9964,3 +9964,12 @@ section h3,
 section p {
     color: ${white} !important;
 }
+
+================================
+
+zybooks.com
+
+CSS
+.zyimage{
+    background-color: #FFF;
+}


### PR DESCRIPTION
Fix for CSS on zyBooks zyimage class which provides the white backgrounds for zyBooks transparent images.