### PR TITLE
forsal.pl logo fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3978,6 +3978,19 @@ html {
 
 ================================
 
+forsal.pl
+
+INVERT
+.serviceLogo
+.homePageUrl
+
+CSS
+.mini-tabs {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 forum.eset.com
 forums.laptopvideo2go.com
 nieidealny.pl


### PR DESCRIPTION
Sample https://forsal.pl/biznes/aktualnosci/artykuly/8143659,cd-projekt-mial-szacunkowo-115-mld-zl-zysku-netto-w-2020-r.html
Fix
![20210419-1618816600-001](https://user-images.githubusercontent.com/9846948/115196284-09168c80-a0f0-11eb-928a-c5e7679182d6.png)
![20210419-1618816579-001](https://user-images.githubusercontent.com/9846948/115196289-09af2300-a0f0-11eb-8e07-6cae4ac4b4e1.png)
![20210419-1618816554-001](https://user-images.githubusercontent.com/9846948/115196291-0a47b980-a0f0-11eb-964f-8f027d670437.png)
