### PR TITLE
invert invisible icons for onscreen keyboard

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2998,6 +2998,13 @@ CSS
 
 ================================
 
+edulastic.com
+
+INVERT
+img.keyboardButton
+
+================================
+
 eff.org
 
 INVERT


### PR DESCRIPTION
Edulastic has an onscreen keyboard for entering math equations. It uses images to show the icons, and these images were not being inverted in dark mode - grey image on black background was basically unusable. This should invert those buttons, to make it easy to read them. 

Before:
![image](https://user-images.githubusercontent.com/72410860/111558159-79c23600-874b-11eb-8067-eadf19bd3619.png)
This commit:
![image](https://user-images.githubusercontent.com/72410860/111558199-8fcff680-874b-11eb-89f9-464039e1c84e.png)
