### PR TITLE
Fix for nalog.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6457,6 +6457,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+nalog.ru
+
+INVERT
+.header__logo
+
+================================
+
 nasa.gov
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
- Invert logo.

Example of site page: https://www.nalog.ru/rn77/