### PR TITLE
Fix for vtimes.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11099,6 +11099,16 @@ article:hover::before {
 
 ================================
 
+vtimes.io
+
+INVERT
+.site-header__logo
+.sticky-nav__logo
+.article__block__disclaimer__close::after
+.article__block__disclaimer__close::before
+
+================================
+
 w3.org
 
 INVERT


### PR DESCRIPTION
- Invert logos.
- Invert close icon.

Example of site page: https://www.vtimes.io/2021/04/27/sud-ogranichil-deyatelnost-fbk-a4737