### PR TITLE
neovim.io isn't dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -448,7 +448,6 @@ namechk.com
 nanhu.ca
 nchristopher.me
 neal.fun/size-of-space
-neovim.io
 neundex.com
 newgrounds.com
 nexusmods.com


### PR DESCRIPTION
Changes:
- Removed `neovim.io` from the dark site list