### PR TITLE
rytmy.pl logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9548,6 +9548,13 @@ INVERT
 
 ================================
 
+rytmy.pl
+
+INVERT
+.logo-rytmy-a
+
+================================
+
 saladelcembalo.org
 
 INVERT


### PR DESCRIPTION
https://rytmy.pl/
![20210610-1623346894](https://user-images.githubusercontent.com/9846948/121571900-dfa91b80-ca23-11eb-9c0f-142431eb6cb1.png)
