### PR TITLE
Updated svt.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9285,7 +9285,6 @@ header img[src*=svt]
 [class^="_play-pause-button-simple"]::before
 
 CSS
-[class^="VideoPlayerTheme__live__splash"],
 .nyh_breaking__top-prefix,
 .nyh_teaser__live-text {
     color: var(--darkreader-neutral-background) !important;
@@ -9294,7 +9293,36 @@ CSS
     border-right-color: #262a2b !important;
 }
 .nyh_navigation .nyh_submenu::before {
-    border-bottom-color: black;
+    border-bottom-color: var(--darkreader-neutral-background);
+}
+.nyh_feedbox-item,
+.flexbox .nyh_teaser.nyh_teaser--group-secondary,
+.GroupSecondaryTeasers__container___2v5SH,
+.GroupSecondaryTeasers__showMoreButton___gOOOl,
+.CurrentTopics__item___1x0Gw,
+.nyh_menu-card__submenu-item,
+.nyh_mobile-menu__list-item,
+.nyh_teaser.nyh_teaser--no-border-top,
+.nyh_submenu-menucard {
+    border-top-color: var(--darkreader-border--nyh-color-grey-lighter);
+    border-right-color: var(--darkreader-border--nyh-color-grey-lighter);
+    border-bottom-color: var(--darkreader-border--nyh-color-grey-lighter);
+}
+.flexbox .nyh_teaser.nyh_teaser--group-secondary:not(.nyh_teaser--play) {
+    border-right-color: transparent;
+    border-left-color: transparent;
+}
+.nyh_submenu {
+    border-color: var(--darkreader-border--nyh-color-grey-lighter);
+}
+.PaginationButton__button___wUYlE {
+    background: var(--darkreader-neutral-background)
+}
+.nyh_fact-box__body--closed::after {
+    background: linear-gradient(to bottom, rgba(var(--nyh-color-grey-darkest-rgb), 0.5) 0%, rgba(var(--nyh-color-grey-darkest-rgb), 1) 100%);
+}
+.nyh_navigation .nyh_submenu::before {
+    border-bottom-color: var(--darkreader-bg--nyh-color-white);
 }
 
 ================================


### PR DESCRIPTION
This mainly darkens all white borders I didn't cover in my last PR #4718

# Noteworthy things

| <center>Before</center> | <center>After</center> |
| ----------------------- | ---------------------- |
| ![svt1off]              | ![svt1on]              |

Darkened the white borders around the article boxes.

| <center>Before</center> | <center>After</center> |
| ----------------------- | ---------------------- |
| ![svt2off]              | ![svt2on]              |

Darkened the white borders around the dropdown news categories and fixed the little arrow at the top.

| <center>Before</center> | <center>After</center> |
| ----------------------- | ---------------------- |
| ![svt3off]              | ![svt3on]              |

Made the shade of the factbox darker. Although I never managed to get the correct colors, it looks better than it did before.

| <center>Before</center> | <center>After</center> |
| ----------------------- | ---------------------- |
| ![svt4off]              | ![svt4on]              |

Turned the white borders around the sidebar articles into a dark grey shade.

[svt1off]: https://user-images.githubusercontent.com/17113053/114943120-cb8ed680-9e45-11eb-8bf2-9618e916d781.png
[svt1on]: https://user-images.githubusercontent.com/17113053/114943121-cc276d00-9e45-11eb-8c4f-1bc9a0065557.png
[svt2off]: https://user-images.githubusercontent.com/17113053/114943123-cc276d00-9e45-11eb-9555-d28412767073.png
[svt2on]: https://user-images.githubusercontent.com/17113053/114943126-ccc00380-9e45-11eb-9063-1a87be64b942.png
[svt3off]: https://user-images.githubusercontent.com/17113053/114943128-ccc00380-9e45-11eb-8a75-e621f966ab47.png
[svt3on]: https://user-images.githubusercontent.com/17113053/114943129-ccc00380-9e45-11eb-8d72-bbf7d35d8518.png
[svt4off]: https://user-images.githubusercontent.com/17113053/114943130-cd589a00-9e45-11eb-80e5-29c16da8226e.png
[svt4on]: https://user-images.githubusercontent.com/17113053/114943114-ca5da980-9e45-11eb-9fb4-a6854de49cc3.png
[svt5off]: https://user-images.githubusercontent.com/17113053/114943117-caf64000-9e45-11eb-9d3f-8696aada00fa.png
[svt6on]: https://user-images.githubusercontent.com/17113053/114943118-cb8ed680-9e45-11eb-8086-2ccc9cda70ab.png