### PR TITLE
Fix for ditu.baidu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2584,11 +2584,13 @@ map.baidu.com
 
 INVERT
 .BMap_contextMenu
+.BMap_cpyCtrl
 .BMap_simple_bubble_pop
 .c-title
 .icon
 #maps
 #mapType-wrapper
+.message-banner
 .poidetail-widget-generalInfo
 .toolscontainer
 


### PR DESCRIPTION
- Invert copyright banner at bottom left
- Invert pop-up ad about app downloading