### PR TITLE
oisd.nl fix logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6816,6 +6816,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+oisd.nl
+
+INVERT
+img[alt=logo]
+
+================================
+
 olx.pl
 
 IGNORE IMAGE ANALYSIS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6819,7 +6819,7 @@ IGNORE INLINE STYLE
 oisd.nl
 
 INVERT
-img[alt=logo]
+img[alt="logo"]
 
 ================================
 


### PR DESCRIPTION
In default logo image is not changed - stay white. This is fix. 

![20210329-1617035517-001](https://user-images.githubusercontent.com/9846948/112869304-470a2d00-90bd-11eb-80df-8f73f1c0db8b.png)


