### PR TITLE
dark-site remove libreddit

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -378,8 +378,6 @@ leakth.is
 lecantiche.com
 lemmi.no
 letterboxd.com
-libredd.it
-libreddit.spike.codes
 lightweightpdf.com
 linux.org.ru
 liquidplus.com


### PR DESCRIPTION
Now they have a [light theme](https://github.com/spikecodes/libreddit/issues/34) and the default theme depends on the system.