### PR TITLE
Refactor: Stricter type declaration on message literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@rollup/plugin-node-resolve": "13.0.0",
         "@rollup/plugin-replace": "2.4.2",
         "@rollup/pluginutils": "4.1.0",
-        "@types/chrome": "0.0.146",
+        "@types/chrome": "0.0.154",
         "@types/jasmine": "3.7.8",
         "@types/jest": "26.0.24",
         "@types/karma": "6.3.1",
@@ -1457,9 +1457,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.146",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.146.tgz",
-      "integrity": "sha512-gghzXAVEGCWzo6ygME/sFAuU/PFNI8peDft3Eu8AA0GWHi2minRzB+uA2bGGJQYubdtt/qgPdXvZ45KThbGfSA==",
+      "version": "0.0.154",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.154.tgz",
+      "integrity": "sha512-6QmP744MeMUZUIUHED4d4L2la5dIF1e6bcrkGF4yGQTyO94ER+r++Ss165wkzA5cAGUYt8kToDa6L9xtNqVMxg==",
       "dev": true,
       "dependencies": {
         "@types/filesystem": "*",
@@ -13939,9 +13939,9 @@
       }
     },
     "@types/chrome": {
-      "version": "0.0.146",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.146.tgz",
-      "integrity": "sha512-gghzXAVEGCWzo6ygME/sFAuU/PFNI8peDft3Eu8AA0GWHi2minRzB+uA2bGGJQYubdtt/qgPdXvZ45KThbGfSA==",
+      "version": "0.0.154",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.154.tgz",
+      "integrity": "sha512-6QmP744MeMUZUIUHED4d4L2la5dIF1e6bcrkGF4yGQTyO94ER+r++Ss165wkzA5cAGUYt8kToDa6L9xtNqVMxg==",
       "dev": true,
       "requires": {
         "@types/filesystem": "*",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@rollup/plugin-node-resolve": "13.0.0",
     "@rollup/plugin-replace": "2.4.2",
     "@rollup/pluginutils": "4.1.0",
-    "@types/chrome": "0.0.146",
+    "@types/chrome": "0.0.154",
     "@types/jasmine": "3.7.8",
     "@types/jest": "26.0.24",
     "@types/karma": "6.3.1",

--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -131,12 +131,11 @@ export default class Messenger {
 
     reportChanges(data: ExtensionData) {
         if (this.changeListenerCount > 0 || isFirefox) {
-            const message: Message = {
+            chrome.runtime.sendMessage<Message>({
                 from: 'background',
                 type: 'changes',
                 data
-            };
-            chrome.runtime.sendMessage(message);
+            });
         }
     }
 }

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -48,9 +48,9 @@ export default class TabManager {
                     const reply = (options: ConnectionMessageOptions) => {
                         const message = getConnectionMessage(options);
                         if (message instanceof Promise) {
-                            message.then((asyncMessage) => asyncMessage && chrome.tabs.sendMessage(sender.tab.id, asyncMessage, {frameId: sender.frameId}));
+                            message.then((asyncMessage) => asyncMessage && chrome.tabs.sendMessage<Message>(sender.tab.id, asyncMessage, {frameId: sender.frameId}));
                         } else if (message) {
-                            chrome.tabs.sendMessage(sender.tab.id, message, {frameId: sender.frameId});
+                            chrome.tabs.sendMessage<Message>(sender.tab.id, message, {frameId: sender.frameId});
                         }
                     };
 
@@ -102,7 +102,7 @@ export default class TabManager {
 
                 // Using custom response due to Chrome and Firefox incompatibility
                 // Sometimes fetch error behaves like synchronous and sends `undefined`
-                const sendResponse = (response: Partial<Message>) => chrome.tabs.sendMessage(sender.tab.id, {type: 'fetch-response', id, ...response});
+                const sendResponse = (response: Partial<Message>) => chrome.tabs.sendMessage<Message>(sender.tab.id, {type: 'fetch-response', id, ...response});
                 if (isThunderbird) {
                     // In thunderbird some CSS is loaded on a chrome:// URL.
                     // Thunderbird restricted Add-ons to load those URL's.
@@ -131,7 +131,7 @@ export default class TabManager {
             }
             if (type === 'request-export-css') {
                 const activeTab = await this.getActiveTab();
-                chrome.tabs.sendMessage(activeTab.id, {type: 'export-css'}, {frameId: 0});
+                chrome.tabs.sendMessage<Message>(activeTab.id, {type: 'export-css'}, {frameId: 0});
             }
         });
     }
@@ -180,9 +180,9 @@ export default class TabManager {
                     }
                     const message = getMessage(this.getTabURL(tab), frameId === 0 ? null : url);
                     if (tab.active && frameId === 0) {
-                        chrome.tabs.sendMessage(tab.id, message, {frameId});
+                        chrome.tabs.sendMessage<Message>(tab.id, message, {frameId});
                     } else {
-                        setTimeout(() => chrome.tabs.sendMessage(tab.id, message, {frameId}));
+                        setTimeout(() => chrome.tabs.sendMessage<Message>(tab.id, message, {frameId}));
                     }
                 });
             });

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -109,9 +109,9 @@ export interface TabInfo {
 
 export interface Message {
     type: string;
-    from: string;
-    data: any;
-    id?: any;
+    from?: string;
+    data?: any;
+    id?: number;
     error?: any;
 }
 

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -29,7 +29,7 @@ function onMessage({type, data}: Message) {
             break;
         }
         case 'export-css': {
-            collectCSS().then((collectedCSS) => chrome.runtime.sendMessage({type: 'export-css-response', data: collectedCSS}));
+            collectCSS().then((collectedCSS) => chrome.runtime.sendMessage<Message>({type: 'export-css-response', data: collectedCSS}));
             break;
         }
         case 'unsupported-sender':
@@ -53,24 +53,24 @@ function onMessage({type, data}: Message) {
 // TODO: Use background page color scheme watcher when browser bugs fixed.
 const colorSchemeWatcher = watchForColorSchemeChange(({isDark}) => {
     logInfo('Media query was changed');
-    chrome.runtime.sendMessage({type: 'color-scheme-change', data: {isDark}});
+    chrome.runtime.sendMessage<Message>({type: 'color-scheme-change', data: {isDark}});
 });
 
 chrome.runtime.onMessage.addListener(onMessage);
-chrome.runtime.sendMessage({type: 'frame-connect'});
+chrome.runtime.sendMessage<Message>({type: 'frame-connect'});
 
 function onPageHide(e: PageTransitionEvent) {
     if (e.persisted === false) {
-        chrome.runtime.sendMessage({type: 'frame-forget'});
+        chrome.runtime.sendMessage<Message>({type: 'frame-forget'});
     }
 }
 
 function onFreeze() {
-    chrome.runtime.sendMessage({type: 'frame-freeze'});
+    chrome.runtime.sendMessage<Message>({type: 'frame-freeze'});
 }
 
 function onResume() {
-    chrome.runtime.sendMessage({type: 'frame-resume'});
+    chrome.runtime.sendMessage<Message>({type: 'frame-resume'});
 }
 
 addEventListener('pagehide', onPageHide);

--- a/src/ui/connect/connector.ts
+++ b/src/ui/connect/connector.ts
@@ -10,7 +10,7 @@ export default class Connector implements ExtensionActions {
 
     private async sendRequest<T>(type: string, data?: any) {
         return new Promise<T>((resolve, reject) => {
-            chrome.runtime.sendMessage({from: 'ui', type, ...data}, ({data, error}) => {
+            chrome.runtime.sendMessage<Message>({from: 'ui', type, ...data}, ({data, error}) => {
                 if (error) {
                     reject(error);
                 } else {
@@ -56,7 +56,7 @@ export default class Connector implements ExtensionActions {
     };
 
     private sendMessage(data: any) {
-        chrome.runtime.sendMessage({from: 'ui', ...data});
+        chrome.runtime.sendMessage<Message>({from: 'ui', ...data});
     }
 
     subscribeToChanges(callback: (data: ExtensionData) => void) {


### PR DESCRIPTION
This depends on recently published [@types/chrome](https://www.npmjs.com/package/@types/chrome) version 0.0.154. (The change I need was released in 0.0.149, but we might s well go all the way to the latest version while at it).

Motivation: This change would have prevented #6266.