### PR TITLE
Fix for yandex.ru/pogoda

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13528,6 +13528,17 @@ INVERT
 
 ================================
 
+yandex.*/pogoda
+
+INVERT
+.maps-widget-nowcast__map-link
+.weather-maps__map > ymaps > ymaps > ymaps > ymaps
+.color-scale__line
+.weather-table__wind-direction > .icon_wind
+.icon_color_black
+
+================================
+
 yandex.*/support
 
 INVERT


### PR DESCRIPTION
- Invert map.
- invert icons.

Example of site pages: https://yandex.ru/pogoda/moscow?via=brd, https://yandex.ru/pogoda/moscow/maps/nowcast?via=mmapw, https://yandex.ru/pogoda/moscow/details?via=ms, https://yandex.ru/pogoda/moscow/month?via=ms