### PR TITLE
papaya.rocks

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8741,6 +8741,21 @@ CSS
 
 ================================
 
+papaya.rocks
+
+INVERT
+.favorite.js-open-login
+.header__title
+.js-logo
+.js-logo-big
+.js-menu-toggle
+.js-open-search
+.nav__item--profile
+.search__button
+.search__close
+
+================================
+
 park-in.gr
 
 CSS


### PR DESCRIPTION
https://papaya.rocks/pl/news/rachel-weisz-i-colin-farrell-znow-razem-na-duzym-ekranie

![20210615-1623768978](https://user-images.githubusercontent.com/9846948/122076230-fe7c2900-cdfa-11eb-838d-66e92459b0c1.png)
![20210615-1623768991](https://user-images.githubusercontent.com/9846948/122076237-ffad5600-cdfa-11eb-95ca-4c91aebcaa1f.png)
![20210615-1623769006](https://user-images.githubusercontent.com/9846948/122076238-ffad5600-cdfa-11eb-91e9-a8841eab1c76.png)
