### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9709,7 +9709,8 @@ img.act-icon-dark-gray
 [data-attrid^="variable"] img
 
 CSS
-.RNNXgb {
+.RNNXgb,
+.aajZCb {
     box-shadow: 0 0 2px 0 ${rgba(0,0,0,0.16)}, 0 0 0 1px ${rgba(0,0,0,0.08)} !important;
 }
 .Gor6zc {


### PR DESCRIPTION
add a box-shadow to the google search input box's suggestions dropdown. it has the same background color as the body and just about everything else on the page, so without this it's hard to see where it ends and the main content begins. i tried changing the background color instead but it's hard to find a color that looks equally good inverted. is there a way to set a color template so that it won't just be inverted in dark mode but will also have the hue inverted? with CSS i know we can do hue-rotate(180deg) invert(1). or alternatively feColorMatrix could do it with a single filter. anyway the box shadow seems fine to me, and it only makes sense to give it the same shadow as the input box, since the designer seems to have intended to make the suggestions dropdown look like it's part of the input box. which is a pretty standard web design principle i guess, so overall this makes more visual sense

edit: i also noticed the box-shadow applied to the input box only works on the regular search page, not on image search or anything else. because the input box has a different class on those pages. i think the selector should be [jsname="RNNXgb"] instead of .RNNXgb, since it keeps that attribute throughout. but i'll do that later