### PR TITLE
Fix background for admin.migadu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -352,6 +352,15 @@ svg.reviews__icon-topic
 
 ================================
 
+admin.migadu.com
+
+CSS
+.container {
+    background-image: none !important;
+}
+
+================================
+
 aftonbladet.se
 
 CSS


### PR DESCRIPTION
<https://admin.migadu.com> has a large white background image that
obscures content in dark mode. This commit removes the image to make the
site usable.

The screenshots below show the landing page's behavior. Additional content
is more affected for logged in users.

## Current behavior
![Current behavior](https://user-images.githubusercontent.com/392720/107865474-d1137480-6e34-11eb-91bd-04a63d62b2d5.png)

## With this change
![With this change](https://user-images.githubusercontent.com/392720/107865478-df619080-6e34-11eb-8c2d-89764a52435a.png)