### PR TITLE
fix for linkedin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4747,7 +4747,7 @@ div#header a:visited {
 linkedin.com
 
 INVERT
-img[src*="-logo"]
+img[src*="-logo"]:not([alt*="HRejterzy"])
 
 CSS
 :root {


### PR DESCRIPTION
exluded one company logo from invert (as it was photo)
![image](https://user-images.githubusercontent.com/56877029/104761834-bd0c2280-5763-11eb-93c6-261915914d34.png)
