### PR TITLE
Fix for dynamic on wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4163,7 +4163,6 @@ canvas
 explainxkcd.com
 
 INVERT
-.mwe-math-element
 .mw-ext-score
 .main-footer-menuToggle
 img[src*="Loudspeaker.svg"]


### PR DESCRIPTION
It was inverting `.mwe-math-element` which then becomes unreadable as it's black on dark background