### PR TITLE
Fix for github.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3933,6 +3933,9 @@ CSS
 .merge-status-list {
     border-color: ${#c0c5c7} !important;
 }
+.user-has-reacted {
+    background-color: rgba(17, 88, 199, 0.2) !important;
+}
 
 IGNORE INLINE STYLE
 a[href^="https://apps.apple.com/app/"] g


### PR DESCRIPTION
- Increase the visibility of the line with reactions if the user has reacted.

Example of site pages: https://github.com/darkreader/darkreader/issues/835 (you need to click on any reaction to the message)