### PR TITLE
Fixes videolan.org bullet text color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11778,7 +11778,7 @@ videolan.org
 
 CSS
 ul {
-    color: var(--darkreader-neutral-text);
+    color: var(--darkreader-neutral-text) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11774,6 +11774,15 @@ CSS
 
 ================================
 
+videolan.org
+
+CSS
+ul {
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
 vimeo.com
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
Example: [https://www.videolan.org/videolan/](https://www.videolan.org/videolan/)