### PR TITLE
Fix audible.com player controls

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1244,6 +1244,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+audible.com
+
+INVERT
+#adbl-cloud-player-controls
+
+================================
+
 audycje.tokfm.pl/widget
 
 CSS

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -162,7 +162,7 @@ INVERT
 
 audible.com
 
-INVERT
+NO INVERT
 img.adbl-cp-cursor
 
 ================================


### PR DESCRIPTION
Fixes inversion of the audible.com player controls in both filter and dynamic modes. The previously entered fix for filter mode was incorrect at time of PR.