### PR TITLE
Added fix for app.kognity.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -617,6 +617,23 @@ CSS
 
 ================================
 
+app.kognity.com
+
+INVERT
+img.KogCalculator
+// .content-image-figure > img
+
+CSS
+body, .KogDashboard-insideLoader {
+    background: none var(--darkreader-neutral-background) !important;
+
+}
+img {
+    background-color: white !important;
+}
+
+================================
+
 app.mysms.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -628,7 +628,7 @@ body, .KogDashboard-insideLoader {
     background: none var(--darkreader-neutral-background) !important;
 
 }
-img:not([src*="png"]) {
+img:not([src*="png"]):not([src*="svg"]) {
     background-color: white !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -621,13 +621,14 @@ app.kognity.com
 
 INVERT
 img.KogCalculator
+.content-image-figure > img[src*="png"]
 
 CSS
 body, .KogDashboard-insideLoader {
     background: none var(--darkreader-neutral-background) !important;
 
 }
-img {
+img:not([src*="png"]) {
     background-color: white !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -621,7 +621,6 @@ app.kognity.com
 
 INVERT
 img.KogCalculator
-// .content-image-figure > img
 
 CSS
 body, .KogDashboard-insideLoader {


### PR DESCRIPTION
This website requires a paid login, as a result it may not be possible to visually inspect the changes. Instead, here are some screenshots.

First, without darkreader enabled:
![image](https://user-images.githubusercontent.com/9437154/105059478-9e659e80-5a77-11eb-8d3b-4f408aaa82ae.png)

Without any additional styling, the page has a greenish background color and it's really difficult to view graphs:
![image](https://user-images.githubusercontent.com/9437154/105059696-db319580-5a77-11eb-8fc7-1a7443db8579.png)

The proposed code makes all images appear on white backgrounds so that they are more easily visible and it corrects the background color:
![image](https://user-images.githubusercontent.com/9437154/105059828-fc928180-5a77-11eb-9ab9-122124839f14.png)

Inverting the images looks great with graphs and diagrams but also causes normal images to be inverted. There is no class/id to distinguish between graphs and photos:
![image](https://user-images.githubusercontent.com/9437154/105060237-70348e80-5a78-11eb-8540-53f7049a4dd9.png)
![image](https://user-images.githubusercontent.com/9437154/105060289-7f1b4100-5a78-11eb-8f73-e144d43631c5.png)


