### PR TITLE
Ubereats map and logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -139,6 +139,7 @@ IGNORE INLINE STYLE
 
 INVERT
 img[alt*='Home']
+body > #root > #wrapper > #main-content h1 + div
 body > #root > #wrapper > div[class^='c']
 body > #root > #wrapper > div[class^='c'] > header
 body > #root > #wrapper > div[class^='c'] > footer

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -135,6 +135,17 @@ IGNORE INLINE STYLE
 
 ================================
 
+*.ubereats.com
+
+INVERT
+img[alt*='Home']
+body > #root > #wrapper > div[class^='c']
+body > #root > #wrapper > div[class^='c'] > header
+body > #root > #wrapper > div[class^='c'] > footer
+body > #root > #wrapper > div[class^='c'] > #main-content > div:first-child
+
+================================
+
 01net.com
 
 CSS


### PR DESCRIPTION
Some inversions for UberEats to display the map on the order tracking and checkout pages, and to site-wide invert the Logo because it looks nicer that way.

The reason for the long-form css selector chaining is to avoid inadvertently applying inversions on other pages, so I tried to make the selectors too specific to match other pages.

I initially tried to do something like *.ubereats.com/*/orders to narrow down the changes to only a subset of pages, but had no luck. Perhaps a feature suggestion for next version if I'm not the only person crazy enough to want to apply styles like this.

Love the plugin, long may it reign!