### PR TITLE
Fix invisible subheadings on changkun.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1432,6 +1432,15 @@ div[style*="speed-dial-light.jpg"] {
 
 ================================
 
+changkun.de
+
+CSS
+.content h2, h3 {
+    z-index: 0 !important;
+}
+
+================================
+
 cheapshark.com
 
 CSS


### PR DESCRIPTION
Example: https://changkun.de/modern-cpp/en-us/02-usability/index.html#nullptr

#### Before
![image](https://user-images.githubusercontent.com/9250103/106189140-2a7a7300-61a8-11eb-880c-5d62421a6612.png)


#### After
![image](https://user-images.githubusercontent.com/9250103/106189021-0454d300-61a8-11eb-9c45-a7e68090d9f0.png)
