### PR TITLE
Don't invert logo on mediawiki.org

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1317,6 +1317,13 @@ CSS
 
 ================================
 
+mediawiki.org
+
+IGNORE IMAGE ANALYSIS
+.mw.wiki-logo
+
+================================
+
 medium.com
 
 NO INVERT


### PR DESCRIPTION
The logo has been changed, but this extension breaks it.