### PR TITLE
https://cloud.linode.com/ is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -128,6 +128,7 @@ chessbomb.com
 cinema-city.pl
 clash3d.com
 clashofstats.com
+cloud.linode.com
 clt.gg
 codepen.io
 codesandbox.io


### PR DESCRIPTION
https://cloud.linode.com/ has a great dark mode built in:

<img width="629" alt="Screenshot 2021-06-11 at 19 44 20" src="https://user-images.githubusercontent.com/3296254/121728348-7261bd00-caed-11eb-917b-7be5a996a46d.png">
