### PR TITLE
Add more workarounds for thunderbird

### DIFF
--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -76,7 +76,9 @@ export default class TabManager {
                         }
                     };
 
-                    const isPanel = sender.tab == null;
+                    // Workaround for thunderbird, not sure how. But sometimes sender.tab is undefined but accessing it.
+                    // Will actually throw a very nice error.
+                    const isPanel = typeof sender === 'undefined' || typeof sender.tab === 'undefined';
                     if (isPanel) {
                         // NOTE: Vivaldi and Opera can show a page in a side panel,
                         // but it is not possible to handle messaging correctly (no tab ID, frame ID).

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -6,8 +6,10 @@ import {watchForColorSchemeChange} from './utils/watch-color-scheme';
 import {collectCSS} from './dynamic-theme/css-collection';
 import type {Message} from '../definitions';
 import {MessageType} from '../utils/message';
+import {isThunderbird} from '../utils/platform';
 
 function onMessage({type, data}: Message) {
+    logInfo('onMessage', type, data);
     switch (type) {
         case MessageType.BG_ADD_CSS_FILTER:
         case MessageType.BG_ADD_STATIC_THEME: {
@@ -74,6 +76,10 @@ function onResume() {
     chrome.runtime.sendMessage<Message>({type: MessageType.CS_FRAME_RESUME});
 }
 
-addEventListener('pagehide', onPageHide);
-addEventListener('freeze', onFreeze);
-addEventListener('resume', onResume);
+// Thunderbird don't has "tabs", and emails aren't 'frozen' or 'cached'.
+// And will currently error: `Promise rejected after context unloaded: Actor 'Conduits' destroyed before query 'RuntimeMessage' was resolved`
+if (!isThunderbird) {
+    addEventListener('pagehide', onPageHide);
+    addEventListener('freeze', onFreeze);
+    addEventListener('resume', onResume);
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,6 @@
 import type {UserSettings} from '../definitions';
 import {isIPV6, compareIPV6} from './ipv6';
+import {isThunderbird} from './platform';
 
 let anchor: HTMLAnchorElement;
 
@@ -177,6 +178,11 @@ export function isPDF(url: string) {
 export function isURLEnabled(url: string, userSettings: UserSettings, {isProtected, isInDarkList}: {isProtected: boolean; isInDarkList: boolean}) {
     if (isProtected && !userSettings.enableForProtectedPages) {
         return false;
+    }
+    // Only URL's with emails are getting here on thunderbird
+    // So we can skip the checks and just return true.
+    if (isThunderbird) {
+        return true;
     }
     if (isPDF(url)) {
         return userSettings.enableForPDF;


### PR DESCRIPTION
- Resolves #6521


@bershanskiy I've disabled the pagehide event for now, as That was erroring(error is currently included in the comment) and dark reader seems to still work when disabled, if you could check https://thunderbird.topicbox.com/groups/addons/T90f2914acf15917b/mx-fails-in-91-promise-rejected-after-context-unloaded to see why this *might* happen would be nice. But like I said in my comment, their are no tabs, so once the tab is hidden, it means it's gone and another email is opened or something otherwise.

@alexanderby If you read this, that probably means on a monday so I won't be able to respond in any quickly time manner, but it will be nice to have a hotfix deployed for thunderbird as mentioned in #6521 it currently doesn't work at all and v91 is currently rolling out(as beta-ish?)

Regards,
Gusted