### PR TITLE
app.roll20.net fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -670,6 +670,38 @@ CSS
 
 ================================
 
+app.roll20.net
+
+INVERT
+.sheet-hp
+.sheet-ac
+.sheet-textbox
+.sheet-name-container
+.sheet-attributes-container
+.sheet-attr-container button
+.sheet-row
+.sheet-header
+.sheet-hlabel-container
+.sheet-vitals
+.sheet-init button
+.sheet-spell-level
+.sheet-spell-level input
+.sheet-textbox .sheet-options
+.sheet-speed input
+.sheet-part select
+.sheet-resources .sheet-subcontainer
+.sheet-resources .sheet-label
+.sheet-subcontainer .sheet-top
+.sheet-textbox .sheet-label
+.sheet-attack .sheet-options
+
+CSS
+.sheet-attributes-container, .sheet-init, .sheet-speed, .sheet-trait, .sheet-part, .sheet-spell-level, .sheet-details {
+    color: ${white} !important;
+}
+
+================================
+
 app.timelyapp.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -696,7 +696,13 @@ INVERT
 .sheet-attack .sheet-options
 
 CSS
-.sheet-attributes-container, .sheet-init, .sheet-speed, .sheet-trait, .sheet-part, .sheet-spell-level, .sheet-details {
+.sheet-attributes-container,
+.sheet-init,
+.sheet-speed,
+.sheet-trait,
+.sheet-part,
+.sheet-spell-level,
+.sheet-details {
     color: ${white} !important;
 }
 


### PR DESCRIPTION
Fixes for character sheets on app.roll20.net. While not perfect, these fixes should make the sheet generally usable by reducing instances of white-on-white and grey-on-black. These changes were made using a D&D 5E character sheet for reference and may not work in other contexts.