### PR TITLE
Do not consider extension enabled until it is ready

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -64,6 +64,10 @@ export class Extension {
     };
 
     isEnabled(): boolean {
+        if (!this.ready) {
+            return false;
+        }
+
         if (this.isEnabledCached !== null) {
             return this.isEnabledCached;
         }
@@ -173,6 +177,9 @@ export class Extension {
             return;
         }
         chrome.commands.onCommand.addListener(async (command) => {
+            if (!this.ready) {
+                return;
+            }
             if (command === 'toggle') {
                 logInfo('Toggle command entered');
                 this.changeSettings({

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -118,13 +118,13 @@ export class Extension {
         if (this.user.settings.syncSitesFixes) {
             await this.config.load({local: false});
         }
-        this.onAppToggle();
         this.changeSettings(this.user.settings);
         logInfo('loaded', this.user.settings);
 
         this.registerCommands();
 
         this.ready = true;
+        this.onAppToggle();
         if (isThunderbird) {
             this.tabs.registerMailDisplayScript();
         } else {


### PR DESCRIPTION
This fixes two race conditions:
 - `isEnabled()` needs to know Automation settings, so we need to load them before `isEnabled()` can return meaningful value. This bug actually surfaces if you reload extension and open popup quickly enough. It produces the following message: 
    > Error in event handler: TypeError: Cannot destructure property 'latitude' of 'this.user.settings.location' as it is undefined.
 - commands perform actions like "toggle" extension ON/OFF and modify extension settings, but we need to load settings before we can flip/toggle them. I was not able to trigger this bug for real.