### PR TITLE
Removed Mixer and MSI

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -445,7 +445,6 @@ miaou.drycat.fr
 minehut.com
 miniroyale2.io
 missions.ingress.com
-mixer.com
 mixxx.org
 mkbhd.com
 mmorpg.com
@@ -455,7 +454,6 @@ monkeytype.com
 monkrus.ws
 mope.io
 mouse-sensitivity.com
-msi.com
 music.youtube.com
 mwomercs.com
 mynoise.net


### PR DESCRIPTION
[Mixer](mixer.gg) no longer exists (redirects to Facebook Gaming) and [MSI](https://www.msi.com) is not dark.