### PR TITLE
Fix dynamic mode article background color on hs.fi

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4325,6 +4325,15 @@ INVERT
 
 ================================
 
+hs.fi
+
+CSS
+article, article > article {
+  background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 hypixel.net
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4328,8 +4328,9 @@ INVERT
 hs.fi
 
 CSS
-article, article > article {
-  background-color: var(--darkreader-neutral-background) !important;
+article, 
+article > article {
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
Changes brown article element background color on article listing pages to `var(--darkreader-neutral-background)`. A different background color has apparently been added to business sections. This is a recent design change on the site.

Preferably I would like to retain a different background color but I didn't find any documentation on other background color variables to use. Or would this be a case to use a hardcoded value?

URL: https://www.hs.fi

**Before:**
![image](https://user-images.githubusercontent.com/9029939/110353358-a71e2e00-803f-11eb-9bc7-318c8a0a4adf.png)

**After:**
![image](https://user-images.githubusercontent.com/9029939/110353450-c0bf7580-803f-11eb-92c0-1fc60a0b0b72.png)
