### PR TITLE
Add otzdarva.com to dark sites exceptions list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -564,6 +564,7 @@ openemu.org
 orama-interactive.itch.io/pixelorama
 orteil.dashnet.org/cookieclicker
 osu.ppy.sh
+otzdarva.com
 ovagames.com
 overcoder.dev
 overdodactyl.github.io/ShadowFox


### PR DESCRIPTION
[otzdarva.com](https://otzdarva.com) is already dark by default.