### PR TITLE
urbanterror.info is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -791,6 +791,7 @@ unc0ver.dev
 undergroundcellar.com
 underlords.com
 undertale.com
+urbanterror.info
 userdiag.com
 ussr.obys.agency
 uwatchfree.ax


### PR DESCRIPTION
I am submitting this website to be added to the dark-sites.config file. However, before adding it to the list, I have a question.

The entire site is dark by default, but this one section which is their shop: https://www.urbanterror.info/shop/ is not dark. Does this situation automatically disqualify the site for the dark list? I was not sure in this case and I was just looking for clarity on what to do when this come up.