### PR TITLE
Fix dark filter (inversion) mode

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -27,6 +27,9 @@ REMOVE BG
 .compatibility-with-darkreader-below-4-3-3
 
 CSS
+input, select, textarea {
+    color: var(--darkreader-selection-text);
+}
 .compatibility-with-darkreader-below-4-3-3 {
     background: white !important;
 }


### PR DESCRIPTION
This is another fix that needs to be carefully considered before accepting, as it affects global elements.

I have found this fix required when using dark themes in the Windows OS and using Firefox.  Without this fix, HTML input, select, and textarea fields will sometimes be impossible to read, as they will be white on white.