### PR TITLE
Do not invert any popups on Gurushots.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4119,6 +4119,9 @@ CSS
     background-color: var(--darkreader-neutral-text) !important;
 }
 
+NO INVERT
+iframe.ab-modal-interactions *
+
 ================================
 
 habr.com


### PR DESCRIPTION
Currently inverted popups look like this:
![image](https://user-images.githubusercontent.com/3602819/107544118-8d213500-6bd2-11eb-9ded-b428a484dab4.png)

Original popups look like this:
![image](https://user-images.githubusercontent.com/3602819/107544171-9f02d800-6bd2-11eb-82c8-5793cac5dc7d.png)

Non inverted popups would look like this:
![image](https://user-images.githubusercontent.com/3602819/107544241-b2ae3e80-6bd2-11eb-871a-493e18b86230.png)
