### PR TITLE
Added support for ds300's jetzt speed reader extension

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15,6 +15,10 @@ CSS
     opacity: 0.5 !important;
 }
 
+IGNORE INLINE STYLE
+.sr-wrapper *
+.sr-reader *
+
 ================================
 
 *.schoolathome.ca

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -12,6 +12,8 @@ svg image
 [style*="background-image: url"]
 [background]
 twitterwidget
+.sr-reader
+.sr-backdrop
 
 NO INVERT
 [style*="background:url"] *

--- a/src/config/static-themes.config
+++ b/src/config/static-themes.config
@@ -9,6 +9,7 @@ NEUTRAL TEXT
 html
 body
 :not([style*="color:"])
+.sr-reader *:not([class*='sr-pivot'])
 
 RED TEXT
 h1:not([style*="color:"])
@@ -37,6 +38,8 @@ BLUE BORDER
 
 FADE BG
 div:empty
+.sr-reader *
+.sr-backdrop
 
 FADE TEXT
 input::placeholder


### PR DESCRIPTION
It has *its own theme system*, and without these changes it **ruins the reader**.
Either you have to be on dynamic mode the whole time, or deal with weird background mismatching.

---

This, to the best of my ability |(I had some trouble getting it to work 100% in static theme mode, but it's pretty close) fixes those issues by adding ignore filters to DarkReader's fix list files.
Another, more long-term manageable solution would be this: #4835 


The extension this ensures compatibility with can be found here: https://github.com/ds300/jetzt