### PR TITLE
Add feedly.com to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3274,6 +3274,18 @@ CSS
 
 ================================
 
+feedly.com
+
+CSS
+.entry.u0:hover {
+    background-color: rgb(35, 35, 35) !important;
+}
+.entry--selected.u0, .entry--selected.u0:hover, button.secondary:hover {
+    background-color: rgb(50, 50, 50) !important;
+}
+
+================================
+
 feynmanlectures.caltech.edu
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3280,8 +3280,9 @@ CSS
 .entry.u0:hover {
     background-color: ${#ccc} !important;
 }
-.entry--selected.u0,
-.entry--selected.u0:hover,
+.entry--selected.u0, .entry--selected.u0:hover,
+.entry--selected.u4,
+.entry--selected.u5,
 button.secondary:hover {
     background-color: ${#ccc} !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3278,10 +3278,12 @@ feedly.com
 
 CSS
 .entry.u0:hover {
-    background-color: rgb(35, 35, 35) !important;
+    background-color: ${#ccc} !important;
 }
-.entry--selected.u0, .entry--selected.u0:hover, button.secondary:hover {
-    background-color: rgb(50, 50, 50) !important;
+.entry--selected.u0,
+.entry--selected.u0:hover,
+button.secondary:hover {
+    background-color: ${#ccc} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3278,7 +3278,8 @@ feedly.com
 
 CSS
 .entry.u0:hover,
-.entry--selected.u0, .entry--selected.u0:hover,
+.entry--selected.u0,
+.entry--selected.u0:hover,
 .entry--selected.u4,
 .entry--selected.u5,
 button.secondary:hover {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3277,9 +3277,7 @@ CSS
 feedly.com
 
 CSS
-.entry.u0:hover {
-    background-color: ${#ccc} !important;
-}
+.entry.u0:hover,
 .entry--selected.u0, .entry--selected.u0:hover,
 .entry--selected.u4,
 .entry--selected.u5,


### PR DESCRIPTION
Better background for articles in list view when selected or mouse-over (when you don't want to use the site's own dark mode to get automatic mode switching which feedly.com doesn't support)