### PR TITLE
Add new website to dynamic theme fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -373,6 +373,14 @@ CSS
 
 ================================
 
+academy.abeka.com
+
+INVERT
+.logo img
+.center-align img
+
+================================
+
 academy.dqlab.id
 
 INVERT


### PR DESCRIPTION
Adds the learning website academy.abeka.com to the dynamic theme fixes.
Inverts the site logo and the logo in the middle of the student video window.