### PR TITLE
Added Blur Busters, GitHub, Material UI and Twitch to dark sites exceptions

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -87,6 +87,7 @@ blog.counter-strike.net
 blog.dota2.com
 blog.ja-ke.tech
 blox.link
+blurbusters.com
 bogleech.com
 bondoer.fr
 bonsaihd.live
@@ -298,6 +299,7 @@ gifrun.com
 gifyourgame.com
 gikken.co
 giphy.com
+github.com
 githubuniverse.com
 gitkraken.com
 gitmoji.kaki87.net
@@ -431,6 +433,7 @@ mango.pdf.zone
 marekmaskarinec.github.io
 maroon.jonah.pw
 marte.dev
+material-ui.com
 matteotiscia.com
 mcrpw.github.io
 mcskinhistory.com
@@ -733,6 +736,7 @@ tuner.ninja
 tusharsadhwani.dev
 twelvesmith.com
 twist.moe
+twitch.tv
 tycrek.com
 tynker.com/ide
 typing.works


### PR DESCRIPTION
[Blur Busters](https://blurbusters.com), GitHub, [Material UI](https://material-ui.com) and [Twitch](https://www.twitch.tv) are browser/OS theme aware and will automatically switch accordingly.

Can be confirmed on Windows 10 by toggling OS wide theme while visiting those sites in a private tab. Twitch only checks on page load and may need a refresh.

![image](https://user-images.githubusercontent.com/9457934/114831134-5fde4680-9e10-11eb-90e9-c82638bbaa0b.png)
