### PR TITLE
Fix whitespace character

### DIFF
--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -46,7 +46,7 @@ const shorthandVarDependantProperties = [
 ];
 
 const shorthandVarDepPropRegexps = isSafari ? shorthandVarDependantProperties.map((prop) => {
-    const regexp = new RegExp(`${prop}:\s*(.*?)\s*;`);
+    const regexp = new RegExp(`${prop}:\\s*(.*?)\\s*;`);
     return [prop, regexp] as [string, RegExp];
 }) : null;
 


### PR DESCRIPTION
- So due to string formatting within javascript, you need to have a double slash `//` to have have in the string a `/` so a `/s` becomes `s` as it isn't one of the reserved characters(ex `n` `t` `r`) but when you have in a string `//s` it will become `/s`.

Visualizing of the bug:
![image](https://user-images.githubusercontent.com/25481501/115202901-29961500-a0f7-11eb-96f9-b5c8ed6c8ed5.png)


@alexanderby Caught my eye while scrimming trough the code, not sure if this fixes any bugs, because it still passes every test.