### PR TITLE
Fix for mail.google.com (gmail)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7473,7 +7473,6 @@ img.Hk
 img.Ha
 .asor_t0
 .asor_i4
-.ita-icon-0
 .d-Na-Jo.d-Na-N-ax3
 .RK-QJ-Jk
 .RK-Mo.RK-Qq-LF
@@ -7484,8 +7483,8 @@ img[src$="google_gsuite"]
 img[src$="profile_mask2.png"]
 .rY>.sa
 .buh
-.qj.qr::before
-.qj.qr::after
+.aEc .qj
+.n3 .qr
 .mixmax-flyout__wrapper
 
 CSS
@@ -7508,6 +7507,13 @@ CSS
 }
 .buj {
     background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_compact_v1_1x.png) !important;
+}
+div[class*="bym"][role="navigation"] {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.ain .TO,
+.TO.ol {
+    background-color: rgba(255,255,255,0.05) !important;
 }
 ::-webkit-scrollbar-thumb {
     background-color: #424242 !important;


### PR DESCRIPTION
- Invert category icons.
- Darken the background of the pop-up side menu.
- Remove obsolete rule.