### PR TITLE
Refactor: do not store frame URL of and do not send messages to inactive tabs

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -350,7 +350,7 @@ export class Extension {
         if (this.wasEnabledOnLastCheck === null || this.wasEnabledOnLastCheck !== isEnabled) {
             this.wasEnabledOnLastCheck = isEnabled;
             this.onAppToggle();
-            this.tabs.invalidateTimestamp();
+            this.tabs.sendMessage();
             this.reportChanges();
             this.stateManager.saveState();
         }
@@ -469,7 +469,7 @@ export class Extension {
         }
         await this.stateManager.loadState();
         this.wasEnabledOnLastCheck = this.isEnabled;
-        this.tabs.invalidateTimestamp();
+        this.tabs.sendMessage();
         this.saveUserSettings();
         this.reportChanges();
         this.stateManager.saveState();

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -61,7 +61,8 @@ export class Extension {
                 }
                 return this.getConnectionMessage(url, frameURL);
             },
-            onColorSchemeChange: this.onColorSchemeChange,
+            getTabMessage: this.getTabMessage,
+            onColorSchemeChange: this.onColorSchemeChange
         });
         this.user = new UserStorage({onRemoteSettingsChange: () => this.onRemoteSettingsChange()});
         this.startBarrier = new PromiseBarrier();
@@ -349,7 +350,7 @@ export class Extension {
         if (this.wasEnabledOnLastCheck === null || this.wasEnabledOnLastCheck !== isEnabled) {
             this.wasEnabledOnLastCheck = isEnabled;
             this.onAppToggle();
-            this.tabs.sendMessage(this.getTabMessage);
+            this.tabs.invalidateTimestamp();
             this.reportChanges();
             this.stateManager.saveState();
         }
@@ -468,7 +469,7 @@ export class Extension {
         }
         await this.stateManager.loadState();
         this.wasEnabledOnLastCheck = this.isEnabled;
-        this.tabs.sendMessage(this.getTabMessage);
+        this.tabs.invalidateTimestamp();
         this.saveUserSettings();
         this.reportChanges();
         this.stateManager.saveState();

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -62,7 +62,7 @@ export class Extension {
                 return this.getConnectionMessage(url, frameURL);
             },
             getTabMessage: this.getTabMessage,
-            onColorSchemeChange: this.onColorSchemeChange
+            onColorSchemeChange: this.onColorSchemeChange,
         });
         this.user = new UserStorage({onRemoteSettingsChange: () => this.onRemoteSettingsChange()});
         this.startBarrier = new PromiseBarrier();

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -74,7 +74,7 @@ export default class TabManager {
                 frames[frameId] = {
                     url: senderURL,
                     state: DocumentState.ACTIVE,
-                    timestamp: timestamp,
+                    timestamp,
                 };
             }
 

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -214,7 +214,14 @@ export default class TabManager {
         });
     }
 
-    async invalidateTimestamp() {
+    getTabURL(tab: chrome.tabs.Tab): string {
+        // It can happen in cases whereby the tab.url is empty.
+        // Luckily this only and will only happen on `about:blank`-like pages.
+        // Due to this we can safely use `about:blank` as fallback value.
+        return tab.url || 'about:blank';
+    }
+
+    async sendMessage() {
         this.timestamp++;
 
         (await queryTabs({}))
@@ -233,13 +240,6 @@ export default class TabManager {
                         this.tabs[tab.id][frameId].timestamp = this.timestamp;
                     });
             });
