### PR TITLE
Fix shadows on Google

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13297,9 +13297,9 @@ CSS
 .minidiv .sfbg,
 #searchform.minidiv,
 .minidiv .emcav .RNNXgb .S6VXfe,
-.sbfc .RNNXgb,
+.CvDJxb .RNNXgb,
 .aajZCb {
-    box-shadow:0 1px 6px 0 rgba(0, 0, 0, 0.28) !important;
+    box-shadow:0 1px 6px 0 rgba(0,0,0,.28) !important;
 }
 .RNNXgb:hover {
     box-shadow:0 1px 6px 2px rgba(0,0,0,.28) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13294,9 +13294,15 @@ img.act-icon-dark-gray
 [src="/chrome/static/images/google-translate/screen-english.png"]
 
 CSS
-.RNNXgb,
+.minidiv .sfbg,
+#searchform.minidiv,
+.minidiv .emcav .RNNXgb .S6VXfe,
+.sbfc .RNNXgb,
 .aajZCb {
-    box-shadow: 0 0 2px 0 ${rgba(0,0,0,0.16)}, 0 0 0 1px ${rgba(0,0,0,0.08)} !important;
+    box-shadow:0 1px 6px 0 rgba(0, 0, 0, 0.28) !important;
+}
+.RNNXgb:hover {
+    box-shadow:0 1px 6px 2px rgba(0,0,0,.28) !important;
 }
 .Gor6zc {
     background-color: white !important;


### PR DESCRIPTION
Fixes shadows

Before this, there were two issues:
- The shadows around the search bar were lighter than the background.
- Without Dark Reader, the shadows around the search bar change become darker when when hovered over. This behaviour wasn't accurate with Dark Reader.