### PR TITLE
Added styles for codeforces.com and colorpicker.me

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2567,12 +2567,26 @@ span[class^="burger"]
 codeforces.com
 
 INVERT
+#header > div:first-child img
+.action-link > div > img:first-child
 .roundbox-lt
 .roundbox-rt
 .roundbox-lb
 .roundbox-rb
 .delete-resource-link
 a.contestParticipantCountLinkMargin > img
+.recent-actions > ul > li img[src*="hourglass"]
+
+CSS
+.lt, .rt, .lb, .rb, .ilt, .irt {
+    display: none;
+}
+input[type="submit"], input[type="button"], select {
+    border-style: solid;
+}
+input[type="submit"]:hover, input[type="button"]:hover, select:hover {
+    border-style: groove;
+}
 
 ================================
 
@@ -2611,6 +2625,15 @@ colorhunt.co
 
 IGNORE INLINE STYLE
 .palette > div
+
+================================
+
+colorpicker.me
+
+IGNORE INLINE STYLE
+html
+body
+button
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2578,7 +2578,12 @@ a.contestParticipantCountLinkMargin > img
 .recent-actions > ul > li img[src*="hourglass"]
 
 CSS
-.lt, .rt, .lb, .rb, .ilt, .irt {
+.lt,
+.rt,
+.lb,
+.rb,
+.ilt,
+.irt {
     display: none;
 }
 input[type="submit"], input[type="button"], select {


### PR DESCRIPTION
[**codeforces.com**](https://codeforces.com):
- `#header > div:first-child img` reverts the Codeforces logo in header. Before: ![изображение](https://user-images.githubusercontent.com/38539949/129109043-4c15d188-d1c3-4be8-9a4b-df68344ecf9f.png)
After: ![изображение](https://user-images.githubusercontent.com/38539949/129109102-45cdf42f-ba9e-42d4-92c0-2ab6cc544089.png)

- `.action-link > div > img:first-child` reverts an icon. Before: ![screenshot](https://user-images.githubusercontent.com/38539949/129108691-36a05215-f173-4d74-848f-604df08d02cc.png)
After: ![screenshot](https://user-images.githubusercontent.com/38539949/129108744-18d24f9f-1f0a-42d7-8046-ff59e7fa578b.png)
- `.recent-actions > ul > li img[src*="hourglass"]` reverts a minor icon. Before: ![изображение](https://user-images.githubusercontent.com/38539949/129109337-77bc7e70-4da1-4639-b7dc-c374c0a18324.png) After: ![изображение](https://user-images.githubusercontent.com/38539949/129109276-112378fd-b844-4dda-9607-ececc52cf3b7.png)
- `display: none` for `.lt, .rt, .lb, .rb, .ilt, .irt` fixes border corners, e.g. here: 
![изображение](https://user-images.githubusercontent.com/38539949/129109570-e22ba21a-9e45-47ef-93a7-e7d83d1cfa37.png) 
![изображение](https://user-images.githubusercontent.com/38539949/129109603-22f067cd-fdfc-4531-938d-1e814ce328aa.png)
- Since this website does not have styles for inputs and buttons, `border-style: solid/groove` looks better than the default `border-style: inset/outset`. `border-style: solid/groove` copies the default behavior for a light theme, in which the input becomes darker on hover (but the border remains).

---

As for [**colorpicker.me**](https://colorpicker.me): the whole point of this website is to show the real color, so it's weird when it gets distorted.