### PR TITLE
Add support for alternate StyleSheets

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -7,7 +7,7 @@ import {logWarn} from '../utils/log';
 import {replaceCSSRelativeURLsWithAbsolute, removeCSSComments, replaceCSSFontFace, getCSSURLValue, cssImportRegex, getCSSBaseBath} from './css-rules';
 import {bgFetch} from './network';
 import {createStyleSheetModifier} from './stylesheet-modifier';
-import {isShadowDomSupported, isSafari, isThunderbird} from '../../utils/platform';
+import {isShadowDomSupported, isSafari, isThunderbird, isChromium} from '../../utils/platform';
 
 declare global {
     interface HTMLStyleElement {
@@ -136,6 +136,9 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
         syncStyle.classList.add('darkreader');
         syncStyle.classList.add('darkreader--sync');
         syncStyle.media = 'screen';
+        if (!isChromium && element.title) {
+            syncStyle.title = element.title;
+        }
         syncStyleSet.add(syncStyle);
     }
 


### PR DESCRIPTION
- Test page: https://media.prod.mdn.mozit.cloud/samples/cssref/altstyles/index.html
- Official spec about this behavior: https://html.spec.whatwg.org/#rel-alternate
- https://developer.mozilla.org/en-US/docs/Web/CSS/Alternative_style_sheets
- When title is specified it will be registered for Firefox to only load it when it has been selected under the subMenu (View > Page-View).
- Copying the title attribute to the `--sync` element will follow the alternate stylesheet.
- Resolves #737