### PR TITLE
Color inversions for 'move' menu elements

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2624,6 +2624,7 @@ img[src$="googlelogo_dark_clr_74x24px.svg"]
 body[itemtype*="PresentationObject"] #docs-titlebar-share-client-button .scb-button-icon
 g.punch-filmstrip-indicator > image
 .docs-gm .docos-icon-overflow-three-dots-size
+.de-fe-cb-he .de-Cf-f,.de-ik-db-Gi, .de-fe-Gf-Df-Ld-u .de-ik-Ld-Df,.de-ik-pg-je,.de-ik-Rh-je,.de-ik-pg,.de-ik-Rh,.de-ik-kk-n-af
 
 CSS
 .docs-preview-palette-item {
@@ -2656,6 +2657,9 @@ CSS
 }
 .docs-title-input-label:not([style*="pointer-events: auto"]) > #docs-title-input-label-inner {
     visibility: hidden !important;
+}
+.de-Zd-Kc ::-webkit-scrollbar-thumb {
+    background-color: rgb(255 255 255 / 20%);
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2624,7 +2624,12 @@ img[src$="googlelogo_dark_clr_74x24px.svg"]
 body[itemtype*="PresentationObject"] #docs-titlebar-share-client-button .scb-button-icon
 g.punch-filmstrip-indicator > image
 .docs-gm .docos-icon-overflow-three-dots-size
-.de-fe-cb-he .de-Cf-f,.de-ik-db-Gi, .de-fe-Gf-Df-Ld-u .de-ik-Ld-Df,.de-ik-pg-je,.de-ik-Rh-je,.de-ik-pg,.de-ik-Rh,.de-ik-kk-n-af
+.de-fe-cb-he .de-Cf-f
+.de-ik-db-Gi
+.de-fe-Gf-Df-Ld-u .de-ik-Ld-Df
+.de-ik-pg-je,.de-ik-Rh-je
+.de-ik-pg,.de-ik-Rh
+.de-ik-kk-n-af
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
When clicking the move icon (between the star and cloud icons) at the top, a small menu window ui lets you choose the destination. Some of the following icon elements were not inverted and I'm adding them to INVERT:
- Open folder in new window
- Window closing "x"
- Create new folder
- Select folder right chevron (hover)
- Shared with me (at root)
- Starred (at root)

Also added to CSS a bright color for the scrollbar thumb for this little window.