### PR TITLE
Add `trim()` to non-fallback variable.

### DIFF
--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -550,7 +550,7 @@ function getVariableNameAndFallback(match: string) {
         name = match.substring(4, commaIndex).trim();
         fallback = match.substring(commaIndex + 1, match.length - 1).trim();
     } else {
-        name = match.substring(4, match.length - 1);
+        name = match.substring(4, match.length - 1).trim();
         fallback = '';
     }
     return {name, fallback};
@@ -558,19 +558,19 @@ function getVariableNameAndFallback(match: string) {
 
 export function replaceCSSVariablesNames(
     value: string,
-    nemeReplacer: (varName: string) => string,
+    nameReplacer: (varName: string) => string,
     fallbackReplacer?: (fallbackValue: string) => string,
 ): string {
     const matchReplacer = (match: string) => {
         const {name, fallback} = getVariableNameAndFallback(match);
-        const newName = nemeReplacer(name);
+        const newName = nameReplacer(name);
         if (!fallback) {
             return `var(${newName})`;
         }
 
         let newFallback: string;
         if (isVarDependant(fallback)) {
-            newFallback = replaceCSSVariablesNames(fallback, nemeReplacer, fallbackReplacer);
+            newFallback = replaceCSSVariablesNames(fallback, nameReplacer, fallbackReplacer);
         } else if (fallbackReplacer) {
             newFallback = fallbackReplacer(fallback);
         } else {

--- a/tests/inject/dynamic/variables.tests.ts
+++ b/tests/inject/dynamic/variables.tests.ts
@@ -42,6 +42,25 @@ describe('CSS VARIABLES OVERRIDE', () => {
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
     });
 
+    it('should override style with variables(that contain spaces)', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --bg: gray;',
+            '        --text: red;',
+            '    }',
+            '    h1 { background: var( --bg ); }',
+            '    h1 strong { color: var( --text ); }',
+            '</style>',
+            '<h1>CSS <strong>variables</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container).backgroundColor).toBe('rgb(0, 0, 0)');
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
+    });
+
     it('should override style with variables (reverse order)', () => {
         container.innerHTML = multiline(
             '<style>',


### PR DESCRIPTION
- Resolves #6094
- Variables like `var( --e-global-color-text )` would be treated as ` --e-global-color-text ` which is wrong of course and now will be treated as `--e-global-color-text`.
- Also fixed a typo.


@arche-dev This should also prevent further issues and wouldn't require more CSS Fixes ;)