### PR TITLE
Removing redundancy github.*.* includes github.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4893,7 +4893,6 @@ a[href="https://github.com"]
 
 ================================
 
-github.com
 github.*.*
 
 INVERT


### PR DESCRIPTION
I should have seen this when i submitted my last PR but

`github.*.*` includes `github.com`, so no reason to have both. I just eliminated the redundancy.