### PR TITLE
Fix `@import` formatting

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -544,7 +544,9 @@ async function linkLoading(link: HTMLLinkElement, loadingId: number) {
 }
 
 function getCSSImportURL(importDeclaration: string) {
-    return getCSSURLValue(importDeclaration.substring(8).replace(/;$/, ''));
+    // Substring(7) is used to remove `@import` from the string.
+    // And then use .trip() to remove the possible whitespaces.
+    return getCSSURLValue(importDeclaration.substring(7).trim().replace(/;$/, ''));
 }
 
 async function loadText(url: string) {

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -544,8 +544,8 @@ async function linkLoading(link: HTMLLinkElement, loadingId: number) {
 }
 
 function getCSSImportURL(importDeclaration: string) {
-    // Substring(7) is used to remove `@import` from the string.
-    // And then use .trip() to remove the possible whitespaces.
+    // substring(7) is used to remove `@import` from the string.
+    // And then use .trim() to remove the possible whitespaces.
     return getCSSURLValue(importDeclaration.substring(7).trim().replace(/;$/, ''));
 }
 

--- a/tests/inject/dynamic/style-override.tests.ts
+++ b/tests/inject/dynamic/style-override.tests.ts
@@ -91,6 +91,23 @@ describe('STYLE ELEMENTS', () => {
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
     });
 
+    it('should override style with @import"..."', async () => {
+        container.innerHTML = multiline(
+            '<style>',
+            `    @import"data:text/css;utf8,${encodeURIComponent('h1 { background: gray; }')}";`,
+            '    h1 strong { color: red; }',
+            '</style>',
+            '<h1>Style <strong>with @import"..."</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(50);
+        expect(getComputedStyle(container).backgroundColor).toBe('rgb(0, 0, 0)');
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
+    });
+
     it('should restore override', async () => {
         container.innerHTML = multiline(
             '<style class="testcase-style">',


### PR DESCRIPTION
- Don't assume their's are space after `@import`.
- Resolve replacing imports like `@import"/base.css"`
- Resolves #6645


@FadeMind Could you confirm that [darkreader-chrome.zip](https://github.com/darkreader/darkreader/files/7076658/darkreader-chrome.zip) solves the issue.