### PR TITLE
Fix chart keys on oclc.org sites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6707,6 +6707,13 @@ CSS
 
 ================================
 
+oclc.org
+
+IGNORE INLINE STYLE
+.chart-key
+
+================================
+
 resmigazete.gov.tr
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5979,6 +5979,13 @@ CSS
 
 ================================
 
+oclc.org
+
+IGNORE INLINE STYLE
+.chart-key
+
+================================
+
 olx.pl
 
 IGNORE IMAGE ANALYSIS
@@ -6704,13 +6711,6 @@ CSS
 .monaco-editor .cursor {
     background-color: ${#000};
 }
-
-================================
-
-oclc.org
-
-IGNORE INLINE STYLE
-.chart-key
 
 ================================
 


### PR DESCRIPTION
OCLC is a global library services organization.  This fixes chart keys on sites within their domain.  This is needed because when the color of chart keys are changed by Dark Reader, they no longer match the corresponding charts.