### PR TITLE
Updated app.kognity.com fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -633,12 +633,15 @@ img.KogCalculator
 .content-image-figure > img[src*="png"]
 
 CSS
-body, .KogDashboard-insideLoader {
+body, .KogDashboard-insideLoader, .subtopic-modal-body, .subtopic-modal-footer {
     background: none var(--darkreader-neutral-background) !important;
 
 }
 img:not([src*="png"]):not([src*="svg"]) {
     background-color: white !important;
+}
+.ng-scope > .final-node-level:hover, button.KogButton:hover {
+    background-color: #1B1D1E !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -633,9 +633,15 @@ img.KogCalculator
 .content-image-figure > img[src*="png"]
 
 CSS
-body, .KogDashboard-insideLoader, .subtopic-modal-body, .subtopic-modal-footer {
+body,
+.KogDashboard-insideLoader,
+.subtopic-modal-body,
+.subtopic-modal-footer {
     background: none var(--darkreader-neutral-background) !important;
 
+}
+header.PopoverHeader {
+    background-color: rgb(27, 29, 30) !important;
 }
 img:not([src*="png"]):not([src*="svg"]) {
     background-color: white !important;


### PR DESCRIPTION
When viewing a topic overview, the modal, the subtopic items, the "Previous Subtopic" button and the "Next Subtopic" button all had weird greenish colors.
This website required a paid login, so screenshots are provided instead.

Previously:
![image](https://user-images.githubusercontent.com/9437154/105347785-ab090480-5be7-11eb-8033-3a3b9603d68d.png)

Fixed
![image](https://user-images.githubusercontent.com/9437154/105347854-c3791f00-5be7-11eb-9b23-813ace375e5b.png)

