### PR TITLE
Fix for mumble.info

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8602,6 +8602,14 @@ CSS
 
 ================================
 
+mumble.info
+
+INVERT
+.os
+.suggested-download-button-caption
+
+================================
+
 music.163.com
 
 INVERT


### PR DESCRIPTION
Fixes "Downloads" page.

Before:
![1](https://user-images.githubusercontent.com/6563728/129448305-755130a7-a571-4544-aabc-2d4febe0e1c0.png)

After:
![2](https://user-images.githubusercontent.com/6563728/129448309-ef1e3a19-9fcc-447e-8077-17b66da5e76d.png)