### PR TITLE
Add orama-interactive.itch.io/pixelorama, remove searx.nixnet.services

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -528,6 +528,7 @@ open.spotify.com
 openbase.io
 opendota.com
 openemu.org
+orama-interactive.itch.io/pixelorama
 orteil.dashnet.org/cookieclicker
 osu.ppy.sh
 ovagames.com
@@ -641,7 +642,6 @@ search.biboumail.fr
 search.nebulacentre.net
 searx.dojocasts.com
 searx.ninja
-searx.nixnet.services
 searx.prvcy.eu
 secrethitler.io
 securegroup.com


### PR DESCRIPTION
searx.nixnet.services doesn't seem to be dark anymore.

I've got a question about orama-interactive.itch.io. The main site is already dark, but few of it's subpages aren't, should I just add the whole bunch of dark subpages (I've only added one) or add the main domain?