### PR TITLE
Fix for ftp.nluug.nl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3679,7 +3679,7 @@ img[src$="layout/logo.svg"]
 ftp.nluug.nl
 
 INVERT
-[src="/opmaak/images/nluug-ds-200x143.gif"]
+img[alt="[NLUUG]"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3676,7 +3676,7 @@ img[src$="layout/logo.svg"]
 
 ================================
 
-ftp.nluug.n
+ftp.nluug.nl
 
 INVERT
 [src="/opmaak/images/nluug-ds-200x143.gif"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3676,6 +3676,13 @@ img[src$="layout/logo.svg"]
 
 ================================
 
+ftp.nluug.n
+
+INVERT
+[src="/opmaak/images/nluug-ds-200x143.gif"]
+
+================================
+
 funpay.ru
 
 INVERT


### PR DESCRIPTION
Example Link: https://ftp.nluug.nl/pub/graphics/blender/release/Blender2.92/

Changes:
- Inverted logo