### PR TITLE
add adridoesthings.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -9,6 +9,7 @@
 accounts.pubg.com
 acm.sdut.edu.cn/onlinejudge3/
 addictinggames.com
+adridoesthings.com
 adventofcode.com
 agent-stats.com
 agfy.co


### PR DESCRIPTION
Changes:

- Add [adridoesthings.com](adridoesthings.com) to dark-sites.config