### PR TITLE
new keys for French translations in Developer Tools popup

### DIFF
--- a/src/_locales/ar.config
+++ b/src/_locales/ar.config
@@ -171,6 +171,42 @@
 أدوات المطور
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/be.config
+++ b/src/_locales/be.config
@@ -171,6 +171,42 @@
 Прылады
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/bn.config
+++ b/src/_locales/bn.config
@@ -171,6 +171,42 @@ Default
 Dev tools
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/cs.config
+++ b/src/_locales/cs.config
@@ -171,6 +171,42 @@ Více...
 Nástroje
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/de.config
+++ b/src/_locales/de.config
@@ -171,6 +171,42 @@ Weiterlesen
 Erweitert
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/el.config
+++ b/src/_locales/el.config
@@ -171,6 +171,42 @@ Sepia
 Εργαλεία
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/en-GB.config
+++ b/src/_locales/en-GB.config
@@ -171,6 +171,42 @@ Read more
 Dev tools
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/en-US.config
+++ b/src/_locales/en-US.config
@@ -171,6 +171,42 @@ Read more
 Dev tools
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/en.config
+++ b/src/_locales/en.config
@@ -171,6 +171,42 @@ Read more
 Dev tools
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/es.config
+++ b/src/_locales/es.config
@@ -171,6 +171,42 @@ Lea más
 Herramientas
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/fa-IR.config
+++ b/src/_locales/fa-IR.config
@@ -171,6 +171,42 @@
 ابزار توسعه دهنده
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/fa.config
+++ b/src/_locales/fa.config
@@ -171,6 +171,42 @@
 ابزار توسعه دهنده
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/fr.config
+++ b/src/_locales/fr.config
@@ -171,6 +171,42 @@ Lire la suite
 Dévelop.
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Outils de dév
+
+@dynamic_theme_editor
+Éditeur de thème dynamique
+
+@reset
+Réinitialiser
+
+@apply
+Appliquer
+
+@preview_new_design
+Voir nouveau design
+
+@switch_to_old_design
+Voir ancien design
+
+@dev_tools_description_1
+Plus d'infos sur cet outil
+
+@dev_tools_description_2
+ici
+
+@dev_tools_description_3
+Site web
+
+@dev_tools_description_4
+populaire
+
+@dev_tools_description_5
+semble incorrect? Courriel:
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/he.config
+++ b/src/_locales/he.config
@@ -171,6 +171,42 @@
 Dev tools
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/hi.config
+++ b/src/_locales/hi.config
@@ -171,6 +171,42 @@
 डेवलपर टूल
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/id.config
+++ b/src/_locales/id.config
@@ -171,6 +171,42 @@ Baca lainnya
 Pengembang
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/it.config
+++ b/src/_locales/it.config
@@ -171,6 +171,42 @@ Scopri di più
 Strumenti
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/ja.config
+++ b/src/_locales/ja.config
@@ -171,6 +171,42 @@
 開発者ツール
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/ko.config
+++ b/src/_locales/ko.config
@@ -171,6 +171,42 @@
 개발자 도구
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/nl.config
+++ b/src/_locales/nl.config
@@ -171,6 +171,42 @@ Meer hierover
 Tools
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/no.config
+++ b/src/_locales/no.config
@@ -171,6 +171,42 @@ Les mer
 Utvikler
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/pl.config
+++ b/src/_locales/pl.config
@@ -171,6 +171,42 @@ Więcej
 Narzędzia
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/pt-BR.config
+++ b/src/_locales/pt-BR.config
@@ -171,6 +171,42 @@ Saiba mais
 Ferramentas
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/pt-PT.config
+++ b/src/_locales/pt-PT.config
@@ -171,6 +171,42 @@ Ler mais
 Ferramentas
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/ro.config
+++ b/src/_locales/ro.config
@@ -171,6 +171,42 @@ Citește mai mult
 Instrumente
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/ru.config
+++ b/src/_locales/ru.config
@@ -171,6 +171,42 @@
 Разраб.
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/si.config
+++ b/src/_locales/si.config
@@ -171,6 +171,42 @@ Text stroke
 Dev මෙවලම්
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/sk.config
+++ b/src/_locales/sk.config
@@ -171,6 +171,42 @@ Viac informácií
 Vývojárske nástroje
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/sv.config
+++ b/src/_locales/sv.config
@@ -171,6 +171,42 @@ Läs mer
 Verktyg
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/th.config
+++ b/src/_locales/th.config
@@ -171,6 +171,42 @@
 เครื่องมือนักพัฒนา
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/tr.config
+++ b/src/_locales/tr.config
@@ -171,6 +171,42 @@ Daha fazla oku
 Geliş. araçları
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/uk.config
+++ b/src/_locales/uk.config
@@ -171,6 +171,42 @@
 Інструменти розробника
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/vi.config
+++ b/src/_locales/vi.config
@@ -171,6 +171,42 @@ Tin tức
 Dev tools
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/zh-CN.config
+++ b/src/_locales/zh-CN.config
@@ -171,6 +171,42 @@
 开发者工具
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/_locales/zh-TW.config
+++ b/src/_locales/zh-TW.config
@@ -171,6 +171,42 @@
 開發者工具
 
 
