### PR TITLE
Fix dynamic mode for wordnik.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13055,6 +13055,14 @@ INVERT
 
 ================================
 
+wordnik.com
+
+INVERT
+img[alt="wordnik logo"]
+.footer-logo
+
+================================
+
 worldcubeassociation.org
 
 CSS


### PR DESCRIPTION
For `img[alt="wordnik logo"]`, I think it would be better to apply a `filter` that includes `brightness(0.8)`, as the bright white is too intense for a dark theme (IMO).  But I understand the trepidation (and reasons) for not wanting filters with static values.