### PR TITLE
d3ward.github.io is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -159,6 +159,7 @@ cyberdrop.me
 cyberpunk.net
 cybersole.io
 cytu.be
+d3ward.github.io
 daily-fire.com
 daily.dev
 daksh.eu.org


### PR DESCRIPTION
https://d3ward.github.io/toolz/src/adblock.html

* dark via switch icon on right top

![20210509-1620555437-001](https://user-images.githubusercontent.com/9846948/117568441-823a4b80-b0c0-11eb-8661-e2518189fd49.png)
