### PR TITLE
start64.com logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9820,6 +9820,13 @@ html {
 
 ================================
 
+start64.com
+
+INVERT
+img[alt="logo"]
+
+================================
+
 startpage.com
 
 INVERT


### PR DESCRIPTION
https://www.start64.com/

before fix
![20210512-1620817579-001](https://user-images.githubusercontent.com/9846948/117965610-44892d00-b323-11eb-8999-d36614f776d2.png)

after fix
![20210512-1620817658-001](https://user-images.githubusercontent.com/9846948/117965607-43f09680-b323-11eb-8a10-7ed1dd201023.png)