### PR TITLE
wired.co.uk logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12632,6 +12632,7 @@ INVERT
 body a svg
 .c-nav__open-icon
 .c-nav__close-icon
+.standard-navigation__logo-image > img
 
 ================================
 


### PR DESCRIPTION
https://www.wired.co.uk/

![20210607-1623049760](https://user-images.githubusercontent.com/9846948/120974357-50c0a880-c770-11eb-99da-f1e77d0cf42b.png)
