### PR TITLE
Move src/inject/utils/log.ts to src/utils/log.ts

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -1,6 +1,5 @@
 import {isPDF} from '../../utils/url';
 import {isFirefox, isEdge} from '../../utils/platform';
-import {logWarn} from '../../inject/utils/log';
 
 declare const browser: {
     commands: {
@@ -44,7 +43,7 @@ export async function readSyncStorage<T extends {[key: string]: any}>(defaults: 
     return new Promise<T>((resolve) => {
         chrome.storage.sync.get(defaults, (sync: T) => {
             if (chrome.runtime.lastError) {
-                logWarn(chrome.runtime.lastError.message);
+                console.error(chrome.runtime.lastError.message);
                 resolve(defaults);
                 return;
             }
@@ -57,7 +56,7 @@ export async function readLocalStorage<T extends {[key: string]: any}>(defaults:
     return new Promise<T>((resolve) => {
         chrome.storage.local.get(defaults, (local: T) => {
             if (chrome.runtime.lastError) {
-                logWarn(chrome.runtime.lastError.message);
+                console.error(chrome.runtime.lastError.message);
                 resolve(defaults);
                 return;
             }


### PR DESCRIPTION
Move log utils from `src/inject/utils` to `src/utils` because this file is imported by background as well, specifically `src/background/utils/extension-api.ts`.