### PR TITLE
Asana: Fix white bg on PortfolioItemRow class

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1026,14 +1026,12 @@ INVERT
 .DatePickerCalendarDate--today .DatePickerCalendarDate-button::after
 
 CSS
-.InboxExpandableThread.InboxExpandableThread--selected {
-    background: var(--darkreader-neutral-background) !important;
-}
+.InboxExpandableThread.InboxExpandableThread--selected,
 .PortfolioItemRow {
     background: var(--darkreader-neutral-background) !important;
 }
 .PortfolioItemRow:hover {
-    background: var(--darkreader-neutral-hover) !important;
+    background: ${#FFF} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1029,6 +1029,12 @@ CSS
 .InboxExpandableThread.InboxExpandableThread--selected {
     background: var(--darkreader-neutral-background) !important;
 }
+.PortfolioItemRow {
+    background: var(--darkreader-neutral-background) !important;
+}
+.PortfolioItemRow:hover {
+    background: var(--darkreader-neutral-hover) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Applies the same fix as was applied to the `InboxExpandableThread` class on the line above this (line 1029 currently).
Selecting a Portfolio Item causes a modal window to appear, which blurs everything else behind it, so there's no need to apply the same fix to the `PortfolioItemRow--selected` class in this case.