### PR TITLE
Fix for google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12772,7 +12772,7 @@ a[href*="about/products"][title]
 .JOmIqc
 .hLcKi
 #EcMbV
-#xRRFWe
+#wrap a[href="/mobile/"]
 .vk-sf-b
 .vk-t-btn
 .ChZgtd div::before

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12772,6 +12772,7 @@ a[href*="about/products"][title]
 .JOmIqc
 .hLcKi
 #EcMbV
+#xRRFWe
 .vk-sf-b
 .vk-t-btn
 .ChZgtd div::before


### PR DESCRIPTION
Fixes menu button on mobile view.

Before:
![png](https://user-images.githubusercontent.com/6563728/119232055-474e0400-bb13-11eb-9111-f490e4a36390.png)

After:
![png](https://user-images.githubusercontent.com/6563728/119232068-4f0da880-bb13-11eb-92e3-621467e4475b.png)