### PR TITLE
kcsoftwares.com bugtracker new bug color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5629,6 +5629,9 @@ CSS
 kcsoftwares.com
 
 CSS
+.status-10-fg {
+    color: #FF14FF !important;
+}
 .status-30-fg { 
     color: #FFF719 !important;
 }


### PR DESCRIPTION
One more color fix for kcsoftwares.com bug tracker. 
![20210423-1619168944-001](https://user-images.githubusercontent.com/9846948/115848634-5c584a00-a424-11eb-8619-1cf8956a8074.png)
![20210423-1619168935-001](https://user-images.githubusercontent.com/9846948/115848636-5cf0e080-a424-11eb-8f5f-e94f5432b814.png)
