### PR TITLE
ebok.enea.pl internal ads font fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3899,6 +3899,11 @@ INVERT
 .navbar-brand
 .slider-content > .slider-title
 
+CSS
+.col-lg-12.col-md-12 > div > div > p {
+    color: var(--darkreader-neutral-background) !important;
+}
+
 ================================
 
 enjen.net


### PR DESCRIPTION
Dashboard have two internal ads boxes with self promo. 
This is fix for font color. 
Selector is tricky and ugly. 
After fix
![20210616-1623860380](https://user-images.githubusercontent.com/9846948/122257024-e3c7b400-cecf-11eb-8e0f-007ba91d9c6b.png)

![20210616-1623860719](https://user-images.githubusercontent.com/9846948/122257537-651f4680-ced0-11eb-9c11-5390589d3fb4.png)
