### PR TITLE
Change foreground color of openai.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8202,9 +8202,6 @@ header[style*="background-image"],
     background: ${white} !important;
     color: ${black} !important;
 }
-section, div, div.d-flex, ol>li::before, ul>li::before, p, text, a, span:not(.token), table, th, td, time {
-    color: ${black} !important;
-}
 span.token.comment {
     color: ${#aaa} !important;
 }


### PR DESCRIPTION
After inversion the foreground color of openai.com is white. Fixing it.