### PR TITLE
Add monokai.nl to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -440,6 +440,7 @@ monitoror.com
 monkey-type.com
 monkeytype.com
 monkrus.ws
+monokai.nl
 mope.io
 mouse-sensitivity.com
 msi.com


### PR DESCRIPTION
Site: https://monokai.nl/ *(Requires JavaScript to run)*

Certified dark site :+1: