### PR TITLE
Proper cleanup of inline style

### DIFF
--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -85,8 +85,8 @@ const overrides: Overrides = {
 };
 
 const overridesList = Object.values(overrides);
-const customPropsList = {};
-overridesList.forEach(({cssProp, customProp}) => customPropsList[customProp] = cssProp);
+const normalizedPropList = {};
+overridesList.forEach(({cssProp, customProp}) => normalizedPropList[customProp] = cssProp);
 
 const INLINE_STYLE_ATTRS = ['style', 'fill', 'stop-color', 'stroke', 'bgcolor', 'color'];
 export const INLINE_STYLE_SELECTOR = INLINE_STYLE_ATTRS.map((attr) => `[${attr}]`).join(', ');
@@ -320,8 +320,8 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
         if (overrides.hasOwnProperty(property)) {
             setCustomProp(property, property, value);
         } else {
-            const customProp = customPropsList[property];
-            if (customProp && (!element.style[customProp] && !element.hasAttribute(customProp))) {
+            const overridenProp = normalizedPropList[property];
+            if (overridenProp && (!element.style.getPropertyValue(overridenProp) && !element.hasAttribute(overridenProp))) {
                 element.style.setProperty(property, '');
             }
         }

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -321,7 +321,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
             setCustomProp(property, property, value);
         } else {
             const customProp = customPropsList[property];
-            if (customProp && !element.style[customProp]) {
+            if (customProp && (!element.style[customProp] && !element.hasAttribute(customProp))) {
                 element.style.setProperty(property, '');
             }
         }

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -85,6 +85,8 @@ const overrides: Overrides = {
 };
 
 const overridesList = Object.values(overrides);
+const customPropsList = {};
+overridesList.forEach(({cssProp, customProp}) => customPropsList[customProp] = cssProp);
 
 const INLINE_STYLE_ATTRS = ['style', 'fill', 'stop-color', 'stroke', 'bgcolor', 'color'];
 export const INLINE_STYLE_SELECTOR = INLINE_STYLE_ATTRS.map((attr) => `[${attr}]`).join(', ');
@@ -317,6 +319,11 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
         }
         if (overrides.hasOwnProperty(property)) {
             setCustomProp(property, property, value);
+        } else {
+            const customProp = customPropsList[property];
+            if (customProp && !element.style[customProp]) {
+                element.style.setProperty(property, '');
+            }
         }
     });
     if (element.style && element instanceof SVGTextElement && element.style.fill) {

--- a/tests/inject/dynamic/inline-override.tests.ts
+++ b/tests/inject/dynamic/inline-override.tests.ts
@@ -53,4 +53,15 @@ describe('INLINE STYLES', () => {
         expect(getComputedStyle(span).color).toBe('rgb(140, 255, 140)');
         expect(getComputedStyle(span).backgroundColor).toBe('rgb(102, 102, 102)');
     });
+
+    it('should clean up the customProp after originial is gone', async () => {
+        container.innerHTML = '<span style="outline: red;">Watch inline style</span>';
+        createOrUpdateDynamicTheme(theme, null, false);
+        const span = document.querySelector('span');
+        expect(span.getAttribute('style')).toBe('outline: red; --darkreader-inline-outline:#b30000;');
+
+        span.style.outline = '';
+        await timeout(0);
+        expect(span.getAttribute('style')).toBe('');
+    });
 });

--- a/tests/inject/dynamic/inline-override.tests.ts
+++ b/tests/inject/dynamic/inline-override.tests.ts
@@ -55,12 +55,12 @@ describe('INLINE STYLES', () => {
     });
 
     it('should clean up the customProp after originial is gone', async () => {
-        container.innerHTML = '<span style="outline: red;">Watch inline style</span>';
+        container.innerHTML = '<span style="color: red;">Watch inline style</span>';
         createOrUpdateDynamicTheme(theme, null, false);
         const span = document.querySelector('span');
-        expect(span.getAttribute('style')).toBe('outline: red; --darkreader-inline-outline:#b30000;');
+        expect(span.getAttribute('style')).toBe('color: red; --darkreader-inline-color:#ff1a1a;');
 
-        span.style.outline = '';
+        span.style.color = '';
         await timeout(0);
         expect(span.getAttribute('style')).toBe('');
     });


### PR DESCRIPTION
When you remove a orginial inlineStyle darkreader's inline style wouldn't be removed. This is now fixed.

```html
<span style="color: red;">Hi</span> // Original HTML
<span data-darkreader-inline-color style="color: red; --darkreader-inline-color:#ff1a1a;">Hi</span> // Modified by dark reader
<span data-darkreader-inline-color style="--darkreader-inline-color:#ff1a1a;">Hi</span> // Modified by site to remove color: red
<span style="--darkreader-inline-color:#ff1a1a;">Hi</span> // Dark reader removes the attribute
```
This was the case, but you be better of removing the `--darkreader-inline-color` as well ->

```html
<span style="color: red;">Hi</span> // Original HTML
<span data-darkreader-inline-color style="color: red; --darkreader-inline-color:#ff1a1a;">Hi</span> // Modified by dark reader
<span data-darkreader-inline-color style="--darkreader-inline-color:#ff1a1a;">Hi</span> // Modified by site to remove color: red
<span>Hi</span> // Dark reader removes the attribute & inline CSS prop.
```