### PR TITLE
Added GitHub to the list of sites with dark mode

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -329,6 +329,7 @@ gifrun.com
 gifyourgame.com
 gikken.co
 giphy.com
+github.com
 githubuniverse.com
 gitkraken.com
 gitmoji.kaki87.net


### PR DESCRIPTION
I am also aware of the fact that some GitHub sites like GitHub marketplace (`github.com/marketplace`) still use light mode and hence have propose a solution.
See - #6365 