### PR TITLE
SVG icon fill color CSS overrides for asana.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1080,6 +1080,12 @@ INVERT
 .DatePickerCalendarDate--today .DatePickerCalendarDate-button::after
 
 CSS
+.MultiColorIcon-path--fadedBlack {
+    fill: ${#AAA} !important;
+}
+.MultiColorIcon--unselected .MultiColorIcon-path--fadedWhite {
+    fill: ${#FFF} !important;
+}
 .DailySummaryInboxThread--selected,
 .TaskAddedToPotInboxThread--selected,
 .InboxExpandableThread.InboxExpandableThread--selected,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1080,11 +1080,11 @@ INVERT
 .DatePickerCalendarDate--today .DatePickerCalendarDate-button::after
 
 CSS
-.MultiColorIcon-path--fadedBlack {
-    fill: ${#AAA} !important;
+.MultiColorIcon--unselected .MultiColorIcon-path--fadedBlack {
+    fill: var(--darkreader-bg--color-icon) !important;
 }
-.MultiColorIcon--unselected .MultiColorIcon-path--fadedWhite {
-    fill: ${#FFF} !important;
+.MultiColorIcon-path--white {
+    fill: var(--darkreader-text--color-icon-foreground) !important;
 }
 .DailySummaryInboxThread--selected,
 .TaskAddedToPotInboxThread--selected,


### PR DESCRIPTION
Fixes SVG icons in selector modal being indistinguishable from background when selecting an icon for a project, portfolio, etc.

CSS classes modified: 
   .MultiColorIcon-path--fadedBlack
   .MultiColorIcon--unselected .MultiColorIcon-path--fadedWhite