### PR TITLE
Fix github.blog

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4603,7 +4603,6 @@ github.blog
 INVERT
 a[href="https://github.com"]
 .site-branding > svg
-.wp-post-image
 .icon-logo-github
 .aligncenter
 .wp-image-56594


### PR DESCRIPTION
Github's blog's post image contains the face of the author, which looks horrifying when inverted.