### PR TITLE
fix domain for iubh-fernstudium.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4962,7 +4962,7 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
-iubh-fernstudium.de
+iu-fernstudium.de
 
 INVERT
 .cp-logo


### PR DESCRIPTION
German university IUBH changed their name and domain to IU - this change updates the domain to make the dynamic theme work again.