### PR TITLE
Fix for dark themes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6,6 +6,9 @@ INVERT
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
 
 CSS
+input, select, textarea {
+    color: var(--darkreader-selection-text) !important;
+}
 .vimvixen-hint {
     background-color: ${#ffd76e} !important;
     border-color: ${#c59d00} !important;


### PR DESCRIPTION
This is a fix that needs to be carefully considered before accepting, as it affects global elements.

I have found this fix required when using dark themes in the Windows OS and using Firefox.  Without this fix, HTML input, select, and textarea fields will sometimes be impossible to read, as they will be white on white.

I have been running with this fix for several months without any issues (and with it working successfully to resolve the aforementioned issue), but I have not performed any testing outside of my environments.