### PR TITLE
Fix recursion of `update` for legit media errors

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -305,7 +305,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
                 isAsyncCancelled: () => cancelAsyncOperations,
             });
             isOverrideEmpty = syncStyle.sheet.cssRules.length === 0;
-            if (sheetModifier.hasNotLoadedImports()) {
+            if (sheetModifier.getNotLoadedLinkStatus() === 'found') {
                 // "update" function schedules rebuilding the style
                 // ideally to wait for link loading, because some sites put links any time,
                 // but it can be complicated, so waiting for document completion can do the trick

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -305,7 +305,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
                 isAsyncCancelled: () => cancelAsyncOperations,
             });
             isOverrideEmpty = syncStyle.sheet.cssRules.length === 0;
-            if (sheetModifier.getNotLoadedLinkStatus() === 'found') {
+            if (sheetModifier.shouldRebuiltStyle()) {
                 // "update" function schedules rebuilding the style
                 // ideally to wait for link loading, because some sites put links any time,
                 // but it can be complicated, so waiting for document completion can do the trick

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -305,7 +305,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
                 isAsyncCancelled: () => cancelAsyncOperations,
             });
             isOverrideEmpty = syncStyle.sheet.cssRules.length === 0;
-            if (sheetModifier.shouldRebuiltStyle()) {
+            if (sheetModifier.shouldRebuildStyle()) {
                 // "update" function schedules rebuilding the style
                 // ideally to wait for link loading, because some sites put links any time,
                 // but it can be complicated, so waiting for document completion can do the trick

--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -30,11 +30,6 @@ export function createStyleSheetModifier() {
     const rulesModCache = new Map<string, ModifiableCSSRule>();
     const varTypeChangeCleaners = new Set<() => void>();
     let prevFilterKey: string = null;
-    // 'false' It means Dark Reader didn't find any non loaded link(s) on this stylesheet.
-    // 'true' It means that Dark Reader has found non loaded link(s).
-    let hasNonLoadedLink = false;
-
-    let hasRebuilt = false;
     interface ModifySheetOptions {
         sourceCSSRules: CSSRuleList;
         theme: Theme;
@@ -44,8 +39,10 @@ export function createStyleSheetModifier() {
         isAsyncCancelled: () => boolean;
     }
 
-    function shouldRebuiltStyle() {
-        return hasNonLoadedLink && !hasRebuilt;
+    let hasNonLoadedLink = false;
+    let wasRebuilt = false;
+    function shouldRebuildStyle() {
+        return hasNonLoadedLink && !wasRebuilt;
     }
 
     function modifySheet(options: ModifySheetOptions) {
@@ -58,7 +55,7 @@ export function createStyleSheetModifier() {
         const themeChanged = (themeKey !== prevFilterKey);
 
         if (hasNonLoadedLink) {
-            hasRebuilt = true;
+            wasRebuilt = true;
         }
 
         const modRules: ModifiableCSSRule[] = [];
@@ -315,5 +312,5 @@ export function createStyleSheetModifier() {
         buildStyleSheet();
     }
 
-    return {modifySheet, shouldRebuiltStyle};
+    return {modifySheet, shouldRebuildStyle};
 }


### PR DESCRIPTION
- Imagine a scenario whereby some media error is legit and cannot be accessed by dark reader(not related to it not being loaded yet).
- With this patch we limit such scenario to only allow once to `update`. This prevents recursion and avoid infinite dead lock within dark reader.

@alexanderby Seems like the patch actually had a little flaw. This PR should be merged before the next release as nobody likes to see "dark reader is slow" because we are recursion on something that shouldn't be happening.