### PR TITLE
Add inventory-profiles-next.github.io as already dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -411,6 +411,7 @@ infocon.org
 inker.co
 intactphone.com
 intothetrenches.1917.movie
+inventory-profiles-next.github.io
 iptorrents.com
 iq.com
 isitchristmas.com


### PR DESCRIPTION
Note: the site is dark by default, then checks whether the system theme is dark or light via media queries, so if you go on the site and see it's light, it might be your browser's theme