### PR TITLE
Don't invert logo on mediawiki.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6344,6 +6344,13 @@ section[class$="container"][style^="background-image"] {
 
 ================================
 
+mediawiki.org
+
+IGNORE IMAGE ANALYSIS
+.mw.wiki-logo
+
+================================
+
 medium.com
 
 INVERT


### PR DESCRIPTION
The logo has been changed, but this extension breaks it.