### PR TITLE
Fix for thisoldhouse.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11512,6 +11512,14 @@ INVERT
 
 ================================
 
+thisoldhouse.com
+
+INVERT
+.c-masthead__main
+a.c-footer__logo-link > svg
+
+================================
+
 thompsonstein.com
 
 INVERT


### PR DESCRIPTION
- Resolves #6231

This inverts the top bar image 
```css
.c-masthead__main
```

Attempted fix svg but like 80% of the letters are black >:c
![image](https://user-images.githubusercontent.com/66189242/125152504-832d3f00-e13c-11eb-8830-ffc49cba3292.png)

```css
a.c-footer__logo-link > svg
```

For the footer line, I have no idea what to invert
