### PR TITLE
Fix for tosdr.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10874,6 +10874,21 @@ body {
 
 ================================
 
+tosdr.org
+
+INVERT
+img[src*="tosdr-logo-128.svg"]
+img[src*="/img/news/"]
+img[src*="guidelines.svg"]
+
+CSS
+.badge-warning {
+    color: #212529 !important;
+    background-color: #ffc107 !important;
+}
+
+================================
+
 track.toggl.com
 
 CSS


### PR DESCRIPTION
Changes:
- Inverted logo
- Inverted news logos
- Inverted guidelines
- Changed `badge-warning` back to normal