### PR TITLE
Updated svt.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11546,40 +11546,38 @@ CSS
 .nyh_teaser__live-text {
     color: var(--darkreader-neutral-background) !important;
 }
-[class*="_Post__contentVisitor"]::after {
-    border-right-color: #262a2b !important;
+button[class^="PaginationButton"],
+a[class^="PaginationButton"],
+.nyh_screamer {
+    background: var(--darkreader-bg--nyh-color-white) !important;
+}
+button[class^="PaginationButton"]:hover,
+a[class^="PaginationButton"]:hover {
+    background: var(--darkreader-border--color-play-white) !important;
+}
+.flexbox .nyh_teaser.nyh_teaser--group-secondary {
+    border-right: none !important;
+}
+[class*="GroupSecondaryTeasers__container___"],
+.nyh_feedbox-item+.nyh_feedbox-item,
+.nyh_teaser.nyh_teaser--no-border-top {
+    border-top: none !important;
 }
 .nyh_navigation .nyh_submenu::before {
-    border-bottom-color: var(--darkreader-neutral-background);
+    border-bottom-color: var(--darkreader-bg--nyh-color-white) !important;
 }
-.nyh_feedbox-item,
-.flexbox .nyh_teaser.nyh_teaser--group-secondary,
-.GroupSecondaryTeasers__container___2v5SH,
-.GroupSecondaryTeasers__showMoreButton___gOOOl,
-.CurrentTopics__item___1x0Gw,
-.nyh_menu-card__submenu-item,
+[class*="_Post__contentVisitor___"]::after {
+    border-right-color: var(--darkreader-bg--nyh-color-grey-lighter) !important;
+}
+[class*="CurrentTopics__item___"],
+[class*="GroupSecondaryTeasers__showMoreButton___"],
 .nyh_mobile-menu__list-item,
-.nyh_teaser.nyh_teaser--no-border-top,
-.nyh_submenu-menucard {
-    border-top-color: var(--darkreader-border--nyh-color-grey-lighter);
-    border-right-color: var(--darkreader-border--nyh-color-grey-lighter);
-    border-bottom-color: var(--darkreader-border--nyh-color-grey-lighter);
-}
-.flexbox .nyh_teaser.nyh_teaser--group-secondary:not(.nyh_teaser--play) {
-    border-right-color: transparent;
-    border-left-color: transparent;
-}
+.nyh_submenu-menucard,
 .nyh_submenu {
-    border-color: var(--darkreader-border--nyh-color-grey-lighter);
+    border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
 }
-.PaginationButton__button___wUYlE {
-    background: var(--darkreader-neutral-background)
-}
-.nyh_fact-box__body--closed::after {
-    background: linear-gradient(to bottom, rgba(var(--nyh-color-grey-darkest-rgb), 0.5) 0%, rgba(var(--nyh-color-grey-darkest-rgb), 1) 100%);
-}
-.nyh_navigation .nyh_submenu::before {
-    border-bottom-color: var(--darkreader-bg--nyh-color-white);
+.nyh_is-open .nyh_menu-card__link--mobile {
+    border: none !important;
 }
 
 ================================


### PR DESCRIPTION
This acts as a continuation of my last PR for this site at #5567

# Noteworthy things

|Before | After|
|-- | --|
| ![svt1 off] | ![svt1 on]  |

I rewrote all border code from my previous PR and added `!important` in order for it to work as intended.

|Before | After|
|-- | --|
| ![svt2 off] | ![svt2 on] |
| ![svt3 off]  | ![svt3 on] |

Gave the button to load more articles and the news header link a more contrasting background color.

## Code clean-up
In order to improve readability and maintenance, I decided to shorten down some of the code.

**Before:**
```css
.CurrentTopics__item___1x0Gw {
    border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
}
.GroupSecondaryTeasers__showMoreButton___gOOOl {
    border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
}
.nyh_mobile-menu__list-item {
    border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
}
.nyh_submenu-menucard {
    border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
}
```
**After:**
```css
[class*="CurrentTopics__item___"],
[class*="GroupSecondaryTeasers__showMoreButton___"],
.nyh_mobile-menu__list-item,
.nyh_submenu-menucard,
.nyh_submenu {
    border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
}
```

[svt1 off]: https://user-images.githubusercontent.com/17113053/128785652-5719a42a-d4cb-47da-a83f-f51f974533cd.png
[svt1 on]: https://user-images.githubusercontent.com/17113053/128785610-033869e8-9983-4820-a48e-be0631cbc74f.png
[svt2 off]: https://user-images.githubusercontent.com/17113053/128785619-167f8a7e-febc-4dab-99b0-cf3cf755abb9.png
[svt2 on]: https://user-images.githubusercontent.com/17113053/128785616-153f621b-8d43-435e-be8f-953e92aea9d1.png
[svt3 off]: https://user-images.githubusercontent.com/17113053/128785614-7986b9fa-46dd-4e82-bdc0-dba903e4e85e.png
[svt3 on]: https://user-images.githubusercontent.com/17113053/128785615-cc775e59-1a9a-4270-9ac5-375e18a12ce6.png