### PR TITLE
dumpert.nl is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -223,6 +223,7 @@ drunkenslug.com
 dsc.gg
 duckychannel.com.tw
 duelingnexus.com
+dumpert.nl
 dyno.gg
 ecobee.com/consumerportal
 editor.freepik.com


### PR DESCRIPTION
https://www.dumpert.nl/

![20210523-1621789973-001](https://user-images.githubusercontent.com/9846948/119270023-f285b880-bbfa-11eb-9c80-19f91959c206.png)
![20210523-1621789959-001](https://user-images.githubusercontent.com/9846948/119270024-f3b6e580-bbfa-11eb-865b-53b96c83470c.png)
![20210523-1621789951-001](https://user-images.githubusercontent.com/9846948/119270025-f3b6e580-bbfa-11eb-9dcd-af03f5d8a0dd.png)
