### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10136,6 +10136,7 @@ section p {
 zybooks.com
 
 CSS
+.image-content-resource img,
 .zyimage {
     background-color: var(--darkreader-neutral-text) !important;
 }


### PR DESCRIPTION
Support for additional image types contained on zyBooks that rely on a light background within "image-content-resource img" elements.