### PR TITLE
Add early-detection for cross-origin imports

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -114,6 +114,10 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
         return element instanceof HTMLStyleElement && element.textContent.trim().match(cssImportRegex);
     }
 
+    // It loops trough the cssRules and check for CSSImportRule and their `href`.
+    // If the `href` isn't local and doesn't start with the same-origin.
+    // We can be ensure that's a cross-origin import
+    // And should add a cors-sheet to this element.
     function hasCrossOriginImports(cssRules: CSSRuleList) {
         let result = false;
         if (cssRules) {
@@ -122,7 +126,6 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             for (let i = 0, len = cssRules.length; i < len; i++) {
                 rule = cssRules[i];
                 if ((rule as CSSImportRule).href) {
-                    // Doest the origin start the same origin(if it has any)?
                     if ((rule as CSSImportRule).href.startsWith('http') && !(rule as CSSImportRule).href.startsWith(location.origin)) {
                         result = true;
                         break cssRulesLoop;


### PR DESCRIPTION
- Add a early-detection for cross-origin imports so we can add a `cors-copy` to the style(which luckily resolves any cross-origin imports to normal CSS).
- Resolves #6216


Alexander, is their anyway to add tests for this kind of things? So we can ensure we don't break this functionality at a later stage.