### PR TITLE
Use Alarms API instead of intervals in automation

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -86,8 +86,7 @@ export class Extension {
                 const longitude = this.user.settings.location.longitude;
 
                 if (latitude != null && longitude != null) {
-                    const now = new Date();
-                    goodTime = isNightAtLocation(now, latitude, longitude);
+                    goodTime = isNightAtLocation(latitude, longitude);
                 }
                 break;
             }

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -82,8 +82,7 @@ export class Extension {
                 }
                 return isSystemDarkModeEnabled();
             case 'location': {
-                const latitude = this.user.settings.location.latitude;
-                const longitude = this.user.settings.location.longitude;
+                const {latitude, longitude} = this.user.settings.location;
 
                 if (latitude != null && longitude != null) {
                     timingInformation = isNightAtLocation(latitude, longitude);

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -71,8 +71,7 @@ export class Extension {
         let goodTime: TimeCheck = null;
         switch (automation) {
             case 'time':
-                const now = new Date();
-                goodTime = isInTimeInterval(now, this.user.settings.time.activation, this.user.settings.time.deactivation);
+                goodTime = isInTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
                 break;
             case 'system':
                 if (isFirefox) {

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -68,10 +68,10 @@ export class Extension {
 
         const {automation} = this.user.settings;
 
-        let goodTime: TimeCheck = null;
+        let timingInformation: TimeCheck = null;
         switch (automation) {
             case 'time':
-                goodTime = isInTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
+                timingInformation = isInTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
                 break;
             case 'system':
                 if (isFirefox) {
@@ -86,18 +86,18 @@ export class Extension {
                 const longitude = this.user.settings.location.longitude;
 
                 if (latitude != null && longitude != null) {
-                    goodTime = isNightAtLocation(latitude, longitude);
+                    timingInformation = isNightAtLocation(latitude, longitude);
                 }
                 break;
             }
             default:
                 return this.user.settings.enabled;
         }
-        this.isEnabledNow = goodTime.rightNow;
-        if (goodTime.nextCheck) {
-            chrome.alarms.create(Extension.ALARM_NAME, {when: goodTime.nextCheck});
+        this.isEnabledNow = timingInformation.rightNow;
+        if (timingInformation.nextCheck) {
+            chrome.alarms.create(Extension.ALARM_NAME, {when: timingInformation.nextCheck});
         }
-        return goodTime.rightNow;
+        return timingInformation.rightNow;
     }
 
     private awaiting: Array<() => void>;

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -101,6 +101,11 @@ export interface LocationSettings {
     longitude: number;
 }
 
+export interface TimeCheck {
+    rightNow: boolean;
+    nextCheck: number;
+}
+
 export interface TabInfo {
     url: string;
     isProtected: boolean;

--- a/src/ui/popup/main-page/sun-moon-icon.tsx
+++ b/src/ui/popup/main-page/sun-moon-icon.tsx
@@ -18,7 +18,7 @@ export default function SunMoonIcon({date, latitude, longitude}) {
         );
     }
 
-    if (isNightAtLocation(date, latitude, longitude)) {
+    if (isNightAtLocation(latitude, longitude, date)) {
         // moon icon
         return (
             <svg viewBox="0 0 16 16">

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -29,11 +29,11 @@ function parse24HTime(time: string) {
     return time.split(':').map((x) => parseInt(x));
 }
 
-function compareTime(a: number[], b: number[]) {
-    if (a[0] === b[0] && a[1] === b[1]) {
+function compareTime(time1: number[], time2: number[]) {
+    if (time1[0] === time2[0] && time1[1] === time2[1]) {
         return 0;
     }
-    if (a[0] < b[0] || (a[0] === b[0] && a[1] < b[1])) {
+    if (time1[0] < time2[0] || (time1[0] === time2[0] && time1[1] < time2[1])) {
         return -1;
     }
     return 1;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -268,8 +268,6 @@ export function isNightAtLocation(
     } else if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
         // Timeline:
         // --- sunset <----> sunrise ---
-        // Timeline:
-        // --- sunset <----> sunrise ---
         //               ^
         //          Current time
         rightNow = true;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -224,10 +224,11 @@ function getSunsetSunriseUTCTime(
 }
 
 export function isNightAtLocation(
-    date: Date,
     latitude: number,
     longitude: number,
+    date?: Date,
 ): TimeCheck {
+    date = date || new Date();
     const time = getSunsetSunriseUTCTime(date, latitude, longitude);
 
     if (time.alwaysDay) {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -290,7 +290,7 @@ export function isNightAtLocation(
         // --- sunset <----> sunrise ---
         //  ^
         // Current time
-        rightNow = false
+        rightNow = false;
         nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunsetTime);
     }
     if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
@@ -298,7 +298,7 @@ export function isNightAtLocation(
         // --- sunset <----> sunrise ---
         //               ^
         //          Current time
-        rightNow = true
+        rightNow = true;
         nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunriseTime);
     }
     if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
@@ -306,7 +306,7 @@ export function isNightAtLocation(
         // --- sunset <----> sunrise ---
         //                            ^
         //                         Current time
-        rightNow = false
+        rightNow = false;
         nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1, 0, 0, 0, sunsetTime);
     }
     return {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -196,7 +196,7 @@ function getSunsetSunriseUTCTime(
         return {
             alwaysDay: false,
             alwaysNight: false,
-            time: UT * getDuration({hours: 1}),
+            time: Math.round(UT * getDuration({hours: 1})),
         };
     }
 
@@ -247,48 +247,70 @@ export function isNightAtLocation(
         date.getUTCSeconds() * getDuration({seconds: 1})
     );
 
-    if (sunsetTime > sunriseTime) {
+    if (sunriseTime < sunsetTime) {
         // Timeline:
         // --- sunrise <----> sunset ---
-        const inTimeInterval = (currentTime > sunsetTime) || (currentTime < sunriseTime);
+        let rightNow: boolean;
         let nextCheck: number;
-        if (inTimeInterval) {
-            // Timeline:
-            // --- sunrise <----> sunset ---
-            //               ^
-            //          Current time
-            nextCheck = sunsetTime - currentTime;
-        } else {
+        if (currentTime < sunriseTime) {
             // Timeline:
             // --- sunrise <----> sunset ---
             //  ^
             // Current time
-            nextCheck = sunriseTime - currentTime;
+            rightNow = true;
+            nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunriseTime);
+        }
+        if ((sunriseTime < currentTime) && (currentTime < sunsetTime)) {
+            // Timeline:
+            // --- sunrise <----> sunset ---
+            //               ^
+            //          Current time
+            rightNow = false;
+            nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunsetTime);
+        }
+        if (sunsetTime < currentTime) {
+            // Timeline:
+            // --- sunrise <----> sunset ---
+            //                            ^
+            //                        Current time
+            rightNow = true;
+            nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1, 0, 0, 0, sunriseTime);
         }
         return {
-            rightNow: inTimeInterval,
+            rightNow,
             nextCheck,
         };
     }
     // Timeline:
     // --- sunset <----> sunrise ---
-    const inTimeInterval = (currentTime > sunsetTime) && (currentTime < sunriseTime);
+    let rightNow: boolean;
     let nextCheck: number;
-    if (inTimeInterval) {
-        // Timeline:
-        // --- sunset <----> sunrise ---
-        //               ^
-        //          Current time
-        nextCheck = sunriseTime - currentTime;
-    } else {
+    if (currentTime < sunsetTime) {
         // Timeline:
         // --- sunset <----> sunrise ---
         //  ^
         // Current time
-        nextCheck = sunsetTime - currentTime;
+        rightNow = false
+        nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunsetTime);
+    }
+    if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
+        // Timeline:
+        // --- sunset <----> sunrise ---
+        //               ^
+        //          Current time
+        rightNow = true
+        nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunriseTime);
+    }
+    if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
+        // Timeline:
+        // --- sunset <----> sunrise ---
+        //                            ^
+        //                         Current time
+        rightNow = false
+        nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1, 0, 0, 0, sunsetTime);
     }
     return {
-        rightNow: inTimeInterval,
+        rightNow,
         nextCheck,
     };
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -43,19 +43,47 @@ function dummyTime() {
     return (new Date()).getTime() + getDuration({seconds: 10});
 }
 
-export function isInTimeInterval(date: Date, time0: string, time1: string): TimeCheck {
+// a <= b
+function nextIntervalTime(a, b, t, date: Date): number {
+    if (compareTime(a, b) === 0) {
+        return null;
+    }
+
+    if (compareTime(t, a) < 0) {
+        // t < a <= b
+        // Schedule for todate at time a
+        date.setHours(a[0]);
+        date.setMinutes(a[1]);
+        return date.getTime();
+    }
+
+    if (compareTime(t, b) < 0) {
+        // a <= t < b
+        // Schedule for today at time b
+        date.setHours(b[0]);
+        date.setMinutes(b[1]);
+        return date.getTime();
+    }
+
+    // a <= b <= t
+    // Schedule for tomorrow at time a
+    return (new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1, a[0], a[1])).getTime();
+}
+
+export function isInTimeInterval(time0: string, time1: string, date?: Date): TimeCheck {
+    date = date || new Date();
     const a = parse24HTime(time0);
     const b = parse24HTime(time1);
     const t = [date.getHours(), date.getMinutes()];
     if (compareTime(a, b) > 0) {
         return {
             rightNow: compareTime(a, t) <= 0 || compareTime(t, b) < 0,
-            nextCheck: dummyTime()
+            nextCheck: nextIntervalTime(b, a, t, date)
         };
     }
     return {
         rightNow: compareTime(a, t) <= 0 && compareTime(t, b) < 0,
-        nextCheck: dummyTime()
+        nextCheck: nextIntervalTime(a, b, t, date)
     };
 }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -39,10 +39,6 @@ function compareTime(time1: number[], time2: number[]) {
     return 1;
 }
 
-function dummyTime() {
-    return (new Date()).getTime() + getDuration({seconds: 10});
-}
-
 // a <= b
 function nextIntervalTime(a, b, t, date: Date): number {
     if (compareTime(a, b) === 0) {
@@ -252,13 +248,47 @@ export function isNightAtLocation(
     );
 
     if (sunsetTime > sunriseTime) {
+        // Timeline:
+        // --- sunrise <----> sunset ---
+        const inTimeInterval = (currentTime > sunsetTime) || (currentTime < sunriseTime);
+        let nextCheck: number;
+        if (inTimeInterval) {
+            // Timeline:
+            // --- sunrise <----> sunset ---
+            //               ^
+            //          Current time
+            nextCheck = sunsetTime - currentTime;
+        } else {
+            // Timeline:
+            // --- sunrise <----> sunset ---
+            //  ^
+            // Current time
+            nextCheck = sunriseTime - currentTime;
+        }
         return {
-            rightNow: (currentTime > sunsetTime) || (currentTime < sunriseTime),
-            nextCheck: dummyTime()
+            rightNow: inTimeInterval,
+            nextCheck,
         };
     }
+    // Timeline:
+    // --- sunset <----> sunrise ---
+    const inTimeInterval = (currentTime > sunsetTime) && (currentTime < sunriseTime);
+    let nextCheck: number;
+    if (inTimeInterval) {
+        // Timeline:
+        // --- sunset <----> sunrise ---
+        //               ^
+        //          Current time
+        nextCheck = sunriseTime - currentTime;
+    } else {
+        // Timeline:
+        // --- sunset <----> sunrise ---
+        //  ^
+        // Current time
+        nextCheck = sunsetTime - currentTime;
+    }
     return {
-        rightNow: (currentTime > sunsetTime) && (currentTime < sunriseTime),
-        nextCheck: dummyTime()
+        rightNow: inTimeInterval,
+        nextCheck,
     };
 }

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -245,19 +245,11 @@ export function isNightAtLocation(
         date.getUTCSeconds() * getDuration({seconds: 1})
     );
 
+    let rightNow: boolean;
+    let nextCheck: number;
     if (sunriseTime < sunsetTime) {
         // Timeline:
         // --- sunrise <----> sunset ---
-        let rightNow: boolean;
-        let nextCheck: number;
-        if (currentTime < sunriseTime) {
-            // Timeline:
-            // --- sunrise <----> sunset ---
-            //  ^
-            // Current time
-            rightNow = true;
-            nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunriseTime);
-        }
         if ((sunriseTime < currentTime) && (currentTime < sunsetTime)) {
             // Timeline:
             // --- sunrise <----> sunset ---
@@ -265,48 +257,32 @@ export function isNightAtLocation(
             //          Current time
             rightNow = false;
             nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunsetTime);
-        }
-        if (sunsetTime < currentTime) {
+        } else {
             // Timeline:
             // --- sunrise <----> sunset ---
-            //                            ^
-            //                        Current time
+            //   ^                       ^
+            //           Current time
             rightNow = true;
-            nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1, 0, 0, 0, sunriseTime);
+            nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + (sunsetTime < currentTime ? 1 : 0), 0, 0, 0, sunriseTime);
         }
-        return {
-            rightNow,
-            nextCheck,
-        };
-    }
-    // Timeline:
-    // --- sunset <----> sunrise ---
-    let rightNow: boolean;
-    let nextCheck: number;
-    if (currentTime < sunsetTime) {
+    } else if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
         // Timeline:
         // --- sunset <----> sunrise ---
-        //  ^
-        // Current time
-        rightNow = false;
-        nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunsetTime);
-    }
-    if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
         // Timeline:
         // --- sunset <----> sunrise ---
         //               ^
         //          Current time
         rightNow = true;
         nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, sunriseTime);
-    }
-    if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
+    } else {
         // Timeline:
         // --- sunset <----> sunrise ---
-        //                            ^
-        //                         Current time
+        //   ^                       ^
+        //           Current time
         rightNow = false;
-        nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + 1, 0, 0, 0, sunsetTime);
+        nextCheck = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() + (sunriseTime < currentTime ? 1 : 0), 0, 0, 0, sunsetTime);
     }
