### PR TITLE
Fix for apple.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -923,8 +923,6 @@ apple.com
 INVERT
 .ac-slider-ax-track
 .controls-progress-indicator
-.image-airtag
-.image-iphone-12
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -918,6 +918,16 @@ CSS
 
 ================================
 
+apple.com
+
+INVERT
+.ac-slider-ax-track
+.controls-progress-indicator
+.image-airtag
+.image-iphone-12
+
+================================
+
 aras.com
 
 CSS


### PR DESCRIPTION
For some reason DR is covering up some of the images?
![image](https://user-images.githubusercontent.com/66189242/117094531-8cbcb400-ad53-11eb-9716-20135c10ec72.png)

![image](https://user-images.githubusercontent.com/66189242/117094568-a100b100-ad53-11eb-9b0f-9ca10d29bbf9.png)


Changes:
- Inverted images with the `image-airtag` and `image-iphone-12` class (URLs don't seem to work)
- Inverted playback bar for Apple events (https://www.apple.com/apple-events/april-2021/)