### PR TITLE
Fix red background on myanimelist.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7963,6 +7963,15 @@ INVERT
 
 ================================
 
+myanimelist.net
+
+CSS
+body:not(.ownlist) {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 mybrandnewlogo.com
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
The background on the left and right of the main page of https://myanimelist.net/ are manually set to `#D20202` which is very bright and presumably only there to be annoying.
Here, I change it to the neutral background color which looks much nicer. I used the same selector that `#D20202` was under;
```css
body:not(.ownlist) {
    background-color: var(--darkreader-neutral-background) !important;
}
```