### PR TITLE
Add shortcut for changing theme engine per-site

### DIFF
--- a/src/_locales/en.config
+++ b/src/_locales/en.config
@@ -140,6 +140,9 @@ Dynamic
 @theme_generation_mode
 Theme generation mode
 
+@theme_generation_mode_current_site
+Theme generation mode for current site
+
 @custom_browser_theme_on
 Custom
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -57,6 +57,9 @@
         },
         "switchEngine": {
             "description": "__MSG_theme_generation_mode__"
+        },
+        "switchEngineForCurrentSite": {
+            "description": "__MSG_theme_generation_mode_current_site__"
         }
     }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -59,6 +59,9 @@
             "description": "__MSG_theme_generation_mode__"
         },
         "switchEngineForCurrentSite": {
+            "suggested_key": {
+                "default": "Alt+Shift+S"
+            },
             "description": "__MSG_theme_generation_mode_current_site__"
         }
     }


### PR DESCRIPTION
This addresses my feature request, #5988.

Submitting as a draft for now because at this point I've just gotten it good enough for me personally to use.

The way it works right now:
- There is a new keyboard shortcut for the extension, "Theme mode for current site"
- If you execute the shortcut, it will create a site-specific theme if there is none, and set the theme engine to be the next one in the list for that site theme

Things of note:
- I don't know how this project's translation system works, or if I need to update the other locale files with anything. This currently fails a unit test about the locale files.
- It looks like even before my changes, the 'change theme generation mode' shortcut always only changes the global setting. If you have a per-site theme (eg "Only on <x.com>" set to true), then the original shortcut would do nothing visible until you turn "only on ..." off, or visit a different page that uses the global theme. How the original shortcut behaves might merit changes if this PR might be merged into the main repo.
- This probably doesn't behave as expected if you have user-created themes for multiple sites. It will change the theme's engine instead of just changing the engine per-site. I'll defer fixing this until contributors have chimed in about whether they think any of this is feasible to have merged in.