### PR TITLE
Fix tabs on proton UI

### DIFF
--- a/src/background/window-theme.ts
+++ b/src/background/window-theme.ts
@@ -59,7 +59,6 @@ const $colors = {
     sidebar_border: '#333',
     sidebar_text: 'black',
     tab_background_text: 'white',
-    tab_line: '#23aeff',
     tab_loading: '#23aeff',
     // 'textcolor' is the predecessor of 'tab_background_text'.
     // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme#colors


### PR DESCRIPTION
The `tab_line` property was in proton more notice-able and more likely ugly then rather a niece thing to have.

Resolves #5954