+
     return {
         rightNow,
         nextCheck,

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -116,9 +116,9 @@ function getSunsetSunriseUTCTime(
     latitude: number,
     longitude: number,
 ) {
-    const dec31 = new Date(date.getUTCFullYear(), 0, 0);
+    const dec31 = Date.UTC(date.getUTCFullYear(), 0, 0, 0, 0, 0, 0);
     const oneDay = getDuration({days: 1});
-    const dayOfYear = Math.floor((Number(date) - Number(dec31)) / oneDay);
+    const dayOfYear = Math.floor((date.getTime() - dec31) / oneDay);
 
     const zenith = 90.83333333333333;
     const D2R = Math.PI / 180;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -40,30 +40,30 @@ function compareTime(time1: number[], time2: number[]) {
 }
 
 // a <= b
-function nextIntervalTime(a, b, t, date: Date): number {
-    if (compareTime(a, b) === 0) {
+function nextIntervalTime(time1, time2, currentTime, date: Date): number {
+    if (compareTime(time1, time2) === 0) {
         return null;
     }
 
-    if (compareTime(t, a) < 0) {
+    if (compareTime(currentTime, time1) < 0) {
         // t < a <= b
         // Schedule for todate at time a
-        date.setHours(a[0]);
-        date.setMinutes(a[1]);
+        date.setHours(time1[0]);
+        date.setMinutes(time1[1]);
         return date.getTime();
     }
 
-    if (compareTime(t, b) < 0) {
+    if (compareTime(currentTime, time2) < 0) {
         // a <= t < b
         // Schedule for today at time b
-        date.setHours(b[0]);
-        date.setMinutes(b[1]);
+        date.setHours(time2[0]);
+        date.setMinutes(time2[1]);
         return date.getTime();
     }
 
     // a <= b <= t
     // Schedule for tomorrow at time a
-    return (new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1, a[0], a[1])).getTime();
+    return (new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1, time1[0], time1[1])).getTime();
 }
 
 export function isInTimeInterval(time0: string, time1: string, date?: Date): TimeCheck {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -233,12 +233,12 @@ export function isNightAtLocation(
     if (time.alwaysDay) {
         return {
             rightNow: false,
-            nextCheck: dummyTime()
+            nextCheck: date.getTime() + getDuration({days: 1})
         };
     } else if (time.alwaysNight) {
         return {
             rightNow: true,
-            nextCheck: dummyTime()
+            nextCheck: date.getTime() + getDuration({days: 1})
         };
     }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -66,8 +66,7 @@ function nextIntervalTime(time1, time2, currentTime, date: Date): number {
     return (new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1, time1[0], time1[1])).getTime();
 }
 
-export function isInTimeInterval(time0: string, time1: string, date?: Date): TimeCheck {
-    date = date || new Date();
+export function isInTimeInterval(time0: string, time1: string, date: Date = new Date()): TimeCheck {
     const a = parse24HTime(time0);
     const b = parse24HTime(time1);
     const t = [date.getHours(), date.getMinutes()];
@@ -222,9 +221,8 @@ function getSunsetSunriseUTCTime(
 export function isNightAtLocation(
     latitude: number,
     longitude: number,
-    date?: Date,
+    date: Date = new Date(),
 ): TimeCheck {
-    date = date || new Date();
     const time = getSunsetSunriseUTCTime(date, latitude, longitude);
 
     if (time.alwaysDay) {

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -1,16 +1,16 @@
 import {isInTimeInterval, isNightAtLocation, parseTime, getDuration} from '../../src/utils/time';
 
 test('Time interval', () => {
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '12:00')).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '10:00', '10:00')).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 12), '10:00', '10:00')).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 8), '10:00', '10:00')).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '10:00')).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 9, 2), '9:01', '10:00')).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '10:01')).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '18:00', '12:00')).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '18:00', '9:00')).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 22), '18:00', '9:00')).toBe(true);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '12:00').rightNow).toBe(true);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '10:00', '10:00').rightNow).toBe(false);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 12), '10:00', '10:00').rightNow).toBe(false);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 8), '10:00', '10:00').rightNow).toBe(false);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '10:00').rightNow).toBe(false);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 9, 2), '9:01', '10:00').rightNow).toBe(true);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '10:01').rightNow).toBe(true);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '18:00', '12:00').rightNow).toBe(true);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '18:00', '9:00').rightNow).toBe(false);
+    expect(isInTimeInterval(new Date(2018, 11, 4, 22), '18:00', '9:00').rightNow).toBe(true);
 });
 
 test('Time parse', () => {
@@ -36,27 +36,27 @@ test('Duration', () => {
 test('Sunrize/sunset', () => {
     const utcDate = (y, m, d, hh, mm) => new Date(Date.UTC(y, m, d, hh, mm));
 
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, 0)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 5, 0), 52, 0)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 7, 0), 52, 0)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 12, 0), 52, 0)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 18, 0), 52, 0)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 20, 0), 52, 0)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, 0)).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, 0).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 5, 0), 52, 0).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 7, 0), 52, 0).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 12, 0), 52, 0).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 18, 0), 52, 0).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 20, 0), 52, 0).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, 0).rightNow).toBe(true);
 
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, 30)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 3, 0), 52, 30)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 5, 0), 52, 30)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 10, 0), 52, 30)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 16, 0), 52, 30)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 18, 0), 52, 30)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, 30)).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, 30).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 3, 0), 52, 30).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 5, 0), 52, 30).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 10, 0), 52, 30).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 16, 0), 52, 30).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 18, 0), 52, 30).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, 30).rightNow).toBe(true);
 
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, -30)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 7, 0), 52, -30)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 9, 0), 52, -30)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 14, 0), 52, -30)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 20, 0), 52, -30)).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 22, 0), 52, -30)).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, -30)).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, -30).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 7, 0), 52, -30).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 9, 0), 52, -30).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 14, 0), 52, -30).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 20, 0), 52, -30).rightNow).toBe(false);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 22, 0), 52, -30).rightNow).toBe(true);
+    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, -30).rightNow).toBe(true);
 });

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -1,4 +1,4 @@
-import {isInTimeInterval, isNightAtLocation, parseTime, getDuration} from '../../src/utils/time';
+import {isInTimeInterval, isNightAtLocation, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
 
 test('Time interval', () => {
     expect(isInTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 12).getTime()});
@@ -31,6 +31,13 @@ test('Duration', () => {
         hours: 8,
         days: 3
     })).toEqual(289488000);
