### PR TITLE
Add Site to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -211,6 +211,7 @@ eleaks.to
 elitedangerous.com
 ellie-app.com
 elybeatmaker.com
+elypia.org
 emanuelemilella.com
 emeraldchat.com/app
 emuparadise.me


### PR DESCRIPTION
Just adds a website which is dark mode by default to the dark-sites.config.