### PR TITLE
Specify reffer on loading Text

### DIFF
--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -80,7 +80,7 @@ export default class TabManager {
 
         chrome.runtime.onMessage.addListener(async ({type, data, id}: Message, sender) => {
             if (type === 'fetch') {
-                const {url, responseType, mimeType} = data;
+                const {url, responseType, mimeType, origin} = data;
 
                 // Using custom response due to Chrome and Firefox incompatibility
                 // Sometimes fetch error behaves like synchronous and sends `undefined`
@@ -94,7 +94,7 @@ export default class TabManager {
                     }
                 }
                 try {
-                    const response = await fileLoader.get({url, responseType, mimeType});
+                    const response = await fileLoader.get({url, responseType, mimeType, origin});
                     sendResponse({data: response});
                 } catch (err) {
                     sendResponse({error: err && err.message ? err.message : err});

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -98,6 +98,7 @@ interface FetchRequestParameters {
     url: string;
     responseType: 'data-url' | 'text';
     mimeType?: string;
+    origin?: string;
 }
 
 export function createFileLoader() {
@@ -111,14 +112,14 @@ export function createFileLoader() {
         'text': loadAsText,
     };
 
-    async function get({url, responseType, mimeType}: FetchRequestParameters) {
+    async function get({url, responseType, mimeType, origin}: FetchRequestParameters) {
         const cache = caches[responseType];
         const load = loaders[responseType];
         if (cache.has(url)) {
             return cache.get(url);
         }
 
-        const data = await load(url, mimeType);
+        const data = await load(url, mimeType, origin);
         cache.set(url, data);
         return data;
     }

--- a/src/inject/dynamic-theme/network.ts
+++ b/src/inject/dynamic-theme/network.ts
@@ -2,6 +2,7 @@ interface FetchRequest {
     url: string;
     responseType: 'data-url' | 'text';
     mimeType?: string;
+    origin?: string;
 }
 
 let counter = 0;

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -492,7 +492,7 @@ async function loadText(url: string) {
     if (url.startsWith('data:')) {
         return await (await fetch(url)).text();
     }
-    return await bgFetch({url, responseType: 'text', mimeType: 'text/css'});
+    return await bgFetch({url, responseType: 'text', mimeType: 'text/css', origin: window.location.origin});
 }
 
 async function replaceCSSImports(cssText: string, basePath: string, cache = new Map<string, string>()) {

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,11 +1,12 @@
 import {isFirefox} from './platform';
 
-async function getOKResponse(url: string, mimeType?: string) {
+async function getOKResponse(url: string, mimeType?: string, origin?: string) {
     const response = await fetch(
         url,
         {
             cache: 'force-cache',
             credentials: 'omit',
+            referrer: origin
         },
     );
 
@@ -40,7 +41,7 @@ export async function readResponseAsDataURL(response: Response) {
     return dataURL;
 }
 
-export async function loadAsText(url: string, mimeType?: string) {
-    const response = await getOKResponse(url, mimeType);
+export async function loadAsText(url: string, mimeType?: string, origin?: string) {
+    const response = await getOKResponse(url, mimeType, origin);
     return await response.text();
 }


### PR DESCRIPTION
Certain sites like binance requires the Referer header to be set to the origin, otherwise certain services like cloudflare will kick in.

See this nice behavior(any css file will do from binance)

```bash
curl https://bin.bnbstatic.com/static/fonts/index.min.css
```
Oh no cloudflare!

```bash
curl 'https://bin.bnbstatic.com/static/fonts/index.min.css' -H 'Referer: https://www.binance.com/'
```
Yay!


Resolves #5916
Resolves #5922