### PR TITLE
Add CSS patch styles to sheet.best

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10258,6 +10258,30 @@ CSS
 
 ================================
 
+sheet.best
+
+CSS
+.MuiButton-containedPrimary,
+.MuiButton-containedPrimary * {
+    background-color: #207245 !important;
+}
+.MuiPaper-root {
+    background-color: #fff1 !important;
+}
+.MuiTouchRipple-root,
+.MuiIconButton-label > *,
+.MuiPaper-root * {
+    background-color: #FFF0 !important;
+}
+.MuiLinearProgress-colorPrimary {
+    background-color: #113c24 !important;
+}
+.MuiLinearProgress-barColorPrimary {
+    background-color: #48cb83 !important;
+}
+
+================================
+
 shop.dr-rath.com
 
 CSS


### PR DESCRIPTION
Added compatibility styling patch to fix the default dark theming in the website [sheet.best](https://sheet.best).

#  Admin screen (sample)
## Original
![sheet best_admin1(Laptop HD) original](https://user-images.githubusercontent.com/26395118/124179322-514f1500-da78-11eb-9db1-291b715baedd.png)

## Default Dark Reader theming
![sheet best_admin1(Laptop HD) default-styled](https://user-images.githubusercontent.com/26395118/124179147-01704e00-da78-11eb-9121-d6916b900be5.png)

## New (fixed) Dark Reader theming
![sheet best_admin1(Laptop HD) corrected](https://user-images.githubusercontent.com/26395118/124179210-1cdb5900-da78-11eb-89a5-0b928d958db5.png)
