### PR TITLE
dnd5e.wikidot.com adjustments

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2415,6 +2415,21 @@ INVERT
 
 ================================
 
+dnd5e.wikidot.com
+
+CSS
+.feature {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.feature.offcolor {
+    background-color: ${rgb(255, 250, 180)} !important;
+}
+th {
+    background-color: ${rgb(230, 216, 170)} !important;
+}
+
+================================
+
 dndbeyond.com
 
 CSS


### PR DESCRIPTION
Adjustments for some background colors on dnd5e.wikidot.com. The pale yellow background of .feature rows on the main page and the moderate brown table headers in subpages would previously become uncomfortably light; this change makes them darker while still standing out enough to be noticeable.