### PR TITLE
Added official Dead by Daylight sites and Dead by Daylight, Elder Scrolls, Star Trek, and Payday fandom wikis to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -269,7 +269,6 @@ fluxpoint.dev
 flyordie.io
 fortnite-api.com
 forum.cswarzone.com
-forum.deadbydaylight.com
 forum.lastos.org
 forum.privacytools.io
 forum.snahp.it
@@ -633,7 +632,6 @@ securegroup.com
 serebii.net
 sheet.host
 sherlock-project.github.io
-shop.deadbydaylight.com
 showtimeanytime.com
 shpposter.club
 shriram-balaji.github.io
@@ -690,7 +688,6 @@ sumo.app
 sunxdcc.com
 supabase.io
 supinic.com
-support.deadbydaylight.com
 surviv.io
 svtplay.se
 symfony.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -7,6 +7,7 @@
 314n.org
 5stardata.info
 9anime.to
+account.bhvr.com
 accounts.pubg.com
 acm.sdut.edu.cn/onlinejudge3/
 addictinggames.com
@@ -168,6 +169,7 @@ darkreader.org
 dash.cavebot.xyz
 datomatic.no-intro.org
 dcards.snaz.in
+deadbydaylight.com
 deepweblinks.net
 del.dog
 deltarune.com
@@ -265,6 +267,7 @@ fluxpoint.dev
 flyordie.io
 fortnite-api.com
 forum.cswarzone.com
+forum.deadbydaylight.com
 forum.lastos.org
 forum.privacytools.io
 forum.snahp.it
@@ -626,6 +629,7 @@ securegroup.com
 serebii.net
 sheet.host
 sherlock-project.github.io
+shop.deadbydaylight.com
 showtimeanytime.com
 shpposter.club
 shriram-balaji.github.io
@@ -682,6 +686,7 @@ sumo.app
 sunxdcc.com
 supabase.io
 supinic.com
+support.deadbydaylight.com
 surviv.io
 svtplay.se
 symfony.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -170,6 +170,7 @@ dash.cavebot.xyz
 datomatic.no-intro.org
 dcards.snaz.in
 deadbydaylight.com
+deadbydaylight.fandom.com
 deepweblinks.net
 del.dog
 deltarune.com
@@ -224,6 +225,7 @@ editor.freepik.com
 editor.method.ac
 egee.io
 eggsy.xyz
+elderscrolls.fandom.com
 eleaks.to
 elitedangerous.com
 ellie-app.com
@@ -447,6 +449,7 @@ mednafen.github.io
 mee6.xyz
 melody.ml
 melonds.kuribo64.net
+memory-alpha.fandom.com
 merklex.io
 metronom.us
 metropool.nl
@@ -525,6 +528,7 @@ parahumans.wordpress.com
 paranoid.email
 pathof.info
 pathofexile.com
+payday.fandom.com
 peertube.co.uk
 peertube.nocturlab.fr
 peertube.pontostroy.gq


### PR DESCRIPTION
Most official Dead by Daylight sites are dark by default.
- [account.bhvr.com](https://account.bhvr.com)
- [deadbydaylight.com](https://deadbydaylight.com)
- [forum.deadbydaylight.com](https://forum.deadbydaylight.com)
- [shop.deadbydaylight.com](https://shop.deadbydaylight.com)
- [support.deadbydaylight.com](https://support.deadbydaylight.com)

These 4 fandom wikis are all dark by default.
- [deadbydaylight.fandom.com](https://deadbydaylight.fandom.com)
- [elderscrolls.fandom.com](https://elderscrolls.fandom.com)
- [memory-alpha.fandom.com](https://memory-alpha.fandom.com)
- [payday.fandom.com](https://payday.fandom.com)