### PR TITLE
Faster iterateCSSRules function

### DIFF
--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -8,7 +8,9 @@ export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule
         // Don't rely on prototype or instanceof, they are slow implementations within the browsers.
         // However we can rely on certain properties to indentify which CSSRule we are dealing with.
         // And it's 2x so fast, https://jsben.ch/B0eLa
-        if ((rule as CSSImportRule).href) {
+        if ((rule as CSSStyleRule).selectorText) {
+            iterate((rule as CSSStyleRule));
+        } else if ((rule as CSSImportRule).href) {
             try {
                 iterateCSSRules((rule as CSSImportRule).styleSheet.cssRules, iterate);
             } catch (err) {
@@ -26,8 +28,6 @@ export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule
             if (CSS.supports((rule as CSSSupportsRule).conditionText)) {
                 iterateCSSRules((rule as CSSSupportsRule).cssRules, iterate);
             }
-        } else if ((rule as CSSStyleRule).selectorText) {
-            iterate((rule as CSSStyleRule));
         } else {
             logWarn(`CSSRule type not supported`, rule);
         }

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -5,26 +5,29 @@ import {logWarn} from '../utils/log';
 
 export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule) => void) {
     forEach(rules, (rule) => {
-        if (rule instanceof CSSMediaRule) {
-            const media = Array.from(rule.media);
+        // Don't rely on prototype or instanceof, they are slow implementations within the browsers.
+        // However we can rely on certain properties to indentify which CSSRule we are dealing with.
+        // And it's 2x so fast, https://jsben.ch/B0eLa
+        if ((rule as CSSImportRule).href) {
+            try {
+                iterateCSSRules((rule as CSSImportRule).styleSheet.cssRules, iterate);
+            } catch (err) {
+                logWarn(err);
+            }
+        } else if ((rule as CSSMediaRule).media) {
+            const media = Array.from((rule as CSSMediaRule).media);
             const isScreenOrAll = media.some((m) => m.startsWith('screen') || m.startsWith('all'));
             const isPrintOrSpeech = media.some((m) => m.startsWith('print') || m.startsWith('speech'));
 
             if (isScreenOrAll || !isPrintOrSpeech) {
-                iterateCSSRules(rule.cssRules, iterate);
+                iterateCSSRules((rule as CSSMediaRule).cssRules, iterate);
             }
-        } else if (rule instanceof CSSStyleRule) {
-            iterate(rule);
-        } else if (rule instanceof CSSImportRule) {
-            try {
-                iterateCSSRules(rule.styleSheet.cssRules, iterate);
-            } catch (err) {
-                logWarn(err);
+        } else if ((rule as CSSSupportsRule).conditionText) {
+            if (CSS.supports((rule as CSSSupportsRule).conditionText)) {
+                iterateCSSRules((rule as CSSSupportsRule).cssRules, iterate);
             }
-        } else if (rule instanceof CSSSupportsRule) {
-            if (CSS.supports(rule.conditionText)) {
-                iterateCSSRules(rule.cssRules, iterate);
-            }
+        } else if ((rule as CSSStyleRule).selectorText) {
+            iterate((rule as CSSStyleRule));
         } else {
             logWarn(`CSSRule type not supported`, rule);
         }


### PR DESCRIPTION
- Use feature detection over the `instanceof` keyword to improve speed.
- See benchmark at: https://jsben.ch/B0eLa
- The order of the property detection is important, because certain types have multiple "detection points", e.g. the CSSImportRule has `media` property, so we ensure we first check for that with the `href` property. 
- Addresses 1 of the performance concerns in #6161

Performance recorded on https://mail.google.com/

139ms(before)
![image](https://user-images.githubusercontent.com/25481501/124365382-2d85fd80-dc37-11eb-8083-d7eddbaaa596.png)

63ms(this patch)
![image](https://user-images.githubusercontent.com/25481501/124365394-3f67a080-dc37-11eb-9350-ede46027561a.png)

Which is a 55% improvement. 

Please note that this function is used very frequently without any hesitant so any improvements is overall better for multiple functions that rely on this. 