### PR TITLE
Block onlineuniversities.com background image

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6248,7 +6248,7 @@ onlineuniversities.com
 
 CSS
 body {
-    background-image: none;
+    background-image: none !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6244,6 +6244,15 @@ INVERT
 
 ================================
 
+onlineuniversities.com
+
+CSS
+body {
+    background-image: none;
+}
+
+================================
+
 op.gg
 
 INVERT


### PR DESCRIPTION
By default onlineuniversities.com uses "background-image: url(blob:https://www.onlineuniversities.com/005d09d2-a8cf-4ca1-8b38-5e3ac790b867);" to add a nearly invisible texture to the document body. This commit blocks that texture by overriding background-image back to none in order to prevent [this](https://i.imgur.com/84mXuI0.png) coloration of the background (far from #282a36, which it should be).