### PR TITLE
Partial fix for ggmania.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5036,6 +5036,15 @@ CSS
 
 ================================
 
+ggmania.com
+
+CSS
+body {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 git-scm.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5040,7 +5040,7 @@ ggmania.com
 
 CSS
 body {
-    background: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
 }
 
 ================================


### PR DESCRIPTION
The background file bg2.gif is being applied across the entire body with DR enabled in Dynamic mode.
This change makes a partial fix to replace the tiled GIF background with the DR neutral background.
Needed for this website as of DR v4.9.34.