### PR TITLE
Fix gray inverted background in Filter mode

### DIFF
--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -79,11 +79,10 @@ export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterVa
 
     if (!frameURL) {
         const light = [255, 255, 255];
-        // If browser not affected by Chromium Issue 501582, set light background on html
-        // else apply color matrix first to invert light color before setting as background
-        const bgColor = hasPatchForChromiumIssue501582() && config.mode === FilterMode.dark ?
-            light :
-            applyColorMatrix(light, createFilterMatrix(config)).map(Math.round);
+        // If browser affected by Chromium Issue 501582, set dark background on html
+        const bgColor = !hasPatchForChromiumIssue501582() && config.mode === FilterMode.dark ?
+            applyColorMatrix(light, createFilterMatrix(config)).map(Math.round) :
+            light;
         lines.push('');
         lines.push('/* Page background */');
         lines.push('html {');

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -22,7 +22,7 @@ export enum FilterMode {
 export function hasPatchForChromiumIssue501582() {
     return Boolean(
         isChromium &&
-        compareChromeVersions(chromiumVersion, '81.0.4035.0') <= 0
+        compareChromeVersions(chromiumVersion, '81.0.4035.0') >= 0
     );
 }
 
@@ -79,10 +79,11 @@ export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterVa
 
     if (!frameURL) {
         const light = [255, 255, 255];
-        // If browser affected by Chromium Issue 501582, set html element's background dark
+        // If browser not affected by Chromium Issue 501582, set light background on html
+        // else apply color matrix first to invert light color before setting as background
         const bgColor = hasPatchForChromiumIssue501582() && config.mode === FilterMode.dark ?
-            applyColorMatrix(light, createFilterMatrix(config)).map(Math.round) :
-            light;
+            light :
+            applyColorMatrix(light, createFilterMatrix(config)).map(Math.round);
         lines.push('');
         lines.push('/* Page background */');
         lines.push('html {');

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -22,7 +22,7 @@ export enum FilterMode {
 export function hasChromiumIssue501582() {
     return Boolean(
         isChromium &&
-        compareChromeVersions(chromiumVersion, '81.0.4035.0') >= 0
+        compareChromeVersions(chromiumVersion, '81.0.4035.0') <= 0
     );
 }
 
@@ -80,15 +80,7 @@ export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterVa
     if (!frameURL) {
         // If user has the chrome issue the colors should be the other way around as of the rootcolors will affect the whole background color of the page
         const rootColors = hasChromiumIssue501582() && config.mode === FilterMode.dark ? [0, 0, 0] : [255, 255, 255];
-        const [r, g, b] = applyColorMatrix(rootColors, createFilterMatrix(config));
-        const bgColor = {
-            r: Math.round(r),
-            g: Math.round(g),
-            b: Math.round(b),
-            toString() {
-                return `rgb(${this.r},${this.g},${this.b})`;
-            },
-        };
+        const bgColor = `rgb(${rootColors.join(',')})`;
         lines.push('');
         lines.push('/* Page background */');
         lines.push('html {');

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -78,10 +78,11 @@ export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterVa
     });
 
     if (!frameURL) {
+        const light = [255, 255, 255];
         // If browser affected by Chromium Issue 501582, set html element's background dark
         const bgColor = hasPatchForChromiumIssue501582() && config.mode === FilterMode.dark ?
-            applyColorMatrix([0, 0, 0], createFilterMatrix(config)).map(Math.round) :
-            [255, 255, 255];
+            applyColorMatrix(light, createFilterMatrix(config)).map(Math.round) :
+            light;
         lines.push('');
         lines.push('/* Page background */');
         lines.push('html {');

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -1,5 +1,4 @@
 import {formatSitesFixesConfig} from './utils/format';
-import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
 import {parseSitesFixesConfig} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -1,4 +1,5 @@
 import {formatSitesFixesConfig} from './utils/format';
+import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
 import {parseSitesFixesConfig} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
@@ -18,7 +19,7 @@ export enum FilterMode {
  * Bug report: https://bugs.chromium.org/p/chromium/issues/detail?id=501582
  * Patch: https://chromium-review.googlesource.com/c/chromium/src/+/1979258
  */
-export function hasChromiumIssue501582() {
+export function hasPatchForChromiumIssue501582() {
     return Boolean(
         isChromium &&
         compareChromeVersions(chromiumVersion, '81.0.4035.0') <= 0
@@ -77,12 +78,14 @@ export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterVa
     });
 
     if (!frameURL) {
-        // If user has the chrome issue the colors should be the other way around as of the rootcolors will affect the whole background color of the page
-        const bgColor = hasChromiumIssue501582() && config.mode === FilterMode.dark ? 'black' : 'white';
+        // If browser affected by Chromium Issue 501582, set html element's background dark
+        const bgColor = hasPatchForChromiumIssue501582() && config.mode === FilterMode.dark ?
+            applyColorMatrix([0, 0, 0], createFilterMatrix(config)).map(Math.round) :
+            [255, 255, 255];
         lines.push('');
         lines.push('/* Page background */');
         lines.push('html {');
-        lines.push(`  background: ${bgColor} !important;`);
+        lines.push(`  background: rgb(${bgColor.join(',')}) !important;`);
         lines.push('}');
     }
 

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -78,8 +78,7 @@ export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterVa
 
     if (!frameURL) {
         // If user has the chrome issue the colors should be the other way around as of the rootcolors will affect the whole background color of the page
-        const rootColors = hasChromiumIssue501582() && config.mode === FilterMode.dark ? [0, 0, 0] : [255, 255, 255];
-        const bgColor = `rgb(${rootColors.join(',')})`;
+        const bgColor = hasChromiumIssue501582() && config.mode === FilterMode.dark ? 'black' : 'white';
         lines.push('');
         lines.push('/* Page background */');
         lines.push('html {');


### PR DESCRIPTION
When Filter mode is selected, some pages have a gray background beyond the initial viewport. For instance:
https://nextjs.org/blog

This happens because `background` is set to an already-inverted color on the `html` element, and is therefore inverted for a second time when the CSS filter is applied.

This commit also fixes a bug in how the presence of [Chromium Issue 501582](https://bugs.chromium.org/p/chromium/issues/detail?id=501582) is being detected by `hasChromiumIssue501582()`:
https://github.com/darkreader/darkreader/blob/dc5edc707a57e2a7fda38899e76cd77412818172/src/generators/css-filter.ts#L25
If the issue was resolved in '81.0.4035.0', and it looks like [it was](https://chromium-review.googlesource.com/c/chromium/src/+/1979258), then `hasChromiumIssue501582()` should return `true` when:
```js
 compareChromeVersions(chromiumVersion, '81.0.4035.0') <= 0
```