### PR TITLE
Check for same protocol

### DIFF
--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -35,7 +35,7 @@ export async function getImageDetails(url: string) {
 }
 
 async function getImageDataURL(url: string) {
-    if (getURLHostOrProtocol(url) === (location.host || location.protocol)) {
+    if (getURLHostOrProtocol(url) === ((location.host && url.startsWith(location.protocol)) || location.protocol)) {
         return await loadAsDataURL(url);
     }
     return await bgFetch({url, responseType: 'data-url'});


### PR DESCRIPTION
- Make sure to only load the image when the web page is on `https://` the image is as well on  `https://`.
- Let the background-service handle the request when they are not on the same protocol.
- Resolves #5172