### PR TITLE
Watch for custom tag names in "is" attribute

### DIFF
--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -24,7 +24,16 @@ function collectUndefinedElements(root: ParentNode) {
     }
     forEach(root.querySelectorAll(':not(:defined)'),
         (el) => {
-            const tag = el.tagName.toLowerCase();
+            let tag = el.tagName.toLowerCase();
+            if (!tag.includes('-')) {
+                const extendedTag = el.getAttribute('is');
+                if (extendedTag) {
+                    tag = extendedTag;
+                } else {
+                    // Happens for <template> on YouTube
+                    return;
+                }
+            }
             if (!undefinedGroups.has(tag)) {
                 undefinedGroups.set(tag, new Set());
                 customElementsWhenDefined(tag).then(() => {


### PR DESCRIPTION
Extensions of built-in elements are specified through "is" attribute, so need to watch for their definition to handle them properly (loop through child nodes).