### PR TITLE
invert black on transparent images for Atlassian Cloud, LaTeX Math plugin

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -924,6 +924,7 @@ atlassian.net
 INVERT
 img[src*="https://github.githubassets.com/favicon.ico"].smart-link-icon
 .sc-jTzLTM
+img[src^="https://latexmath.bolo-app.com/render/"]
 
 CSS
 #jira-issue-header, #jira-issue-header-actions {


### PR DESCRIPTION
In Atlassian Confluence Cloud, the LaTeX rendered by plugin https://marketplace.atlassian.com/apps/1210882/latex-math?hosting=cloud&tab=overview is black over transparent.

Example image: https://latexmath.bolo-app.com/render/1.0/img/f651d4e882f4d5bbd6abe004a6561c53

This fix inverts the colors so that it becomes white in dark mode.