### PR TITLE
Excluded various icon fonts to preserve icons 

### DIFF
--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"]) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"], [class*="typcn"]) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"], [class*="typcn"]) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"], [class*="typcn"], mu, icon) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"], [class*="typcn"], mu, icon) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"], [class*="typcn"], mu, [class*="mu-"], icon) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"]) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, [class*="icofont"], [class*="typcn"], mu, [class*="mu-"], icon) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, .icofont, .typcn, mu, [class*="mu-"], .icon) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: FilterConfig): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, .icofont, .typcn, mu, [class*="mu-"], .icon) {');
+    lines.push('*:not(pre, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, .icofont, .typcn, mu, [class*="mu-"], .glyphicon, .icon) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...


### PR DESCRIPTION
- `fas`: Can be found on https://newegg.com
- `material-icons`: Can be found on https://developers.google.com/fonts/docs/material_icons
- `icofont`: Can be found on https://icofont.com
- `typcn`: Can be found on https://www.s-ings.com/typicons/
- `mu`:  Can be found on https://www.s-ings.com/projects/microns-icon-font/
- `glyphicon`: Can be found on searx instances https://searx.space 
- `icon` should catch most other font icons