### PR TITLE
animedigitalnetwork.fr - Fix revealing spoilers

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -622,10 +622,10 @@ animedigitalnetwork.fr
 
 CSS
 .spoiler {
-	color: transparent !important;
+    color: transparent !important;
 }
 .spoiler:hover {
-	color: unset !important;
+    color: unset !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -618,6 +618,18 @@ CSS
 
 ================================
 
+animedigitalnetwork.fr
+
+CSS
+.spoiler {
+	color: transparent !important;
+}
+.spoiler:hover {
+	color: unset !important;
+}
+
+================================
+
 answers.opencv.org
 
 CSS


### PR DESCRIPTION
Fix spoilers revealing their content with dynamic dark mode enabled.
This was kinda problematic, since they didn't work as expected...