### PR TITLE
Add BetterDiscord theme preview/editors

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -313,6 +313,8 @@ gibber.cc
 gidonline.in
 gifrun.com
 gifyourgame.com
+gibbu.github.io/ThemePreview
+gibbu.me/editor
 gikken.co
 giphy.com
 githubuniverse.com
@@ -431,6 +433,7 @@ lecantiche.com
 lemmi.no
 letterboxd.com
 lightweightpdf.com
+limeshark.dev/editor
 link.brawlstars.com/invite
 linux.org.ru
 liquidplus.com


### PR DESCRIPTION
limeshark.dev/editor and gibbu.me/editor are theme editors that already have dark mode and break the theme previews.

gibbu.github.io are for the theme previews on betterdiscord.app (example: https://gibbu.github.io/ThemePreview/?file=https://cdn.jsdelivr.net/gh/ClearVision/ClearVision-v6/ClearVision_v6.theme.css)