### PR TITLE
No greeting/unistall pages for debug-watch build

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -5,14 +5,6 @@ import {getHelpURL, UNINSTALL_URL} from '../utils/links';
 const extension = new Extension();
 extension.start();
 
-chrome.runtime.onInstalled.addListener(({reason}) => {
-    if (reason === 'install') {
-        chrome.tabs.create({url: getHelpURL()});
-    }
-});
-
-chrome.runtime.setUninstallURL(UNINSTALL_URL);
-
 const welcome = `  /''''\\
  (0)==(0)
 /__||||__\\
@@ -51,4 +43,12 @@ if (WATCH) {
         socket.onclose = () => setTimeout(listen, 1000);
     };
     listen();
+} else {
+    chrome.runtime.onInstalled.addListener(({reason}) => {
+        if (reason === 'install') {
+            chrome.tabs.create({url: getHelpURL()});
+        }
+    });
+
+    chrome.runtime.setUninstallURL(UNINSTALL_URL);
 }


### PR DESCRIPTION
This change has no effect in release builds. This just avoids opening install/uninstall pages when developer installs/uninstalls build produced with `npm run debug-watch`.