### PR TITLE
Added WikiWand.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -782,6 +782,7 @@ weavesilk.com
 weboas.is
 widgetbot.io
 wiki.step-project.com
+www.wikiwand.com
 wolfy.fr
 wormate.io
 wowhead.com


### PR DESCRIPTION
[WikiWand](https://www.wikiwand.com) shows WikiPedia content in a pleasant and modern way, as opposed as the tradicional WikiPedia styling. It has a "light" / "dark" setting, so it is not necessary to "endarken" it.