### PR TITLE
Fix for avito.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1174,6 +1174,7 @@ div[class^="index-logo"] > a[class^="index-root"]
 .contacts-phone-3KtSI
 .button-content-phone_size_l-1O5VB
 ._39EVKDP-9p1BREJQ3fhILl._2sPEvPi-1aWpcq1ggVph1C._4wLX_6jxKYoWRyE1U1WcZ
+.suggest-graySuggestCategoryImg-39OJ0
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1174,7 +1174,7 @@ div[class^="index-logo"] > a[class^="index-root"]
 .contacts-phone-3KtSI
 .button-content-phone_size_l-1O5VB
 ._39EVKDP-9p1BREJQ3fhILl._2sPEvPi-1aWpcq1ggVph1C._4wLX_6jxKYoWRyE1U1WcZ
-.suggest-graySuggestCategoryImg-39OJ0
+[class^="suggest-graySuggestCategoryImg"]
 
 ================================
 


### PR DESCRIPTION
- Invert suggested icons in search.

Example of site page: https://www.avito.ru/rossiya