### PR TITLE
properly invert overview icons on collegeboard apclassroom

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -747,6 +747,14 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+apclassroom.collegeboard.org
+
+INVERT
+a.overview-icon svg
+button.Zoom--expander path
+
+================================
+
 api.kde.org
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -751,7 +751,7 @@ apclassroom.collegeboard.org
 
 INVERT
 a.overview-icon svg
-button.Zoom--expander svg g > *:first-child
+button.Zoom--expander svg g > :first-child
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -751,7 +751,7 @@ apclassroom.collegeboard.org
 
 INVERT
 a.overview-icon svg
-button.Zoom--expander path
+button.Zoom--expander svg g > *:first-child
 
 ================================
 


### PR DESCRIPTION
before and afters below - not sure if this page can be easily accessed.


![image](https://user-images.githubusercontent.com/72410860/116824367-a6d17900-ab3e-11eb-82a2-1228cce2f9f1.png)

![image](https://user-images.githubusercontent.com/72410860/116824355-9a4d2080-ab3e-11eb-871f-93abba09208b.png)

![image](https://user-images.githubusercontent.com/72410860/116824388-b781ef00-ab3e-11eb-9f29-5de8ca72c9dd.png)

![image](https://user-images.githubusercontent.com/72410860/116824373-ae911d80-ab3e-11eb-83ed-b2a5644db7c9.png)
