### PR TITLE
Fix for thecode.media

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9968,6 +9968,8 @@ thecode.media
 
 INVERT
 img[src$="/logo.svg"]
+.post-item__arrow
+li::before
 
 ================================
 


### PR DESCRIPTION
- Invert post item arrow.
- Invert point in listing.

Example of site pages: https://thecode.media/, https://thecode.media/comments/