### PR TITLE
use frozen deps in readme npm installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can install the extension from a file.
 Install [Node.js LTS](https://nodejs.org/en/). Download the source code (or check out from git).  
 Open terminal in the root folder and run:  
 
-- `npm install`  
+- `npm ci`  
 - `npm run build`  
 
 This will generate a `build.zip` file that is useable in a Chromium-based browser and also a `build-firefox.xpi` file that is useable in Firefox.


### PR DESCRIPTION
This is a personal preference, but I think it's good to reduce users' exposure to bleeding-edge npm packages.