### PR TITLE
Fix embedded code editor background under dash.cloudflare.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2485,7 +2485,7 @@ a[data-testid^="link-homepage"]
 
 CSS
 .monaco-editor-background, .monaco-editor .margin {
-    background-color: rgb(24 27 29) !important;
+    background-color: ${rgb(226 229 231)} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2483,6 +2483,11 @@ dash.cloudflare.com
 INVERT
 a[data-testid^="link-homepage"]
 
+CSS
+.monaco-editor-background, .monaco-editor .margin {
+    background-color: rgb(24 27 29) !important;
+}
+
 ================================
 
 dashboard.thechurchapp.org


### PR DESCRIPTION
CSS fix for the Monaco editor under Cloudflare's built-in worker editor and changes colors to match theming (from a previous bright yellow). 