### PR TITLE
Fix for flickr.com logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12719,6 +12719,13 @@ html, body {
 
 ================================
 
+www.flickr.com
+
+IGNORE INLINE STYLE
+#icon-flickr_logo_dots path
+
+================================
+
 www.freepascal.org/docs-html
 
 INVERT


### PR DESCRIPTION
Fix for the flickr logo (svg) in the header/nav bar