### PR TITLE
fix for gitlab.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3765,6 +3765,7 @@ gitlab.com
 
 INVERT
 .js-contrib-calendar
+.gl-ml-2
 
 CSS
 :root {


### PR DESCRIPTION
Fix the comment action icons.

![sshot-001](https://user-images.githubusercontent.com/36977733/105353502-3b931500-5be7-11eb-8daf-957da0c1b066.png)
