### PR TITLE
Math symbols visiblity on oalevelsolutions.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8381,6 +8381,13 @@ CSS
 
 ================================
 
+oalevelsolutions.com
+
+INVERT
+.WordSection1 > p > span > img
+
+================================
+
 obserwatorgospodarczy.pl
 
 INVERT


### PR DESCRIPTION
The math symbols on oalevelsolutions.com are not correctly shown with dark reader dynamic mode as they are transparent images which need to be inverted.
example link: http://oalevelsolutions.com/past-papers-solutions/cambridge-international-examinations/as-a-level-mathematics-9709/pure-mathematics-p1-9709-01/year-2020-february-march-p1-9709-12/cie_20_fm_9709_12_q_3/