### PR TITLE
[static-theme] Preserve transparency when applying transformation matrix

### DIFF
--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -62,7 +62,7 @@ export default function createStaticStylesheet(config: FilterConfig, url: string
     const theme = Object.entries(srcTheme).reduce((t, [prop, color]) => {
         const [r, g, b, a] = color;
         t[prop] = applyColorMatrix([r, g, b], createFilterMatrix({...config, mode: 0}));
-        if(a !== undefined) {
+        if (a !== undefined) {
             t[prop].push(a);
         }
         return t;

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -60,7 +60,11 @@ function mix(color1: number[], color2: number[], t: number) {
 export default function createStaticStylesheet(config: FilterConfig, url: string, frameURL: string, staticThemes: StaticTheme[]) {
     const srcTheme = config.mode === 1 ? darkTheme : lightTheme;
     const theme = Object.entries(srcTheme).reduce((t, [prop, color]) => {
+        const [r, g, b, a] = color;
         t[prop] = applyColorMatrix(color, createFilterMatrix({...config, mode: 0}));
+        if(a !== undefined) {
+            t[prop].push(a);
+        }
         return t;
     }, {} as ThemeColors);
 

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -61,7 +61,7 @@ export default function createStaticStylesheet(config: FilterConfig, url: string
     const srcTheme = config.mode === 1 ? darkTheme : lightTheme;
     const theme = Object.entries(srcTheme).reduce((t, [prop, color]) => {
         const [r, g, b, a] = color;
-        t[prop] = applyColorMatrix(color, createFilterMatrix({...config, mode: 0}));
+        t[prop] = applyColorMatrix([r, g, b], createFilterMatrix({...config, mode: 0}));
         if(a !== undefined) {
             t[prop].push(a);
         }

--- a/src/generators/utils/matrix.ts
+++ b/src/generators/utils/matrix.ts
@@ -21,12 +21,10 @@ export function createFilterMatrix(config: FilterConfig) {
     return m;
 }
 
-export function applyColorMatrix([r, g, b, a]: number[], matrix: number[][]) {
+export function applyColorMatrix([r, g, b]: number[], matrix: number[][]) {
     const rgb = [[r / 255], [g / 255], [b / 255], [1], [1]];
     const result = multiplyMatrices(matrix, rgb);
-    let res = [0, 1, 2].map((i) => clamp(Math.round(result[i][0] * 255), 0, 255));
-    if(a !== undefined) res.push(a);
-    return res;
+    return [0, 1, 2].map((i) => clamp(Math.round(result[i][0] * 255), 0, 255));
 }
 
 export const Matrix = {

--- a/src/generators/utils/matrix.ts
+++ b/src/generators/utils/matrix.ts
@@ -24,7 +24,9 @@ export function createFilterMatrix(config: FilterConfig) {
 export function applyColorMatrix([r, g, b, a]: number[], matrix: number[][]) {
     const rgb = [[r / 255], [g / 255], [b / 255], [1], [1]];
     const result = multiplyMatrices(matrix, rgb);
-    return [0, 1, 2].map((i) => clamp(Math.round(result[i][0] * 255), 0, 255)).concat([a]);
+    let res = [0, 1, 2].map((i) => clamp(Math.round(result[i][0] * 255), 0, 255));
+    if(a !== undefined) res.push(a);
+    return res;
 }
 
 export const Matrix = {

--- a/src/generators/utils/matrix.ts
+++ b/src/generators/utils/matrix.ts
@@ -21,10 +21,10 @@ export function createFilterMatrix(config: FilterConfig) {
     return m;
 }
 
-export function applyColorMatrix([r, g, b]: number[], matrix: number[][]) {
+export function applyColorMatrix([r, g, b, a]: number[], matrix: number[][]) {
     const rgb = [[r / 255], [g / 255], [b / 255], [1], [1]];
     const result = multiplyMatrices(matrix, rgb);
-    return [0, 1, 2].map((i) => clamp(Math.round(result[i][0] * 255), 0, 255));
+    return [0, 1, 2].map((i) => clamp(Math.round(result[i][0] * 255), 0, 255)).concat([a]);
 }
 
 export const Matrix = {


### PR DESCRIPTION
`FADE BG` and `FADE TEXT` in static mode had no transparency, because `applyColorMatrix()` dropped the alpha value.

~~I hope this way of fixing it is ok. This adds an `undefined` alpha value to colors that don't have it, but since `rgb()` has a check for it, I suppose it's ok.
Should I have used `push()` instead of `concat()`?~~

EDIT: I changed it to push the alpha value instead of concatenating, since an undefined alpha created issues in other places