### PR TITLE
Ubereats Map and Logo Fix v2

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -150,11 +150,12 @@ IGNORE INLINE STYLE
 
 INVERT
 img[alt*='Home']
-body > #root > #wrapper > #main-content h1 + div
-body > #root > #wrapper > div[class^='c']
-body > #root > #wrapper > div[class^='c'] > header
-body > #root > #wrapper > div[class^='c'] > footer
-body > #root > #wrapper > div[class^='c'] > #main-content > div:first-child
+div[class^='c5'] .gm-style
+#main-content > h1 + div
+#wrapper > div:nth-of-type(2)
+#wrapper > div:nth-of-type(2) > header
+#wrapper > div:nth-of-type(2) > footer
+#wrapper > div:nth-of-type(2) > #main-content > div:first-child
 
 ================================
 


### PR DESCRIPTION
More reliable fix for Ubereats that doesn't require reloading the tracking page to get the map to appear properly, and also now covers the mini-map on the checkout page.
Also removed the unnecessary depth to the selectors as suggested last time.