### PR TITLE
Indicate when extension does not have proper access

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -154,7 +154,9 @@ export class Extension {
                     await new Promise<void>((resolve) => this.awaiting.push(resolve));
                 }
                 const url = await this.tabs.getActiveTabURL();
-                return this.getURLInfo(url);
+                const info = this.getURLInfo(url);
+                info.isInjected = await this.tabs.canAccessActiveTab();
+                return info;
             },
             changeSettings: (settings) => this.changeSettings(settings),
             setTheme: (theme) => this.setTheme(theme),
@@ -421,6 +423,7 @@ export class Extension {
             url,
             isInDarkList,
             isProtected,
+            isInjected: null
         };
     }
 

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -223,6 +223,10 @@ export default class TabManager {
             });
     }
 
+    async canAccessActiveTab(): Promise<boolean> {
+        const tab = await this.getActiveTab();
+        return Boolean(this.tabs[tab.id]);
+    }
     async getActiveTabURL() {
         return this.getTabURL(await this.getActiveTab());
     }

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -104,6 +104,7 @@ export interface LocationSettings {
 export interface TabInfo {
     url: string;
     isProtected: boolean;
+    isInjected: boolean;
     isInDarkList: boolean;
 }
 

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -70,6 +70,7 @@ export function getMockActiveTabInfo(): TabInfo {
         url: 'https://darkreader.org/',
         isProtected: false,
         isInDarkList: false,
+        isInjected: true,
     };
 }
 

--- a/src/ui/popup/components/header/index.tsx
+++ b/src/ui/popup/components/header/index.tsx
@@ -41,7 +41,7 @@ function Header({data, actions, tab, onMoreToggleSettingsClick}: HeaderProps) {
                     tab={tab}
                     actions={actions}
                 />
-                {tab.isProtected ? (
+                {tab.isProtected || !tab.isInjected ? (
                     <span class="header__site-toggle__unable-text">
                         {getLocalMessage('page_protected')}
                     </span>

--- a/src/ui/popup/components/site-toggle/index.tsx
+++ b/src/ui/popup/components/site-toggle/index.tsx
@@ -13,12 +13,13 @@ export default function SiteToggleButton({data, tab, actions}: ExtWrapper & {tab
             actions.toggleURL(tab.url);
         }
     }
+    const pdf = isPDF(tab.url);
     const toggleHasEffect = (
         data.settings.enableForProtectedPages ||
-        !tab.isProtected
+        (!tab.isProtected && !pdf) ||
+        tab.isInjected
     );
-    const pdf = isPDF(tab.url);
-    const isSiteEnabled = isURLEnabled(tab.url, data.settings, tab);
+    const isSiteEnabled = isURLEnabled(tab.url, data.settings, tab) && tab.isInjected;
     const host = getURLHostOrProtocol(tab.url);
 
     const urlText = host


### PR DESCRIPTION
Fixes #6538.

Relevant section of the popup UI:
![image](https://user-images.githubusercontent.com/45960703/130328433-b507dc05-49bd-43ce-b07b-ccfbb4a2255c.png)

May be, a more specific message for local files is more appropriate. It could even take user directly to the browser page with the relevant toggle.

@Gusted What do you think of this?