### PR TITLE
Should add root variable after type is discovered

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -185,6 +185,9 @@ function createDynamicStyleOverrides() {
         });
     variablesStore.matchVariablesAndDependants();
     variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
+    variablesStore.setOnRootVariableChange(() => {
+        variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
+    });
     styleManagers.forEach((manager) => manager.render(filter, ignoredImageAnalysisSelectors));
     if (loadingStyles.size === 0) {
         cleanFallbackStyle();

--- a/tests/inject/dynamic/variables.tests.ts
+++ b/tests/inject/dynamic/variables.tests.ts
@@ -1157,4 +1157,19 @@ describe('CSS VARIABLES OVERRIDE', () => {
             expect(updatedStyle.borderColor).toBe('rgb(0, 217, 0)');
         }
     });
+
+    it('should add variables to root after the variable type is discovered', async () => {
+        document.documentElement.setAttribute('style', '--text: red;');
+        container.innerHTML = multiline(
+            '<style class="testcase-sheet">',
+            '</style>',
+            '<h1>Dependency variable</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        const sheet = (document.querySelector('.testcase-sheet') as HTMLStyleElement).sheet;
+        sheet.insertRule('h1 { color: var(--text);');
+
+        await timeout(0);
+        expect(getComputedStyle(document.querySelector('h1')).color).toBe('rgb(255, 26, 26)');
+    });
 });


### PR DESCRIPTION
- Resolves #6215
- Imagine a scenario whereby the root variable aren't yet discovered. But at a later stage they are, with this patch that should result in a rebuild of the root variables and actually include the new found variable with the correct type.