### PR TITLE
wiesci24.pl logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12353,6 +12353,13 @@ img[src*="carriers/"]
 
 ================================
 
+wiesci24.pl
+
+INVERT
+.tdb-logo-img
+
+================================
+
 wiki.archlinux.org
 
 CSS


### PR DESCRIPTION
https://wiesci24.pl/

![20210606-1622995422](https://user-images.githubusercontent.com/9846948/120931424-bb7ecf00-c6f1-11eb-9448-d547a429c8b7.png)