+
+    expect(getDurationInMinutes({
+        seconds: 27,
+        minutes: 25,
+        hours: 5,
+        days: 7
+    })).toEqual(10405.45);
 });
 
 test('Sunrize/sunset', () => {
@@ -59,4 +66,12 @@ test('Sunrize/sunset', () => {
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 20, 29, 34, 848)});
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 7, 24, 10, 637)});
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 7, 24, 10, 637)});
+
+    // Polar day and night
+    expect(isNightAtLocation(71, 0, utcDate(2019, 5, 15, 0, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 5, 16, 0, 0, 0, 0)});
+    expect(isNightAtLocation(-71, 0, utcDate(2019, 5, 15, 0, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 5, 16, 0, 0, 0, 0)});
+
+    // Places where sunset comes before sunrise (in UTC)
+    expect(isNightAtLocation(0, 180, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 6, 0, 50, 152)});
+    expect(isNightAtLocation(0, 180, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 17, 54, 18, 610)});
 });

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -36,27 +36,27 @@ test('Duration', () => {
 test('Sunrize/sunset', () => {
     const utcDate = (y, m, d, hh, mm) => new Date(Date.UTC(y, m, d, hh, mm));
 
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 0, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 5, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 7, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 12, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 18, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 20, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 5, 24, 2, 501)});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 5, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 5, 24, 2, 501)});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 12, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: true, nextCheck: 1568093042501});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568093140142});
 
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 0, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 3, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 5, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 10, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 16, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 18, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: 1567999434365});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 3, 0))).toEqual({rightNow: true, nextCheck: 1567999434365});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 5, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 10, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 16, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: true, nextCheck: 1568085834365});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568085932005});
 
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 0, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 7, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 9, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 14, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0)).rightNow).toBe(false);
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0)).rightNow).toBe(true);
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: 1568013850637});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: true, nextCheck: 1568013850637});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 9, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 14, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual({rightNow: true, nextCheck: 1568100348279});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568100348279});
 });

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -36,27 +36,27 @@ test('Duration', () => {
 test('Sunrize/sunset', () => {
     const utcDate = (y, m, d, hh, mm) => new Date(Date.UTC(y, m, d, hh, mm));
 
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, 0).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 5, 0), 52, 0).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 7, 0), 52, 0).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 12, 0), 52, 0).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 18, 0), 52, 0).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 20, 0), 52, 0).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, 0).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 0, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 5, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 7, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 12, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 18, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 20, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59)).rightNow).toBe(true);
 
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, 30).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 3, 0), 52, 30).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 5, 0), 52, 30).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 10, 0), 52, 30).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 16, 0), 52, 30).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 18, 0), 52, 30).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, 30).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 0, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 3, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 5, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 10, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 16, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 18, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59)).rightNow).toBe(true);
 
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 0, 0), 52, -30).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 7, 0), 52, -30).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 9, 0), 52, -30).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 14, 0), 52, -30).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 20, 0), 52, -30).rightNow).toBe(false);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 22, 0), 52, -30).rightNow).toBe(true);
-    expect(isNightAtLocation(utcDate(2019, 8, 9, 23, 59), 52, -30).rightNow).toBe(true);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 0, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 7, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 9, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 14, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0)).rightNow).toBe(false);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0)).rightNow).toBe(true);
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59)).rightNow).toBe(true);
 });

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -1,16 +1,16 @@
 import {isInTimeInterval, isNightAtLocation, parseTime, getDuration} from '../../src/utils/time';
 
 test('Time interval', () => {
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '12:00').rightNow).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '10:00', '10:00').rightNow).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 12), '10:00', '10:00').rightNow).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 8), '10:00', '10:00').rightNow).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '10:00').rightNow).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 9, 2), '9:01', '10:00').rightNow).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '9:00', '10:01').rightNow).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '18:00', '12:00').rightNow).toBe(true);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 10), '18:00', '9:00').rightNow).toBe(false);
-    expect(isInTimeInterval(new Date(2018, 11, 4, 22), '18:00', '9:00').rightNow).toBe(true);
+    expect(isInTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 12).getTime()});
+    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: false, nextCheck: null});
+    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual({rightNow: false, nextCheck: null});
+    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual({rightNow: false, nextCheck: null});
+    expect(isInTimeInterval('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: false, nextCheck: new Date(2018, 11, 5, 9).getTime()});
+    expect(isInTimeInterval('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 10).getTime()});
+    expect(isInTimeInterval('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 10, 1).getTime()});
+    expect(isInTimeInterval('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 12).getTime()});
+    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: false, nextCheck: new Date(2018, 11, 4, 18).getTime()});
+    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 5, 9).getTime()});
 });
 
 test('Time parse', () => {

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -38,25 +38,25 @@ test('Sunrize/sunset', () => {
 
     expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 5, 24, 2, 501)});
     expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 5, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 5, 24, 2, 501)});
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 12, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: true, nextCheck: 1568093042501});
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568093042501});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 18, 29, 46, 448)});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 12, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 18, 29, 46, 448)});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 18, 29, 46, 448)});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 5, 24, 2, 501)});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 5, 24, 2, 501)});
 
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: 1567999434365});
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 3, 0))).toEqual({rightNow: true, nextCheck: 1567999434365});
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 5, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 10, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 16, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: true, nextCheck: 1568085834365});
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568085834365});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 3, 23, 54, 365)});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 3, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 3, 23, 54, 365)});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 5, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 16, 29, 58, 45)});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 10, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 16, 29, 58, 45)});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 16, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 16, 29, 58, 45)});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 3, 23, 54, 365)});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 3, 23, 54, 365)});
 
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: 1568013850637});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: true, nextCheck: 1568013850637});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 9, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 14, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual({rightNow: true, nextCheck: 1568100250637});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568100250637});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 7, 24, 10, 637)});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 9, 7, 24, 10, 637)});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 9, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 20, 29, 34, 848)});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 14, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 20, 29, 34, 848)});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: false, nextCheck: Date.UTC(2019, 8, 9, 20, 29, 34, 848)});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 7, 24, 10, 637)});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: Date.UTC(2019, 8, 10, 7, 24, 10, 637)});
 });

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -42,7 +42,7 @@ test('Sunrize/sunset', () => {
     expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 12, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
     expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: false, nextCheck: 1568053786448});
     expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: true, nextCheck: 1568093042501});
