### PR TITLE
add ppluss.de to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -544,6 +544,7 @@ poelab.com
 poison.gg
 pony.tube
 powercord.dev
+ppluss.de
 pr0gramm.com
 pre.fyp.nl
 premid.app


### PR DESCRIPTION
Changes:
- Add ppluss.de to dark-sites.config
