### PR TITLE
Follow-up to "Use Alarms API instead of intervals in automation"

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -8,7 +8,7 @@ import TabManager from './tab-manager';
 import UserStorage from './user-storage';
 import {setWindowTheme, resetWindowTheme} from './window-theme';
 import {getFontList, getCommands, setShortcut, canInjectScript} from './utils/extension-api';
-import {isInTimeInterval, nextIntervalTime, isNightAtLocation} from '../utils/time';
+import {isInTimeInterval, nextIntervalTime, isNightAtLocation, nextSunriseOrSunset} from '../utils/time';
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import ThemeEngines from '../generators/theme-engines';
 import createCSSFilterStylesheet from '../generators/css-filter';
@@ -87,9 +87,8 @@ export class Extension {
                 const {latitude, longitude} = this.user.settings.location;
 
                 if (latitude != null && longitude != null) {
-                    const info = isNightAtLocation(latitude, longitude);
-                    this.isEnabledCached = info.rightNow;
-                    nextCheck = info.nextCheck;
+                    this.isEnabledCached = isNightAtLocation(latitude, longitude);
+                    nextCheck = nextSunriseOrSunset(latitude, longitude);
                 }
                 break;
             }

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -8,7 +8,7 @@ import TabManager from './tab-manager';
 import UserStorage from './user-storage';
 import {setWindowTheme, resetWindowTheme} from './window-theme';
 import {getFontList, getCommands, setShortcut, canInjectScript} from './utils/extension-api';
-import {isInTimeInterval, nextIntervalTime, isNightAtLocation, nextSunriseOrSunset} from '../utils/time';
+import {isInTimeInterval, nextTimeInterval, isNightAtLocation, nextNightAtLocation} from '../utils/time';
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import ThemeEngines from '../generators/theme-engines';
 import createCSSFilterStylesheet from '../generators/css-filter';
