### PR TITLE
Fix for creative.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2742,6 +2742,22 @@ td[background="image/Index_QI_CenterBar.gif"] a {
 
 ================================
 
+creative.com
+
+INVERT
+img.creative-logo
+div.prod-image-not-avail
+div.col-sm-2 > div.pdt-icon > a > img
+.sb-upgrade > h3
+.sb-upgrade > p
+
+CSS
+.input::placeholder  {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 crowdin.com
 
 INVERT


### PR DESCRIPTION
- Resolves #6233

This inverts the product and the "image not available" image on main support page
```css
div.prod-image-not-avail
```
![image](https://user-images.githubusercontent.com/66189242/125153509-ae675c80-e143-11eb-9bd2-699c9d759332.png)

![image](https://user-images.githubusercontent.com/66189242/125153518-c8a13a80-e143-11eb-936f-29531404b66d.png)


Inverts logo
```css
img.creative-logo
```
![image](https://user-images.githubusercontent.com/66189242/125153484-8677f900-e143-11eb-8de2-f12b8de249e4.png)

![image](https://user-images.githubusercontent.com/66189242/125153485-8c6dda00-e143-11eb-8560-e8685f50cc7b.png)

This inverts the product page image (also prevents inverting the images that are perfectly dark in the main support page :D)
```css
div.col-sm-2 > div.pdt-icon > a > img
```
![image](https://user-images.githubusercontent.com/66189242/125153499-9db6e680-e143-11eb-8de8-e04084a87c96.png)

![image](https://user-images.githubusercontent.com/66189242/125153525-dfe02800-e143-11eb-9129-cacd5b540d04.png)


Inverts the "sound blaster buying guide" tile text so its readable
```css
.sb-upgrade > h3
.sb-upgrade > p
```
![image](https://user-images.githubusercontent.com/66189242/125153479-795b0a00-e143-11eb-8da0-4db980f77375.png)


This makes the placeholder text (no text has been entered) in the search bar readable
```css
.input::placeholder  {
    color: var(--darkreader-neutral-text) !important;
}
```

![image](https://user-images.githubusercontent.com/66189242/125153568-27ff4a80-e144-11eb-804b-c00cf52f356b.png)

---

Wasn't able to fix the category tiles:

![image](https://user-images.githubusercontent.com/66189242/125153586-45341900-e144-11eb-9524-81ed8f88503d.png)

if i did this, it'll look veryyy ugly (was the only thing i could think of)

```css
div.cat-icon-wrapper > a > div.cat-icon
```

![image](https://user-images.githubusercontent.com/66189242/125153599-744a8a80-e144-11eb-9269-fd510d0f5d11.png)

Also wasn't able to fix the big block thingys (i have no idea why it auto inverted, gonna have to summon @Gusted for why it auto inverted :c )

![image](https://user-images.githubusercontent.com/66189242/125153624-ab20a080-e144-11eb-9538-fac39508d361.png)

also I didn't see any `img` element which is weird (i found out later its in ::after or something)

```html
<div class="tws-series">
              <h3>TWS-Series</h3>
              <p>
                For the value seekers who want to skip the fuss of charging their true wireless earbuds every other day, with superb audio quality to boot.
              </p>
              <a href="/tws/" class="btn-learn-more btn-grey">
                  Learn More
                  ::after <!-- I think the image is here -->
              </a>
 </div>
 ```
 
 but hey what if i add `.tws-series` under `INVERT`
 
 
![image](https://user-images.githubusercontent.com/66189242/125153768-90026080-e145-11eb-9c1c-6af3ce01eedd.png)

vs

![image](https://user-images.githubusercontent.com/66189242/125153793-bc1de180-e145-11eb-9df4-7356d6a2d241.png)

I mean it inverted but now the brightness just went down by like 60% which I think shouldn't happen right?