### PR TITLE
Fix for kinzhal.media

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5785,6 +5785,18 @@ input[name="kp_query"]:focus {
 
 ================================
 
+kinzhal.media
+
+INVERT
+img[src$="logo.svg"]
+img[src$="search.svg"]
+img[src$="close.svg"]
+.footer-soc
+.footer__18
+.kinzhal-icon
+
+================================
+
 knife.media
 
 INVERT


### PR DESCRIPTION
- Invert logo.
- Invert search icon.
- Invert close icon.
- Invert footer icons.
- Invert dagger icon in article.

Example of site page: https://kinzhal.media/calendario/