### PR TITLE
Use Alarms API for reconnecting socket on dev build

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -18,6 +18,16 @@ const WATCH = __WATCH__;
 
 if (WATCH) {
     const PORT = __PORT__;
+    const ALARM_NAME = 'socket-close';
+
+    const socketAlarmListener = (alarm) => {
+        if (alarm.name === ALARM_NAME) {
+            listen();
+        }
+    };
+
+    chrome.alarms.onAlarm.addListener(socketAlarmListener);
+
     const listen = () => {
         const socket = new WebSocket(`ws://localhost:${PORT}`);
         const send = (message: any) => socket.send(JSON.stringify(message));
@@ -48,15 +58,7 @@ if (WATCH) {
                 }
             }
         };
-        socket.onclose = () => {
-            const ALARM_NAME = 'socket-close';
-            chrome.alarms.onAlarm.addListener((alarm) => {
-                if (alarm.name === ALARM_NAME) {
-                    listen();
-                }
-            });
-            chrome.alarms.create(ALARM_NAME, {delayInMinutes: 1 / 60});
-        };
+        socket.onclose = () => chrome.alarms.create(ALARM_NAME, {delayInMinutes: 1 / 60});
     };
     listen();
 } else {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -48,7 +48,15 @@ if (WATCH) {
                 }
             }
         };
-        socket.onclose = () => setTimeout(listen, 1000);
+        socket.onclose = () => {
+            const ALARM_NAME = 'socket-close';
+            chrome.alarms.onAlarm.addListener((alarm) => {
+                if (alarm.name === ALARM_NAME) {
+                    listen();
+                }
+            });
+            chrome.alarms.create(ALARM_NAME, {delayInMinutes: 1 / 60});
+        };
     };
     listen();
 } else {


### PR DESCRIPTION
This commit replaces one more instance of `setTimeout` in the background context with an alarm. This is direct continuation of work done in #6296.

Note: This alarm runs in 1s (like the original code) and browsers can log warnings promissing to throttle alarms in release builds to once a minute. This is not a problem, since this code will never run in release builds.