### PR TITLE
Fix for BestBuy.com radio button selections not being visible

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1125,6 +1125,15 @@ body {
 
 ================================
 
+bestbuy.com
+
+CSS
+input[type="radio" i] {
+    background-color: initial;
+}
+
+================================
+
 beta.protonmail.com
 
 CSS


### PR DESCRIPTION
Radio button selections in checkout were not visible. Setting background color of that particular type input back to `initial` fixed the issue.