### PR TITLE
Fix issue #6610

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -20,6 +20,7 @@ import {isSystemDarkModeEnabled} from '../utils/media-query';
 import {isFirefox, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
 import {logInfo, logWarn} from '../utils/log';
+import {PromiseBarrier, PromiseBarrierState} from '../utils/promise-barrier';
 
 export class Extension {
     config: ConfigManager;
@@ -35,6 +36,7 @@ export class Extension {
     private wasEnabledOnLastCheck: boolean = null;
     private popupOpeningListener: () => void = null;
     private wasLastColorSchemeDark: boolean = null;
+    private startBarrier: PromiseBarrier = null;
 
     static ALARM_NAME = 'auto-time-alarm';
     constructor() {
@@ -53,6 +55,7 @@ export class Extension {
             onColorSchemeChange: this.onColorSchemeChange,
         });
         this.user = new UserStorage({onRemoteSettingsChange: () => this.onRemoteSettingsChange()});
+        this.startBarrier = new PromiseBarrier();
 
         chrome.alarms.onAlarm.addListener(this.alarmListener);
     }
@@ -126,6 +129,7 @@ export class Extension {
         }
 
         this.news.subscribe();
+        this.startBarrier.resolve();
     }
 
     private getMessengerAdapter(): ExtensionAdapter {
@@ -161,6 +165,9 @@ export class Extension {
     async onCommand(command: string, url: string) {
         if (!this.user.settings) {
             await this.user.loadSettings();
+        }
+        if (this.startBarrier.state === PromiseBarrierState.PENDING) {
+            await this.startBarrier.entry();
         }
         switch (command) {
             case 'toggle':

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -20,7 +20,7 @@ import {isSystemDarkModeEnabled} from '../utils/media-query';
 import {isFirefox, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
 import {logInfo, logWarn} from '../utils/log';
-import {PromiseBarrier, PromiseBarrierState} from '../utils/promise-barrier';
+import {PromiseBarrier} from '../utils/promise-barrier';
 
 export class Extension {
     config: ConfigManager;
@@ -163,7 +163,7 @@ export class Extension {
     }
 
     async onCommand(command: string, url: string) {
-        if (this.startBarrier.state === PromiseBarrierState.PENDING) {
+        if (this.startBarrier.isPending()) {
             await this.startBarrier.entry();
         }
         switch (command) {

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -163,9 +163,6 @@ export class Extension {
     }
 
     async onCommand(command: string, url: string) {
-        if (!this.user.settings) {
-            await this.user.loadSettings();
-        }
         if (this.startBarrier.state === PromiseBarrierState.PENDING) {
             await this.startBarrier.entry();
         }

--- a/src/background/icon-manager.ts
+++ b/src/background/icon-manager.ts
@@ -8,10 +8,6 @@ const ICON_PATHS = {
 };
 
 export default class IconManager {
-    constructor() {
-        this.setActive();
-    }
-
     setActive() {
         if (!chrome.browserAction.setIcon || isThunderbird) {
             // Fix for Firefox Android and Thunderbird.

--- a/src/utils/promise-barrier.ts
+++ b/src/utils/promise-barrier.ts
@@ -1,9 +1,3 @@
-export const PromiseBarrierState = {
-    PENDING: 'pending',
-    FULFILLED: 'fulfilled',
-    REJECTED: 'rejected',
-};
-
 export class PromiseBarrier {
     private resolves: Array<(value?: any) => void> = [];
     private rejects: Array<(reason?: any) => void> = [];
@@ -48,12 +42,15 @@ export class PromiseBarrier {
         return new Promise<void>((resolve) => setTimeout(() => resolve()));
     }
 
-    get state() {
-        if (this.wasResolved) {
-            return PromiseBarrierState.FULFILLED;
-        } else if (this.wasRejected) {
-            return PromiseBarrierState.REJECTED;
-        }
-        return PromiseBarrierState.PENDING;
+    isPending(): boolean {
+        return !this.wasResolved && !this.wasRejected;
+    }
+
+    isFulfilled(): boolean {
+        return this.wasResolved;
+    }
+
+    isRejected(): boolean {
+        return this.wasRejected;
     }
 }

--- a/tests/utils/promise-barrier.tests.ts
+++ b/tests/utils/promise-barrier.tests.ts
@@ -1,4 +1,4 @@
-import {PromiseBarrier, PromiseBarrierState} from '../../src/utils/promise-barrier';
+import {PromiseBarrier} from '../../src/utils/promise-barrier';
 
 test('Promise barrier utility', async () => {
     const barrier = new PromiseBarrier();
@@ -12,20 +12,28 @@ test('Promise barrier utility', async () => {
     expect(fn1).toBeCalled();
     expect(fn2).not.toBeCalled();
 
-    expect(barrier.state).toBe(PromiseBarrierState.PENDING);
+    expect(barrier.isPending()).toBe(true);
+    expect(barrier.isFulfilled()).toBe(false);
+    expect(barrier.isRejected()).toBe(false);
     await barrier.resolve(2);
-    expect(barrier.state).toBe(PromiseBarrierState.FULFILLED);
+    expect(barrier.isFulfilled()).toBe(true);
+    expect(barrier.isPending()).toBe(false);
+    expect(barrier.isRejected()).toBe(false);
     expect(fn1).toBeCalledTimes(1);
     expect(fn2).toBeCalledWith(2);
 });
 
 test('Promise barrier utility: awaiting for barrier after it was settled', async () => {
-    const barrierResolved = new PromiseBarrier();
-    expect(barrierResolved.state).toBe(PromiseBarrierState.PENDING);
-    const promise1 = barrierResolved.resolve('Hello World!');
-    expect(barrierResolved.state).toBe(PromiseBarrierState.FULFILLED);
+    const barrierFulfilled = new PromiseBarrier();
+    expect(barrierFulfilled.isPending()).toBe(true);
+    expect(barrierFulfilled.isFulfilled()).toBe(false);
+    expect(barrierFulfilled.isRejected()).toBe(false);
+    const promise1 = barrierFulfilled.resolve('Hello World!');
+    expect(barrierFulfilled.isFulfilled()).toBe(true);
+    expect(barrierFulfilled.isPending()).toBe(false);
+    expect(barrierFulfilled.isRejected()).toBe(false);
     const fn1 = jest.fn();
-    (async () => fn1(await barrierResolved.entry()))();
+    (async () => fn1(await barrierFulfilled.entry()))();
     await promise1;
     expect(fn1).toBeCalledWith('Hello World!');
 
@@ -44,20 +52,30 @@ test('Promise barrier utility: awaiting for barrier after it was settled', async
 });
 
 test('Promise barrier utility: resolving multiple times', async () => {
-    const barrierResolved = new PromiseBarrier();
-    expect(barrierResolved.state).toBe(PromiseBarrierState.PENDING);
-    barrierResolved.resolve('Hello World!');
-    expect(barrierResolved.state).toBe(PromiseBarrierState.FULFILLED);
-    barrierResolved.resolve('Hello World 2!');
-    expect(barrierResolved.state).toBe(PromiseBarrierState.FULFILLED);
+    const barrierFulfilled = new PromiseBarrier();
+    expect(barrierFulfilled.isPending()).toBe(true);
+    expect(barrierFulfilled.isFulfilled()).toBe(false);
+    expect(barrierFulfilled.isRejected()).toBe(false);
+    barrierFulfilled.resolve('Hello World!');
+    expect(barrierFulfilled.isFulfilled()).toBe(true);
+    expect(barrierFulfilled.isPending()).toBe(false);
+    expect(barrierFulfilled.isRejected()).toBe(false);
+    barrierFulfilled.resolve('Hello World 2!');
+    expect(barrierFulfilled.isFulfilled()).toBe(true);
+    expect(barrierFulfilled.isPending()).toBe(false);
+    expect(barrierFulfilled.isRejected()).toBe(false);
     const fn1 = jest.fn();
-    (async () => fn1(await barrierResolved.entry()))();
+    (async () => fn1(await barrierFulfilled.entry()))();
     setTimeout(() => expect(fn1).toBeCalledWith('Hello World!'));
 
     const barrierRejected = new PromiseBarrier();
-    expect(barrierRejected.state).toBe(PromiseBarrierState.PENDING);
+    expect(barrierRejected.isPending()).toBe(true);
+    expect(barrierRejected.isFulfilled()).toBe(false);
+    expect(barrierRejected.isRejected()).toBe(false);
     await barrierRejected.reject('rejection reason');
-    expect(barrierRejected.state).toBe(PromiseBarrierState.REJECTED);
+    expect(barrierRejected.isRejected()).toBe(true);
+    expect(barrierRejected.isPending()).toBe(false);
+    expect(barrierRejected.isFulfilled()).toBe(false);
     barrierRejected.reject('rejection reason 2');
     const fn2 = jest.fn();
     (async () => {


### PR DESCRIPTION
This PR fixes two bugs which both lead to #6610:
 - it removes `IconManager.constructor()` because this constructor would be called on every invocation of background context and set icon to "ON" state unconditionally. Since there is a race between this constructor's call and other calls (e.g, from `Extension.onToggle()` called by `Extension.start()`), `IconManager.constructor()` could incorrectly unconditioally set icon to ON. This bug was always present, even in persistent context.
 - adds an extra barrier to ensure that when shortcut command is entered, `Extension.start()` runs before `Extension.onCommand()`. This is needed because `Extension.start()` tampers with the icon and `Extension.isEnabledCached`.