### PR TITLE
fix dark mode on roll20 4e character sheets

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -746,8 +746,8 @@ INVERT
 .sheet-name-container
 .sheet-attributes-container
 .sheet-attr-container button
-.sheet-row
-.sheet-header
+sheet-row
+sheet-header
 .sheet-hlabel-container
 .sheet-vitals
 .sheet-init button

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -746,7 +746,6 @@ INVERT
 .sheet-name-container
 .sheet-attributes-container
 .sheet-attr-container button
-sheet-row
 .sheet-hlabel-container
 .sheet-vitals
 .sheet-init button

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -747,7 +747,6 @@ INVERT
 .sheet-attributes-container
 .sheet-attr-container button
 sheet-row
-sheet-header
 .sheet-hlabel-container
 .sheet-vitals
 .sheet-init button


### PR DESCRIPTION
I am not positive this is the best way to solve this issue, so feedback would be great. Currently dark mode is really poor and inconsistent on roll20, specifically the character sheets. By making two selectors more broad, the page becomes much more usable. On a dnd 4e sheet, before:
![image](https://user-images.githubusercontent.com/72410860/112733658-7cb4e780-8efe-11eb-91ed-1ed23f041a20.png)
and after:
![image](https://user-images.githubusercontent.com/72410860/112733685-a3731e00-8efe-11eb-9fa7-e35c4469c857.png)
The black bars would be difficult to remove, and would go against the design of the sheet - roll20 frankly has really poorly designed 4th edition sheets.


<details>
<summary>another example</summary>

![image](https://user-images.githubusercontent.com/72410860/112733761-19778500-8eff-11eb-8c15-46e1fd9b9c3f.png)
Where before it could be:
![image](https://user-images.githubusercontent.com/72410860/112733790-4cba1400-8eff-11eb-9362-eb23301bced6.png)
or
![image](https://user-images.githubusercontent.com/72410860/112733824-65c2c500-8eff-11eb-99c3-100419028b82.png)
depending on your luck with the way the page loads.

</details>
<details>
<summary>4e powers</summary>

Before:
![image](https://user-images.githubusercontent.com/72410860/112734244-c8b55b80-8f01-11eb-8ff0-14cfd37bcc4f.png)
After:
![image](https://user-images.githubusercontent.com/72410860/112734259-df5bb280-8f01-11eb-8fcc-4c2e49135a55.png)

</details>

If this isn't the best way to fix it, please let me know. Notably, the 5e sheet is also a bit of a mess (and could use fixing) because it tries to be too fancy, but this change does not make it worse.