### PR TITLE
`rule` can be empty/null

### DIFF
--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -253,7 +253,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
     function setCustomProp(targetCSSProp: string, modifierCSSProp: string, cssVal: string) {
         const {customProp, dataAttr} = overrides[targetCSSProp];
 
-        const mod = getModifiableCSSDeclaration(modifierCSSProp, cssVal, null, variablesStore, ignoreImageSelectors, null);
+        const mod = getModifiableCSSDeclaration(modifierCSSProp, cssVal, {} as CSSStyleRule, variablesStore, ignoreImageSelectors, null);
         if (!mod) {
             return;
         }

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -344,7 +344,7 @@ export function getBgImageModifier(
             }
             let url = getCSSURLValue(urlValue);
             const {parentStyleSheet} = rule;
-            const baseURL = parentStyleSheet.href ?
+            const baseURL = (parentStyleSheet && parentStyleSheet.href) ?
                 getCSSBaseBath(parentStyleSheet.href) :
                 parentStyleSheet.ownerNode?.baseURI || location.origin;
             url = getAbsoluteURL(baseURL, url);


### PR DESCRIPTION
Fix a silent crash/error.

For some weird reason the browsers, won't error/crash when the `rule` is empty(inline-style modifications). And just closes dark reader for no good reason.

Regression introduced in #6175