### PR TITLE
Removed DPReview

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -206,7 +206,6 @@ dota2.ru
 dotabuff.com
 dotapicker.com
 dplay.com
-dpreview.com
 draculatheme.com
 draftkings.com
 drakewars.com


### PR DESCRIPTION
[DPReview](https://www.dpreview.com) is not dark. There is a theme toggle at the top right, but it defaults to light.