### PR TITLE
Enhance site list that able to filter invalid url

### DIFF
--- a/src/ui/popup/components/site-list-settings/index.tsx
+++ b/src/ui/popup/components/site-list-settings/index.tsx
@@ -9,7 +9,13 @@ interface SiteListSettingsProps extends ExtWrapper {
 
 export default function SiteListSettings({data, actions, isFocused}: SiteListSettingsProps) {
     function isSiteUrlValid(value: string) {
-        return /^([^\.\s]+?\.?)+$/.test(value);
+        var pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+        '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+        '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
+        return !!pattern.test(value);
     }
 
     return (


### PR DESCRIPTION
Before enhancement, the 'Site list' can accept invalid URL such as '1234412', 'afbdfjb' and etc. After enhancement, the 'Site list' will filter out invalid URL and only accept valid URL such as 'www.google.com'. 