### PR TITLE
internetowa.tv revert images fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4943,6 +4943,7 @@ INVERT
 img[src*="/img/"]
 
 ================================
+
 ipko.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4937,6 +4937,12 @@ INVERT
 
 ================================
 
+internetowa.tv
+
+INVERT
+img[src*="/img/"]
+
+================================
 ipko.pl
 
 INVERT


### PR DESCRIPTION
Some logos are PNG without transparency, others have hard looking darker colors. Solution? Revert all except movies/series covers (other access path). 

![20210330-1617081881-001](https://user-images.githubusercontent.com/9846948/112937983-0942ee00-9129-11eb-95a2-e09b9ba95f6c.png)

Please review and merge. 

Regards
