### PR TITLE
Additional Support for Github Enterprise

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4771,7 +4771,7 @@ a[href="https://github.com"]
 ================================
 
 github.com
-github.*.com
+github.*.*
 
 INVERT
 [src="https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg"]
@@ -4876,6 +4876,22 @@ CSS
     fill: var(--color-calendar-graph-day-L3-bg) !important;
 }
 .ContributionCalendar-day[data-level="4"] {
+    fill: var(--color-calendar-graph-day-L4-bg) !important;
+}
+.day,
+.day[data-Count="0"] {
+    fill: var(--color-calendar-graph-day-bg) !important;
+}
+.day[data-Count="1"] {
+    fill: var(--color-calendar-graph-day-L1-bg) !important;
+}
+.day[data-Count="2"] {
+    fill: var(--color-calendar-graph-day-L2-bg) !important;
+}
+.day[data-Count="3"] {
+    fill: var(--color-calendar-graph-day-L3-bg) !important;
+}
+.day[data-Count="4"] {
     fill: var(--color-calendar-graph-day-L4-bg) !important;
 }
 :root {


### PR DESCRIPTION
Related to pull #2868, not all Github Enterprise domains end in .com
I changed github.*.com to github.*.* . This should get any enterprise version of github.

Additionally, on Github Enterprise Server 3.0.6 at least, there are a couple of subtle differences in their CSS that make the overrides not work, which causes the colors to not display on days one has contributed. I've corrected those:
1. The classes is just `day` instead of `ContributionCalendar-day`
2. Attribute change: `data-Count` replaces  `data-level`