### PR TITLE
Fix rulesTextCache for rules with mediaRule as parent

### DIFF
--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -26,7 +26,7 @@ const asyncQueue = createAsyncTasksQueue();
 
 export function createStyleSheetModifier() {
     let renderId = 0;
-    const rulesTextCache = new Map<string, string>();
+    const rulesTextCache = new Set<string>();
     const rulesModCache = new Map<string, ModifiableCSSRule>();
     const varTypeChangeCleaners = new Set<() => void>();
     let prevFilterKey: string = null;
@@ -51,12 +51,15 @@ export function createStyleSheetModifier() {
 
         const modRules: ModifiableCSSRule[] = [];
         iterateCSSRules(rules, (rule) => {
-            const cssText = rule.cssText;
+            let cssText = rule.cssText;
             let textDiffersFromPrev = false;
 
             notFoundCacheKeys.delete(cssText);
+            if (rule.parentRule instanceof CSSMediaRule) {
+                cssText += ';' + (rule.parentRule as CSSMediaRule).media.mediaText;
+            }
             if (!rulesTextCache.has(cssText)) {
-                rulesTextCache.set(cssText, cssText);
+                rulesTextCache.add(cssText);
                 textDiffersFromPrev = true;
             }
 

--- a/tests/inject/dynamic/media-query.tests.ts
+++ b/tests/inject/dynamic/media-query.tests.ts
@@ -135,4 +135,21 @@ describe('MEDIA QUERIES', () => {
         expect(document.querySelector('.testcase-style-2').nextElementSibling.classList.contains('darkreader--sync')).toBe(true);
     });
 
+    it('should handle same cssText but different media rule', () => {
+        container.innerHTML = multiline(
+            '<style class="testcase-style">',
+            '   @media screen and (min-width: 200000000000000000000px) {',
+            '       h1 { background: green; }',
+            '   }',
+            '   @media screen and (min-width: 4px) {',
+            '       h1 { background: green; }',
+            '   }',
+            '</style>',
+            '<h1>Some test foor...... <strong>Oh uhm removing styles :(</strong>!</h1>',
+        );
+
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(document.querySelector('h1')).backgroundColor).toBe('rgb(0, 102, 0)');
+    });
+
 });


### PR DESCRIPTION
- Add the mediaText of the parent into the cssText to correctly check the cache and not match with other CSS that is from another mediaRule.
- Change Map to Set as we don't use the implementation as key/value

Thanks to @FadeMind ;) for stumbling onto this