### PR TITLE
Add fix for heise.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4195,6 +4195,13 @@ INVERT
 
 ================================
 
+heise.de
+
+INVERT
+.heise-online-logo
+
+================================
+
 helix.ru
 
 INVERT


### PR DESCRIPTION
This inverts the dark "heise online" logo in the top left corner on german tech news site https://heise.de

The dark "heise+" logo right next to it is still too dark. I didn't create a fix for it yet, because it's not as straightforward and I am not a subscriber of heise+ anyway :smiley: 