### PR TITLE
Fix for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9107,6 +9107,8 @@ img[alt="The Signpost"]
 .mw-hiero-outer.mw-hiero-table
 a.image[href*="ile:Hiero_Ca"] > img
 [src*="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Egyptian_3_symbol.png/10px-Egyptian_3_symbol.png"]
+span[class^="ts-"]
+img[src$="Rename_icon_Cyr.svg.png"]
 
 CSS
 .mwe-popups-discreet > svg,


### PR DESCRIPTION
- Invert "Go to section" icon.
- Invert rename icon.

Example of site page: https://ru.wikipedia.org/wiki/Спутник_V_(вакцина)