### PR TITLE
Fix for developer.mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2956,7 +2956,7 @@ mark, pre b {
 developer.mozilla.org
 
 INVERT
-body:not(#home) header a.logo
+.logo
 mark
 .icon-thumbs-down-alt
 .last-modified::before
@@ -2965,13 +2965,20 @@ button.top-level-entry::before
 a.breadcrumb::after
 a.breadcrumb-penultimate::after
 a.external::before
-th.bc-platform-desktop::before
 th.bc-platform-mobile::before
-span[class*="bc-head-icon"]::before
 abbr.only-icon::before
 abbr.only-icon i::before
 button.only-icon::before
 a.external::after
+.bc-head-icon-chrome::before
+.bc-head-icon-edge::before
+.bc-head-icon-ie::before
+.bc-head-icon-opera::before
+.bc-head-icon-safari::before
+.bc-head-icon-webview_android::before
+.bc-head-icon-chrome_android::before
+.bc-head-icon-opera_android::before
+.bc-head-icon-safari_ios::before
 
 ================================
 


### PR DESCRIPTION
- Invert footer logo.
- Correctly invert icons in the browser compatibility table.

I tried to make the rules shorter, but I couldn't. Example of site page: https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme