### PR TITLE
gazeta.pl invert logo on subpages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4174,6 +4174,7 @@ plotek.pl
 INVERT
 .column
 .navigation__logo
+.main-navigation__logo
 
 CSS
 .top_section_bg, .bottom_section_bg {


### PR DESCRIPTION
Site sample https://zdrowie.gazeta.pl/Zdrowie/0,0.html

![20210420-1618915513-001](https://user-images.githubusercontent.com/9846948/115383563-448b8680-a1d6-11eb-9bcb-e2834d3083cb.png)
