### PR TITLE
Fix for what-if.xkcd.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9937,6 +9937,12 @@ INVERT
 .archive-image
 .logo
 
+CSS
+.entry {
+    background-image: none !important;
+    background-color: var(--darkreader-neutral-background);
+}
+
 ================================
 
 whatsapp.com


### PR DESCRIPTION
Removed non-dark-mode-friendly background image on https://what-if.xkcd.com .
Right now it actually gets inverted but with a too light background. Is it possible to invert it completely?
For example, under Filter it looks OK.