### PR TITLE
Use crypto.randomUUID() in Utils UID

### DIFF
--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -3,9 +3,9 @@ function hexify(number: number) {
 }
 
 export function generateUID() {
-    // TODO: remove any cast once types are updated
+    // TODO: remove any cast once type declarations are updated
     if ((crypto as any).randomUUID) {
-        return (crypto as any).randomUUID().replaceAll('-', ' ');
+        return (crypto as any).randomUUID().replaceAll('-', '');
     }
 
     return Array.from(crypto.getRandomValues(new Uint8Array(16))).map((x) => hexify(x)).join('');

--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -3,5 +3,10 @@ function hexify(number: number) {
 }
 
 export function generateUID() {
+    // TODO: remove any cast once types are updated
+    if ((crypto as any).randomUUID) {
+        return (crypto as any).randomUUID().replaceAll('-', ' ');
+    }
+
     return Array.from(crypto.getRandomValues(new Uint8Array(16))).map((x) => hexify(x)).join('');
 }

--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -3,8 +3,8 @@ function hexify(number: number) {
 }
 
 export function generateUID() {
-    // TODO: remove any cast once type declarations are updated
-    if ((crypto as any).randomUUID) {
+    if ('randomUUID' in crypto) {
+        // TODO: remove any cast once type declarations are updated
         const uuid = (crypto as any).randomUUID();
         return uuid.substring(0, 8) + uuid.substring(9, 13) + uuid.substring(14, 18) + uuid.substring(19, 23) + uuid.substring(24);
     }

--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -5,7 +5,8 @@ function hexify(number: number) {
 export function generateUID() {
     // TODO: remove any cast once type declarations are updated
     if ((crypto as any).randomUUID) {
-        return (crypto as any).randomUUID().replaceAll('-', '');
+        const uuid = (crypto as any).randomUUID();
+        return uuid.substring(0, 8) + uuid.substring(9, 13) + uuid.substring(14, 18) + uuid.substring(19, 23) + uuid.substring(24);
     }
 
     return Array.from(crypto.getRandomValues(new Uint8Array(16))).map((x) => hexify(x)).join('');

--- a/tests/utils/uid.tests.ts
+++ b/tests/utils/uid.tests.ts
@@ -1,0 +1,32 @@
+import {randomFillSync} from 'crypto';
+import {generateUID} from '../../src/utils/uid';
+
+test('Unique identifier generation', () => {
+    // Make sure we are not messing up global context for the tests
+    expect('crypto' in globalThis).toEqual(false);
+
+    // Create a shim for crypto API
+    // TODO: remove any cast once type declarations are updated
+    const shim1 = jest.fn();
+    globalThis.crypto = {
+        getRandomValues: (buffer) => {
+            shim1();
+            return randomFillSync(buffer)
+        },
+    } as any;
+    const uid1 = generateUID();
+    expect(/^[a-f0-9]{32}$/.test(uid1)).toEqual(true);
+    expect(shim1).toHaveBeenCalled();
+
+    const shim2 = jest.fn();
+    globalThis.crypto = {
+        randomUUID: () => {
+            shim2();
+            return 'a19cc926-bf7f-4d5f-bf9c-202bc7a4c7c6';
+        },
+    } as any;
+    expect(generateUID()).toEqual('a19cc926bf7f4d5fbf9c202bc7a4c7c6');
+    expect(shim2).toHaveBeenCalled();
+
+    globalThis.crypto = undefined;
+});

--- a/tests/utils/uid.tests.ts
+++ b/tests/utils/uid.tests.ts
@@ -2,7 +2,7 @@ import {randomFillSync} from 'crypto';
 import {generateUID} from '../../src/utils/uid';
 
 test('Unique identifier generation', () => {
-    // Make sure we are not messing up global context for the tests
+    // Make sure we are not messing up global context for somebody else
     expect('crypto' in globalThis).toEqual(false);
 
     // Create a shim for crypto API
@@ -28,5 +28,5 @@ test('Unique identifier generation', () => {
     expect(generateUID()).toEqual('a19cc926bf7f4d5fbf9c202bc7a4c7c6');
     expect(shim2).toHaveBeenCalled();
 
-    globalThis.crypto = undefined;
+    delete globalThis.crypto;
 });

--- a/tests/utils/uid.tests.ts
+++ b/tests/utils/uid.tests.ts
@@ -11,7 +11,7 @@ test('Unique identifier generation', () => {
     globalThis.crypto = {
         getRandomValues: (buffer) => {
             shim1();
-            return randomFillSync(buffer)
+            return randomFillSync(buffer);
         },
     } as any;
     const uid1 = generateUID();


### PR DESCRIPTION
Chrome 92 added support for `crypto.randomUUID()` function which returns string representation of a Universally Unique Identifiers (UUID) based on RFC4122. This new method is approximatelly 2x faster than the old one based on `crypto.getRandomValues()` and manual hex encoding (when measuring time required for generating 10000 strings).

Note: this method leads to reduced entropy of the resulting string (by 6 bits) because `crypto.randomUUID()` produces UUID with predefined version identifiers. I don't think this entropy reduction is critical given the overall entropy of the string and the way this function is used.

(Of course, `generateUID()` isn't critical for performance, but it would be nice to use the proper API instead of manual byte manipulations.)

## Sources
- [Chrome Platform status entry](https://www.chromestatus.com/feature/5689159362543616)
- [Specification draft](https://wicg.github.io/uuid/)