### PR TITLE
Fix for dash.cloudflare.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1915,6 +1915,13 @@ span[class^="skycon swip"]
 
 ================================
 
+dash.cloudflare.com
+
+INVERT
+a[data-testid^="link-homepage"]
+
+================================
+
 datacamp.com
 
 CSS


### PR DESCRIPTION
Invert the "CloudFlare" logo in the top left corner on dash.cloudflare.com

Can be tested without login: https://dash.cloudflare.com