### PR TITLE
Add minor fixes for trip101.com (dynamic filter)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8957,6 +8957,16 @@ INVERT
 
 ================================
 
+trip101.com
+
+INVERT
+.logo
+.name
+.partner-logo
+img.partner-img
+
+================================
+
 tutorialspoint.com
 
 INVERT


### PR DESCRIPTION
Trip101 is an up-and-coming travel website based in Singapore. However, there are some weird issues on the website when using Dark Reader. Some logos and images don't look nice on dynamic filter, hence the optimization.