### PR TITLE
Fix Wikipedias media player

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11093,7 +11093,6 @@ div.post-content.footer-content > h2 > img
 img[src*="Loudspeaker.svg"]
 img[alt="The Signpost"]
 .mw-hiero-outer.mw-hiero-table
-.k-menu-bar
 a.image[href*="ile:Hiero_Ca"] > img
 [src*="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7a/Egyptian_3_symbol.png/10px-Egyptian_3_symbol.png"]
 img[src$="Rename_icon_Cyr.svg.png"]
@@ -11363,6 +11362,9 @@ sup.reference:target {
 IGNORE INLINE STYLE
 .legend-color
 .infobox > tbody > tr > td[style*="background-color"]
+
+IGNORE IMAGE ANALYSIS
+.k-player .k-menu-bar li a
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10096,6 +10096,7 @@ img[alt="Aksara kawi name.png"]
 img[src*="/static/images/mobile/copyright/wikipedia-wordmark"]
 img[src*="/static/images/mobile/copyright/wikipedia-tagline"]
 img[src*="UML_diagrams_overview.svg"]
+.k-menu-bar
 
 CSS
 .mwe-popups-discreet > svg,
@@ -10139,11 +10140,18 @@ ol.references li:target,
 sup.reference:target {
     background-color: ${lightblue} !important;
 }
+.control-bar {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+.k-player {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 IGNORE INLINE STYLE
 .legend-color
 .infobox > tbody > tr > td[style*="background-color"]
- 
+
 ================================
 
 wikisource.org

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10143,7 +10143,7 @@ sup.reference:target {
 IGNORE INLINE STYLE
 .legend-color
 .infobox > tbody > tr > td[style*="background-color"]
-
+ 
 ================================
 
 wikisource.org


### PR DESCRIPTION
Changes:
- Made the background of the player `var(--darkreader-neutral-background)` and removed background image
- Inverted menu bar (Actions were in retina burning white)

Some pages with an audio player:
- https://en.wikipedia.org/wiki/Flush_toilet (Scroll down a bit)'
- https://en.wikipedia.org/wiki/Canada (2 players on the "info" bar)

Things-I-dont-know-how-to-fix:
- Icons are also black