### PR TITLE
Fix for t.me and telegram.me

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8525,6 +8525,14 @@ CSS
 
 ================================
 
+t.me
+telegram.me
+
+INVERT
+.tgme_logo
+
+================================
+
 tablesgenerator.com
 
 INVERT


### PR DESCRIPTION
- Invert logo.

Example of site pages: https://t.me/durov, https://telegram.me/durov