### PR TITLE
Fix for mediawiki.org and wikipedia.org textlogo on Timeless mediawiki skin

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7438,7 +7438,9 @@ section[class$="container"][style^="background-image"] {
 ================================
 
 mediawiki.org
-wikitech.wikimedia.org
+
+INVERT
+#p-logo-text
 
 IGNORE IMAGE ANALYSIS
 .mw.wiki-logo
@@ -12806,6 +12808,7 @@ span#MathJax_Zoom
 .main-footer-menuToggle
 div.post-content.footer-content > h2 > img
 .mw-hiero-outer.mw-hiero-table
+#p-logo-text
 
 CSS
 .mwe-popups-discreet > svg,
@@ -12871,6 +12874,13 @@ wikisource.org
 
 INVERT
 .mwe-math-element
+
+================================
+
+wikitech.wikimedia.org
+
+IGNORE IMAGE ANALYSIS
+.mw.wiki-logo
 
 ================================
 


### PR DESCRIPTION
Invert textlogo on both website, should be visible for users of Timeless mediawiki skin

https://www.mediawiki.org/w/index.php?title=Main_Page&useskin=timeless
https://en.wikipedia.org/w/index.php?title=Main_Page&useskin=timeless

![wikipedia_not_inverted_textlogo](https://user-images.githubusercontent.com/10338703/122668431-44adff80-d1e2-11eb-8018-a693c2060ec5.png)
![mediawiki_not_inverted_textlogo](https://user-images.githubusercontent.com/10338703/122668432-45469600-d1e2-11eb-9e9a-5246c16381f4.png)

![wikipedia_textlogo](https://user-images.githubusercontent.com/10338703/122668305-9bffa000-d1e1-11eb-8f03-6310c953a372.png)
![mediawiki_textlogo](https://user-images.githubusercontent.com/10338703/122668307-9dc96380-d1e1-11eb-9d15-2e1c6a29c539.png)
