### PR TITLE
Remove UserStorage.constructor argument onRemoteSettingsChange

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -50,7 +50,7 @@ export class Extension {
             },
             onColorSchemeChange: this.onColorSchemeChange,
         });
-        this.user = new UserStorage({onRemoteSettingsChange: () => this.onRemoteSettingsChange()});
+        this.user = new UserStorage();
         this.awaiting = [];
     }
 
@@ -369,11 +369,6 @@ export class Extension {
         this.tabs.sendMessage(this.getTabMessage);
         this.saveUserSettings();
         this.reportChanges();
-    }
-
-    private onRemoteSettingsChange() {
-        // TODO: Requires proper handling and more testing
-        // to prevent cycling across instances.
     }
 
 

--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -6,16 +6,11 @@ import {readSyncStorage, readLocalStorage, writeSyncStorage, writeLocalStorage, 
 
 const SAVE_TIMEOUT = 1000;
 
-interface UserStorageOptions {
-    onRemoteSettingsChange: () => any;
-}
-
 export default class UserStorage {
-    constructor({onRemoteSettingsChange}: UserStorageOptions) {
+    constructor() {
         this.settings = null;
         subscribeToOuterSettingsChange(async () => {
             await this.loadSettings();
-            onRemoteSettingsChange();
         });
     }
 


### PR DESCRIPTION
This commit removes one argument of `UserStorage` which is not used anyway.

Comment says:
> TODO: Requires proper handling and more testing
>  to prevent cycling across instances.

Sync inconsistency and races can be fixed in a much simpler way:
 - always use `local` storage area everywhere in core extension logic, background, UI, etc.
 - define dedicated import/export logic for transfering data between `local` and `sync` aread

Basically, every extension install can always have its own coherent state recorded in `local` area. At the same time, the `local` and `sync` areas can be kept in sync by dedicated import/export logic with sanity checks and data merging.