### PR TITLE
Fix for drive.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3362,10 +3362,15 @@ drive.google.com
 INVERT
 img[src$="google_gsuite"]
 div[role="menuitem"] svg
+div[role="dialog"] div[role="button"][tabindex="0"]
 
 CSS
 span[data-type="spelling"] {
     mix-blend-mode: normal !important;
+}
+div[role="menu"] div[role="menuitem"][class*=" "] > div > div > div,
+div[role="button"][aria-disabled="true"] > div {
+    filter: invert(50%) !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
- Invert icons in file picker in the main interface.

Example of site page: https://drive.google.com/drive

Discussion: https://github.com/darkreader/darkreader/pull/5208