### PR TITLE
Fix for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10065,7 +10065,6 @@ img[alt="The Signpost"]
 .mw-hiero-outer.mw-hiero-table
 a.image[href*="ile:Hiero_Ca"] > img
 [src*="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Egyptian_3_symbol.png/10px-Egyptian_3_symbol.png"]
-span[class^="ts-"]
 img[src$="Rename_icon_Cyr.svg.png"]
 img[alt="Aksara Sunda.png"]
 img[alt="Aksara kawi name.png"]


### PR DESCRIPTION
- Remove obsolete rule.

Since the icon "Go to the section" was changed (https://github.com/darkreader/darkreader/pull/4794), and also on https://ru.wikipedia.org/wiki/Симметрия ​the spelling of the word with accents breaks down