### PR TITLE
Fixed compatibility with Wikipedia with MathJax

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11949,6 +11949,9 @@ wikipedia.org
 
 INVERT
 .mwe-math-element
+.MathJax
+span[id="MathJax_Zoom"] > .
+span[id="MathJax_Zoom"]
 .mw-ext-score
 .mw-wiki-logo
 .central-textlogo__image

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11949,9 +11949,8 @@ wikipedia.org
 
 INVERT
 .mwe-math-element
-.MathJax
-span[id="MathJax_Zoom"] > .
-span[id="MathJax_Zoom"]
+.MathJax:not(span#MathJax_Zoom > .MathJax)
+span#MathJax_Zoom
 .mw-ext-score
 .mw-wiki-logo
 .central-textlogo__image


### PR DESCRIPTION
The Wikipedia with MathJax extension was not inverting properly, these lines hopefully fix that. New to github, not sure if I did anything wrong. 

To replicate, get the [Wikipedia with MathJax](https://chrome.google.com/webstore/detail/wikipedia-with-mathjax/fhomhkjcommffnlajeemenejemmegcmi?hl=en) extension and go to any Wikipedia page with math, eg [here](https://en.wikipedia.org/wiki/Vacuum_permittivity).