### PR TITLE
Add teddit instances to inversion fix or dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -656,6 +656,8 @@ teamos-hkrg.com
 teaspeak.de
 techgaun.github.io/active-forks
 techwithalext.tk
+teddit.namazso.eu
+teddit.zaggy.nl
 telecineplay.com.br
 televizeseznam.cz
 telugucz.com

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2044,6 +2044,15 @@ img
 
 ================================
 
+teddit.net
+teddit.ggc-project.de
+teddit.kavin.rocks
+
+INVERT
+.preview
+
+================================
+
 terraform.io
 
 INVERT


### PR DESCRIPTION
https://codeberg.org/teddit/teddit

You can click the preview button of any image post on the homepage (or any sub) for sampling. Without fix:

![Screen Shot 2021-02-19 at 16 06 49](https://user-images.githubusercontent.com/16656689/108561584-82e6f100-72cc-11eb-9717-b54b0d267ab7.png)

With fix:

![Screen Shot 2021-02-19 at 16 06 34](https://user-images.githubusercontent.com/16656689/108561580-7fec0080-72cc-11eb-8e8a-4aaee03e5fd7.png)

3 instances that use light mode by default is added to the inversion-fixes.config while 2 instances that use dark mode by default is added to dark-sites.config.