### PR TITLE
Faster UI render

### DIFF
--- a/src/ui/controls/color-picker/hsb-picker.tsx
+++ b/src/ui/controls/color-picker/hsb-picker.tsx
@@ -27,6 +27,15 @@ interface HSBPickerState {
     sbTouchStartHandler: (e: TouchEvent) => void;
 }
 
+const HSBPickerDefaults: HSBPickerState = {
+    wasPrevHidden: true,
+    hueCanvasRendered: false,
+    activeHSB: null,
+    activeChangeHandler: null,
+    hueTouchStartHandler: null,
+    sbTouchStartHandler: null
+};
+
 function rgbToHSB({r, g, b}: RGBA) {
     const min = Math.min(r, g, b);
     const max = Math.max(r, g, b);
@@ -105,7 +114,7 @@ function renderSB(hue: number, canvas: HTMLCanvasElement) {
 
 export default function HSBPicker(props: HSBPickerProps) {
     const context = getContext();
-    const store = context.store as HSBPickerState;
+    const store = context.getStore(HSBPickerDefaults) as HSBPickerState;
     store.activeChangeHandler = props.onChange;
 
     const prevColor = context.prev && context.prev.props.color;
@@ -122,16 +131,14 @@ export default function HSBPicker(props: HSBPickerProps) {
 
     function onSBCanvasRender(canvas: HTMLCanvasElement) {
         if (isElementHidden(canvas)) {
-            store.wasPrevHidden = true;
             return;
         }
         const hue = activeHSB.h;
         const prevHue = prevColor && rgbToHSB(parse(prevColor)).h;
-        if (!store.wasPrevHidden && hue === prevHue) {
-            return;
+        if (store.wasPrevHidden || hue === prevHue) {
+            store.wasPrevHidden = false;
+            renderSB(hue, canvas);
         }
-        store.wasPrevHidden = false;
-        renderSB(hue, canvas);
     }
 
     function onHueCanvasRender(canvas: HTMLCanvasElement) {

--- a/src/ui/controls/color-picker/hsb-picker.tsx
+++ b/src/ui/controls/color-picker/hsb-picker.tsx
@@ -135,7 +135,7 @@ export default function HSBPicker(props: HSBPickerProps) {
         }
         const hue = activeHSB.h;
         const prevHue = prevColor && rgbToHSB(parse(prevColor)).h;
-        if (store.wasPrevHidden || hue === prevHue) {
+        if (store.wasPrevHidden || hue !== prevHue) {
             store.wasPrevHidden = false;
             renderSB(hue, canvas);
         }

--- a/src/ui/controls/color-picker/hsb-picker.tsx
+++ b/src/ui/controls/color-picker/hsb-picker.tsx
@@ -19,7 +19,7 @@ interface HSBPickerProps {
 }
 
 interface HSBPickerState {
-    prevHidden: boolean;
+    wasPrevHidden: boolean;
     hueCanvasRendered: boolean;
     activeHSB: HSB;
     activeChangeHandler: (color: string) => void;
@@ -122,23 +122,23 @@ export default function HSBPicker(props: HSBPickerProps) {
 
     function onSBCanvasRender(canvas: HTMLCanvasElement) {
         if (isElementHidden(canvas)) {
-            context.store.wasPrevHidden = true;
+            store.wasPrevHidden = true;
             return;
         }
         const hue = activeHSB.h;
         const prevHue = prevColor && rgbToHSB(parse(prevColor)).h;
-        if (!context.store.wasPrevHidden && hue === prevHue) {
+        if (!store.wasPrevHidden && hue === prevHue) {
             return;
         }
-        context.store.wasPrevHidden = false;
+        store.wasPrevHidden = false;
         renderSB(hue, canvas);
     }
 
     function onHueCanvasRender(canvas: HTMLCanvasElement) {
-        if (isElementHidden(canvas) || context.store.hueCanvasRendered) {
+        if (isElementHidden(canvas) || store.hueCanvasRendered) {
             return;
         }
-        context.store.hueCanvasRendered = true;
+        store.hueCanvasRendered = true;
         renderHue(canvas);
     }
 

--- a/src/ui/controls/color-picker/hsb-picker.tsx
+++ b/src/ui/controls/color-picker/hsb-picker.tsx
@@ -27,7 +27,7 @@ interface HSBPickerState {
     sbTouchStartHandler: (e: TouchEvent) => void;
 }
 
-const HSBPickerDefaults: HSBPickerState = {
+const hsbPickerDefaults: HSBPickerState = {
     wasPrevHidden: true,
     hueCanvasRendered: false,
     activeHSB: null,
@@ -114,7 +114,7 @@ function renderSB(hue: number, canvas: HTMLCanvasElement) {
 
 export default function HSBPicker(props: HSBPickerProps) {
     const context = getContext();
-    const store = context.getStore(HSBPickerDefaults) as HSBPickerState;
+    const store = context.getStore(hsbPickerDefaults) as HSBPickerState;
     store.activeChangeHandler = props.onChange;
 
     const prevColor = context.prev && context.prev.props.color;
@@ -136,13 +136,13 @@ export default function HSBPicker(props: HSBPickerProps) {
         const hue = activeHSB.h;
         const prevHue = prevColor && rgbToHSB(parse(prevColor)).h;
         if (store.wasPrevHidden || hue !== prevHue) {
-            store.wasPrevHidden = false;
             renderSB(hue, canvas);
         }
+        store.wasPrevHidden = false;
     }
 
     function onHueCanvasRender(canvas: HTMLCanvasElement) {
-        if (isElementHidden(canvas) || store.hueCanvasRendered) {
+        if (store.hueCanvasRendered || isElementHidden(canvas)) {
             return;
         }
         store.hueCanvasRendered = true;

--- a/src/ui/controls/utils.ts
+++ b/src/ui/controls/utils.ts
@@ -21,3 +21,7 @@ export function omitAttrs(omit: string[], attrs: Malevic.NodeAttrs) {
     });
     return result;
 }
+
+export function isElementHidden(element: HTMLElement) {
+    return element.offsetParent === null;
+}


### PR DESCRIPTION
- Resolves #5035

Well this is only 1 of the problems, it should do the job for now to make the rendering for malevic a bit easier(might consider adding this into malevic)

Other pitfall is the immense recursive calling of `execute` that over time is taking time.

Fast machine(Firefox) (reduces by ~66ms):

Before:
![image](https://user-images.githubusercontent.com/25481501/120243810-14fd7e80-c258-11eb-8857-8c68635372b7.png)

After:
![image](https://user-images.githubusercontent.com/25481501/120243741-eed7de80-c257-11eb-9197-a856f821e88a.png)

Specially slow machine(Firefox) (reduces by ~473ms):

Before:
![image](https://user-images.githubusercontent.com/25481501/120244252-44f95180-c259-11eb-8bce-e0e29aecc831.png)

After:
![image](https://user-images.githubusercontent.com/25481501/120244196-1ed3b180-c259-11eb-8867-83d341e83926.png)
