### PR TITLE
Path of Exile wiki & poe.ninja are dark already

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -532,6 +532,7 @@ parahumans.wordpress.com
 paranoid.email
 pathof.info
 pathofexile.com
+pathofexile.fandom.com
 payday.fandom.com
 peertube.co.uk
 peertube.nocturlab.fr
@@ -564,6 +565,7 @@ pluto.tv
 poal.co
 poczta.int.pl
 poe-racing.com
+poe.ninja
 poe.trade
 poeapp.com
 poelab.com


### PR DESCRIPTION
Path of Exile wiki:

![image](https://user-images.githubusercontent.com/416568/117555722-04475780-b062-11eb-8121-e640e01fc707.png)

poe.ninja:

![image](https://user-images.githubusercontent.com/416568/117555742-0f9a8300-b062-11eb-802c-ecb591417718.png)
