### PR TITLE
Fix for psprices.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9562,12 +9562,8 @@ psprices.com
 
 INVERT
 .store-logo
-#game-price-dynamics
-
-CSS
-body, footer {
-    background: var(--darkreader-neutral-background) !important; 
-}
+.highcharts-label text
+.game--description::after
 
 ================================
 


### PR DESCRIPTION
- Remove obsolete rules.
- Invert the text in the popup menu on the chart.
- Invert the background of the spoiler description.

Example of site page: https://psprices.com/region-ru/game/254011/tsifrovoe-izdanie-uncharted-4-put-vora