### PR TITLE
Add giggl.app & phineas.io to the dark-sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -329,6 +329,7 @@ giantbomb.com
 gibber.cc
 gifrun.com
 gifyourgame.com
+giggl.app
 gikken.co
 giphy.com
 githubuniverse.com
@@ -581,6 +582,7 @@ peertube.servebeer.com
 peertube.zapashcanon.fr
 peterlindbergh.obys.agency
 petersalomonsen.com/webassemblymusic/livecodev2
+phineas.io
 photomosh.com
 photopea.com
 pic.cleoold.com


### PR DESCRIPTION
Both giggl.app & phineas.io are dark-themed, regardless of the system theme.