### PR TITLE
gazetaswietokrzyska.pl fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4652,6 +4652,18 @@ CSS
 
 ================================
 
+gazetaswietokrzyska.pl
+
+INVERT
+.logo
+
+CSS
+.elementor-column-wrap.elementor-element-populated {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 geeksforgeeks.org
 
 CSS


### PR DESCRIPTION
https://gazetaswietokrzyska.pl/informacje-dnia/wracaja-koncerty-rzad-luzuje-obostrzenia-jest-nowe-rozporzadzenie/

![20210526-1622016464-001](https://user-images.githubusercontent.com/9846948/119625202-3a2e5f00-be0a-11eb-97d8-3993f0c8bb01.png)
