### PR TITLE
Add fixes for iubh-fernstudium.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4363,6 +4363,15 @@ INVERT
 
 ================================
 
+iubh-fernstudium.de
+
+INVERT
+.cp-logo
+.cp-contact-bubble__svg-open
+svg[class$="transform"]
+
+================================
+
 jailbreak.fce365.info
 
 CSS


### PR DESCRIPTION
Fixes:

- Top-left corner logo (e.g. https://www.iubh-fernstudium.de)
- Contact bubble in bottom right corner (e.g. https://www.iubh-fernstudium.de)
- `+` and `-` icons in semester content overview (e.g. https://www.iubh-fernstudium.de/bachelor/informatik/)