### PR TITLE
Properly show content on suite.smarttech-prod.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9368,6 +9368,13 @@ INVERT
 
 ================================
 
+suite.smarttech-prod.com
+
+INVERT
+.smart-wbp-canvas-layer
+
+================================
+
 support.discord.com
 
 INVERT


### PR DESCRIPTION
Invert content on the interactive whiteboard on suite.smarttech-prod.com. Before the change, the white background was changed to dark, but the content (such as text) was still black, making it hard to read. This was the only way I found to fix it, by just inverting the content.

[Before change](https://imgur.com/a/dBV7uU1)
[After change](https://imgur.com/a/txB0dep)