### PR TITLE
fix: Add Vercel to the list of dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -735,6 +735,7 @@ vizality.com
 vortetty.k3live.com
 vrv.co
 vuecinemas.nl
+vercel.com
 w0rp.com
 w41k3r.com
 wallhaven.cc


### PR DESCRIPTION
Things added/changed:

- Add [Vercel](https://vercel.com) to the list of dark sites.
