### PR TITLE
Fix for habitica.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4351,6 +4351,13 @@ CSS
 
 ================================
 
+habitica.com
+
+INVERT
+.logo path:nth-child(2)
+
+================================
+
 habr.com
 
 INVERT


### PR DESCRIPTION
- Invert logo

The logo after login was shown incorrectly.

Before:
![2021-03-17-055204-bbb67b](https://user-images.githubusercontent.com/1006477/111384911-04237f00-86e5-11eb-947d-c3f487e4f755.png)

After:
![2021-03-17-055154-06a1cf](https://user-images.githubusercontent.com/1006477/111384924-07b70600-86e5-11eb-809c-d8f4b498f1e4.png)
