### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2012,6 +2012,16 @@ span[role="presentation"] {
 
 ================================
 
+cloud.google.com
+
+CSS
+code, pre, th, td, .devsite-top-logo-row-middle, nav.devsite-tabs-wrapper, devsite-footer-linkboxes, devsite-footer-utility {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 code.qt.io
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2015,7 +2015,14 @@ span[role="presentation"] {
 cloud.google.com
 
 CSS
-code, pre, th, td, .devsite-top-logo-row-middle, nav.devsite-tabs-wrapper, devsite-footer-linkboxes, devsite-footer-utility {
+code,
+pre,
+th,
+td,
+.devsite-top-logo-row-middle,
+nav.devsite-tabs-wrapper,
+devsite-footer-linkboxes,
+devsite-footer-utility {
     background-color: var(--darkreader-neutral-background) !important;
     color: var(--darkreader-neutral-text) !important;
 }


### PR DESCRIPTION
Updated the dynamic CSS for `cloud.google.com` dev pages

Test URL: https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler

## Before and After
### `code`
<img src="https://user-images.githubusercontent.com/17806916/115596129-98f13d80-a28c-11eb-9c95-447b61b41aa4.png" width="45%"></img>   <img src="https://user-images.githubusercontent.com/17806916/115596565-187f0c80-a28d-11eb-8a25-05622c801be5.png" width="45%"></img>

### `pre`
<img src="https://user-images.githubusercontent.com/17806916/115596288-c8a04580-a28c-11eb-802a-61766558c562.png" width="45%"></img>   <img src="https://user-images.githubusercontent.com/17806916/115596606-23d23800-a28d-11eb-8f60-fe980907cec8.png" width="45%"></img>

### `th, td`
<img src="https://user-images.githubusercontent.com/17806916/115596317-d2c24400-a28c-11eb-8e65-f622fbd0ce20.png" width="45%"></img>   <img src="https://user-images.githubusercontent.com/17806916/115596647-2df43680-a28d-11eb-821f-dfce3798050b.png" width="45%"></img>

### `.devsite-top-logo-row-middle, nav.devsite-tabs-wrapper`
<img src="https://user-images.githubusercontent.com/17806916/115596357-de156f80-a28c-11eb-8bd1-0f98d7617be9.png" width="45%"></img>   <img src="https://user-images.githubusercontent.com/17806916/115596700-42383380-a28d-11eb-9108-ce96efd7d7fc.png" width="45%"></img>

### `devsite-footer-linkboxes, devsite-footer-utility`
<img src="https://user-images.githubusercontent.com/17806916/115596409-ec638b80-a28c-11eb-9ae9-f7d796a46941.png" width="45%"></img>   <img src="https://user-images.githubusercontent.com/17806916/115596747-53814000-a28d-11eb-90de-f3b0d9e7ceb6.png" width="45%"></img> 
