### PR TITLE
Cleanup CS context when BG is unreachable

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -29,7 +29,7 @@ function sendMessage(message: Message) {
     }
     try {
         chrome.runtime.sendMessage<Message>(message);
-    } catch(e) {
+    } catch (e) {
         /*
          * Background can be unreachable if:
          *  - extension was disabled


### PR DESCRIPTION
When extension is uninstalled, disabled, reloaded, or updated, browser terminates the background context (or in case of non-persistent event pages/service workers, just unregisters background context's event handlers). However, browser does not terminate content scripts. After this commit, content script detects the first time background context becomes unreachable to messages and cleans up its resources.

Ideally, there would be a way for content script to be notified of these events, but there is none.

## Repro steps
 - build from `master` prior to this change
 - install extension
 - open a tab
 - reload extension
 - close the tab

## Outcome after this commit
No error in the console.

## Outcome propor to this change
Error in the console that "receiving end does not exist".