### PR TITLE
fix embedded code and table header color for developers.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2693,6 +2693,10 @@ a.button,
 .devsite-landing-row-item {
     border-color: var(--darkreader-border--devsite-select-border) !important;
 }
+p code {
+    color: var(--darkreader-neutral-text) !important;
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2697,6 +2697,9 @@ p code {
     color: var(--darkreader-neutral-text) !important;
     background-color: var(--darkreader-neutral-background) !important;
 }
+th {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
fix colors for embedded code.

before:
![image](https://user-images.githubusercontent.com/72410860/114637148-8455e980-9c7d-11eb-857c-32a01279544b.png)
after:
![image](https://user-images.githubusercontent.com/72410860/114637124-7607cd80-9c7d-11eb-9287-81e92128f6e1.png)
