### PR TITLE
Non-persistent background context

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -212,7 +212,7 @@ export class Extension {
             isReady: this.ready,
             settings: this.user.settings,
             fonts: this.fonts,
-            news: this.news.latest,
+            news: await this.news.getLatest(),
             shortcuts: await this.getShortcuts(),
             devtools: {
                 dynamicFixesText: this.devtools.getDynamicThemeFixesText(),

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -3,6 +3,7 @@ import {createFileLoader} from './utils/network';
 import type {Message} from '../definitions';
 import {isThunderbird} from '../utils/platform';
 import {logInfo, logWarn} from '../inject/utils/log';
+import {StateManager} from './utils/state-manager';
 
 async function queryTabs(query: chrome.tabs.QueryInfo) {
     return new Promise<chrome.tabs.Tab[]>((resolve) => {
@@ -41,21 +42,27 @@ enum DocumentState {
 }
 
 export default class TabManager {
-    private tabs: Map<number, Map<number, FrameInfo>>;
+    private tabs: {[tabId: number]: {[frameId: number]: FrameInfo}};
+    private stateManager: StateManager;
+    static LOCAL_STORAGE_KEY = 'TabManager-state';
 
     constructor({getConnectionMessage, onColorSchemeChange}: TabManagerOptions) {
-        this.tabs = new Map();
-        chrome.runtime.onMessage.addListener((message, sender) => {
-            function addFrame(tabs: any, tabId: number, frameId: number, senderURL: string) {
-                let frames: Map<number, FrameInfo>;
-                if (tabs.has(tabId)) {
-                    frames = tabs.get(tabId);
+        this.stateManager = new StateManager(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}});
+        this.tabs = {};
+
+        chrome.runtime.onMessage.addListener(async (message, sender) => {
+            function addFrame(tabs: {[tabId: number]: {[frameId: number]: FrameInfo}}, tabId: number, frameId: number, senderURL: string) {
+                let frames: {[frameId: number]: FrameInfo};
+                if (tabs[tabId]) {
+                    frames = tabs[tabId];
                 } else {
-                    frames = new Map();
-                    tabs.set(tabId, frames);
+                    frames = {};
+                    tabs[tabId] = frames;
                 }
-                frames.set(frameId, {url: senderURL, state: DocumentState.ACTIVE});
+                frames[frameId] = {url: senderURL, state: DocumentState.ACTIVE};
             }
+
+            await this.stateManager.loadState();
 
             switch (message.type) {
                 case 'frame-connect': {
@@ -94,18 +101,29 @@ export default class TabManager {
                         logWarn('Unexpected message', message, sender);
                         break;
                     }
+                    const tabId = sender.tab.id;
+                    const frameId = sender.frameId;
 
-                    const framesForDeletion = this.tabs.get(sender.tab.id);
-                    framesForDeletion && framesForDeletion.delete(sender.frameId);
+                    if (frameId === 0) {
+                        delete this.tabs[tabId];
+                    }
+
+                    if (this.tabs[tabId] && this.tabs[tabId][frameId]) {
+                        // We need to use delete here because Object.entries()
+                        // in sendMessage() would enumerate undefined as well.
+                        delete this.tabs[tabId][frameId];
+                    }
                     break;
                 }
                 case 'frame-freeze':
-                    this.tabs.get(sender.tab.id).get(sender.frameId).state = DocumentState.FROZEN;
+                    this.tabs[sender.tab.id][sender.frameId].state = DocumentState.FROZEN;
                     break;
                 case 'frame-resume':
                     addFrame(this.tabs, sender.tab.id, sender.frameId, sender.url);
                     break;
             }
+
+            this.stateManager.saveState();
         });
 
         const fileLoader = createFileLoader();
@@ -160,7 +178,7 @@ export default class TabManager {
     async updateContentScript(options: {runOnProtectedPages: boolean}) {
         (await queryTabs({}))
             .filter((tab) => options.runOnProtectedPages || canInjectScript(tab.url))
-            .filter((tab) => !this.tabs.has(tab.id))
+            .filter((tab) => !Boolean(this.tabs[tab.id]))
             .forEach((tab) => {
                 if (!tab.discarded) {
                     chrome.tabs.executeScript(tab.id, {
@@ -184,10 +202,10 @@ export default class TabManager {
 
     async sendMessage(getMessage: (url: string, frameUrl: string) => any) {
         (await queryTabs({}))
-            .filter((tab) => this.tabs.has(tab.id))
+            .filter((tab) => Boolean(this.tabs[tab.id]))
             .forEach((tab) => {
-                const frames = this.tabs.get(tab.id);
-                frames.forEach(({url, state}, frameId) => {
+                const frames = this.tabs[tab.id];
+                Object.entries(frames).forEach(([_, {url, state}], frameId) => {
                     if (state !== DocumentState.ACTIVE && state !== DocumentState.PASSIVE) {
                         // TODO: avoid sending messages to frozen tabs for performance reasons.
                         logInfo('Sending message to a frozen tab.');

--- a/src/background/utils/migration.ts
+++ b/src/background/utils/migration.ts
@@ -1,0 +1,14 @@
+import {isChromium} from 'utils/platform';
+
+export function isNonPersistent() {
+    if (!isChromium) {
+        return false;
+    }
+    const background = chrome.runtime.getManifest().background;
+    if ('persistent' in background) {
+        return background.persistent === false;
+    }
+    if ('service_worker' in background) {
+        return true;
+    }
+}

--- a/src/background/utils/state-manager.ts
+++ b/src/background/utils/state-manager.ts
@@ -1,0 +1,168 @@
+import {logWarn} from 'inject/utils/log';
+import {PromiseBarrier} from '../../utils/promise-barrier';
+import {isNonPersistent} from './migration';
+
+/*
+ * State manager is a state machine which works as follows:
+ *    +-----------+       +------------+
+ *    |  Initial  |------>|  Disabled  |
+ *    +-----------+       +------------+
+ *           |
+ *           | StateManager.loadState() is called,
+ *           | StateManager will call chrome.storage.local.get()
+ *           |
+ *           v
+ *    +-----------+
+ *    |  Loading  |
+ *    +-----------+
+ *           |
+ *           | chrome.storage.local.get() callback is called,
+ *           | StateManager has loaded the data.
+ *           |
+ *           v
+ *     +----------+
+ *     |  Ready   |<---------------------------------+
+ *     +----------+                                  |
+ *           |                                       |
+ *           | StateManager.saveState() is called,   |
+ *           | StateManager will callect data and    |
+ *           | call chrome.storage.local.set()       |
+ *           v                                       |
+ *    +-----------+----------------------------------+
+ *    |  Saving   |
+ *    +-----------+<---------------------------------+
+ *           |                                       |
+ *           | StateManager.saveState() is called    |
+ *           | before ongoing write operation ends.  |
+ *           |                                       |
+ *           v                                       |
+ *    +-----------------+                            |
+ *    | Saving Override |----------------------------+
+ *    +-----------------+
+ *
+ * Initial - Only constructor was called.
+ * Disabled - current build and/or platform uses persistent background.
+ *   Storage anager is disabled (is a NOOP).
+ * Loading - loadState() is called
+ * Ready - data was retreived from storage.
+ * Saving - saveState() is called and there is no chrome.storage.local.set()
+ *   operation in progress. We just need to collect and save the data.
+ * Saving Override - saveState() is called before the last write operation
+ *   was complete (data became obsolete even before it was written to storage).
+ *   We wait for ongoing write operation to end and only then start a new one.
+ */
+export enum StateManagerState {
+    INITIAL = 0,
+    DISABLED = 1,
+    LOADING = 2,
+    READY = 3,
+    SAVING = 4,
+    SAVING_OVERRIDE = 5,
+}
+
+export class StateManager {
+    private localStorageKey: string;
+    private parent;
+    private defaults;
+
+    private meta: StateManagerState = StateManagerState.INITIAL;
+    // loadStateBarrier is guaranteed to exists only when meta is LOADING.
+    private loadStateBarrier: PromiseBarrier = null;
+
+    constructor(localStorageKey: string, parent, defaults){
+        if (!isNonPersistent()) {
+            // Do nothing if the current build uses persistent background
+            this.meta = StateManagerState.DISABLED;
+            return;
+        }
+        this.localStorageKey = localStorageKey;
+        this.parent = parent;
+        this.defaults = defaults;
+
+        // TODO(Anton): consider calling this.loadState() to preload data
+    }
+
+    private collectState() {
+        const state = {};
+        for (const key of Object.keys(this.defaults)) {
+            state[key] = this.parent[key] || this.defaults[key];
+        }
+        return state;
+    }
+
+    // This function is not guaranteed to save state before returning
+    async saveState(): Promise<void> {
+        switch (this.meta) {
+            case StateManagerState.DISABLED:
+                return;
+            case StateManagerState.LOADING:
+                // fallthrough
+            case StateManagerState.INITIAL:
+                // Make sure not to overwrite data before it is loaded
+                logWarn('StateManager.saveState is called while loading data. Possible data race!');
+                await this.loadStateBarrier.entry();
+                this.meta = StateManagerState.SAVING;
+                break;
+            case StateManagerState.READY:
+                this.meta = StateManagerState.SAVING;
+                break;
+            case StateManagerState.SAVING:
+                // Another save is in progress
+                this.meta = StateManagerState.SAVING_OVERRIDE;
+                return;
+            case StateManagerState.SAVING_OVERRIDE:
+                // Do nothing
+                return;
+        }
+
+        chrome.storage.local.set({[this.localStorageKey]: this.collectState()}, () => {
+            switch (this.meta) {
+                case StateManagerState.INITIAL:
+                case StateManagerState.DISABLED:
+                case StateManagerState.LOADING:
+                case StateManagerState.READY:
+                    logWarn('Unexpected state. Possible data race!');
+                    // fallthrough
+                case StateManagerState.SAVING:
+                    this.meta = StateManagerState.READY;
+                    break;
+                case StateManagerState.SAVING_OVERRIDE:
+                    this.meta = StateManagerState.READY;
+                    this.saveState();
+            }
+        });
+    }
+
+    async loadState(): Promise<void> {
+        switch (this.meta) {
+            case StateManagerState.INITIAL:
+                // Need to load
+                this.meta = StateManagerState.LOADING;
+                this.loadStateBarrier = new PromiseBarrier();
+                return new Promise<void>((resolve) => {
+                    chrome.storage.local.get(this.localStorageKey, (data) => {
+                        this.meta = StateManagerState.READY;
+                        if (data[this.localStorageKey]) {
+                            Object.assign(this.parent, data[this.localStorageKey]);
+                        } else {
+                            Object.assign(this.parent, this.defaults);
+                        }
+                        this.loadStateBarrier.resolve();
+                        this.loadStateBarrier = null;
+                        resolve();
+                    });
+                });
+            case StateManagerState.DISABLED:
+                // fallthrough
+            case StateManagerState.READY:
+                // fallthrough
+            case StateManagerState.SAVING:
+                // fallthrough
+            case StateManagerState.SAVING_OVERRIDE:
+                return;
+            case StateManagerState.LOADING:
+                // Background state is being loaded, just need to wait
+                return this.loadStateBarrier.entry();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `StateManager` class which preserves background context state across unloads by storing it into `chrome.storage.local`. This change is hidden behind extra checks to avoid any regressions:
 - this change will activate only if background is declared non-persistent in manifest
 - this change will not activate for Firefox (which does not support non-persistent backgrounds anyway)

I'll merge this soon because (1) this will avoid merge conflicts later and (2) I need this change to fine-tune `StateManager` behavior based on real usage (I'll just use this new build for a while and optimize for my usage).