### PR TITLE
Fix for citilink.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1461,6 +1461,9 @@ INVERT
 
 citilink.ru
 
+INVERT
+div[class$="RatingDetail__progress_active"]
+
 IGNORE INLINE STYLE
 .Icon
 


### PR DESCRIPTION
- Invert review active progress bar.

Example of site page: https://www.citilink.ru/catalog/computers_and_notebooks/hdd/ssd_in/1128416/, https://www.citilink.ru/catalog/computers_and_notebooks/hdd/ssd_in/1128416/otzyvy/

<details>
<summary>Screenshot</summary>

![screenshot-www citilink ru-2021 01 17-00_22_00](https://user-images.githubusercontent.com/19418601/104823276-135b8d00-585a-11eb-80f5-8c30f8b5a709.png)

![screenshot-www citilink ru-2021 01 17-00_22_00 (1)](https://user-images.githubusercontent.com/19418601/104823278-15255080-585a-11eb-8351-2a09945146e5.png)

</details>