### PR TITLE
Fix for psprices.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9422,7 +9422,7 @@ CSS
 psprices.com
 
 INVERT
-.d-inline-block
+.store-logo
 #game-price-dynamics
 
 CSS


### PR DESCRIPTION
- Specify the selector for the PS Store logo. Since the previous one broke other elements on the site.