### PR TITLE
Add the Godot game engine (godotengine.org)

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -303,6 +303,7 @@ glslsandbox.com
 go.dailynow.co
 goaudio.cc
 god.freevar.com
+godotengine.org
 gog.com/forum
 gogalaxy.com
 gogoanime.se


### PR DESCRIPTION
[Godot](https://godotengine.org), _it's temporarily changed for April Fools_

[Godot Asset Library](https://godotengine.org/asset-library/asset) is an exception, it needs to be inverted.

Would `inversion-fixes.config` need to be edited for it?

EDIT: The default inversion for the asset library works great