### PR TITLE
Add valh.io to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -696,6 +696,7 @@ v3rmillion.net
 v7player.wostreaming.net
 v8.dev
 vakhtangov.ru
+valh.io
 vancedapp.com
 vcjhwebdev.github.io/useless-translator/
 verify.bots.gg


### PR DESCRIPTION
valh.io is my personal blog and has a dark default theme. A light theme can be optionally toggled using the "THEME" button in the top-right corner.