### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -594,6 +594,7 @@ robofight.io
 rocketleagueesports.com
 roleypoly.com
 romefrontend.dev
+royal.uk
 rtbyte.xyz
 runicgames.com
 rust.facepunch.com


### PR DESCRIPTION
Adding royal.uk due to Duke of Edinburgh death announcement. With darkreader enabled, the bottom section of the page which sits outside of the viewport is grey and causes a visual mismatch between the black of the page.