### PR TITLE
Fix article title on getpocket.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4779,6 +4779,15 @@ login-container {
 
 ================================
 
+getpocket.com
+
+CSS
+a .title span {
+    text-shadow: none !important;
+}
+
+================================
+
 gg.pl
 
 INVERT


### PR DESCRIPTION
Fix getpocket.com 's article titles in lists, e.g. https://getpocket.com/explore

Current: has `text-shadow` that makes it hard to read

Fix: remove the `text-shadow`

Note:
- The specific CSS selector that needs to be overridden is `.c16ptaiz > a .title span`
- In the fix , I use a slightly simpler and more generic one: `a .title span` , following 
  - the simplifying selector guideline
  - make the fix more resilient to the site's style changes.

---

Before the fix:

![image](https://user-images.githubusercontent.com/250644/120145425-5890b380-c198-11eb-9e4e-00133fd490e7.png)

After the fix:

![image](https://user-images.githubusercontent.com/250644/120145493-752ceb80-c198-11eb-95a5-4e67363f3436.png)


