### PR TITLE
Add fixes for Google Classroom

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2311,6 +2311,9 @@ div[style="bottom: 0px;"] > div[style^="opacity:"] div[role="button"] > div:not(
 div[role="menu"] > div[role="menuitem"] > div > div:not([style*="background-image"]) {
     background-image: url('//ssl.gstatic.com/docs/common/viewer/v3/v-sprite35.svg') !important;
 }
+li[guidedhelpid="classworkTopicListGh"]:not(hover) > div {
+    opacity: 99% !important;
+}
 
 ================================
 


### PR DESCRIPTION
On any Google Classroom, in the "Classwork" tab, there is a list, and each item of the list is some material or assignment. A list item gets highlighted when is it clicked or hovered on.
When an item is clicked (and thus highlighted) and the item above it hovered on, they both normally get the same color (in this example, the lower one has been clicked and the higher hovered over);
![Two highlighted in light mode](https://user-images.githubusercontent.com/69745509/122641939-e58ab500-d125-11eb-9a0c-c7d73ff584e6.png)

but with Dark Reader, the lower one goes completely blank.
![Two highlighted in dark mode - 1](https://user-images.githubusercontent.com/69745509/122641944-ede2f000-d125-11eb-8bb6-3fcf31232b9d.png)

With some experimentation, I came to the conclusion that giving the two highlighted nodes different colors solves the problem; I still don't know why though.
This change leaves the opacity of the hovered-over list item at 100%; all the remaining list items are given an opacity of 99%. This creates the required color difference without drastically changing the look to the user.
![Two highlighted in dark mode - 2](https://user-images.githubusercontent.com/69745509/122641947-f3d8d100-d125-11eb-977b-2db87cb4697e.png)
