### PR TITLE
Fix for market.yandex.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7548,6 +7548,13 @@ INVERT
 
 ================================
 
+market.yandex.*
+
+INVERT
+div[data-apiary-widget-name="@market/GeoPointsMap"] > div > div > div > ymaps > ymaps > ymaps > ymaps
+
+================================
+
 marketplace.visualstudio.com
 
 CSS


### PR DESCRIPTION
- Invert map.

Example of site page: https://market.yandex.ru/geo?productId=752262035