### PR TITLE
Fix for QR code in account.orchid.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -367,6 +367,13 @@ CSS
 
 ================================
 
+account.orchid.com
+
+INVERT
+.walletconnect-qrcode__image
+
+================================
+
 account.ui.com
 
 CSS


### PR DESCRIPTION
The QR code can be accessed by clicking the "Connect Wallet" button. It is incorrectly inverted in the Dynamic, Filter, and Filter+ themes, but correctly displayed in Static theme. I haven't made a fix for Filter and Filter+.