### PR TITLE
Use Alarms API

### DIFF
--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -49,7 +49,7 @@ class LimitedCacheStorage {
                 this.removeExpiredRecords();
             }
         });
-        chrome.alarms.create(LimitedCacheStorage.ALARM_NAME, {periodInMinutes: getDurationInMinutes({minutes: 1})});
+        chrome.alarms.create(LimitedCacheStorage.ALARM_NAME, {periodInMinutes: 1});
     }
 
     has(url: string) {

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -1,6 +1,6 @@
 import {loadAsDataURL, loadAsText} from '../../utils/network';
 import {getStringSize} from '../../utils/text';
-import {getDuration, getDurationInMinutes} from '../../utils/time';
+import {getDuration} from '../../utils/time';
 
 interface RequestParams {
     url: string;

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -9,6 +9,7 @@
         "page": "background/index.html"
     },
     "permissions": [
+        "alarms",
         "storage",
         "tabs",
         "theme",

--- a/src/manifest-thunderbird.json
+++ b/src/manifest-thunderbird.json
@@ -9,6 +9,7 @@
         "page": "background/index.html"
     },
     "permissions": [
+        "alarms",
         "storage",
         "tabs",
         "theme",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,6 +37,7 @@
         }
     ],
     "permissions": [
+        "alarms",
         "fontSettings",
         "storage",
         "tabs",

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -54,25 +54,25 @@ interface Duration {
     seconds?: number;
 }
 
-export function getDurationInMinutes(time: Duration) {
+export function getDuration(time: Duration) {
     let duration = 0;
     if (time.seconds) {
-        duration += time.seconds * 1000 / 60;
+        duration += time.seconds * 1000;
     }
     if (time.minutes) {
-        duration += time.minutes * 1000;
+        duration += time.minutes * 60 * 1000;
     }
     if (time.hours) {
-        duration += time.hours * 60 * 1000;
+        duration += time.hours * 60 * 60 * 1000;
     }
     if (time.days) {
-        duration += time.days * 24 * 60 * 1000;
+        duration += time.days * 24 * 60 * 60 * 1000;
     }
     return duration;
 }
 
-export function getDuration(time: Duration) {
-    return getDurationInMinutes(time) * 60;
+export function getDurationInMinutes(time: Duration) {
+    return getDuration(time) / 1000 / 60;
 }
 
 function getSunsetSunriseUTCTime(

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -54,21 +54,25 @@ interface Duration {
     seconds?: number;
 }
 
-export function getDuration(time: Duration) {
+export function getDurationInMinutes(time: Duration) {
     let duration = 0;
     if (time.seconds) {
-        duration += time.seconds * 1000;
+        duration += time.seconds * 1000 / 60;
     }
     if (time.minutes) {
-        duration += time.minutes * 60 * 1000;
+        duration += time.minutes * 1000;
     }
     if (time.hours) {
-        duration += time.hours * 60 * 60 * 1000;
+        duration += time.hours * 60 * 1000;
     }
     if (time.days) {
-        duration += time.days * 24 * 60 * 60 * 1000;
+        duration += time.days * 24 * 60 * 1000;
     }
     return duration;
+}
+
+export function getDuration(time: Duration) {
+    return getDurationInMinutes(time) * 60;
 }
 
 function getSunsetSunriseUTCTime(


### PR DESCRIPTION
Use [Alarms API](https://developer.chrome.com/docs/extensions/reference/alarms/) instead of timeouts because those are not persisted after non-persistent background shutdown. Alarms will survive across background shutdowns and re-activations and will actually re-activate unloaded background.

This patch adds one more permission, `alarms`, which is necessary to use this API (it does not generate any extra permission messages during install). This patch migrates two `setInterval` call sites and leaves [few more](https://github.com/darkreader/darkreader/blob/a5c5c9a6e683419befd87cbadde31525193b589d/src/background/extension.ts#L240) because I plan to refactor those in a different way.