### PR TITLE
wysokieobcasy.pl logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13127,6 +13127,13 @@ CSS
 
 ================================
 
+wysokieobcasy.pl
+
+INVERT
+.vin-img-link-pic.vin-local-img-link-pic
+
+================================
+
 x-kom.pl
 
 INVERT


### PR DESCRIPTION
https://www.wysokieobcasy.pl/wysokie-obcasy/0,0.html

![20210611-1623421509](https://user-images.githubusercontent.com/9846948/121702074-d8404b80-cad1-11eb-9db5-8e099dd940d3.png)

(same CMS like `wyborcza.pl`, same owner)