### PR TITLE
Fix for bugs.chromium.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2017,6 +2017,7 @@ bugs.chromium.org
 
 INVERT
 i.material-icons
+.project-logo
 
 CSS
 :root {


### PR DESCRIPTION
- Invert logo.

The fix works fine for
- https://bugs.chromium.org/p/chromium/issues/list
- https://bugs.chromium.org/p/boringssl/issues/list
- https://bugs.chromium.org/p/git/issues/list
- https://bugs.chromium.org/p/skia/issues/list
- https://bugs.chromium.org/p/v8/issues/list
- https://bugs.chromium.org/p/webrtc/issues/list

but not very well for https://bugs.chromium.org/p/monorail/issues/list. But to exclude https://bugs.chromium.org/p/monorail/issues/list, the rule must be greatly complicated.