### PR TITLE
Ensure proper destroy of manager 

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -204,7 +204,7 @@ function createDynamicStyleOverrides() {
 }
 
 let loadingStylesCounter = 0;
-const loadingStyles = new Set();
+const loadingStyles = new Set<number>();
 
 function createManager(element: StyleElement) {
     const loadingStyleId = ++loadingStylesCounter;
@@ -224,6 +224,7 @@ function createManager(element: StyleElement) {
     function loadingEnd() {
         loadingStyles.delete(loadingStyleId);
         logInfo(`Removed loadingStyle ${loadingStyleId}, now awaiting: ${loadingStyles.size}`);
+        logInfo(`To-do to be loaded`, loadingStyles);
         if (loadingStyles.size === 0 && isDOMReady()) {
             cleanFallbackStyle();
         }
@@ -269,7 +270,7 @@ function onDOMReady() {
         cleanFallbackStyle();
         return;
     }
-    logWarn(`DOM is ready, but still have ${loadingStyles} styles being loaded.`);
+    logWarn(`DOM is ready, but still have styles being loaded.`, loadingStyles);
 }
 
 let documentVisibilityListener: () => void = null;

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -269,7 +269,7 @@ function onDOMReady() {
         cleanFallbackStyle();
         return;
     }
-    logWarn(loadingStyles);
+    logWarn(`DOM is ready, but still have ${loadingStyles} styles being loaded.`);
 }
 
 let documentVisibilityListener: () => void = null;

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -2,7 +2,7 @@ import {overrideInlineStyle, getInlineOverrideStyle, watchForInlineStyles, stopW
 import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-theme-color';
 import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache, getSelectionColor} from './modify-css';
 import type {StyleElement, StyleManager} from './style-manager';
-import {manageStyle, getManageableStyles, storedRejectorsForLoadingLinks} from './style-manager';
+import {manageStyle, getManageableStyles, cleanLoadingLinks} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
 import {forEach, push, toArray} from '../../utils/array';
 import {removeNode, watchForNodePosition, iterateShadowHosts, isDOMReady, addDOMReadyListener, removeDOMReadyListener} from '../utils/dom';
@@ -465,7 +465,7 @@ export function removeDynamicTheme() {
     shadowRootsWithOverrides.clear();
     forEach(styleManagers.keys(), (el) => removeManager(el));
     loadingStyles.clear();
-    storedRejectorsForLoadingLinks.clear();
+    cleanLoadingLinks();
     forEach(document.querySelectorAll('.darkreader'), removeNode);
 
     adoptedStyleManagers.forEach((manager) => {

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -2,8 +2,7 @@ import {overrideInlineStyle, getInlineOverrideStyle, watchForInlineStyles, stopW
 import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-theme-color';
 import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache, getSelectionColor} from './modify-css';
 import type {StyleElement, StyleManager} from './style-manager';
-import {loadingLinkStyles} from './style-manager';
-import {manageStyle, getManageableStyles} from './style-manager';
+import {manageStyle, getManageableStyles, loadingLinkStyles} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
 import {forEach, push, toArray} from '../../utils/array';
 import {removeNode, watchForNodePosition, iterateShadowHosts, isDOMReady, addDOMReadyListener, removeDOMReadyListener} from '../utils/dom';

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -2,7 +2,7 @@ import {overrideInlineStyle, getInlineOverrideStyle, watchForInlineStyles, stopW
 import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-theme-color';
 import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache, getSelectionColor} from './modify-css';
 import type {StyleElement, StyleManager} from './style-manager';
-import {manageStyle, getManageableStyles, loadingLinkStyles} from './style-manager';
+import {manageStyle, getManageableStyles, storedRejectorsForLoadingLinks} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
 import {forEach, push, toArray} from '../../utils/array';
 import {removeNode, watchForNodePosition, iterateShadowHosts, isDOMReady, addDOMReadyListener, removeDOMReadyListener} from '../utils/dom';
@@ -465,7 +465,7 @@ export function removeDynamicTheme() {
     shadowRootsWithOverrides.clear();
     forEach(styleManagers.keys(), (el) => removeManager(el));
     loadingStyles.clear();
-    loadingLinkStyles.clear();
+    storedRejectorsForLoadingLinks.clear();
     forEach(document.querySelectorAll('.darkreader'), removeNode);
 
     adoptedStyleManagers.forEach((manager) => {

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -2,6 +2,7 @@ import {overrideInlineStyle, getInlineOverrideStyle, watchForInlineStyles, stopW
 import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-theme-color';
 import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache, getSelectionColor} from './modify-css';
 import type {StyleElement, StyleManager} from './style-manager';
+import {loadingLinkStyles} from './style-manager';
 import {manageStyle, getManageableStyles} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
 import {forEach, push, toArray} from '../../utils/array';
@@ -464,8 +465,8 @@ export function removeDynamicTheme() {
     });
     shadowRootsWithOverrides.clear();
     forEach(styleManagers.keys(), (el) => removeManager(el));
-    loadingStylesCounter = 0;
     loadingStyles.clear();
+    loadingLinkStyles.clear();
     forEach(document.querySelectorAll('.darkreader'), removeNode);
 
     adoptedStyleManagers.forEach((manager) => {

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -465,6 +465,7 @@ export function removeDynamicTheme() {
     shadowRootsWithOverrides.clear();
     forEach(styleManagers.keys(), (el) => removeManager(el));
     loadingStylesCounter = 0;
+    loadingStyles.clear();
     forEach(document.querySelectorAll('.darkreader'), removeNode);
 
     adoptedStyleManagers.forEach((manager) => {

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -3,7 +3,7 @@ import {forEach} from '../../utils/array';
 import {getMatches} from '../../utils/text';
 import {getAbsoluteURL} from '../../utils/url';
 import {watchForNodePosition, removeNode, iterateShadowHosts} from '../utils/dom';
-import {logWarn} from '../utils/log';
+import {logInfo, logWarn} from '../utils/log';
 import {replaceCSSRelativeURLsWithAbsolute, removeCSSComments, replaceCSSFontFace, getCSSURLValue, cssImportRegex, getCSSBaseBath} from './css-rules';
 import {bgFetch} from './network';
 import {createStyleSheetModifier} from './stylesheet-modifier';
@@ -167,6 +167,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             ) {
                 try {
                     loadingLinkID = ++loadingLinkStyle;
+                    logInfo(`Linkelement ${loadingLinkID} is not loaded yet and thus will be await for`, element);
                     await linkLoading(element, loadingLinkID);
                 } catch (err) {
                     // NOTE: Some @import resources can fail,
@@ -484,11 +485,12 @@ async function linkLoading(link: HTMLLinkElement, loadingID: number) {
         };
         const onLoad = () => {
             cleanUp();
+            logInfo(`Linkelement ${loadingID} has been loaded`);
             resolve();
         };
         const onError = () => {
             cleanUp();
-            reject(`Link loading failed ${link.href}`);
+            reject(`Linkelement ${loadingID} couldn't be loaded. ${link.href}`);
         };
         loadingLinkStyles.set(loadingID, reject);
         link.addEventListener('load', onLoad);

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -81,8 +81,8 @@ document.addEventListener('__darkreader__inlineScriptsAllowed', () => {
     canOptimizeUsingProxy = true;
 });
 
-let loadingLinkStyle = 0;
-const loadingLinkStyles = new Map<number, (reason?: any) => void>();
+export let loadingLinkStyle = 0;
+export const loadingLinkStyles = new Map<number, (reason?: any) => void>();
 
 export function manageStyle(element: StyleElement, {update, loadingStart, loadingEnd}): StyleManager {
     const prevStyles: HTMLStyleElement[] = [];

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -429,7 +429,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
         removeNode(corsCopy);
         removeNode(syncStyle);
         loadingEnd();
-        if (loadingLinkID) {
+        if (loadingLinkID && loadingLinkStyles.has(loadingLinkID)) {
             loadingLinkStyles.get(loadingLinkID)();
             loadingLinkStyles.delete(loadingLinkID);
         }

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -502,6 +502,9 @@ async function linkLoading(link: HTMLLinkElement, loadingId: number) {
         });
         link.addEventListener('load', onLoad);
         link.addEventListener('error', onError);
+        if (!link.href) {
+            onError();
+        }
     });
 }
 

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -132,5 +132,24 @@ describe('LINK STYLES', () => {
         await timeout(0);
         expect(document.querySelector('.testcase--link').nextElementSibling.classList.contains(isSafari ? 'darkreader--cors' : 'darkreader--sync')).toBe(false);
     });
+    it("Shouldn't wait on link that won't be loaded", async () => {
+        const link = createStyleLink(null);
+        link.setAttribute('data-href', `data:text/css;utf8,${encodeURIComponent(multiline(
+            'h1 { background: green !important; }',
+            'h1 strong { color: orange !important; }',
+        ))}`);
+        container.innerHTML = multiline(
+            '<style>',
+            '   h1 { background: gray; }',
+            '</style>',
+            '<h1>Link <strong>loading with non-href attribute</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(0);
+        const h1 = document.querySelector('h1');
+        expect(getComputedStyle(h1).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(document.querySelector('.darkreader--fallback').textContent).toBe('');
+    });
 });
 


### PR DESCRIPTION
- Ensure that `LoadingEnd` is called, to check if the `fallbackStyle` can be removed.
- Ensure that we reject the promise of `linkLoading`
- Ensure that when dark reader is toggled that the map/set is cleared.
- Add a bunch of debugging code to make it easier next time to debug these kinds of issues.
- Error on loading styles that doesn't have a `href`

- Resolves #6075
- Resolves #6135