### PR TITLE
Fix crossword puzzles on nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6271,6 +6271,7 @@ nytimes.com
 
 INVERT
 .svelte-1v1dl99
+#xwd-board
 
 CSS
 .css-oylsik,
@@ -6288,6 +6289,9 @@ a[data-testid] > svg {
 }
 .svelte-15nnlbj {
     font-weight: bold !important;
+}
+#xwd-board rect[class^="Cell-block--"] {
+    fill: ${black} !important;
 }
 
 ================================


### PR DESCRIPTION
Most of the board can simply be inverted. Blacked out squares aren't
properly inverted, so additional custom CSS targets those squares
specifically.