### PR TITLE
Fix transparent image backgrounds for canvas.usask.ca in dark mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1380,6 +1380,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+canvas.usask.ca
+
+CSS
+#questions .text img {
+    background-color: currentColor;
+}
+
+================================
+
 carmax.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1384,7 +1384,7 @@ canvas.usask.ca
 
 CSS
 #questions .text img {
-    background-color: currentColor;
+    background-color: currentColor !important;
 }
 
 ================================


### PR DESCRIPTION
Questions with transparent images and dark text were really difficult to read in dark mode.

This makes the background of the image lighter so that the dark text is readable