### PR TITLE
Don't request resources when blocked

### DIFF
--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -78,6 +78,15 @@ export default class TabManager {
 
         const fileLoader = createFileLoader();
 
+        const onWebRequestError = (responseDetails: chrome.webRequest.WebResponseErrorDetails) => {
+            if (responseDetails.error.toLowerCase().includes('abort')) {
+                fileLoader.set({url: responseDetails.url, responseType: 'data-url', value: ''});
+                fileLoader.set({url: responseDetails.url, responseType: 'text', value: ''});
+            }
+        };
+
+        !isThunderbird && chrome.webRequest.onErrorOccurred.addListener(onWebRequestError, {urls: ['<all_urls>']});
+
         chrome.runtime.onMessage.addListener(async ({type, data, id}: Message, sender) => {
             if (type === 'fetch') {
                 const {url, responseType, mimeType} = data;

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -98,6 +98,7 @@ interface FetchRequestParameters {
     url: string;
     responseType: 'data-url' | 'text';
     mimeType?: string;
+    value?: string;
 }
 
 export function createFileLoader() {
@@ -111,6 +112,11 @@ export function createFileLoader() {
         'text': loadAsText,
     };
 
+    async function set({url, responseType, value}: FetchRequestParameters) {
+        const cache = caches[responseType];
+        cache.set(url, value);
+    }
+
     async function get({url, responseType, mimeType}: FetchRequestParameters) {
         const cache = caches[responseType];
         const load = loaders[responseType];
@@ -123,5 +129,5 @@ export function createFileLoader() {
         return data;
     }
 
-    return {get};
+    return {get, set};
 }

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -12,6 +12,7 @@
         "storage",
         "tabs",
         "theme",
+        "webRequest",
         "<all_urls>"
     ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -40,6 +40,7 @@
         "fontSettings",
         "storage",
         "tabs",
+        "webRequest",
         "<all_urls>"
     ],
     "commands": {


### PR DESCRIPTION
- When a content blocker(ex UBlock origin) blocked a resource we set for such URL an empty value so we won't "bypass" the blockade. 
- Resolves #5556