### PR TITLE
Fix for allmacworld.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -460,6 +460,19 @@ CSS
 
 ================================
 
+allmacworld.com
+
+INVERT
+.logo
+.tie-appear.post-thumbnail
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/blocs-free-download/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/waves-v11-complete-download-free/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/3dequalizer-4-for-mac-free-download/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/sylenth1-for-mac-free-download/"]
+.tie-appear.post-thumbnail > [href="https://allmacworld.com/synapse-audio-legend-free-download/"]
+
+================================
+
 amap.com
 
 INVERT


### PR DESCRIPTION
Fix for https://allmacworld.com even though I'm using linux :D

Fixes:
- Inverted the logo
- Inverted all the app icons 
   - Inverted the inverted (yes) for most broken app icons