### PR TITLE
Fix for iOS 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8199,6 +8199,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.0.tgz",
       "integrity": "sha512-46z7DUmcjoYdaWyXouuFNNfUo6eFa94t23c53c+lG/9Cvauk4a98rAUp9672X5dxGdQmLpPzTxzu8f/OeEPaFA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,7 @@ import type {Theme, DynamicThemeFix} from '../definitions';
 import ThemeEngines from '../generators/theme-engines';
 import {createOrUpdateDynamicTheme, removeDynamicTheme} from '../inject/dynamic-theme';
 import {collectCSS} from '../inject/dynamic-theme/css-collection';
+import {isMatchMediaChangeEventListenerSupported} from '../utils/platform';
 
 let isDarkReaderEnabled = false;
 const isIFrame = (() => {
@@ -53,9 +54,17 @@ export function auto(themeOptions: Partial<Theme> | false = {}, fixes: DynamicTh
     if (themeOptions) {
         store = {themeOptions, fixes};
         handleColorScheme();
-        darkScheme.addEventListener('change', handleColorScheme);
+        if (isMatchMediaChangeEventListenerSupported) {
+            darkScheme.addEventListener('change', handleColorScheme);
+        } else {
+            darkScheme.addListener(handleColorScheme);
+        }
     } else {
-        darkScheme.removeEventListener('change', handleColorScheme);
+        if (isMatchMediaChangeEventListenerSupported) {
+            darkScheme.removeEventListener('change', handleColorScheme);
+        } else {
+            darkScheme.removeListener(handleColorScheme);
+        }
         disable();
     }
 }

--- a/src/inject/utils/watch-color-scheme.ts
+++ b/src/inject/utils/watch-color-scheme.ts
@@ -1,10 +1,20 @@
+import {isMatchMediaChangeEventListenerSupported} from '../../utils/platform';
+
 export function watchForColorSchemeChange(callback: ({isDark}) => void) {
-    const query = window.matchMedia('(prefers-color-scheme: dark)');
+    const query = matchMedia('(prefers-color-scheme: dark)');
     const onChange = () => callback({isDark: query.matches});
-    query.addEventListener('change', onChange);
+    if (isMatchMediaChangeEventListenerSupported) {
+        query.addEventListener('change', onChange);
+    } else {
+        query.addListener(onChange);
+    }
     return {
         disconnect() {
-            query.removeEventListener('change', onChange);
+            if (isMatchMediaChangeEventListenerSupported) {
+                query.removeEventListener('change', onChange);
+            } else {
+                query.removeListener(onChange);
+            }
         },
     };
 }

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -12,6 +12,10 @@ export const isWindows = platform.startsWith('win');
 export const isMacOS = platform.startsWith('mac');
 export const isMobile = userAgent.includes('mobile');
 export const isShadowDomSupported = typeof ShadowRoot === 'function';
+export const isMatchMediaChangeEventListenerSupported = (
+    typeof MediaQueryList === 'function' &&
+    typeof MediaQueryList.prototype.addEventListener === 'function'
+);
 
 export const chromiumVersion = (() => {
     const m = userAgent.match(/chrom[e|ium]\/([^ ]+)/);


### PR DESCRIPTION
Use deprecated `matchMedia().addListener` instead of `addEventListener('change')` when missing.