### PR TITLE
Fix for FRITZ!Box web UI input elements

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3979,7 +3979,8 @@ div.formular input[type="radio"]
 div.formular input[type="checkbox"]
 
 CSS
-div.formular input[type="radio"], div.formular input[type="checkbox"] {
+div.formular input[type="radio"], 
+div.formular input[type="checkbox"] {
     background-color: transparent !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3979,9 +3979,8 @@ div.formular input[type="radio"]
 div.formular input[type="checkbox"]
 
 CSS
-div.formular input[type="radio"], 
-div.formular input[type="checkbox"] {
-  background-color:transparent;
+div.formular input[type="radio"], div.formular input[type="checkbox"] {
+    background-color:transparent;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3980,7 +3980,7 @@ div.formular input[type="checkbox"]
 
 CSS
 div.formular input[type="radio"], div.formular input[type="checkbox"] {
-    background-color:transparent;
+    background-color: transparent !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3972,6 +3972,20 @@ INVERT
 
 ================================
 
+fritz.box
+
+INVERT
+div.formular input[type="radio"]
+div.formular input[type="checkbox"]
+
+CSS
+div.formular input[type="radio"], 
+div.formular input[type="checkbox"] {
+  background-color:transparent;
+}
+
+================================
+
 ftp.nluug.nl
 
 INVERT


### PR DESCRIPTION
Fix for the [Fritz!Box web UI](https://en.avm.de/service/fritzbox/fritzbox-7590/knowledge-base/publication/show/1_Opening-the-FRITZ-Box-user-interface/). The dynamic theme works really well, except for the inversion of the input elements. 

| before| after |
|---|---|
|![before](https://user-images.githubusercontent.com/962956/113765084-1c068580-971c-11eb-82ec-394ee49d92ba.png)|![after](https://user-images.githubusercontent.com/962956/113765097-1f9a0c80-971c-11eb-938b-3906ea97b491.png)|

