### PR TITLE
Fix static theme for Reddit video player

### DIFF
--- a/src/config/static-themes.config
+++ b/src/config/static-themes.config
@@ -124,6 +124,29 @@ TRANSPARENT BG
 
 ================================
 
+reddit.com
+
+RED BG
+.reddit-video-player-root .seek-bar-progress
+.reddit-video-player-root .volume-slider-progress
+.reddit-video-player-root .volume-slider-thumb
+
+BLUE BG
+.reddit-video-player-root .seek-bar-buffered
+.reddit-video-player-root .volume-slider-track
+
+FADE BG
+.reddit-video-player-root .ended-controls
+.reddit-video-player-root .playback-controls
+
+TRANSPARENT BG
+.reddit-video-player-root video + div
+.reddit-video-player-root .ended-controls :not(button)
+.reddit-video-seek-bar-root
+.reddit-video-player-root .playback-controls .control-button
+
+================================
+
 youtube.com
 
 RED BG


### PR DESCRIPTION
This fixes the Reddit video player, which was previously covered by an overlay, and also didn't display the progress. Here's the before and after:

![2](https://user-images.githubusercontent.com/787075/126908815-7dd9f18c-491a-4fad-9f41-099143d18851.jpg)


Edit: Here's a sample link https://old.reddit.com/r/nextfuckinglevel/comments/ord4lb/amazing_landing_pilot_manages_to_land_plane/