### PR TITLE
General improvements

### DIFF
--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -73,14 +73,14 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
                     iterate(prop, val);
                 }
             });
-        } else {
-            shorthandVarDependantProperties.forEach((prop) => {
-                const val = style.getPropertyValue(prop);
-                if (val && val.includes('var(')) {
-                    iterate(prop, val);
-                }
-            });
         }
+    } else {
+        shorthandVarDependantProperties.forEach((prop) => {
+            const val = style.getPropertyValue(prop);
+            if (val && val.includes('var(')) {
+                iterate(prop, val);
+            }
+        });
     }
 }
 

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -62,9 +62,9 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
         }
         iterate(property, value);
     });
-    const cssText = style.cssText;
-    if (cssText.includes('var(')) {
-        if (isSafari) {
+    if (isSafari) {
+        const cssText = style.cssText;
+        if (cssText.includes('var(')) {
             // Safari doesn't show shorthand properties' values
             shorthandVarDepPropRegexps.forEach(([prop, regexp]) => {
                 const match = cssText.match(regexp);

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -62,15 +62,18 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
         }
         iterate(property, value);
     });
-    if (isSafari && style.cssText.includes('var(')) {
-        // Safari doesn't show shorthand properties' values
-        shorthandVarDepPropRegexps.forEach(([prop, regexp]) => {
-            const match = style.cssText.match(regexp);
-            if (match && match[1]) {
-                const val = match[1].trim();
-                iterate(prop, val);
-            }
-        });
+    if (isSafari) {
+        const cssText = style.cssText;
+        if (cssText.includes('var(')) {
+            // Safari doesn't show shorthand properties' values
+            shorthandVarDepPropRegexps.forEach(([prop, regexp]) => {
+                const match = cssText.match(regexp);
+                if (match && match[1]) {
+                    const val = match[1].trim();
+                    iterate(prop, val);
+                }
+            });
+        }
     } else {
         shorthandVarDependantProperties.forEach((prop) => {
             const val = style.getPropertyValue(prop);

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -62,9 +62,9 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
         }
         iterate(property, value);
     });
-    if (isSafari) {
-        const cssText = style.cssText;
-        if (cssText.includes('var(')) {
+    const cssText = style.cssText;
+    if (cssText.includes('var(')) {
+        if (isSafari) {
             // Safari doesn't show shorthand properties' values
             shorthandVarDepPropRegexps.forEach(([prop, regexp]) => {
                 const match = cssText.match(regexp);
@@ -73,14 +73,14 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
                     iterate(prop, val);
                 }
             });
+        } else {
+            shorthandVarDependantProperties.forEach((prop) => {
+                const val = style.getPropertyValue(prop);
+                if (val && val.includes('var(')) {
+                    iterate(prop, val);
+                }
+            });
         }
-    } else {
-        shorthandVarDependantProperties.forEach((prop) => {
-            const val = style.getPropertyValue(prop);
-            if (val && val.includes('var(')) {
-                iterate(prop, val);
-            }
-        });
     }
 }
 

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -27,6 +27,10 @@ export interface ModifiableCSSRule {
     declarations: ModifiableCSSDeclaration[];
 }
 
+function getPriority(ruleStyle: CSSStyleDeclaration, property: string) {
+    return Boolean(ruleStyle && ruleStyle.getPropertyPriority(property));
+}
+
 export function getModifiableCSSDeclaration(
     property: string,
     value: string,
@@ -38,12 +42,12 @@ export function getModifiableCSSDeclaration(
     if (property.startsWith('--')) {
         const modifier = getVariableModifier(variablesStore, property, value, rule, ignoreImageSelectors, isCancelled);
         if (modifier) {
-            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
+            return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
     } else if (value.includes('var(')) {
         const modifier = getVariableDependantModifier(variablesStore, property, value);
         if (modifier) {
-            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
+            return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
     } else if (
         (property.includes('color') && property !== '-webkit-print-color-adjust') ||
@@ -53,17 +57,17 @@ export function getModifiableCSSDeclaration(
     ) {
         const modifier = getColorModifier(property, value);
         if (modifier) {
-            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
+            return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
     } else if (property === 'background-image' || property === 'list-style-image') {
         const modifier = getBgImageModifier(value, rule, ignoreImageSelectors, isCancelled);
         if (modifier) {
-            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
+            return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
     } else if (property.includes('shadow')) {
         const modifier = getShadowModifier(value);
         if (modifier) {
-            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
+            return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
     }
     return null;

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -35,16 +35,15 @@ export function getModifiableCSSDeclaration(
     ignoreImageSelectors: string[],
     isCancelled: () => boolean,
 ): ModifiableCSSDeclaration {
-    const important = Boolean(rule && rule.style && rule.style.getPropertyPriority(property));
     if (property.startsWith('--')) {
         const modifier = getVariableModifier(variablesStore, property, value, rule, ignoreImageSelectors, isCancelled);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue: value};
+            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
         }
     } else if (value.includes('var(')) {
         const modifier = getVariableDependantModifier(variablesStore, property, value);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue: value};
+            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
         }
     } else if (
         (property.includes('color') && property !== '-webkit-print-color-adjust') ||
@@ -54,17 +53,17 @@ export function getModifiableCSSDeclaration(
     ) {
         const modifier = getColorModifier(property, value);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue: value};
+            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
         }
     } else if (property === 'background-image' || property === 'list-style-image') {
         const modifier = getBgImageModifier(value, rule, ignoreImageSelectors, isCancelled);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue: value};
+            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
         }
     } else if (property.includes('shadow')) {
         const modifier = getShadowModifier(value);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue: value};
+            return {property, value: modifier, important: Boolean(rule && rule.style && rule.style.getPropertyPriority(property)), sourceValue: value};
         }
     }
     return null;

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -36,16 +36,15 @@ export function getModifiableCSSDeclaration(
     isCancelled: () => boolean,
 ): ModifiableCSSDeclaration {
     const important = Boolean(rule && rule.style && rule.style.getPropertyPriority(property));
-    const sourceValue = value;
     if (property.startsWith('--')) {
         const modifier = getVariableModifier(variablesStore, property, value, rule, ignoreImageSelectors, isCancelled);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue};
+            return {property, value: modifier, important, sourceValue: value};
         }
     } else if (value.includes('var(')) {
         const modifier = getVariableDependantModifier(variablesStore, property, value);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue};
+            return {property, value: modifier, important, sourceValue: value};
         }
     } else if (
         (property.includes('color') && property !== '-webkit-print-color-adjust') ||
@@ -55,17 +54,17 @@ export function getModifiableCSSDeclaration(
     ) {
         const modifier = getColorModifier(property, value);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue};
+            return {property, value: modifier, important, sourceValue: value};
         }
     } else if (property === 'background-image' || property === 'list-style-image') {
         const modifier = getBgImageModifier(value, rule, ignoreImageSelectors, isCancelled);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue};
+            return {property, value: modifier, important, sourceValue: value};
         }
     } else if (property.includes('shadow')) {
         const modifier = getShadowModifier(value);
         if (modifier) {
-            return {property, value: modifier, important, sourceValue};
+            return {property, value: modifier, important, sourceValue: value};
         }
     }
     return null;


### PR DESCRIPTION
- Nothing particular to be note worthy but just found these 2 to be worth fixing.
- Don't create a variable if we don't end up using it multiple times.
- Cache cssText for safari(cssText property is pretty expensive).
- Avoid calculating `!important` when not necessary, a lot of properties coming into `getModifiableDecleration` are worthless to dark reader.