### PR TITLE
Disabling Dark Mode for jadenjsj.ddns.net

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -414,6 +414,7 @@ isthereanydeal.com
 isxander.dev
 iwanttoeat.app
 ixirc.com
+jadenjsj.ddns.net
 jackdaniels.com
 jakobneumann.com
 jakubkaczor.com


### PR DESCRIPTION
It would be very good if you can add a meta tag to disable darkreader, instead of needing to add to a list.