### PR TITLE
Fix for cdc.gov

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1944,6 +1944,13 @@ INVERT
 
 ================================
 
+cdc.gov
+
+INVERT
+.cdc-logo path[fill="#000"]
+
+================================
+
 cdp.contentdelivery.nu
 
 CSS


### PR DESCRIPTION
- Invert logo.

Example of site page: https://www.cdc.gov/ticks/removing_a_tick.html