### PR TITLE
Refactor: precompute staticThemeCommands

### DIFF
--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -212,7 +212,7 @@ const inversionFixesCommands = {
 export function parseInversionFixes(text: string) {
     return parseSitesFixesConfig<InversionFix>(text, {
         commands: Object.keys(inversionFixesCommands),
-        getCommandPropName: (command) => inversionFixesCommands[command] || null,
+        getCommandPropName: (command) => inversionFixesCommands[command],
         parseCommandValue: (command, value) => {
             if (command === 'CSS') {
                 return value.trim();

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -14,7 +14,7 @@ const dynamicThemeFixesCommands = {
 export function parseDynamicThemeFixes(text: string) {
     return parseSitesFixesConfig<DynamicThemeFix>(text, {
         commands: Object.keys(dynamicThemeFixesCommands),
-        getCommandPropName: (command) => dynamicThemeFixesCommands[command] || null,
+        getCommandPropName: (command) => dynamicThemeFixesCommands[command],
         parseCommandValue: (command, value) => {
             if (command === 'CSS') {
                 return value.trim();

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -214,7 +214,7 @@ const staticThemeCommands = {
 export function parseStaticThemes($themes: string) {
     return parseSitesFixesConfig<StaticTheme>($themes, {
         commands: Object.keys(staticThemeCommands),
-        getCommandPropName: (command) => staticThemeCommands[command] || null,
+        getCommandPropName: (command) => staticThemeCommands[command],
         parseCommandValue: (command, value) => {
             if (command === 'NO COMMON') {
                 return true;

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -176,57 +176,45 @@ const ruleGenerators = [
     createRuleGen((t) => t.invert, () => ['filter: invert(100%) hue-rotate(180deg)']),
 ];
 
-const staticThemeCommands = [
-    'NO COMMON',
+const staticThemeCommands = {
+    'NO COMMON': 'noCommon',
 
-    'NEUTRAL BG',
-    'NEUTRAL BG ACTIVE',
-    'NEUTRAL TEXT',
-    'NEUTRAL TEXT ACTIVE',
-    'NEUTRAL BORDER',
+    'NEUTRAL BG': 'neutralBg',
+    'NEUTRAL BG ACTIVE': 'neutralBgActive',
+    'NEUTRAL TEXT': 'neutralText',
+    'NEUTRAL TEXT ACTIVE': 'neutralTextActive',
+    'NEUTRAL BORDER': 'neutralBorder',
 
-    'RED BG',
-    'RED BG ACTIVE',
-    'RED TEXT',
-    'RED TEXT ACTIVE',
-    'RED BORDER',
+    'RED BG': 'redBg',
+    'RED BG ACTIVE': 'redBgActive',
+    'RED TEXT': 'redText',
+    'RED TEXT ACTIVE': 'redTextActive',
+    'RED BORDER': 'redBorder',
 
-    'GREEN BG',
-    'GREEN BG ACTIVE',
-    'GREEN TEXT',
-    'GREEN TEXT ACTIVE',
-    'GREEN BORDER',
+    'GREEN BG': 'greenBg',
+    'GREEN BG ACTIVE': 'greenBgActive',
+    'GREEN TEXT': 'greenText',
+    'GREEN TEXT ACTIVE': 'greenTextActive',
+    'GREEN BORDER': 'greenBorder',
 
-    'BLUE BG',
-    'BLUE BG ACTIVE',
-    'BLUE TEXT',
-    'BLUE TEXT ACTIVE',
-    'BLUE BORDER',
+    'BLUE BG': 'blueBg',
+    'BLUE BG ACTIVE': 'blueBgActive',
+    'BLUE TEXT': 'blueText',
+    'BLUE TEXT ACTIVE': 'blueTextActive',
+    'BLUE BORDER': 'blueBorder',
 
-    'FADE BG',
-    'FADE TEXT',
-    'TRANSPARENT BG',
+    'FADE BG': 'fadeBg',
+    'FADE TEXT': 'fadeText',
+    'TRANSPARENT BG': 'transparentBg',
 
-    'NO IMAGE',
-    'INVERT',
-];
-
-function upperCaseToCamelCase(text: string) {
-    return text
-        .split(' ')
-        .map((word, i) => {
-            return (i === 0
-                ? word.toLowerCase()
-                : (word.charAt(0).toUpperCase() + word.substr(1).toLowerCase())
-            );
-        })
-        .join('');
-}
+    'NO IMAGE': 'noImage',
+    'INVERT': 'invert',
+};
 
 export function parseStaticThemes($themes: string) {
     return parseSitesFixesConfig<StaticTheme>($themes, {
-        commands: staticThemeCommands,
-        getCommandPropName: upperCaseToCamelCase,
+        commands: Object.keys(staticThemeCommands),
+        getCommandPropName: (command) => staticThemeCommands[command] || null,
         parseCommandValue: (command, value) => {
             if (command === 'NO COMMON') {
                 return true;
@@ -244,7 +232,7 @@ export function formatStaticThemes(staticThemes: StaticTheme[]) {
     const themes = staticThemes.slice().sort((a, b) => compareURLPatterns(a.url[0], b.url[0]));
 
     return formatSitesFixesConfig(themes, {
-        props: staticThemeCommands.map(upperCaseToCamelCase),
+        props: Object.values(staticThemeCommands),
         getPropCommandName: camelCaseToUpperCase,
         formatPropValue: (prop, value) => {
             if (prop === 'noCommon') {


### PR DESCRIPTION
This patch merges `staticThemeCommands` array and `upperCaseToCamelCase` method into a simple map literal, which is a sufficiently simple structure for TS to enforce types on. This mathces how other parts of code implement corresponding things ([`src/generators/dynamic-theme.ts`](https://github.com/darkreader/darkreader/blob/master/src/generators/dynamic-theme.ts) and [`src/generators/css-filter.ts`](https://github.com/darkreader/darkreader/blob/master/src/generators/css-filter.ts)).