### PR TITLE
Add fix for wikimedia.de logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9098,6 +9098,13 @@ INVERT
 
 ================================
 
+wikimedia.de
+
+INVERT
+.logo
+
+================================
+
 wikimedia.org
 
 INVERT


### PR DESCRIPTION
This inverts the dark wikimedia logo in the top left corner on https://wikimedia.de