### PR TITLE
Fix for microsoftedge.microsoft.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5867,6 +5867,14 @@ body > .ember-view.dialog_wrapper {
 
 ================================
 
+microsoftedge.microsoft.com
+
+INVERT
+svg[viewBox="0 0 16 16"]
+text[text-anchor="middle"]
+
+================================
+
 midkar.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5870,7 +5870,7 @@ body > .ember-view.dialog_wrapper {
 microsoftedge.microsoft.com
 
 INVERT
-svg[viewBox="0 0 16 16"]
+rect[x="7.5"]
 text[text-anchor="middle"]
 
 ================================


### PR DESCRIPTION
- Invert the separator between reviews and category.
- Invert the letter in the profile logo in user reviews.

Example of site page: https://microsoftedge.microsoft.com/addons/detail/dark-reader/ifoakfbpdcdoeenechcleahebpibofpc