### PR TITLE
Fix for hCaptcha

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4,6 +4,7 @@ INVERT
 .jfk-bubble.gtx-bubble
 .captcheck_answer_label > input + img
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
+span[data-href^="https://www.hcaptcha.com/"] > #icon
 
 CSS
 .vimvixen-hint {


### PR DESCRIPTION
- Invert logo.

Example of site pages: https://www.hcaptcha.com/, https://2captcha.com/demo/hcaptcha