### PR TITLE
Fix for github.blog

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3831,6 +3831,15 @@ github.blog
 INVERT
 a[href="https://github.com"]
 .site-branding > svg
+.wp-post-image
+.icon-logo-github
+.aligncenter
+.wp-image-56594
+.wp-image-56590
+[src^="https://github.blog/wp-content/uploads/2019/03/BlogHeaders_Aligned_CHANGELOG"]
+[src^="https://i0.wp.com/user-images.githubusercontent.com/"]
+[src^="https://i1.wp.com/user-images.githubusercontent.com/"]
+[src^="https://i2.wp.com/user-images.githubusercontent.com/"]
 
 ================================
 


### PR DESCRIPTION
Example Sites: 
- https://github.blog/ 
- https://github.blog/changelog/ 
- https://github.blog/2021-02-24-hello-from-githubs-new-chief-security-officer/ 
- https://github.blog/changelog/2021-03-12-sort-repositories-by-name-in-organizations/

Changes:
- Inverted images from the domain `i0.wp.com` `i1.wp.com` `i2.wp.com`
- Inverted Change-log header image
- Inverted all "blog header" images 
- Inverted all images that have `aligncenter` `wp-image-56594` `wp-image-56590`
- Inverted GitHub logo at the end of the page

The amount of times I pressed reset accidentally: `2`