### PR TITLE
Revert some fixes for creative.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2747,7 +2747,6 @@ creative.com
 
 INVERT
 div.small-logo img.creative-logo
-div.prod-image-not-avail
 div.col-sm-2 > div.pdt-icon > a > img
 .sb-upgrade > h3
 .sb-upgrade > p

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2747,7 +2747,6 @@ creative.com
 
 INVERT
 div.small-logo img.creative-logo
-div.col-sm-2 > div.pdt-icon > a > img
 .sb-upgrade > h3
 .sb-upgrade > p
 


### PR DESCRIPTION
- Resolves #6233

https://github.com/darkreader/darkreader/issues/6233#issuecomment-877733265
```css
div.prod-image-not-avail
```

https://github.com/darkreader/darkreader/issues/6233#issuecomment-877733753
```css
div.col-sm-2 > div.pdt-icon > a > img
```