### PR TITLE
rynekzdrowia.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10678,6 +10678,9 @@ rynekzdrowia.pl
 
 INVERT
 img[src*="rynekzdrowia.svg"]
+img[alt*="partner"]
+.search
+.copyright > img
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10674,6 +10674,13 @@ INVERT
 
 ================================
 
+rynekzdrowia.pl
+
+INVERT
+img[src*="rynekzdrowia.svg"]
+
+================================
+
 rytmy.pl
 
 INVERT


### PR DESCRIPTION
https://www.rynekzdrowia.pl/Polityka-zdrowotna/Nowa-ustawa-covidowa-Restauracje-i-hotele-tylko-dla-zaszczepionych-unikna-lockdownu,224434,14.html

![20210829-1630266607](https://user-images.githubusercontent.com/9846948/131263536-4e1fcd6d-f0b3-4976-8861-c2443d336d7d.png)
![20210829-1630266596](https://user-images.githubusercontent.com/9846948/131263537-8d6c2ee8-d3fd-4385-84d8-e304b48f5d78.png)
![20210829-1630266566](https://user-images.githubusercontent.com/9846948/131263538-62c5ae07-6909-4070-9219-7d499b011534.png)
