### PR TITLE
Add fixes for status.aws.amazon.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7886,7 +7886,8 @@ CSS
 .tabStandard a {
     color: ${white} !important;
 }
-.tabStandard, .selected a {
+.tabStandard,
+.selected a {
     color: ${white} !important;
     background-color: ${black} !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7872,6 +7872,36 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+status.aws.amazon.com
+
+INVERT
+.logo
+.tabStandard
+td > img
+td > a > img
+th > a > img
+th > div > a > img
+
+CSS
+.tabStandard a {
+    color: ${white} !important;
+}
+.tabStandard, .selected a {
+    color: ${white} !important;
+    background-color: ${black} !important;
+}
+tbody > tr > th {
+    background: transparent !important;
+}
+table > tbody > tr > td {
+    background: transparent !important;
+}
+.gradient {
+    background: transparent !important;
+}
+
+================================
+
 status.npmjs.org
 
 INVERT


### PR DESCRIPTION
Fixes:
* Invert header image
* Invert table navigation
* Invert icons
* Remove bright gradient from tables

Can be tested here: https://status.aws.amazon.com