+#==== Developer Tools ====
+
+@developer_tools
+Developer Tools
+
+@dynamic_theme_editor
+Dynamic Theme Editor
+
+@reset
+Reset
+
+@apply
+Apply
+
+@preview_new_design
+Preview new design
+
+@switch_to_old_design
+Switch to old design
+
+@dev_tools_description_1
+Read about this tool
+
+@dev_tools_description_2
+here
+
+@dev_tools_description_3
+If a
+
+@dev_tools_description_4
+popular
+
+@dev_tools_description_5
+website looks incorrect e-mail to
+
+
 #==== Store listing ====
 
 @store_listing

--- a/src/ui/devtools/components/body.tsx
+++ b/src/ui/devtools/components/body.tsx
@@ -6,14 +6,22 @@ import {DEVTOOLS_DOCS_URL} from '../../../utils/links';
 import type {ExtWrapper, TabInfo} from '../../../definitions';
 import {getCurrentThemePreset} from '../../popup/theme/utils';
 import {isFirefox} from '../../../utils/platform';
+import {getLocalMessage} from '../../../utils/locales';
 
 type BodyProps = ExtWrapper & {tab: TabInfo};
 
 function Body({data, tab, actions}: BodyProps) {
     const {state, setState} = useState({errorText: null as string});
     let textNode: HTMLTextAreaElement;
-    const previewButtonText = data.settings.previewNewDesign ? 'Switch to old design' : 'Preview new design';
+    const previewButtonText = data.settings.previewNewDesign ? getLocalMessage('switch_to_old_design') : getLocalMessage('preview_new_design');
     const {theme} = getCurrentThemePreset({data, tab, actions});
+    const devToolsDescription = [
+        getLocalMessage('dev_tools_description_1'),
+        getLocalMessage('dev_tools_description_2'),
+        getLocalMessage('dev_tools_description_3'),
+        getLocalMessage('dev_tools_description_4'),
+        getLocalMessage('dev_tools_description_5'),
+    ];
 
     const wrapper = (theme.engine === ThemeEngines.staticTheme
         ? {
@@ -27,7 +35,7 @@ function Body({data, tab, actions}: BodyProps) {
             apply: (text) => actions.applyDevInversionFixes(text),
             reset: () => actions.resetDevInversionFixes(),
         } : {
-            header: 'Dynamic Theme Editor',
+            header: getLocalMessage('dynamic_theme_editor'),
             fixesText: data.devtools.dynamicFixesText,
             apply: (text) => actions.applyDevDynamicThemeFixes(text),
             reset: () => actions.resetDevDynamicThemeFixes(),
@@ -84,7 +92,7 @@ function Body({data, tab, actions}: BodyProps) {
         <body>
             <header>
                 <img id="logo" src="../assets/images/darkreader-type.svg" alt="Dark Reader" />
-                <h1 id="title">Developer Tools</h1>
+                <h1 id="title">{getLocalMessage('developer_tools')}</h1>
             </header>
             <h3 id="sub-title">{wrapper.header}</h3>
             <textarea
@@ -97,14 +105,13 @@ function Body({data, tab, actions}: BodyProps) {
             />
             <label id="error-text">{state.errorText}</label>
             <div id="buttons">
-                <Button onclick={reset}>Reset</Button>
-                <Button onclick={apply}>Apply</Button>
+                <Button onclick={reset}>{getLocalMessage('reset')}</Button>
+                <Button onclick={apply}>{getLocalMessage('apply')}</Button>
                 <Button class="preview-design-button" onclick={toggleDesign}>{previewButtonText}</Button>
             </div>
             <p id="description">
-                Read about this tool <strong><a href={DEVTOOLS_DOCS_URL} target="_blank" rel="noopener noreferrer">here</a></strong>.
-                If a <strong>popular</strong> website looks incorrect
-                e-mail to <strong>DarkReaderApp@gmail.com</strong>
+                {devToolsDescription[0]} <strong><a href={DEVTOOLS_DOCS_URL} target="_blank" rel="noopener noreferrer"> {devToolsDescription[1]}</a></strong>.&nbsp;
+                {devToolsDescription[2]} <strong>{devToolsDescription[3]}</strong> {devToolsDescription[4]} <strong>DarkReaderApp@gmail.com</strong>
             </p>
         </body>
     );


### PR DESCRIPTION
For https://github.com/darkreader/darkreader/issues/559#issuecomment-831650488

I basically just edited [body.tsx](https://github.com/darkreader/darkreader/compare/master...hchiam:hchiam-DevTools-French-Translation?expand=1#diff-59a139a403cb7b2cdb791fd1247088cb8926616f95bff7326b3e28e46a1d12c0), added the French translations in [fr.config](https://github.com/darkreader/darkreader/compare/master...hchiam:hchiam-DevTools-French-Translation?expand=1#diff-6bdd391e2b00507c1bfa29df472d2e4f8e29df197719cfd3d9a0c73d07c41f86), and set up translations for all the other languages to fallback to the original English text, so that `npm run debug` and `npm test` had no errors. It should be easy for others to update the translations for other languages for the Developer Tools popup in separate PRs after this PR is merged. 

<img width="599" alt="French_translated" src="https://user-images.githubusercontent.com/18131787/117085576-2f574180-ad18-11eb-927e-dce2c5069636.png">
