### PR TITLE
my.nextdns.io more inverts

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7646,6 +7646,9 @@ img[src*="/static/media/sonos"]
 .stream-button
 .tooltipParent > img
 .list-group-item > div > img
+.d-flex > .text-break > img
+.d-flex > .flex-grow-1 > div > img
+img[src*="handshake-logo"]
 
 CSS
 .text-right[style*="opacity: 0.3"] {


### PR DESCRIPTION
- /settings (handshake logo)  `img[src*="handshake-logo"]`
- /analytics (domains icons)  `.d-flex > .text-break > img` 
- /denylist (domains icons)  `.d-flex > .flex-grow-1 > div > img` 
- /allowlist (domains icons)  `.d-flex > .flex-grow-1 > div > img` 

![20210513-1620909813-001](https://user-images.githubusercontent.com/9846948/118127530-1d515f00-b3fa-11eb-8315-3cf8c5babac7.png)
![20210513-1620909724-001](https://user-images.githubusercontent.com/9846948/118127532-1de9f580-b3fa-11eb-86a5-79da40432b38.png)
![20210513-1620909259-001](https://user-images.githubusercontent.com/9846948/118127533-1e828c00-b3fa-11eb-8bf9-f45b37178d3d.png)
![20210513-1620909248-001](https://user-images.githubusercontent.com/9846948/118127534-1e828c00-b3fa-11eb-87f7-8dd100699e74.png)

Same is already done in /logs subpage. 