### PR TITLE
Invert cursor color in Overleaf editor

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8280,6 +8280,7 @@ overleaf.com
 
 INVERT
 .pdf-page-container
+.ace_cursor
 
 ================================
 


### PR DESCRIPTION
Cursor color was dark over dark background

Before the patch:
![image](https://user-images.githubusercontent.com/66875464/117566843-49e33f00-b0b9-11eb-921d-619ec619600d.png)

After the patch:
![image](https://user-images.githubusercontent.com/66875464/117566805-0e487500-b0b9-11eb-976f-d50d718d3eb7.png)