### PR TITLE
Fix svg text for 1843 articles on economist.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3225,6 +3225,13 @@ img[alt="Review and Preview problems below"]
 
 ================================
 
+economist.com
+
+INVERT
+#ds-wordmark-1843 path:nth-child(5)
+
+================================
+
 education.github.com
 
 INVERT


### PR DESCRIPTION
Fixes some svg text for articles from the [1843 magazine](https://www.economist.com/1843) on The Economist.

Before:
![before](https://user-images.githubusercontent.com/46976109/115112226-6be71700-9f7c-11eb-8508-2983de8c69b5.png)

After:
![after](https://user-images.githubusercontent.com/46976109/115112231-71446180-9f7c-11eb-81af-c555bb0b6284.png)
