### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -411,6 +411,7 @@ m4rtyr.github.io
 macbb.org
 magnetoo.io
 magoware.tv
+mail.google.com
 mango.pdf.zone
 marekmaskarinec.github.io
 maroon.jonah.pw


### PR DESCRIPTION
Added _mail.google.com_
Steps to darkify gmail:


**1. Quick settings:**

![image](https://user-images.githubusercontent.com/80106886/110350898-3147a180-8002-11eb-96ee-0180fa653126.png)



**2. Themes - View All:**

![image](https://user-images.githubusercontent.com/80106886/110350964-491f2580-8002-11eb-8a39-1f1a20d49b1e.png)

![image](https://user-images.githubusercontent.com/80106886/110350996-53d9ba80-8002-11eb-8490-25692b972985.png)



**3. Scroll down until colored boxes, and pick the black one.**

![image](https://user-images.githubusercontent.com/80106886/110349300-9601fc80-8000-11eb-903b-813f34e7ffc2.png)


