### PR TITLE
Fix regression introduced in PR #6113

### DIFF
--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -131,7 +131,12 @@ export default class Messenger {
 
     reportChanges(data: ExtensionData) {
         if (this.changeListenerCount > 0 || isFirefox) {
-            chrome.runtime.sendMessage({name: 'background', type: 'changes', data});
+            const message: Message = {
+                from: 'background',
+                type: 'changes',
+                data
+            };
+            chrome.runtime.sendMessage(message);
         }
     }
 }


### PR DESCRIPTION
During review of #6113 I [renamed one message object attribute in definition](https://github.com/darkreader/darkreader/pull/6113#discussion_r668071121),
but accidentally left the old name in one instance. This commit updates
that name and adds type annotation (which would have thrown an error at
build time if I annotated the type).

