### PR TITLE
Ensure `onRootVariable` has been set before used

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -183,11 +183,13 @@ function createDynamicStyleOverrides() {
         .forEach((detail) => {
             variablesStore.addRulesForMatching(detail.rules);
         });
+
     variablesStore.matchVariablesAndDependants();
-    variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
     variablesStore.setOnRootVariableChange(() => {
         variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
     });
+    variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
+
     styleManagers.forEach((manager) => manager.render(filter, ignoredImageAnalysisSelectors));
     if (loadingStyles.size === 0) {
         cleanFallbackStyle();


### PR DESCRIPTION
- Image a scenario whereby the first time `putRootVars` has been called and actually found a untyped variable, it will then put as callback a undefined, because we currently had `this.onRootVariableDefined` being set after the first time `putRootVars` has been called.
- Fixes a "race condition" and a crash in the `test:inject`