-    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568093140142});
+    expect(isNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568093042501});
 
     expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: 1567999434365});
     expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 3, 0))).toEqual({rightNow: true, nextCheck: 1567999434365});
@@ -50,13 +50,13 @@ test('Sunrize/sunset', () => {
     expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 10, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
     expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 16, 0))).toEqual({rightNow: false, nextCheck: 1568046598045});
     expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 18, 0))).toEqual({rightNow: true, nextCheck: 1568085834365});
-    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568085932005});
+    expect(isNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568085834365});
 
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 0, 0))).toEqual({rightNow: true, nextCheck: 1568013850637});
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 7, 0))).toEqual({rightNow: true, nextCheck: 1568013850637});
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 9, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 14, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
     expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0))).toEqual({rightNow: false, nextCheck: 1568060974848});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual({rightNow: true, nextCheck: 1568100348279});
-    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568100348279});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual({rightNow: true, nextCheck: 1568100250637});
+    expect(isNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual({rightNow: true, nextCheck: 1568100250637});
 });


### PR DESCRIPTION
Previously, extension "automation" feature was checking every 10 seconds whether it was "night" or "day", even though typically night-day transition happens only 2 times in a 24 hour period. This commit enables extension to determine when exactly this transition is expected to happen next time and schedule an alarm for exact time.

This commit changes return value of `isInTimeInterval` and `isNightAtLocation` from simple boolen to object which contains the old boolean and a timestamp of when the answer will change. ~~To limit LoC and simplify code review, these functions schedule the new check for a dummy time, which replicates current extension behavior of running the check every 10 seconds.~~