### PR TITLE
Remove outdated CSS for instagram.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6304,10 +6304,6 @@ span.Sprite.embedSpriteGlyph.hideText
 svg[aria-label*="Facebook"]
 
 CSS
-.tlZCJ:checked ~ .mwD2G::before {
-    border-bottom-color: ${rgb(56, 56, 56)} !important;
-    border-left-color: ${rgb(56, 56, 56)} !important;
-}
 div > a[tabindex],
 div > span > a[tabindex] {
     border-color: transparent !important;


### PR DESCRIPTION
The mentioned classes are not found on the webpage anymore. These were added back in https://github.com/darkreader/darkreader/pull/2045, I think eventually they regenerated the names.