@@ -71,7 +71,7 @@ export class Extension {
         switch (automation) {
             case 'time':
                 this.isEnabledCached = isInTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
-                nextCheck = nextIntervalTime(this.user.settings.time.activation, this.user.settings.time.deactivation);
+                nextCheck = nextTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
                 break;
             case 'system':
                 if (isFirefox) {
@@ -88,7 +88,7 @@ export class Extension {
 
                 if (latitude != null && longitude != null) {
                     this.isEnabledCached = isNightAtLocation(latitude, longitude);
-                    nextCheck = nextSunriseOrSunset(latitude, longitude);
+                    nextCheck = nextNightAtLocation(latitude, longitude);
                 }
                 break;
             }

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -8,14 +8,14 @@ import TabManager from './tab-manager';
 import UserStorage from './user-storage';
 import {setWindowTheme, resetWindowTheme} from './window-theme';
 import {getFontList, getCommands, setShortcut, canInjectScript} from './utils/extension-api';
-import {isInTimeInterval, isNightAtLocation} from '../utils/time';
+import {isInTimeInterval, nextIntervalTime, isNightAtLocation} from '../utils/time';
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import ThemeEngines from '../generators/theme-engines';
 import createCSSFilterStylesheet from '../generators/css-filter';
 import {getDynamicThemeFixesFor} from '../generators/dynamic-theme';
 import createStaticStylesheet from '../generators/static-theme';
 import {createSVGFilterStylesheet, getSVGFilterMatrixValue, getSVGReverseFilterMatrixValue} from '../generators/svg-filter';
-import type {ExtensionData, FilterConfig, News, Shortcuts, UserSettings, TabInfo, TimeCheck} from '../definitions';
+import type {ExtensionData, FilterConfig, News, Shortcuts, UserSettings, TabInfo} from '../definitions';
 import {isSystemDarkModeEnabled} from '../utils/media-query';
 import {isFirefox, isThunderbird} from '../utils/platform';
 
@@ -67,36 +67,40 @@ export class Extension {
         }
 
         const {automation} = this.user.settings;
-
-        let timingInformation: TimeCheck = null;
+        let nextCheck: number;
         switch (automation) {
             case 'time':
-                timingInformation = isInTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
+                this.isEnabledNow = isInTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
+                nextCheck = nextIntervalTime(this.user.settings.time.activation, this.user.settings.time.deactivation);
                 break;
             case 'system':
                 if (isFirefox) {
                     // BUG: Firefox background page always matches initial color scheme.
-                    return this.wasLastColorSchemeDark == null
+                    this.isEnabledNow = this.wasLastColorSchemeDark == null
                         ? isSystemDarkModeEnabled()
                         : this.wasLastColorSchemeDark;
+                } else {
+                    this.isEnabledNow = isSystemDarkModeEnabled();
                 }
-                return isSystemDarkModeEnabled();
+                break;
             case 'location': {
                 const {latitude, longitude} = this.user.settings.location;
 
                 if (latitude != null && longitude != null) {
-                    timingInformation = isNightAtLocation(latitude, longitude);
+                    const info = isNightAtLocation(latitude, longitude);
+                    this.isEnabledNow = info.rightNow;
+                    nextCheck = info.nextCheck;
                 }
                 break;
             }
             default:
-                return this.user.settings.enabled;
+                this.isEnabledNow = this.user.settings.enabled;
+                break;
         }
-        this.isEnabledNow = timingInformation.rightNow;
-        if (timingInformation.nextCheck) {
-            chrome.alarms.create(Extension.ALARM_NAME, {when: timingInformation.nextCheck});
+        if (nextCheck) {
+            chrome.alarms.create(Extension.ALARM_NAME, {when: nextCheck});
         }
-        return timingInformation.rightNow;
+        return this.isEnabledNow;
     }
 
     private awaiting: Array<() => void>;

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -8,7 +8,7 @@ import TabManager from './tab-manager';
 import UserStorage from './user-storage';
 import {setWindowTheme, resetWindowTheme} from './window-theme';
 import {getFontList, getCommands, setShortcut, canInjectScript} from './utils/extension-api';
-import {isInTimeInterval, nextTimeInterval, isNightAtLocation, nextNightAtLocation} from '../utils/time';
+import {isInTimeIntervalLocal, nextTimeInterval, isNightAtLocation, nextNightAtLocation} from '../utils/time';
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import ThemeEngines from '../generators/theme-engines';
 import createCSSFilterStylesheet from '../generators/css-filter';
@@ -70,7 +70,7 @@ export class Extension {
         let nextCheck: number;
         switch (automation) {
             case 'time':
-                this.isEnabledCached = isInTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
+                this.isEnabledCached = isInTimeIntervalLocal(this.user.settings.time.activation, this.user.settings.time.deactivation);
                 nextCheck = nextTimeInterval(this.user.settings.time.activation, this.user.settings.time.deactivation);
                 break;
             case 'system':

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -101,11 +101,6 @@ export interface LocationSettings {
     longitude: number;
 }
 
-export interface TimeCheck {
-    rightNow: boolean;
-    nextCheck: number;
-}
-
 export interface TabInfo {
     url: string;
     isProtected: boolean;

--- a/src/ui/popup/main-page/sun-moon-icon.tsx
+++ b/src/ui/popup/main-page/sun-moon-icon.tsx
@@ -18,7 +18,7 @@ export default function SunMoonIcon({date, latitude, longitude}) {
         );
     }
 
-    if (isNightAtLocation(latitude, longitude, date).rightNow) {
+    if (isNightAtLocation(latitude, longitude, date)) {
         // moon icon
         return (
             <svg viewBox="0 0 16 16">

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -237,7 +237,7 @@ export function isNightAtLocation(
         date.getUTCHours() * getDuration({hours: 1}) +
         date.getUTCMinutes() * getDuration({minutes: 1}) +
         date.getUTCSeconds() * getDuration({seconds: 1}) +
-        date.getMilliseconds()
+        date.getUTCMilliseconds()
     );
 
     if (sunriseTime < sunsetTime) {
@@ -289,7 +289,7 @@ export function nextNightAtLocation(
         date.getUTCHours() * getDuration({hours: 1}) +
         date.getUTCMinutes() * getDuration({minutes: 1}) +
         date.getUTCSeconds() * getDuration({seconds: 1}) +
-        date.getMilliseconds()
+        date.getUTCMilliseconds()
     );
 
     if (sunriseTime < sunsetTime) {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -37,14 +37,14 @@ function compareTime(time1: number[], time2: number[]) {
     return 1;
 }
 
-export function nextIntervalTime(time0: string, time1: string, date: Date = new Date()): number {
+export function nextTimeInterval(time0: string, time1: string, date: Date = new Date()): number {
     const a = parse24HTime(time0);
     const b = parse24HTime(time1);
     const t = [date.getHours(), date.getMinutes()];
 
     // Ensure a <= b
     if (compareTime(a, b) > 0) {
-        return nextIntervalTime(time1, time0, date);
+        return nextTimeInterval(time1, time0, date);
     }
 
     if (compareTime(a, b) === 0) {
@@ -269,7 +269,7 @@ export function isNightAtLocation(
     return false;
 }
 
-export function nextSunriseOrSunset(
+export function nextNightAtLocation(
     latitude: number,
     longitude: number,
     date: Date = new Date(),

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -72,7 +72,7 @@ export function nextTimeInterval(time0: string, time1: string, date: Date = new 
     return (new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1, a[0], a[1])).getTime();
 }
 
-export function isInTimeInterval(time0: string, time1: string, date: Date = new Date()): boolean {
+export function isInTimeIntervalLocal(time0: string, time1: string, date: Date = new Date()): boolean {
     const a = parse24HTime(time0);
     const b = parse24HTime(time1);
     const t = [date.getHours(), date.getMinutes()];
@@ -80,6 +80,13 @@ export function isInTimeInterval(time0: string, time1: string, date: Date = new 
         return compareTime(a, t) <= 0 || compareTime(t, b) < 0;
     }
     return compareTime(a, t) <= 0 && compareTime(t, b) < 0;
+}
+
+function isInTimeIntervalUTC(time0: number, time1: number, timestamp: number) {
+    if (time1 < time0) {
+        return timestamp <= time1 || time0 <= timestamp;
+    }
+    return time0 < timestamp && timestamp < time1;
 }
 
 interface Duration {
@@ -240,34 +247,7 @@ export function isNightAtLocation(
         date.getUTCMilliseconds()
     );
 
-    if (sunriseTime < sunsetTime) {
-        // Timeline:
-        // --- sunrise <----> sunset ---
-        if ((sunriseTime < currentTime) && (currentTime < sunsetTime)) {
-            // Timeline:
-            // --- sunrise <----> sunset ---
-            //               ^
-            //          Current time
-            return false;
-        }
-        // Timeline:
-        // --- sunrise <----> sunset ---
-        //   ^                       ^
-        //           Current time
-        return true;
-    }
-    if ((sunsetTime < currentTime) && (currentTime < sunriseTime)) {
-        // Timeline:
-        // --- sunset <----> sunrise ---
-        //               ^
-        //          Current time
-        return true;
-    }
-    // Timeline:
-    // --- sunset <----> sunrise ---
-    //   ^                       ^
-    //           Current time
-    return false;
+    return isInTimeIntervalUTC(sunsetTime, sunriseTime, currentTime);
 }
 
 export function nextNightAtLocation(

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -236,7 +236,8 @@ export function isNightAtLocation(
     const currentTime = (
         date.getUTCHours() * getDuration({hours: 1}) +
         date.getUTCMinutes() * getDuration({minutes: 1}) +
-        date.getUTCSeconds() * getDuration({seconds: 1})
+        date.getUTCSeconds() * getDuration({seconds: 1}) +
+        date.getMilliseconds()
     );
 
     if (sunriseTime < sunsetTime) {
@@ -287,7 +288,8 @@ export function nextNightAtLocation(
     const currentTime = (
         date.getUTCHours() * getDuration({hours: 1}) +
         date.getUTCMinutes() * getDuration({minutes: 1}) +
-        date.getUTCSeconds() * getDuration({seconds: 1})
+        date.getUTCSeconds() * getDuration({seconds: 1}) +
+        date.getMilliseconds()
     );
 
     if (sunriseTime < sunsetTime) {

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -111,9 +111,9 @@ export function getDurationInMinutes(time: Duration) {
 }
 
 function getSunsetSunriseUTCTime(
-    date: Date,
     latitude: number,
     longitude: number,
+    date: Date,
 ) {
     const dec31 = Date.UTC(date.getUTCFullYear(), 0, 0, 0, 0, 0, 0);
     const oneDay = getDuration({days: 1});
@@ -223,7 +223,7 @@ export function isNightAtLocation(
     longitude: number,
     date: Date = new Date(),
 ): boolean {
-    const time = getSunsetSunriseUTCTime(date, latitude, longitude);
+    const time = getSunsetSunriseUTCTime(latitude, longitude, date);
 
     if (time.alwaysDay) {
         return false;
@@ -275,7 +275,7 @@ export function nextNightAtLocation(
     longitude: number,
     date: Date = new Date(),
 ): number {
-    const time = getSunsetSunriseUTCTime(date, latitude, longitude);
+    const time = getSunsetSunriseUTCTime(latitude, longitude, date);
 
     if (time.alwaysDay) {
         return date.getTime() + getDuration({days: 1});

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -1,17 +1,17 @@
-import {isInTimeInterval, nextTimeInterval, isNightAtLocation, nextNightAtLocation, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
+import {isInTimeIntervalLocal, nextTimeInterval, isNightAtLocation, nextNightAtLocation, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
 
 test('Time interval', () => {
-    // isInTimeInterval is time-zone dependent
-    expect(isInTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
-    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(false);
-    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(false);
-    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual(false);
-    expect(isInTimeInterval('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(false);
-    expect(isInTimeInterval('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual(true);
-    expect(isInTimeInterval('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual(true);
-    expect(isInTimeInterval('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
-    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual(false);
-    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual(true);
+    // isInTimeIntervalLocal is time-zone dependent
+    expect(isInTimeIntervalLocal('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
+    expect(isInTimeIntervalLocal('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(false);
+    expect(isInTimeIntervalLocal('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(false);
+    expect(isInTimeIntervalLocal('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual(false);
+    expect(isInTimeIntervalLocal('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(false);
+    expect(isInTimeIntervalLocal('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual(true);
+    expect(isInTimeIntervalLocal('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual(true);
+    expect(isInTimeIntervalLocal('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
+    expect(isInTimeIntervalLocal('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual(false);
+    expect(isInTimeIntervalLocal('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual(true);
 });
 
 test('Time interval prediction', () => {

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -1,4 +1,4 @@
-import {isInTimeInterval, nextIntervalTime, isNightAtLocation, nextSunriseOrSunset, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
+import {isInTimeInterval, nextTimeInterval, isNightAtLocation, nextNightAtLocation, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
 
 test('Time interval', () => {
     expect(isInTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
@@ -14,16 +14,16 @@ test('Time interval', () => {
 });
 
 test('Time interval prediction', () => {
-    expect(nextIntervalTime('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 12).getTime());
-    expect(nextIntervalTime('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(null);
-    expect(nextIntervalTime('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(null);
-    expect(nextIntervalTime('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual(null);
-    expect(nextIntervalTime('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 5, 9).getTime());
-    expect(nextIntervalTime('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual(new Date(2018, 11, 4, 10).getTime());
-    expect(nextIntervalTime('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 10, 1).getTime());
-    expect(nextIntervalTime('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 12).getTime());
-    expect(nextIntervalTime('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 18).getTime());
-    expect(nextIntervalTime('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual(new Date(2018, 11, 5, 9).getTime());
+    expect(nextTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 12).getTime());
+    expect(nextTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(null);
+    expect(nextTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(null);
+    expect(nextTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual(null);
+    expect(nextTimeInterval('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 5, 9).getTime());
+    expect(nextTimeInterval('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual(new Date(2018, 11, 4, 10).getTime());
+    expect(nextTimeInterval('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 10, 1).getTime());
+    expect(nextTimeInterval('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 12).getTime());
+    expect(nextTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 18).getTime());
+    expect(nextTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual(new Date(2018, 11, 5, 9).getTime());
 });
 
 test('Time parse', () => {
@@ -92,35 +92,35 @@ test('Nigth check', () => {
 test('Sunrise/sunset', () => {
     const utcDate = (y, m, d, hh, mm) => new Date(Date.UTC(y, m, d, hh, mm));
 
-    expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 5, 24, 2, 501));
-    expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 5, 0))).toEqual(Date.UTC(2019, 8, 9, 5, 24, 2, 501));
-    expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 7, 0))).toEqual(Date.UTC(2019, 8, 9, 18, 29, 46, 448));
-    expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 12, 0))).toEqual(Date.UTC(2019, 8, 9, 18, 29, 46, 448));
-    expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 18, 0))).toEqual(Date.UTC(2019, 8, 9, 18, 29, 46, 448));
-    expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 20, 0))).toEqual(Date.UTC(2019, 8, 10, 5, 24, 2, 501));
-    expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 23, 59))).toEqual(Date.UTC(2019, 8, 10, 5, 24, 2, 501));
+    expect(nextNightAtLocation(52, 0, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 5, 24, 2, 501));
+    expect(nextNightAtLocation(52, 0, utcDate(2019, 8, 9, 5, 0))).toEqual(Date.UTC(2019, 8, 9, 5, 24, 2, 501));
+    expect(nextNightAtLocation(52, 0, utcDate(2019, 8, 9, 7, 0))).toEqual(Date.UTC(2019, 8, 9, 18, 29, 46, 448));
+    expect(nextNightAtLocation(52, 0, utcDate(2019, 8, 9, 12, 0))).toEqual(Date.UTC(2019, 8, 9, 18, 29, 46, 448));
+    expect(nextNightAtLocation(52, 0, utcDate(2019, 8, 9, 18, 0))).toEqual(Date.UTC(2019, 8, 9, 18, 29, 46, 448));
+    expect(nextNightAtLocation(52, 0, utcDate(2019, 8, 9, 20, 0))).toEqual(Date.UTC(2019, 8, 10, 5, 24, 2, 501));
+    expect(nextNightAtLocation(52, 0, utcDate(2019, 8, 9, 23, 59))).toEqual(Date.UTC(2019, 8, 10, 5, 24, 2, 501));
 
-    expect(nextSunriseOrSunset(52, 30, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 3, 23, 54, 365));
-    expect(nextSunriseOrSunset(52, 30, utcDate(2019, 8, 9, 3, 0))).toEqual(Date.UTC(2019, 8, 9, 3, 23, 54, 365));
-    expect(nextSunriseOrSunset(52, 30, utcDate(2019, 8, 9, 5, 0))).toEqual(Date.UTC(2019, 8, 9, 16, 29, 58, 45));
-    expect(nextSunriseOrSunset(52, 30, utcDate(2019, 8, 9, 10, 0))).toEqual(Date.UTC(2019, 8, 9, 16, 29, 58, 45));
-    expect(nextSunriseOrSunset(52, 30, utcDate(2019, 8, 9, 16, 0))).toEqual(Date.UTC(2019, 8, 9, 16, 29, 58, 45));
-    expect(nextSunriseOrSunset(52, 30, utcDate(2019, 8, 9, 18, 0))).toEqual(Date.UTC(2019, 8, 10, 3, 23, 54, 365));
-    expect(nextSunriseOrSunset(52, 30, utcDate(2019, 8, 9, 23, 59))).toEqual(Date.UTC(2019, 8, 10, 3, 23, 54, 365));
+    expect(nextNightAtLocation(52, 30, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 3, 23, 54, 365));
+    expect(nextNightAtLocation(52, 30, utcDate(2019, 8, 9, 3, 0))).toEqual(Date.UTC(2019, 8, 9, 3, 23, 54, 365));
+    expect(nextNightAtLocation(52, 30, utcDate(2019, 8, 9, 5, 0))).toEqual(Date.UTC(2019, 8, 9, 16, 29, 58, 45));
+    expect(nextNightAtLocation(52, 30, utcDate(2019, 8, 9, 10, 0))).toEqual(Date.UTC(2019, 8, 9, 16, 29, 58, 45));
+    expect(nextNightAtLocation(52, 30, utcDate(2019, 8, 9, 16, 0))).toEqual(Date.UTC(2019, 8, 9, 16, 29, 58, 45));
+    expect(nextNightAtLocation(52, 30, utcDate(2019, 8, 9, 18, 0))).toEqual(Date.UTC(2019, 8, 10, 3, 23, 54, 365));
+    expect(nextNightAtLocation(52, 30, utcDate(2019, 8, 9, 23, 59))).toEqual(Date.UTC(2019, 8, 10, 3, 23, 54, 365));
 
-    expect(nextSunriseOrSunset(52, -30, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 7, 24, 10, 637));
-    expect(nextSunriseOrSunset(52, -30, utcDate(2019, 8, 9, 7, 0))).toEqual(Date.UTC(2019, 8, 9, 7, 24, 10, 637));
-    expect(nextSunriseOrSunset(52, -30, utcDate(2019, 8, 9, 9, 0))).toEqual(Date.UTC(2019, 8, 9, 20, 29, 34, 848));
-    expect(nextSunriseOrSunset(52, -30, utcDate(2019, 8, 9, 14, 0))).toEqual(Date.UTC(2019, 8, 9, 20, 29, 34, 848));
-    expect(nextSunriseOrSunset(52, -30, utcDate(2019, 8, 9, 20, 0))).toEqual(Date.UTC(2019, 8, 9, 20, 29, 34, 848));
-    expect(nextSunriseOrSunset(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual(Date.UTC(2019, 8, 10, 7, 24, 10, 637));
-    expect(nextSunriseOrSunset(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual(Date.UTC(2019, 8, 10, 7, 24, 10, 637));
+    expect(nextNightAtLocation(52, -30, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 7, 24, 10, 637));
+    expect(nextNightAtLocation(52, -30, utcDate(2019, 8, 9, 7, 0))).toEqual(Date.UTC(2019, 8, 9, 7, 24, 10, 637));
+    expect(nextNightAtLocation(52, -30, utcDate(2019, 8, 9, 9, 0))).toEqual(Date.UTC(2019, 8, 9, 20, 29, 34, 848));
+    expect(nextNightAtLocation(52, -30, utcDate(2019, 8, 9, 14, 0))).toEqual(Date.UTC(2019, 8, 9, 20, 29, 34, 848));
+    expect(nextNightAtLocation(52, -30, utcDate(2019, 8, 9, 20, 0))).toEqual(Date.UTC(2019, 8, 9, 20, 29, 34, 848));
+    expect(nextNightAtLocation(52, -30, utcDate(2019, 8, 9, 22, 0))).toEqual(Date.UTC(2019, 8, 10, 7, 24, 10, 637));
+    expect(nextNightAtLocation(52, -30, utcDate(2019, 8, 9, 23, 59))).toEqual(Date.UTC(2019, 8, 10, 7, 24, 10, 637));
 
     // Polar day and night
-    expect(nextSunriseOrSunset(71, 0, utcDate(2019, 5, 15, 0, 0))).toEqual(Date.UTC(2019, 5, 16, 0, 0, 0, 0));
-    expect(nextSunriseOrSunset(-71, 0, utcDate(2019, 5, 15, 0, 0))).toEqual(Date.UTC(2019, 5, 16, 0, 0, 0, 0));
+    expect(nextNightAtLocation(71, 0, utcDate(2019, 5, 15, 0, 0))).toEqual(Date.UTC(2019, 5, 16, 0, 0, 0, 0));
+    expect(nextNightAtLocation(-71, 0, utcDate(2019, 5, 15, 0, 0))).toEqual(Date.UTC(2019, 5, 16, 0, 0, 0, 0));
 
     // Places where sunset comes before sunrise (in UTC)
-    expect(nextSunriseOrSunset(0, 180, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 6, 0, 50, 152));
-    expect(nextSunriseOrSunset(0, 180, utcDate(2019, 8, 9, 7, 0))).toEqual(Date.UTC(2019, 8, 9, 17, 54, 18, 610));
+    expect(nextNightAtLocation(0, 180, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 6, 0, 50, 152));
+    expect(nextNightAtLocation(0, 180, utcDate(2019, 8, 9, 7, 0))).toEqual(Date.UTC(2019, 8, 9, 17, 54, 18, 610));
 });

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -1,16 +1,29 @@
-import {isInTimeInterval, isNightAtLocation, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
+import {isInTimeInterval, nextIntervalTime, isNightAtLocation, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
 
 test('Time interval', () => {
-    expect(isInTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 12).getTime()});
-    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: false, nextCheck: null});
-    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual({rightNow: false, nextCheck: null});
-    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual({rightNow: false, nextCheck: null});
-    expect(isInTimeInterval('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: false, nextCheck: new Date(2018, 11, 5, 9).getTime()});
-    expect(isInTimeInterval('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 10).getTime()});
-    expect(isInTimeInterval('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 10, 1).getTime()});
-    expect(isInTimeInterval('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 4, 12).getTime()});
-    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual({rightNow: false, nextCheck: new Date(2018, 11, 4, 18).getTime()});
-    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual({rightNow: true, nextCheck: new Date(2018, 11, 5, 9).getTime()});
+    expect(isInTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
+    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(false);
+    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(false);
+    expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual(false);
+    expect(isInTimeInterval('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(false);
+    expect(isInTimeInterval('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual(true);
+    expect(isInTimeInterval('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual(true);
+    expect(isInTimeInterval('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
+    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual(false);
+    expect(isInTimeInterval('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual(true);
+});
+
+test('Time interval prediction', () => {
+    expect(nextIntervalTime('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 12).getTime());
+    expect(nextIntervalTime('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(null);
+    expect(nextIntervalTime('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(null);
+    expect(nextIntervalTime('10:00', '10:00', new Date(2018, 11, 4, 8))).toEqual(null);
+    expect(nextIntervalTime('9:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 5, 9).getTime());
+    expect(nextIntervalTime('9:01', '10:00', new Date(2018, 11, 4, 9, 2))).toEqual(new Date(2018, 11, 4, 10).getTime());
+    expect(nextIntervalTime('9:00', '10:01', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 10, 1).getTime());
+    expect(nextIntervalTime('18:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 12).getTime());
+    expect(nextIntervalTime('18:00', '9:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 18).getTime());
+    expect(nextIntervalTime('18:00', '9:00', new Date(2018, 11, 4, 22))).toEqual(new Date(2018, 11, 5, 9).getTime());
 });
 
 test('Time parse', () => {

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -89,7 +89,7 @@ test('Nigth check', () => {
     expect(isNightAtLocation(0, 180, utcDate(2019, 8, 9, 7, 0))).toEqual(true);
 });
 
-test('Sunrize/sunset', () => {
+test('Sunrise/sunset', () => {
     const utcDate = (y, m, d, hh, mm) => new Date(Date.UTC(y, m, d, hh, mm));
 
     expect(nextSunriseOrSunset(52, 0, utcDate(2019, 8, 9, 0, 0))).toEqual(Date.UTC(2019, 8, 9, 5, 24, 2, 501));

--- a/tests/utils/time.tests.ts
+++ b/tests/utils/time.tests.ts
@@ -1,6 +1,7 @@
 import {isInTimeInterval, nextTimeInterval, isNightAtLocation, nextNightAtLocation, parseTime, getDuration, getDurationInMinutes} from '../../src/utils/time';
 
 test('Time interval', () => {
+    // isInTimeInterval is time-zone dependent
     expect(isInTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(true);
     expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(false);
     expect(isInTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(false);
@@ -14,6 +15,7 @@ test('Time interval', () => {
 });
 
 test('Time interval prediction', () => {
+    // nextTimeInterval() returns time-zone dependent timestamp
     expect(nextTimeInterval('9:00', '12:00', new Date(2018, 11, 4, 10))).toEqual(new Date(2018, 11, 4, 12).getTime());
     expect(nextTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 10))).toEqual(null);
     expect(nextTimeInterval('10:00', '10:00', new Date(2018, 11, 4, 12))).toEqual(null);


### PR DESCRIPTION
This PR addresses comments by @alexanderby at #6347.

Specifically:

## Comment 1
> `isInTimeInterval` should only return a boolean value, it should not know anything about next intervals etc.
>
>Try exporting `nextIntervalTime` function, but make its name understandable out of context.

[Source](https://github.com/darkreader/darkreader/pull/6347#discussion_r679990699)

Fix: Split out `nextIntervalTime` into a separate exported function.

## Comment 2

> Maybe you could remove `isEnabledNow`? Is it an optimisation? I think it makes code harder to understand (messes with `isEnabled`) and harder to keep track of its state. Or at least rename to something like `isEnabledByAutomation`.

[Source](https://github.com/darkreader/darkreader/pull/6347#discussion_r679983368)

Fix: This is an important optimisation, I think, especially for when extension is toggled ON on power-constrained devices. I changed `isEnabledNow` to cover all cases, not just automation. Now the name matches the behavior.