### PR TITLE
Fix for mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7552,6 +7552,7 @@ img[src$="profile_mask2.png"]
 .aEc .qj
 .n3 .qr
 .mixmax-flyout__wrapper
+div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
 
 CSS
 @media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {


### PR DESCRIPTION
Fixes Hangouts Chats icon in the old Gmail interface.

![imagen](https://user-images.githubusercontent.com/71190696/128298095-f4f75885-20b1-49b2-9631-48532d7d426a.png)
