### PR TITLE
Fixed math expressions in cubawiki.com.ar

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2075,6 +2075,13 @@ CSS
 
 ================================
 
+cubawiki.com.ar
+
+INVERT
+.mwe-math-fallback-image-inline
+
+================================
+
 cynkra.com
 
 INVERT


### PR DESCRIPTION
The math expressions where black and it couldn't be distinguished with the background 
- Example: https://www.cubawiki.com.ar/index.php/Final_14/06/2019_(Probabilidad_y_Estad%C3%ADstica)
So I fixed