### PR TITLE
Fix Buzzsprout admin page icons from being black in dynamic mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1601,6 +1601,15 @@ CSS
 
 ================================
 
+buzzsprout.com
+
+INVERT
+.icon_edit
+.icon_stats
+.icon_share
+
+================================
+
 caiyunapp.com
 
 INVERT


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/35514663/112241385-24d56280-8c18-11eb-886f-8df16aaa288e.png)

After:
![image](https://user-images.githubusercontent.com/35514663/112241411-2ef76100-8c18-11eb-8bd3-7ceff47af194.png)

