### PR TITLE
account.xiaomi.com bg profile fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -346,6 +346,15 @@ div[class^="Modal-module_content"] form > div > canvas {
 
 ================================
 
+account.xiaomi.com
+
+CSS
+.mi-profile-layout__profile {
+    background-image: none !important;
+}
+
+================================
+
 accounts.google.com
 
 INVERT


### PR DESCRIPTION
https://account.xiaomi.com/ (you need an account to login there)
Fix: removing white background profile image section. I removed sensitive details from images. 
![20210514-1621004579-001](https://user-images.githubusercontent.com/9846948/118290241-7ee6fb80-b4d6-11eb-99fb-805dd6806533.png)
![20210514-1621004524-001](https://user-images.githubusercontent.com/9846948/118290244-7f7f9200-b4d6-11eb-98b6-3ec07a8a5a95.png)

