### PR TITLE
Added fix for snapeda.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7206,11 +7206,7 @@ snapeda.com
 INVERT
 img[title="SnapEDA"]
 img.part-organization
-
-CSS
-canvas:not(#firstfootprint) {
-    background-color: white !important;
-}
+canvas:not(#firstfootprint)
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7201,6 +7201,19 @@ CSS
 
 ================================
 
+snapeda.com
+
+INVERT
+img[title="SnapEDA"]
+img.part-organization
+
+CSS
+canvas:not(#firstfootprint) {
+    background-color: white !important;
+}
+
+================================
+
 softorage.com
 
 CSS


### PR DESCRIPTION
Inverts the website logo and makes the symbol background color white

Website used for testing:
https://www.snapeda.com/parts/ATMEGA328-PU/Microchip%20Technology/view-part/