### PR TITLE
medium.com - Removed underline from links

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5613,11 +5613,6 @@ INVERT
 .svgIcon
 .svgIcon-use
 
-CSS
-a {
-  text-decoration-line: underline !important;
-}
-
 ================================
 
 medium.freecodecamp.org


### PR DESCRIPTION
Since it isn't necessary and medium doesn't use underlines by default so why should it in dark mode.