### PR TITLE
Added logo inversion fixes for some danish news sites

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -167,6 +167,13 @@ img.adbl-cp-cursor
 
 ================================
 
+avisendanmark.dk
+
+INVERT
+.logo
+
+================================
+
 aws.amazon.com
 
 INVERT
@@ -204,6 +211,13 @@ bbc.com
 
 INVERT
 div.orb-nav-section.orb-nav-blocks > a > img
+
+================================
+
+berlingske.dk
+
+INVERT
+.site-header__logo
 
 ================================
 
@@ -1099,10 +1113,24 @@ INVERT
 
 ================================
 
+journalisten.dk
+
+INVERT
+.top-logo
+
+================================
+
 juejin.im
 
 NO INVERT
 .equation
+
+================================
+
+jyllands-posten.dk
+
+INVERT
+.c-icon:not(.c-icon--fill-white)
 
 ================================
 
@@ -1710,6 +1738,13 @@ img
 
 ================================
 
+politiken.dk
+
+INVERT
+.pol-logo
+
+================================
+
 practice.geeksforgeeks.org
 
 INVERT
@@ -2021,6 +2056,13 @@ span.inm > img
 #lensDIV img
 .gs-image-box img.gs-image
 img[alt="Table of Contents"]
+
+================================
+
+stiften.dk
+
+INVERT
+.logo
 
 ================================
 


### PR DESCRIPTION
The logos on some danish news sites that I either frequent or occasionally visit were near invisible on dark backgrounds. I added inversion rules for them in this PR, which mean they are visible again.