### PR TITLE
Add seaofthieves.fandom.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -611,6 +611,7 @@ sapphdavis.com
 sapphdavis.me
 saznajnovo.com
 sb.ltn.fi
+seaofthieves.fandom.com
 search.biboumail.fr
 search.nebulacentre.net
 searx.dojocasts.com


### PR DESCRIPTION
seaofthieves.fandom.com is already in dark mode:

![Sea of thieves Wiki](https://user-images.githubusercontent.com/43346912/116465617-c1b99a00-a86d-11eb-89c7-af0fa1754f53.png)
