### PR TITLE
highlighted text in active night mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5433,6 +5433,15 @@ INVERT
 
 ================================
 
+mendeley.com
+
+CSS
+.highlightLayer * {
+   background-color: var(--darkreader-selection-text) !important; 
+}
+
+================================
+
 messages.android.com
 
 INVERT


### PR DESCRIPTION
A fix for viewing highlighted text in active night mode in PDFviewer of Mendeley.com.