### PR TITLE
Fix for classroom.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2370,14 +2370,13 @@ classroom.google.com
 
 INVERT
 img[src$="dark_create_class_arrow.svg"]
+img[aria-label="YouTube"]
+div[role="dialog"] ~ div[role="menu"] > div[role="menuitem"] > div > div:not([style*="background-image"])
 
 CSS
 div[role="toolbar"] div[role="button"] > div[class*='-']:not([onclick]):not(:link):not(:visited):not([style*="background-image"]):first-child,
 div[role="toolbar"] div[role="button"] > div[class*='-']:not([onclick]):not(:link):not(:visited) > :nth-child(2) > div,
 div[style="bottom: 0px;"] > div[style^="opacity:"] div[role="button"] > div:not([onclick]):not(:link):not(:visited),
-div[role="menu"] > div[role="menuitem"] > div > div:not([style*="background-image"]) {
-    background-image: url('//ssl.gstatic.com/docs/common/viewer/v3/v-sprite35.svg') !important;
-}
 li[guidedhelpid="classworkTopicListGh"]:not(hover) > div {
     opacity: 99% !important;
 }


### PR DESCRIPTION
1. For the YouTube Icon that appears when watching a YT video within GC, I'm unsure of the result. 
![imagen](https://user-images.githubusercontent.com/71190696/128131448-261d9b58-f745-4324-9cfd-6dd933b1bee8.png)
2. The icons of the options of the 3 dot menu of a file preview. Just used #5930 here, which was meant to fix the same issue, but in Drive.
3. Removed line that caused the icons in the file preview to look misplaced, like this: 
![imagen](https://user-images.githubusercontent.com/71190696/128132090-e3cd5a56-9494-45e7-93b4-2b472d9d9384.png)
