### PR TITLE
Enable Dependabot integration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This config file enables [Dependabot](https://dependabot.com/) integration. Dependabot is provided by GitHub for free.

After this file is merged, Dependabot will check for `npm` module updates and create PRs to bump outdated modules. These PRs will automatically trigger all the relevant CI workflows, just like a regular PRs. If you have never used Dependabot, I can answer questions about it. I use Dependabot on most of my projects and it is pretty handy.

## Motivation
Updating dependencies is a chore which can be uatomated with Dependabot.

`npm audit` produces the following report:

```
# npm audit report

css-what  <5.0.1
Severity: high
Denial of Service - https://npmjs.com/advisories/1754
fix available via `npm audit fix`
node_modules/css-what

normalize-url  <=4.5.0 || 5.0.0 - 5.3.0 || 6.0.0
Severity: high
Regular Expression Denial of Service - https://npmjs.com/advisories/1755
fix available via `npm audit fix --force`
Will install web-ext@3.1.1, which is a breaking change
node_modules/normalize-url
node_modules/package-json/node_modules/normalize-url
  cacheable-request  0.1.0 - 6.0.0
  Depends on vulnerable versions of normalize-url
  node_modules/cacheable-request
    got  8.0.0 - 9.5.0
    Depends on vulnerable versions of cacheable-request
    node_modules/got
      download  >=7.0.0
      Depends on vulnerable versions of got
      node_modules/download
        addons-scanner-utils  *
        Depends on vulnerable versions of download
        node_modules/addons-scanner-utils
          addons-linter  >=2.11.0
          Depends on vulnerable versions of addons-scanner-utils
          node_modules/addons-linter
            web-ext  >=3.2.0
            Depends on vulnerable versions of addons-linter
            Depends on vulnerable versions of ws
            node_modules/web-ext

ws  5.0.0 - 5.2.2 || 6.0.0 - 6.2.1 || 7.0.0 - 7.4.5
Severity: moderate
Regular Expression Denial of Service - https://npmjs.com/advisories/1748
fix available via `npm audit fix --force`
Will install web-ext@3.1.1, which is a breaking change
node_modules/web-ext/node_modules/ws
  web-ext  >=3.2.0
  Depends on vulnerable versions of addons-linter
  Depends on vulnerable versions of ws
  node_modules/web-ext

9 vulnerabilities (1 moderate, 8 high)
```