### PR TITLE
Fix leetcode's tree visualizer node color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7072,7 +7072,7 @@ img[alt="logo"]
 
 CSS
 div[class^="data-structure-viewer"] g[class^="node"] > circle {
-    background-color: var(--darkreader-neutral-background) !important;
+    fill: var(--darkreader-neutral-background) !important;
 }
 [class^=question-picker-detail] {
     background: none !important;


### PR DESCRIPTION
The background color property no long works as the circles are colored by fill which supersedes the background color, hence nodes appear as white along with the text inside being white. This makes the node unreadable. This commit fixes the node visualizer by making it readable.

Previous: 
![image](https://user-images.githubusercontent.com/3626859/128625544-37aef2d0-18c4-46ad-a6a2-0d7b6eec882c.png)

Now:
![image](https://user-images.githubusercontent.com/3626859/128625546-3e1bcc3f-e97b-47ea-917e-f524a6198c31.png)
