### PR TITLE
thompsonstein.com logo invert

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10507,6 +10507,13 @@ span.search-icon::before {
 
 ================================
 
+thompsonstein.com
+
+INVERT
+a.logo
+
+================================
+
 thronemaster.net
 
 INVERT


### PR DESCRIPTION
https://www.thompsonstein.com/

After fix
![20210501-1619876054-001](https://user-images.githubusercontent.com/9846948/116784141-eb9fd600-aa92-11eb-94df-bf4575c40a18.png)
