### PR TITLE
add fix for rule34.xxx

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6960,6 +6960,18 @@ select {
 
 ================================
 
+rule34.xxx
+
+CSS
+body {
+    background-image: none;
+}
+div#header ul#subnavbar, div.tips {
+    background-color: var(--darkreader-inline-bgcolor) !important;
+}
+
+================================
+
 runkit.com
 
 INVERT


### PR DESCRIPTION
### Heads up!
this fix is for a site that is not safe for work.

their header uses a 15px green image to color it??? why on earth is beyond me but simply removing it seems to fix it
also changed the navbar so it wouldnt be a dark green, but match the rest of the background instead