### PR TITLE
scmp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9829,6 +9829,19 @@ img.math
 
 ================================
 
+scmp.com
+
+INVERT
+.header-menu-container__menu-top-left-wrapper
+.global-menu-features__menu-icon
+.global-menu-features__search-icon
+.global-menu-features__close-icon
+.social-button__twitter--active
+.social-button__email--active
+.footer-wrapper__logo
+
+================================
+
 scpclassic.wikidot.com
 scpfoundation.net
 scp-wiki.net


### PR DESCRIPTION
https://www.scmp.com/
https://www.scmp.com/news/hong-kong/law-and-crime/article/3137782/coronavirus-hong-kong-judge-finds-ex-lawmaker-tanya
![20210619-1624124938](https://user-images.githubusercontent.com/9846948/122651223-bf6e1080-d137-11eb-9dcc-873d248a2178.png)
![20210619-1624124963](https://user-images.githubusercontent.com/9846948/122651225-c006a700-d137-11eb-8802-34cd4eae63b8.png)
