### PR TITLE
Fix native MathML elements on MediaWiki

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4334,7 +4334,7 @@ canvas
 explainxkcd.com
 
 INVERT
-.mwe-math-element
+.mwe-math-fallback-image-inline
 .mw-ext-score
 .main-footer-menuToggle
 img[src*="Loudspeaker.svg"]
@@ -13212,7 +13212,7 @@ wikibooks.org
 
 INVERT
 .bookend
-.mwe-math-element
+.mwe-math-fallback-image-inline
 
 IGNORE INLINE STYLE
 .infobox td
@@ -13273,7 +13273,7 @@ INVERT
 wikipedia.org
 
 INVERT
-.mwe-math-element
+.mwe-math-fallback-image-inline
 .MathJax:not(span#MathJax_Zoom > .MathJax)
 span#MathJax_Zoom
 .mw-ext-score
@@ -13351,7 +13351,7 @@ wikisource.org
 wikiversity.org
 
 INVERT
-.mwe-math-element
+.mwe-math-fallback-image-inline
 
 ================================
 


### PR DESCRIPTION
`.mwe-math-element` has two children: `.mwe-math-mathml-inline` and `.mwe-math-fallback-image-inline`. The first one is native MathML and should not be inverted, while the later should.

Native MathML could be force enabled with this addon: https://addons.mozilla.org/en-US/firefox/addon/native-mathml/

Tested for wikipedia, wikisource, wikibooks with an example from their corresponding commit, each with MathML on and off.

I updated the one in explainxkcd too but I did not find an example there.