### PR TITLE
Adding mypodficacademia.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -456,6 +456,7 @@ msi.com
 music.youtube.com
 mwomercs.com
 mynoise.net
+mypodficacademia.com
 n-o-d-e.net
 namechk.com
 nanhu.ca


### PR DESCRIPTION
This is a website I run and it uses its dark theme by default.