### PR TITLE
Keep MeWe popup backgrounds transparent

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5666,6 +5666,9 @@ CSS
 body > .ember-view {
     background-color: ${#ebf0f3} !important;
 }
+body > .ember-view.dialog_wrapper {
+    background-color: transparent !important;
+}
 
 ================================
 


### PR DESCRIPTION
MeWe.com DHTML popups also have same `ember-view` class name as whole website holder and while first condition fixes the background of a page, the second (newly added) condition restores DHTML popup background to match original one