### PR TITLE
my.nextdns.io log images fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7559,6 +7559,7 @@ img[src*="/static/media/sonos"]
 .settings-button
 .stream-button
 .tooltipParent > img
+.list-group-item > div > img
 
 CSS
 .text-right[style*="opacity: 0.3"] {


### PR DESCRIPTION
Site: my.nextdns.io/ `<id-config>` /logs

Fix
Domains
![20210508-1620500068-001](https://user-images.githubusercontent.com/9846948/117550250-9a1dbb00-b03f-11eb-8608-d0c9b4a54fff.png)
![20210508-1620500046-001](https://user-images.githubusercontent.com/9846948/117550252-9b4ee800-b03f-11eb-9422-69a3ec4a08e3.png)
![20210508-1620500025-001](https://user-images.githubusercontent.com/9846948/117550253-9b4ee800-b03f-11eb-8934-142e5a22e5f6.png)
Generic
![20210508-1620500126-001](https://user-images.githubusercontent.com/9846948/117550273-ba4d7a00-b03f-11eb-9630-3fc3a8b6709d.png)
