### PR TITLE
Fix for mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7669,6 +7669,7 @@ img[src$="profile_mask2.png"]
 .n3 .qr
 .mixmax-flyout__wrapper
 div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
+form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id])
 
 CSS
 @media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {


### PR DESCRIPTION
- Resolves #6501
- Cannot solve that the "selected" emoji is still an incorrect background-color, due to an google using an obscure way of classes in order to select those emoji's which are hardcoded and will like always be gone in a few weeks.