### PR TITLE
Fix variables on android.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3154,28 +3154,6 @@ developers.google.com
 INVERT
 .devsite-google-wordmark
 
-CSS
-:root {
-    --devsite-header-color-upper: var(--darkreader-neutral-background) !important;
-    --devsite-searchbox-inactive: var(--darkreader-neutral-background) !important;
-    --devsite-button-background: var(--darkreader-neutral-background) !important;
-    --devsite-footer-background: var(--darkreader-neutral-background) !important;
-}
-button,
-a.button,
-.devsite-landing-row-item {
-    border-color: var(--darkreader-border--devsite-select-border) !important;
-}
-.pre-style, 
-code, 
-pre {
-    background: var(--darkreader-neutral-background) !important;
-}
-.devsite-table-wrapper > table > thead > tr > th {
-    color: var(--darkreader-neutral-text) !important;
-    background-color: var(--darkreader-neutral-background) !important;
-}
-
 ================================
 
 dianping.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3086,30 +3086,6 @@ quantumai.google
 INVERT
 .devsite-site-logo
 
-CSS
-:root {
-    --devsite-header-color-upper: var(--darkreader-neutral-background);
-    --devsite-footer-background: var(--darkreader-neutral-background);
-    --devsite-table-heading-background: var(--darkreader-neutral-background);
-    --devsite-search-form-background-active: rgba(255, 255, 255, 0.05);
-    --devsite-searchbox-inactive: rgba(255, 255, 255, 0.05);
-    --devsite-searchbox-hover: rgba(255, 255, 255, 0.1);
-    --devsite-searchbox-active: rgba(255, 255, 255, 0.05);
-    --devsite-inline-code-background: ${#f1f3f4}
-}
-devsite-search .devsite-searchbox::before {
-    background-color: unset;
-}
-.devsite-wrapper {
-    background-color: inherit;
-}
-button {
-    background-color: inherit;
-}
-code {
-    background-color: rgba(255, 255, 255, 0.05);
-}
-
 ================================
 
 developer.apple.com

--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -660,7 +660,7 @@ function tryModifyBorderColor(color: string, theme: Theme) {
         const rgb = tryParseColor(color);
         return rgb ? modifyBorderColor(rgb, theme) : color;
     }
-    let borderParts = color.split(' ');
+    let borderParts = color.split(/\s(?![^\(|\"]*(\)|\"))/g);
     borderParts = borderParts.map((part) => {
         const rgb = tryParseColor(part);
         return rgb ? modifyBorderColor(rgb, theme) : part;

--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -4,7 +4,6 @@ import {iterateCSSRules, iterateCSSDeclarations} from './css-rules';
 import {tryParseColor, getBgImageModifier} from './modify-css';
 import type {CSSValueModifier} from './modify-css';
 import type {Theme} from '../../definitions';
-import {getTempCSSStyleSheet} from '../utils/dom';
 
 export interface ModifiedVarDeclaration {
     property: string;

--- a/tests/inject/dynamic/variables.tests.ts
+++ b/tests/inject/dynamic/variables.tests.ts
@@ -1138,4 +1138,42 @@ describe('CSS VARIABLES OVERRIDE', () => {
             expect(updatedStyle.borderColor).toBe('rgb(0, 217, 0)');
         }
     });
+    it('should return modified value when only fallback is known', async () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --fallback: green',
+            '    }',
+            '    h1 {',
+            '        background: var(--color, var(--fallback));',
+            '    }',
+            '</style>',
+            '<h1>Asynchronous variables</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(0, 102, 0)');
+    });
+    it('should handle border colors', async () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    :root {',
+            '        --border: 1px solid rgb(255, 0, 0)',
+            '    }',
+            '    h1 {',
+            '        border: var(--border);',
+            '    }',
+            '</style>',
+            '<h1>Asynchronous variables</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        const elementStyle = getComputedStyle(container.querySelector('h1'));
+        if (isFirefox) {
+            expect(elementStyle.borderTopColor).toBe('rgb(179, 0, 0)');
+            expect(elementStyle.borderRightColor).toBe('rgb(179, 0, 0)');
+            expect(elementStyle.borderBottomColor).toBe('rgb(179, 0, 0)');
+            expect(elementStyle.borderLeftColor).toBe('rgb(179, 0, 0)');
+        } else {
+            expect(elementStyle.borderColor).toBe('rgb(179, 0, 0)');
+        }
+    });
 });


### PR DESCRIPTION
- Ensure to split `border` as they can contain `1px solid red` and that won't be parsed.
- Allow to return modified string if a fallback value was actually found.
- This should make the site more use-able. As I didn't like the amount of CSS fixes and where obvious some faulty code.