### PR TITLE
Fix for Asana's highlighted inbox entry

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -964,6 +964,11 @@ INVERT
 .siteHeader__logo
 .DatePickerCalendarDate--today .DatePickerCalendarDate-button::after
 
+CSS
+.InboxExpandableThread.InboxExpandableThread--selected {
+    background: var(--darkreader-neutral-background) !important;
+}
+
 ================================
 
 asciinema.org


### PR DESCRIPTION
The highlighted inbox entry in Asana, without fix, on dynamic mode:

![image](https://user-images.githubusercontent.com/1403548/115858113-d68dcc00-a42e-11eb-8fef-9478b521c55d.png)

The highlighted inbox entry in Asana, with fix, on dynamic mode:

![image](https://user-images.githubusercontent.com/1403548/115858060-c7a71980-a42e-11eb-894e-9b6c869dc224.png)
