### PR TITLE
Removed white stripes on LearnOpenGL hover element

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6279,7 +6279,7 @@ learnopengl.com
 CSS
 #hover {
     background-image: none !important;
-    opacity: 1;
+    opacity: 1 !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6274,6 +6274,16 @@ INVERT
 
 ================================
 
+learnopengl.com
+
+CSS
+#hover {
+    background-image: none !important;
+    opacity: 1;
+}
+
+================================
+
 leetcode.com
 leetcode-cn.com
 


### PR DESCRIPTION
There are white stripes on the hover element on LearnOpenGL, this just sets the background image to none and opacity to 1.
this way it's actually possible to read what's there