### PR TITLE
Revert "Fix for mail.protonmail.com (#4065)"

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5769,15 +5769,6 @@ IGNORE INLINE STYLE
 
 ================================
 
-mail.protonmail.com
-
-CSS
-.customCheckbox-input:not(:checked) + .customCheckbox-mask {
-    background: none !important;
-}
-
-================================
-
 manjaro.org
 
 CSS


### PR DESCRIPTION
This reverts commit 93087bc039c4db6352631a7882718e4ad87ce98e.
Fixes https://github.com/darkreader/darkreader/issues/1384


![image](https://user-images.githubusercontent.com/80601335/112737976-16d75880-8f1c-11eb-9983-7e740005874e.png)
The dynamic-theme-fix makes the non-checked checkbox look a bit better, but also causes the checked checkboxes to appear non-checked. Reverting this makes the non-checked checkboxes look a bit weird, but allows the checked ones to be usable. I tried messing with it a bit to get non-checked to look better and have checked still work, but couldn't easily figure out how to not break it due to some inline CSS stuff. 

So if someone else wants, they can follow up with a fix that makes non-checked look better while not  breaking checked.