### PR TITLE
Fix for clients.servarica.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2468,6 +2468,13 @@ img[alt="i-Ready icon"], img[alt="Google Meet icon"], img[alt="Google icon"] {
 
 ================================
 
+clients.servarica.com
+
+INVERT
+.logo
+
+================================
+
 cloud.databricks.com
 pages.databricks.com
 *.azuredatabricks.net
@@ -10925,13 +10932,6 @@ img[src="/img/ufe/icons/stores.svg"]
 img[src="/img/ufe/icons/community.svg"]
 img[src="/img/ufe/icons/me32.svg"]
 svg[data-at="basket_icon_large"]
-
-================================
-
-servarica.com/clients
-
-INVERT
-.logo
 
 ================================
 


### PR DESCRIPTION
- The client area moved to a subdomain.