### PR TITLE
Register LimitedCacheStorage alarm only when needed

### DIFF
--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -42,7 +42,7 @@ class LimitedCacheStorage {
 
     private bytesInUse = 0;
     private records = new Map<string, CacheRecord>();
-    private hasAlarm: boolean = false;
+    private hasAlarm = false;
 
     constructor() {
         chrome.alarms.onAlarm.addListener(async (alarm) => {

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -42,23 +42,23 @@ class LimitedCacheStorage {
 
     private bytesInUse = 0;
     private records = new Map<string, CacheRecord>();
-    private hasAlarm = false;
+    private alarmIsActive = false;
 
     constructor() {
         chrome.alarms.onAlarm.addListener(async (alarm) => {
             if (alarm.name === LimitedCacheStorage.ALARM_NAME) {
                 // We schedule only one-time alarms, so once it goes off,
                 // there are no more alarms scheduled.
-                this.hasAlarm = false;
+                this.alarmIsActive = false;
                 this.removeExpiredRecords();
             }
         });
     }
 
     private ensureAlarmIsScheduled(){
-        if (!this.hasAlarm) {
+        if (!this.alarmIsActive) {
             chrome.alarms.create(LimitedCacheStorage.ALARM_NAME, {delayInMinutes: 1});
-            this.hasAlarm = true;
+            this.alarmIsActive = true;
         }
     }
 


### PR DESCRIPTION
This is direct continuation of #6296. In 6296, we added a new permission `alarms` and replaced `setInterval` with corresponding recurring (periodic) alarm which fires even when cache is empty and therefore there is nothing to do. That alarm is problematic if extension wants to go to sleep for exteneded periods of time but can't because it's resurrected by an alarm every minute. This PR replaces the unconditional periodic alarm with a one-time alarm which is scheduled only when needed (when cache is not empty).

This change will help extension background to go entirely passive (get unloaded) when extension does not do anything. E.g., when extension is set to OFF or when extension is set to ON but user does not load new pages. (After applying this patch and setting `persistent` to `false` in manifest, I observed that extension background consistently goes to sleep as expected.)