### PR TITLE
Fix download button for files on Canvas sites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1790,6 +1790,13 @@ img#ibLogo
 
 ================================
 
+canvas.*.edu
+
+INVERT
+.file_download_btn
+
+================================
+
 canvas.usask.ca
 
 CSS


### PR DESCRIPTION
For all Canvas sites, whose URL depends on the university, thus the wildcard for domain.

Before:
![image](https://user-images.githubusercontent.com/35514663/116177036-bed97080-a6d8-11eb-9908-d63b574023e8.png)

After:
![image](https://user-images.githubusercontent.com/35514663/116177012-b5e89f00-a6d8-11eb-90cd-18a79dd6577a.png)
