### PR TITLE
Remove two dead functions in Connector

### DIFF
--- a/src/ui/connect/connector.ts
+++ b/src/ui/connect/connector.ts
@@ -69,14 +69,6 @@ export default class Connector implements ExtensionActions {
         }
     }
 
-    enable() {
-        this.sendMessage({type: 'enable'});
-    }
-
-    disable() {
-        this.sendMessage({type: 'disable'});
-    }
-
     setShortcut(command: string, shortcut: string) {
         this.sendMessage({type: 'set-shortcut', data: {command, shortcut}});
     }


### PR DESCRIPTION
These two methods are not used, instead, UI uses `changeSettings` method:  https://github.com/darkreader/darkreader/blob/master/src/ui/connect/connector.ts#L84

 - These is no receiving end for messages sent by these functions.
 - Nothing happens if I try to emulate these functions by running `chrome.runtime.sendMessage({from: 'ui', type:'enable'})` (or disable)