### PR TITLE
Fixes for immobilienscout24.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4184,6 +4184,24 @@ CSS
 
 ================================
 
+immobilienscout24.de
+
+INVERT
+img[alt^="ImmobilienScout24"]
+.topnavigation__sso-login__plus-logo
+.button-primary
+.main-search__content--rent--from-0
+.result-list-entry__new-flag
+.product-teaser__image
+.no-of-results-highlighter
+
+CSS
+.result-list__listing {
+	background-color: transparent !important;
+}
+
+================================
+
 infinitysearch.co
 
 INVERT


### PR DESCRIPTION
Fixes:

- "ImmoScout24" logo in top-left corner
- "Plus+" icon in top-right corner
- Green buttons
- Little icons below "Infos zu Corona" on main page
- White background of search results
- Various green text highlights

A few text highlights are still present (hover menu below "Mein Konto" in top-right corner)


Sites to test:

- https://immobilienscout24.de
- Random search results: type in a city and click on the big green search button

