### PR TITLE
Fix for market.yandex.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4731,6 +4731,14 @@ html {
 
 ================================
 
+forms.yandex.ru
+
+INVERT
+.header2__service-logo
+.header2__logo-wrap
+
+================================
+
 forsal.pl
 
 INVERT


### PR DESCRIPTION
- Invert logos.

Example of site pages: https://forms.yandex.ru/admin/, https://forms.yandex.ru/surveys/10022784.8ae29888f3224e212d4a904160b6baf0a05acd37/