-    }
-
-    getTabURL(tab: chrome.tabs.Tab): string {
-        // It can happen in cases whereby the tab.url is empty.
-        // Luckily this only and will only happen on `about:blank`-like pages.
-        // Due to this we can safely use `about:blank` as fallback value.
-        return tab.url || 'about:blank';
     }
 
     async updateContentScript(options: {runOnProtectedPages: boolean}) {

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -3,7 +3,7 @@ import {createFileLoader} from './utils/network';
 import type {Message} from '../definitions';
 import {isFirefox, isMV3, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
-import {logInfo, logWarn} from '../utils/log';
+import {logWarn} from '../utils/log';
 import {StateManager} from './utils/state-manager';
 
 async function queryTabs(query: chrome.tabs.QueryInfo) {
@@ -20,16 +20,19 @@ interface ConnectionMessageOptions {
 
 interface TabManagerOptions {
     getConnectionMessage: (options: ConnectionMessageOptions) => Message | Promise<Message>;
+    getTabMessage: (url: string, frameUrl: string) => Message;
     onColorSchemeChange: ({isDark}: {isDark: boolean}) => void;
 }
 
 interface FrameInfo {
-    url: string;
+    url?: string;
     state: DocumentState;
+    timestamp: number;
 }
 
 interface TabManagerState {
     tabs: {[tabId: number]: {[frameId: number]: FrameInfo}};
+    timestamp: number;
 }
 
 /*
@@ -50,14 +53,17 @@ export default class TabManager {
     private tabs: {[tabId: number]: {[frameId: number]: FrameInfo}};
     private stateManager: StateManager<TabManagerState>;
     private fileLoader: any = null;
+    private getTabMessage: (url: string, frameUrl: string) => Message;
+    private timestamp: number = null;
     static LOCAL_STORAGE_KEY = 'TabManager-state';
 
-    constructor({getConnectionMessage, onColorSchemeChange}: TabManagerOptions) {
-        this.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}});
+    constructor({getConnectionMessage, onColorSchemeChange, getTabMessage}: TabManagerOptions) {
+        this.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0});
         this.tabs = {};
+        this.getTabMessage = getTabMessage;
 
         chrome.runtime.onMessage.addListener(async (message: Message, sender, sendResponse) => {
-            function addFrame(tabs: {[tabId: number]: {[frameId: number]: FrameInfo}}, tabId: number, frameId: number, senderURL: string) {
+            function addFrame(tabs: {[tabId: number]: {[frameId: number]: FrameInfo}}, tabId: number, frameId: number, senderURL: string, timestamp: number) {
                 let frames: {[frameId: number]: FrameInfo};
                 if (tabs[tabId]) {
                     frames = tabs[tabId];
@@ -65,7 +71,11 @@ export default class TabManager {
                     frames = {};
                     tabs[tabId] = frames;
                 }
-                frames[frameId] = {url: senderURL, state: DocumentState.ACTIVE};
+                frames[frameId] = {
+                    url: senderURL,
+                    state: DocumentState.ACTIVE,
+                    timestamp: timestamp,
+                };
             }
 
             switch (message.type) {
@@ -100,7 +110,7 @@ export default class TabManager {
                     const senderURL = sender.url;
                     const tabURL = sender.tab.url;
 
-                    addFrame(this.tabs, tabId, frameId, senderURL);
+                    addFrame(this.tabs, tabId, frameId, senderURL, this.timestamp);
 
                     reply({
                         url: tabURL,
@@ -132,14 +142,28 @@ export default class TabManager {
                 }
                 case MessageType.CS_FRAME_FREEZE:
                     await this.stateManager.loadState();
-                    this.tabs[sender.tab.id][sender.frameId].state = DocumentState.FROZEN;
+                    const info = this.tabs[sender.tab.id][sender.frameId];
+                    info.state = DocumentState.FROZEN;
+                    info.url = null;
                     this.stateManager.saveState();
                     break;
-                case MessageType.CS_FRAME_RESUME:
+                case MessageType.CS_FRAME_RESUME: {
                     await this.stateManager.loadState();
-                    addFrame(this.tabs, sender.tab.id, sender.frameId, sender.url);
+                    const tabId = sender.tab.id;
+                    const frameId = sender.frameId;
+                    const frameURL = sender.url;
+                    if (this.tabs[tabId][frameId].timestamp < this.timestamp) {
+                        const message = this.getTabMessage(this.getTabURL(sender.tab), frameURL);
+                        chrome.tabs.sendMessage<Message>(tabId, message, {frameId});
+                    }
+                    this.tabs[sender.tab.id][sender.frameId] = {
+                        url: sender.url,
+                        state: DocumentState.ACTIVE,
+                        timestamp: this.timestamp,
+                    };
                     this.stateManager.saveState();
                     break;
+                }
 
                 case MessageType.CS_FETCH: {
                     // Using custom response due to Chrome and Firefox incompatibility
@@ -190,6 +214,27 @@ export default class TabManager {
         });
     }
 
+    async invalidateTimestamp() {
+        this.timestamp++;
+
+        (await queryTabs({}))
+            .filter((tab) => Boolean(this.tabs[tab.id]))
+            .forEach((tab) => {
+                const frames = this.tabs[tab.id];
+                Object.entries(frames)
+                    .filter(([, {state}]) => state === DocumentState.ACTIVE || state === DocumentState.PASSIVE)
+                    .forEach(([, {url}], frameId) => {
+                        const message = this.getTabMessage(this.getTabURL(tab), frameId === 0 ? null : url);
+                        if (tab.active && frameId === 0) {
+                            chrome.tabs.sendMessage<Message>(tab.id, message, {frameId});
+                        } else {
+                            setTimeout(() => chrome.tabs.sendMessage<Message>(tab.id, message, {frameId}));
+                        }
+                        this.tabs[tab.id][frameId].timestamp = this.timestamp;
+                    });
+            });
+    }
+
     getTabURL(tab: chrome.tabs.Tab): string {
         // It can happen in cases whereby the tab.url is empty.
         // Luckily this only and will only happen on `about:blank`-like pages.
@@ -230,26 +275,6 @@ export default class TabManager {
                 {file: '/inject/index.js'},
             ]
         });
-    }
-
-    async sendMessage(getMessage: (url: string, frameUrl: string) => Message) {
-        (await queryTabs({}))
-            .filter((tab) => Boolean(this.tabs[tab.id]))
-            .forEach((tab) => {
-                const frames = this.tabs[tab.id];
-                Object.entries(frames).forEach(([, {url, state}], frameId) => {
-                    if (state !== DocumentState.ACTIVE && state !== DocumentState.PASSIVE) {
-                        // TODO: avoid sending messages to frozen tabs for performance reasons.
-                        logInfo('Sending message to a frozen tab.');
-                    }
-                    const message = getMessage(this.getTabURL(tab), frameId === 0 ? null : url);
-                    if (tab.active && frameId === 0) {
-                        chrome.tabs.sendMessage<Message>(tab.id, message, {frameId});
-                    } else {
-                        setTimeout(() => chrome.tabs.sendMessage<Message>(tab.id, message, {frameId}));
-                    }
-                });
-            });
     }
 
     async canAccessActiveTab(): Promise<boolean> {

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -247,6 +247,15 @@ export default class TabManager {
             });
     }
 
+    async registerMailDisplayScript() {
+        await (chrome as any).messageDisplayScripts.register({
+            js: [
+                {file: '/inject/fallback.js'},
+                {file: '/inject/index.js'},
+            ]
+        });
+    }
+
     async sendMessage() {
         this.timestamp++;
 
@@ -266,15 +275,6 @@ export default class TabManager {
                         this.tabs[tab.id][frameId].timestamp = this.timestamp;
                     });
             });
-    }
-
-    async registerMailDisplayScript() {
-        await (chrome as any).messageDisplayScripts.register({
-            js: [
-                {file: '/inject/fallback.js'},
-                {file: '/inject/index.js'},
-            ]
-        });
     }
 
     async canAccessActiveTab(): Promise<boolean> {


### PR DESCRIPTION
Store URLs only for frames which are either "active" or "passive" in Page Life API terminology. Also, differ sending messages to these frames until they become "active" or "passive". This serves three goals:
 - do less work overall. When user has Dev Tools open and tries various fixes and saves them regularly, extension used to send a message to every frame on every incrimental change. Now it will send messages only to frames which are potentially visible to the user.
 - do less work at one time. When user has extension OFF, and then toggles it ON, Dark Reader sends a message to every frame all at once.
 - store less data about frames which are not visible to the user. Do not store URL of these frames. As mentioned earlier, browsers limit amount of data which can be stored without `unlimitedStorage` permission (5MB). It was theoretically posible to exceed the limit by hoarding lots of tabs with long URLs. Now, such hoarding is even harder.

-------------------------

~~This permission does not display any warnings for user, does not cause Chrome to disable extension upon update, and is not even displayed anywhere in the browser UI. Pinging @alexanderby and @Gusted to sign-off on this.~~

~~I tested this manually. I packaged multiple versions of this extension: (1) one from current `master`; (2) another with `unlimitedStorage` permission, and (3) another with a more powerful permission which is known to throw more warnings (`management`). As expected, upon uprading from 1 to 3 there was a warning and extension was disabled (which validates this testing method). Upon upgrading from 1 to 2 there were no warnings or any interruptions at all.~~

~~Docs (apply to MV2 and MV3 despite mv3 in the URL): https://developer.chrome.com/docs/extensions/mv3/permission_warnings/~~