### PR TITLE
doba.pl social and logo header fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2769,6 +2769,15 @@ img[src*="logo.png"]
 
 ================================
 
+doba.pl
+
+INVERT
+.social
+img[src*="logo.png"]
+img[src*="/img/powiaty/"]
+
+================================
+
 docs.codacy.com
 
 INVERT


### PR DESCRIPTION

https://doba.pl/dsw

![20210330-1617091572-001](https://user-images.githubusercontent.com/9846948/112955988-4666aa80-9140-11eb-91d7-ee48b4024f8f.png)
