### PR TITLE
nieidealny.pl invisioncommunity.com forum engine

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3917,6 +3917,7 @@ html {
 
 forum.eset.com
 forums.laptopvideo2go.com
+nieidealny.pl
 
 INVERT
 .ipsReact_button
@@ -5158,6 +5159,34 @@ internetowa.tv
 
 INVERT
 img[src*="/img/"]
+
+================================
+
+invisioncommunity.com
+
+INVERT
+img[src*="customer_logos.png"]
+img[src*="logo_dark.png"]
+img[src*="footer"]
+.cDownloadsCategoryCount
+
+CSS
+.ipsBadge {
+    --darkreader-bg--badge--background: var(--darkreader-neutral-background) !important;
+}
+.ipsReact_reactCount > a, 
+.ipsReact_reactCount > span, 
+.elFullInbox_menu, 
+.ipsMenu_auto, 
+.ipsMenu_footerBar, 
+.ipsMenu_headerBar, 
+.ipsMenu_innerContent, 
+.ipsMenu_item, 
+.ipsMenu_sep, 
+.ipsMenu_title, 
+.ipsPadding {
+	background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Sites:
https://www.nieidealny.pl/forum/topic/7549-3000-4000-laptop-filmy-praca-biurowa/
and 
https://invisioncommunity.com/files/
https://invisioncommunity.com/
https://invisioncommunity.com/files/file/9867-ne-contact-us-check-if-email-is-on-banned-list/


Basicaly ESET Forum, laptopvideo2go.com and nieidealny.pl using Invision forum engine. 
Main homepage invisioncommunity.com need to be excluded from common rules and adjusted exclusively.

Main change for invisioncommunity.com domain is removing `.ipsList_reset` against issue with looking part of home page.
Next, some images need to invert too. 
