### PR TITLE
Fix code blocks on developer.apple.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2603,7 +2603,6 @@ pre, .code-listing {
     background-color: var(--darkreader-neutral-background) !important;
 }
 
-
 IGNORE IMAGE ANALYSIS
 .screen-hero
 .screen-fonts

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2599,7 +2599,8 @@ CSS
 .disabled {
     color: ${gray} !important;
 }
-pre, .code-listing {
+pre,
+.code-listing {
     background-color: var(--darkreader-neutral-background) !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2599,6 +2599,10 @@ CSS
 .disabled {
     color: ${gray} !important;
 }
+pre, .code-listing {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
 
 IGNORE IMAGE ANALYSIS
 .screen-hero


### PR DESCRIPTION
Before the code blocks' background was white but the text was also why so you couldn't see the text.