### PR TITLE
Add workflow for automatic release

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,40 @@
+name: Create binary for release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
+      - name: Set up npm cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-${{ hashFiles('package-lock.json') }}
+            ${{ runner.OS }}
+      
+      - name: Install npm dependencies
+        run: npm ci
+      
+      - name: Build the extension
+        run: npm run release
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            build/release/darkreader-*


### PR DESCRIPTION
- Resolves #3965

This enables automatic creation of releases which includes the binaries of the said tag.

Workflow in action: https://github.com/Gusted/darkreader/actions/runs/1170348637
Result: https://github.com/Gusted/darkreader/releases/tag/v5.1.1