### PR TITLE
Fix dynamic theme for iconify.design

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4392,12 +4392,9 @@ CSS
 iconify.design
 
 IGNORE INLINE STYLE
-svg.iconify path
-svg.iconify g
-.si-svg-wrapper path
-.si-svg-wrapper g
-.block-container .icons path
-.block-container .icons g
+svg.iconify *
+.si-svg-wrapper svg *
+.block-container .icons svg *
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4389,6 +4389,18 @@ CSS
 
 ================================
 
+iconify.design
+
+IGNORE INLINE STYLE
+svg.iconify path
+svg.iconify g
+.si-svg-wrapper path
+.si-svg-wrapper g
+.block-container .icons path
+.block-container .icons g
+
+================================
+
 iett.istanbul
 
 CSS


### PR DESCRIPTION
Darkreader shouldn't affect emojis with color within [iconify.design](https://iconify.design/).

Before fix
![](https://get.snaz.in/5pXiqG7.png)

After fix
![](https://get.snaz.in/8AxyHqU.png)