### PR TITLE
Fix google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10981,7 +10981,6 @@ a[href*="about/products"][title]
 .yPHXsc div
 .mn-dwn-arw
 img.act-icon-dark-gray
-#dimg_15
 [data-attrid="formula-image"]
 [data-attrid^="variable"] img
 [src^="/chrome/static/images/thank-you/"]


### PR DESCRIPTION
- Fix images that had `#dmig_15` tag to be inverted.
- Resolves #5398