### PR TITLE
Fix for developers.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2910,6 +2910,9 @@ a.external::after
 
 developers.google.com
 
+INVERT
+.devsite-google-wordmark
+
 CSS
 :root {
     --devsite-header-color-upper: var(--darkreader-neutral-background) !important;
@@ -2926,6 +2929,10 @@ a.button,
 code, 
 pre {
     background: var(--darkreader-neutral-background) !important;
+}
+.devsite-table-wrapper > table > thead > tr > th {
+    color: var(--darkreader-neutral-text) !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
Changes:
- Inverted Google logo (Can be found on https://developers.google.com/fonts/docs/material_icons)
- Fixed table (also can be found on above link)