### PR TITLE
Just-in-time parsing of config files

### DIFF
--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -1,10 +1,11 @@
 import {readText} from './utils/network';
 import {parseArray} from '../utils/text';
 import {getDuration} from '../utils/time';
-import {parseInversionFixes} from '../generators/css-filter';
-import {parseDynamicThemeFixes} from '../generators/dynamic-theme';
-import {parseStaticThemes} from '../generators/static-theme';
+import {indexInversionFixes, parseInversionFixes} from '../generators/css-filter';
+import {indexDynamicThemeFixes, parseDynamicThemeFixes} from '../generators/dynamic-theme';
+import {indexStaticThemes, parseStaticThemes} from '../generators/static-theme';
 import type {InversionFix, StaticTheme, DynamicThemeFix} from '../definitions';
+import type {SitePropsIndex} from '../generators/utils/parse';
 
 const CONFIG_URLs = {
     darkSites: {
@@ -35,9 +36,12 @@ interface Config {
 
 export default class ConfigManager {
     DARK_SITES?: string[];
-    DYNAMIC_THEME_FIXES?: DynamicThemeFix[];
-    INVERSION_FIXES?: InversionFix[];
-    STATIC_THEMES?: StaticTheme[];
+    DYNAMIC_THEME_FIXES_INDEX?: SitePropsIndex<DynamicThemeFix>;
+    DYNAMIC_THEME_FIXES_RAW?: string;
+    INVERSION_FIXES_INDEX?: SitePropsIndex<InversionFix>;
+    INVERSION_FIXES_RAW?: string;
+    STATIC_THEMES_INDEX?: SitePropsIndex<StaticTheme>;
+    STATIC_THEMES_RAW?: string;
 
     raw = {
         darkSites: null as string,
@@ -137,16 +141,19 @@ export default class ConfigManager {
 
     handleDynamicThemeFixes() {
         const $fixes = this.overrides.dynamicThemeFixes || this.raw.dynamicThemeFixes;
-        this.DYNAMIC_THEME_FIXES = parseDynamicThemeFixes($fixes);
+        this.DYNAMIC_THEME_FIXES_INDEX = indexDynamicThemeFixes($fixes);
+        this.DYNAMIC_THEME_FIXES_RAW = $fixes;
     }
 
     handleInversionFixes() {
         const $fixes = this.overrides.inversionFixes || this.raw.inversionFixes;
-        this.INVERSION_FIXES = parseInversionFixes($fixes);
+        this.INVERSION_FIXES_INDEX = indexInversionFixes($fixes);
+        this.INVERSION_FIXES_RAW = $fixes;
     }
 
     handleStaticThemes() {
         const $themes = this.overrides.staticThemes || this.raw.staticThemes;
-        this.STATIC_THEMES = parseStaticThemes($themes);
+        this.STATIC_THEMES_INDEX = indexStaticThemes($themes);
+        this.STATIC_THEMES_RAW = $themes;
     }
 }

--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -1,9 +1,7 @@
 import {readText} from './utils/network';
 import {parseArray} from '../utils/text';
 import {getDuration} from '../utils/time';
-import {indexInversionFixes} from '../generators/css-filter';
-import {indexDynamicThemeFixes} from '../generators/dynamic-theme';
-import {indexStaticThemes} from '../generators/static-theme';
+import {indexSitesFixesConfig} from '../generators/utils/parse';
 import type {InversionFix, StaticTheme, DynamicThemeFix} from '../definitions';
 import type {SitePropsIndex} from '../generators/utils/parse';
 
@@ -141,19 +139,19 @@ export default class ConfigManager {
 
     handleDynamicThemeFixes() {
         const $fixes = this.overrides.dynamicThemeFixes || this.raw.dynamicThemeFixes;
-        this.DYNAMIC_THEME_FIXES_INDEX = indexDynamicThemeFixes($fixes);
+        this.DYNAMIC_THEME_FIXES_INDEX = indexSitesFixesConfig<DynamicThemeFix>($fixes);
         this.DYNAMIC_THEME_FIXES_RAW = $fixes;
     }
 
     handleInversionFixes() {
         const $fixes = this.overrides.inversionFixes || this.raw.inversionFixes;
-        this.INVERSION_FIXES_INDEX = indexInversionFixes($fixes);
+        this.INVERSION_FIXES_INDEX = indexSitesFixesConfig<InversionFix>($fixes);
         this.INVERSION_FIXES_RAW = $fixes;
     }
 
     handleStaticThemes() {
         const $themes = this.overrides.staticThemes || this.raw.staticThemes;
-        this.STATIC_THEMES_INDEX = indexStaticThemes($themes);
+        this.STATIC_THEMES_INDEX = indexSitesFixesConfig<StaticTheme>($themes);
         this.STATIC_THEMES_RAW = $themes;
     }
 }

--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -1,9 +1,9 @@
 import {readText} from './utils/network';
 import {parseArray} from '../utils/text';
 import {getDuration} from '../utils/time';
-import {indexInversionFixes, parseInversionFixes} from '../generators/css-filter';
-import {indexDynamicThemeFixes, parseDynamicThemeFixes} from '../generators/dynamic-theme';
-import {indexStaticThemes, parseStaticThemes} from '../generators/static-theme';
+import {indexInversionFixes} from '../generators/css-filter';
+import {indexDynamicThemeFixes} from '../generators/dynamic-theme';
+import {indexStaticThemes} from '../generators/static-theme';
 import type {InversionFix, StaticTheme, DynamicThemeFix} from '../definitions';
 import type {SitePropsIndex} from '../generators/utils/parse';
 

--- a/src/background/devtools.ts
+++ b/src/background/devtools.ts
@@ -94,7 +94,7 @@ export default class DevTools {
 
     getDynamicThemeFixesText() {
         const $fixes = this.getSavedDynamicThemeFixes();
-        const fixes = $fixes ? parseDynamicThemeFixes($fixes) : this.config.DYNAMIC_THEME_FIXES;
+        const fixes = $fixes ? parseDynamicThemeFixes($fixes) : parseDynamicThemeFixes(this.config.DYNAMIC_THEME_FIXES_RAW);
         return formatDynamicThemeFixes(fixes);
     }
 
@@ -132,7 +132,7 @@ export default class DevTools {
 
     getInversionFixesText() {
         const $fixes = this.getSavedInversionFixes();
-        const fixes = $fixes ? parseInversionFixes($fixes) : this.config.INVERSION_FIXES;
+        const fixes = $fixes ? parseInversionFixes($fixes) : parseInversionFixes(this.config.INVERSION_FIXES_RAW);
         return formatInversionFixes(fixes);
     }
 
@@ -170,7 +170,7 @@ export default class DevTools {
 
     getStaticThemesText() {
         const $themes = this.getSavedStaticThemes();
-        const themes = $themes ? parseStaticThemes($themes) : this.config.STATIC_THEMES;
+        const themes = $themes ? parseStaticThemes($themes) : parseStaticThemes(this.config.STATIC_THEMES_RAW);
         return formatStaticThemes(themes);
     }
 

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -463,11 +463,11 @@ export class Extension {
                 case ThemeEngines.dynamicTheme: {
                     const filter = {...theme};
                     delete filter.engine;
-                    const fixesNew = getDynamicThemeFixesFor(url, frameURL, this.config.DYNAMIC_THEME_FIXES_RAW, this.config.DYNAMIC_THEME_FIXES_INDEX, this.user.settings.enableForPDF);
+                    const fixes = getDynamicThemeFixesFor(url, frameURL, this.config.DYNAMIC_THEME_FIXES_RAW, this.config.DYNAMIC_THEME_FIXES_INDEX, this.user.settings.enableForPDF);
                     const isIFrame = frameURL != null;
                     return {
                         type: MessageType.BG_ADD_DYNAMIC_THEME,
-                        data: {filter, fixesNew, isIFrame},
+                        data: {filter, fixes, isIFrame},
                     };
                 }
                 default: {

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -11,7 +11,7 @@ import {getFontList, getCommands, setShortcut, canInjectScript} from './utils/ex
 import {isInTimeIntervalLocal, nextTimeInterval, isNightAtLocation, nextNightAtLocation} from '../utils/time';
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import ThemeEngines from '../generators/theme-engines';
-import createCSSFilterStylesheet, {parseInversionFixes} from '../generators/css-filter';
+import createCSSFilterStylesheet from '../generators/css-filter';
 import {getDynamicThemeFixesForNew} from '../generators/dynamic-theme';
 import createStaticStylesheet, {parseStaticThemes} from '../generators/static-theme';
 import {createSVGFilterStylesheet, getSVGFilterMatrixValue, getSVGReverseFilterMatrixValue} from '../generators/svg-filter';
@@ -22,7 +22,7 @@ import {MessageType} from '../utils/message';
 import {logInfo, logWarn} from '../utils/log';
 import {PromiseBarrier} from '../utils/promise-barrier';
 
-// TODO: remove parseStaticThemes and parseInversionFixes
+// TODO: remove parseStaticThemes
 
 export class Extension {
     config: ConfigManager;
@@ -421,20 +421,20 @@ export class Extension {
                 case ThemeEngines.cssFilter: {
                     return {
                         type: MessageType.BG_ADD_CSS_FILTER,
-                        data: createCSSFilterStylesheet(theme, url, frameURL, parseInversionFixes(this.config.INVERSION_FIXES_RAW)),
+                        data: createCSSFilterStylesheet(theme, url, frameURL, this.config.INVERSION_FIXES_RAW, this.config.INVERSION_FIXES_INDEX),
                     };
                 }
                 case ThemeEngines.svgFilter: {
                     if (isFirefox) {
                         return {
                             type: MessageType.BG_ADD_CSS_FILTER,
-                            data: createSVGFilterStylesheet(theme, url, frameURL, parseInversionFixes(this.config.INVERSION_FIXES_RAW)),
+                            data: createSVGFilterStylesheet(theme, url, frameURL, this.config.INVERSION_FIXES_RAW, this.config.INVERSION_FIXES_INDEX),
                         };
                     }
                     return {
                         type: MessageType.BG_ADD_SVG_FILTER,
                         data: {
-                            css: createSVGFilterStylesheet(theme, url, frameURL, parseInversionFixes(this.config.INVERSION_FIXES_RAW)),
+                            css: createSVGFilterStylesheet(theme, url, frameURL, this.config.INVERSION_FIXES_RAW, this.config.INVERSION_FIXES_INDEX),
                             svgMatrix: getSVGFilterMatrixValue(theme),
                             svgReverseMatrix: getSVGReverseFilterMatrixValue(),
                         },

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -12,7 +12,7 @@ import {isInTimeIntervalLocal, nextTimeInterval, isNightAtLocation, nextNightAtL
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import ThemeEngines from '../generators/theme-engines';
 import createCSSFilterStylesheet from '../generators/css-filter';
-import {getDynamicThemeFixesForNew} from '../generators/dynamic-theme';
+import {getDynamicThemeFixesFor} from '../generators/dynamic-theme';
 import createStaticStylesheet from '../generators/static-theme';
 import {createSVGFilterStylesheet, getSVGFilterMatrixValue, getSVGReverseFilterMatrixValue} from '../generators/svg-filter';
 import type {ExtensionData, FilterConfig, News, Shortcuts, UserSettings, TabInfo} from '../definitions';
@@ -463,7 +463,7 @@ export class Extension {
                 case ThemeEngines.dynamicTheme: {
                     const filter = {...theme};
                     delete filter.engine;
-                    const fixesNew = getDynamicThemeFixesForNew(url, frameURL, this.config.DYNAMIC_THEME_FIXES_RAW, this.config.DYNAMIC_THEME_FIXES_INDEX, this.user.settings.enableForPDF);
+                    const fixesNew = getDynamicThemeFixesFor(url, frameURL, this.config.DYNAMIC_THEME_FIXES_RAW, this.config.DYNAMIC_THEME_FIXES_INDEX, this.user.settings.enableForPDF);
                     const isIFrame = frameURL != null;
                     return {
                         type: MessageType.BG_ADD_DYNAMIC_THEME,

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -11,9 +11,9 @@ import {getFontList, getCommands, setShortcut, canInjectScript} from './utils/ex
 import {isInTimeIntervalLocal, nextTimeInterval, isNightAtLocation, nextNightAtLocation} from '../utils/time';
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import ThemeEngines from '../generators/theme-engines';
-import createCSSFilterStylesheet from '../generators/css-filter';
-import {getDynamicThemeFixesFor, getDynamicThemeFixesForNew} from '../generators/dynamic-theme';
-import createStaticStylesheet from '../generators/static-theme';
+import createCSSFilterStylesheet, {parseInversionFixes} from '../generators/css-filter';
+import {getDynamicThemeFixesForNew} from '../generators/dynamic-theme';
+import createStaticStylesheet, {parseStaticThemes} from '../generators/static-theme';
 import {createSVGFilterStylesheet, getSVGFilterMatrixValue, getSVGReverseFilterMatrixValue} from '../generators/svg-filter';
 import type {ExtensionData, FilterConfig, News, Shortcuts, UserSettings, TabInfo} from '../definitions';
 import {isSystemDarkModeEnabled} from '../utils/media-query';
@@ -22,9 +22,7 @@ import {MessageType} from '../utils/message';
 import {logInfo, logWarn} from '../utils/log';
 import {PromiseBarrier} from '../utils/promise-barrier';
 
-// TODO: remove
-import {parseInversionFixes} from '../generators/css-filter';
-import {parseStaticThemes} from '../generators/static-theme';
+// TODO: remove parseStaticThemes and parseInversionFixes
 
 export class Extension {
     config: ConfigManager;
@@ -453,7 +451,6 @@ export class Extension {
                 case ThemeEngines.dynamicTheme: {
                     const filter = {...theme};
                     delete filter.engine;
-                    //const fixes = getDynamicThemeFixesFor(url, frameURL, this.config.DYNAMIC_THEME_FIXES, this.user.settings.enableForPDF);
                     const fixesNew = getDynamicThemeFixesForNew(url, frameURL, this.config.DYNAMIC_THEME_FIXES_RAW, this.config.DYNAMIC_THEME_FIXES_INDEX, this.user.settings.enableForPDF);
                     const isIFrame = frameURL != null;
                     return {

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -13,7 +13,7 @@ import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/u
 import ThemeEngines from '../generators/theme-engines';
 import createCSSFilterStylesheet from '../generators/css-filter';
 import {getDynamicThemeFixesForNew} from '../generators/dynamic-theme';
-import createStaticStylesheet, {parseStaticThemes} from '../generators/static-theme';
+import createStaticStylesheet from '../generators/static-theme';
 import {createSVGFilterStylesheet, getSVGFilterMatrixValue, getSVGReverseFilterMatrixValue} from '../generators/svg-filter';
 import type {ExtensionData, FilterConfig, News, Shortcuts, UserSettings, TabInfo} from '../definitions';
 import {isSystemDarkModeEnabled} from '../utils/media-query';
@@ -21,8 +21,6 @@ import {isFirefox, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
 import {logInfo, logWarn} from '../utils/log';
 import {PromiseBarrier} from '../utils/promise-barrier';
-
-// TODO: remove parseStaticThemes
 
 export class Extension {
     config: ConfigManager;
@@ -445,7 +443,7 @@ export class Extension {
                         type: MessageType.BG_ADD_STATIC_THEME,
                         data: theme.stylesheet && theme.stylesheet.trim() ?
                             theme.stylesheet :
-                            createStaticStylesheet(theme, url, frameURL, parseStaticThemes(this.config.STATIC_THEMES_RAW)),
+                            createStaticStylesheet(theme, url, frameURL, this.config.STATIC_THEMES_RAW, this.config.STATIC_THEMES_INDEX),
                     };
                 }
                 case ThemeEngines.dynamicTheme: {

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -1,6 +1,6 @@
 import {formatSitesFixesConfig} from './utils/format';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
-import {parseSitesFixesConfig} from './utils/parse';
+import {parseSitesFixesConfig, indexSitesFixesConfig} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import {createTextStyle} from './text-style';
@@ -220,6 +220,10 @@ export function parseInversionFixes(text: string) {
             return parseArray(value);
         },
     });
+}
+
+export function indexInversionFixes(text: string) {
+    return indexSitesFixesConfig<InversionFix>(text);
 }
 
 export function formatInversionFixes(inversionFixes: InversionFix[]) {

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -1,6 +1,7 @@
 import {formatSitesFixesConfig} from './utils/format';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
-import {parseSitesFixesConfig, SitePropsIndex, getSitesFixesFor} from './utils/parse';
+import {parseSitesFixesConfig, getSitesFixesFor} from './utils/parse';
+import type {SitePropsIndex} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import {createTextStyle} from './text-style';

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -1,6 +1,6 @@
 import {formatSitesFixesConfig} from './utils/format';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
-import {parseSitesFixesConfig, indexSitesFixesConfig} from './utils/parse';
+import {parseSitesFixesConfig} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import {createTextStyle} from './text-style';
@@ -220,10 +220,6 @@ export function parseInversionFixes(text: string) {
             return parseArray(value);
         },
     });
-}
-
-export function indexInversionFixes(text: string) {
-    return indexSitesFixesConfig<InversionFix>(text);
 }
 
 export function formatInversionFixes(inversionFixes: InversionFix[]) {

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -1,6 +1,6 @@
 import {formatSitesFixesConfig} from './utils/format';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
-import {parseSitesFixesConfig} from './utils/parse';
+import {parseSitesFixesConfig, SitePropsIndex, getSitesFixesFor} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import {createTextStyle} from './text-style';
@@ -26,14 +26,14 @@ export function hasPatchForChromiumIssue501582() {
     );
 }
 
-export default function createCSSFilterStyleSheet(config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
+export default function createCSSFilterStyleSheet(config: FilterConfig, url: string, frameURL: string, fixes: string, index: SitePropsIndex<InversionFix>) {
     const filterValue = getCSSFilterValue(config);
     const reverseFilterValue = 'invert(100%) hue-rotate(180deg)';
-    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, inversionFixes);
+    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, fixes, index);
 }
 
-export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterValue: string, config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
-    const fix = getInversionFixesFor(frameURL || url, inversionFixes);
+export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterValue: string, config: FilterConfig, url: string, frameURL: string, fixes: string, index: SitePropsIndex<InversionFix>) {
+    const fix = getInversionFixesFor(frameURL || url, fixes, index);
 
     const lines: string[] = [];
 
@@ -173,7 +173,18 @@ function createReverseRule(reverseFilterValue: string, fix: InversionFix): strin
 * @param url Site URL.
 * @param inversionFixes List of inversion fixes.
 */
-export function getInversionFixesFor(url: string, inversionFixes: InversionFix[]): InversionFix {
+export function getInversionFixesFor(url: string, fixes: string, index: SitePropsIndex<InversionFix>): InversionFix {
+    const inversionFixes = getSitesFixesFor<InversionFix>(url, fixes, index, {
+        commands: Object.keys(inversionFixesCommands),
+        getCommandPropName: (command) => inversionFixesCommands[command],
+        parseCommandValue: (command, value) => {
+            if (command === 'CSS') {
+                return value.trim();
+            }
+            return parseArray(value);
+        },
+    });
+
     const common = {
         url: inversionFixes[0].url,
         invert: inversionFixes[0].invert || [],

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -88,7 +88,7 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, fixes: Dy
 }
 
 export function getDynamicThemeFixesForNew(url: string, frameURL: string, text: string, index: SitePropsIndex<DynamicThemeFix>, enabledForPDF: boolean) {
-    const fixes = getSitesFixesFor(url, frameURL, text, index, {
+    const fixes = getSitesFixesFor(frameURL || url, text, index, {
         commands: Object.keys(dynamicThemeFixesCommands),
         getCommandPropName: (command) => dynamicThemeFixesCommands[command],
         parseCommandValue: (command, value) => {

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -1,5 +1,5 @@
 import {formatSitesFixesConfig} from './utils/format';
-import {parseSitesFixesConfig, indexSitesFixesConfig, getSitesFixesFor} from './utils/parse';
+import {parseSitesFixesConfig, getSitesFixesFor} from './utils/parse';
 import type {SitePropsIndex} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
@@ -23,10 +23,6 @@ export function parseDynamicThemeFixes(text: string) {
             return parseArray(value);
         },
     });
-}
-
-export function indexDynamicThemeFixes(text: string) {
-    return indexSitesFixesConfig<DynamicThemeFix>(text);
 }
 
 export function formatDynamicThemeFixes(dynamicThemeFixes: DynamicThemeFix[]) {

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -46,48 +46,7 @@ export function formatDynamicThemeFixes(dynamicThemeFixes: DynamicThemeFix[]) {
     });
 }
 
-export function getDynamicThemeFixesFor(url: string, frameURL: string, fixes: DynamicThemeFix[], enabledForPDF: boolean) {
-    if (fixes.length === 0 || fixes[0].url[0] !== '*') {
-        return null;
-    }
-
-    const common = {
-        url: fixes[0].url,
-        invert: fixes[0].invert || [],
-        css: fixes[0].css || [],
-        ignoreInlineStyle: fixes[0].ignoreInlineStyle || [],
-        ignoreImageAnalysis: fixes[0].ignoreImageAnalysis || [],
-    };
-    if (enabledForPDF) {
-        common.invert = common.invert.concat('embed[type="application/pdf"]');
-    }
-    const sortedBySpecificity = fixes
-        .slice(1)
-        .map((theme) => {
-            return {
-                specificity: isURLInList(frameURL || url, theme.url) ? theme.url[0].length : 0,
-                theme
-            };
-        })
-        .filter(({specificity}) => specificity > 0)
-        .sort((a, b) => b.specificity - a.specificity);
-
-    if (sortedBySpecificity.length === 0) {
-        return common;
-    }
-
-    const match = sortedBySpecificity[0].theme;
-
-    return {
-        url: match.url,
-        invert: common.invert.concat(match.invert || []),
-        css: [common.css, match.css].filter((s) => s).join('\n'),
-        ignoreInlineStyle: common.ignoreInlineStyle.concat(match.ignoreInlineStyle || []),
-        ignoreImageAnalysis: common.ignoreImageAnalysis.concat(match.ignoreImageAnalysis || []),
-    };
-}
-
-export function getDynamicThemeFixesForNew(url: string, frameURL: string, text: string, index: SitePropsIndex<DynamicThemeFix>, enabledForPDF: boolean) {
+export function getDynamicThemeFixesFor(url: string, frameURL: string, text: string, index: SitePropsIndex<DynamicThemeFix>, enabledForPDF: boolean) {
     const fixes = getSitesFixesFor(frameURL || url, text, index, {
         commands: Object.keys(dynamicThemeFixesCommands),
         getCommandPropName: (command) => dynamicThemeFixesCommands[command],

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -1,7 +1,7 @@
 import {createTextStyle} from './text-style';
 import {formatSitesFixesConfig} from './utils/format';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
-import {parseSitesFixesConfig} from './utils/parse';
+import {parseSitesFixesConfig, indexSitesFixesConfig} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import type {FilterConfig, StaticTheme} from '../definitions';
@@ -222,6 +222,10 @@ export function parseStaticThemes($themes: string) {
             return parseArray(value);
         }
     });
+}
+
+export function indexStaticThemes(themes: string) {
+    return indexSitesFixesConfig<StaticTheme>(themes);
 }
 
 function camelCaseToUpperCase(text: string) {

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -251,7 +251,8 @@ export function formatStaticThemes(staticThemes: StaticTheme[]) {
 }
 
 function getCommonTheme(staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>): StaticTheme {
-    const staticThemeText = staticThemes.substring(0, staticThemesIndex.offsets[1]);
+    const length = parseInt(staticThemesIndex.offsets.substring(4, 8), 32);
+    const staticThemeText = staticThemes.substring(0, length);
     return parseStaticThemes(staticThemeText)[0];
 }
 

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -251,7 +251,7 @@ export function formatStaticThemes(staticThemes: StaticTheme[]) {
 }
 
 function getCommonTheme(staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>): StaticTheme {
-    const length = parseInt(staticThemesIndex.offsets.substring(4, 8), 32);
+    const length = parseInt(staticThemesIndex.offsets.substring(4, 4 + 3), 36);
     const staticThemeText = staticThemes.substring(0, length);
     return parseStaticThemes(staticThemeText)[0];
 }

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -1,7 +1,8 @@
 import {createTextStyle} from './text-style';
 import {formatSitesFixesConfig} from './utils/format';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
-import {parseSitesFixesConfig} from './utils/parse';
+import {parseSitesFixesConfig, getSitesFixesFor} from './utils/parse';
+import type {SitePropsIndex} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import type {FilterConfig, StaticTheme} from '../definitions';
@@ -57,7 +58,7 @@ function mix(color1: number[], color2: number[], t: number) {
     return color1.map((c, i) => Math.round(c * (1 - t) + color2[i] * t));
 }
 
-export default function createStaticStylesheet(config: FilterConfig, url: string, frameURL: string, staticThemes: StaticTheme[]) {
+export default function createStaticStylesheet(config: FilterConfig, url: string, frameURL: string, staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>) {
     const srcTheme = config.mode === 1 ? darkTheme : lightTheme;
     const theme = Object.entries(srcTheme).reduce((t, [prop, color]) => {
         const [r, g, b, a] = color;
@@ -68,8 +69,8 @@ export default function createStaticStylesheet(config: FilterConfig, url: string
         return t;
     }, {} as ThemeColors);
 
-    const commonTheme = getCommonTheme(staticThemes);
-    const siteTheme = getThemeFor(frameURL || url, staticThemes);
+    const commonTheme = getCommonTheme(staticThemes, staticThemesIndex);
+    const siteTheme = getThemeFor(frameURL || url, staticThemes, staticThemesIndex);
 
     const lines: string[] = [];
 
@@ -249,11 +250,23 @@ export function formatStaticThemes(staticThemes: StaticTheme[]) {
     });
 }
 
-function getCommonTheme(themes: StaticTheme[]) {
-    return themes[0];
+// TODO: do not rely on common theme being the first in the file
+function getCommonTheme(staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>): StaticTheme {
+    const staticThemeText = staticThemes.substring(0, staticThemesIndex.offsets[0].end);
+    return parseStaticThemes(staticThemeText)[0];
 }
 
-function getThemeFor(url: string, themes: StaticTheme[]) {
+function getThemeFor(url: string, staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>) {
+    const themes = getSitesFixesFor<StaticTheme>(url, staticThemes, staticThemesIndex, {
+        commands: Object.keys(staticThemeCommands),
+        getCommandPropName: (command) => staticThemeCommands[command],
+        parseCommandValue: (command, value) => {
+            if (command === 'NO COMMON') {
+                return true;
+            }
+            return parseArray(value);
+        }
+    });
     const sortedBySpecificity = themes
         .slice(1)
         .map((theme) => {

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -251,7 +251,7 @@ export function formatStaticThemes(staticThemes: StaticTheme[]) {
 }
 
 function getCommonTheme(staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>): StaticTheme {
-    const staticThemeText = staticThemes.substring(0, staticThemesIndex.offsets[0].end);
+    const staticThemeText = staticThemes.substring(0, staticThemesIndex.offsets[1]);
     return parseStaticThemes(staticThemeText)[0];
 }
 

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -1,7 +1,7 @@
 import {createTextStyle} from './text-style';
 import {formatSitesFixesConfig} from './utils/format';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
-import {parseSitesFixesConfig, indexSitesFixesConfig} from './utils/parse';
+import {parseSitesFixesConfig} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import type {FilterConfig, StaticTheme} from '../definitions';
@@ -222,10 +222,6 @@ export function parseStaticThemes($themes: string) {
             return parseArray(value);
         }
     });
-}
-
-export function indexStaticThemes(themes: string) {
-    return indexSitesFixesConfig<StaticTheme>(themes);
 }
 
 function camelCaseToUpperCase(text: string) {

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -250,7 +250,6 @@ export function formatStaticThemes(staticThemes: StaticTheme[]) {
     });
 }
 
-// TODO: do not rely on common theme being the first in the file
 function getCommonTheme(staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>): StaticTheme {
     const staticThemeText = staticThemes.substring(0, staticThemesIndex.offsets[0].end);
     return parseStaticThemes(staticThemeText)[0];

--- a/src/generators/svg-filter.ts
+++ b/src/generators/svg-filter.ts
@@ -2,8 +2,9 @@ import {createFilterMatrix, Matrix} from './utils/matrix';
 import {cssFilterStyleSheetTemplate} from './css-filter';
 import type {FilterConfig, InversionFix} from '../definitions';
 import {isFirefox} from '../utils/platform';
+import {SitePropsIndex} from './utils/parse';
 
-export function createSVGFilterStylesheet(config: FilterConfig, url: string, frameURL: string, inversionFixes: InversionFix[]) {
+export function createSVGFilterStylesheet(config: FilterConfig, url: string, frameURL: string, fixes: string, index: SitePropsIndex<InversionFix>) {
     let filterValue: string;
     let reverseFilterValue: string;
     if (isFirefox) {
@@ -14,7 +15,7 @@ export function createSVGFilterStylesheet(config: FilterConfig, url: string, fra
         filterValue = 'url(#dark-reader-filter)';
         reverseFilterValue = 'url(#dark-reader-reverse-filter)';
     }
-    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, inversionFixes);
+    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, fixes, index);
 }
 
 function getEmbeddedSVGFilterValue(matrixValue: string) {

--- a/src/generators/svg-filter.ts
+++ b/src/generators/svg-filter.ts
@@ -2,7 +2,7 @@ import {createFilterMatrix, Matrix} from './utils/matrix';
 import {cssFilterStyleSheetTemplate} from './css-filter';
 import type {FilterConfig, InversionFix} from '../definitions';
 import {isFirefox} from '../utils/platform';
-import {SitePropsIndex} from './utils/parse';
+import type {SitePropsIndex} from './utils/parse';
 
 export function createSVGFilterStylesheet(config: FilterConfig, url: string, frameURL: string, fixes: string, index: SitePropsIndex<InversionFix>) {
     let filterValue: string;

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -4,6 +4,25 @@ interface SiteProps {
     url: string[];
 }
 
+interface SitePropsIndexRecord {
+    start: number;
+    end: number;
+}
+
+// label is a valid DNS label or special '*' value
+interface SitePropsIndexRecordRecursive<T> {
+    children?: {
+        [label: string]: SitePropsIndexRecordRecursive<T>;
+    };
+    records?: number | number[];
+}
+
+export interface SitePropsIndex<T extends SiteProps> {
+    leafs: SitePropsIndexRecord[];
+    root: SitePropsIndexRecordRecursive<T>;
+    cache: Map<number, T>;
+}
+
 interface SitesFixesParserOptions<T> {
     commands: string[];
     getCommandPropName: (command: string) => keyof T;
@@ -46,4 +65,131 @@ export function parseSitesFixesConfig<T extends SiteProps>(text: string, options
     });
 
     return sites;
+}
+
+export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePropsIndex<T> {
+    const root: SitePropsIndexRecordRecursive<T> = {};
+    const leafs: SitePropsIndexRecord[] = [];
+
+    function processBlock(recordStart: number, recordEnd: number) {
+        // TODO: more formal definition of URLs and delimiters
+        const block = text.substring(recordStart, recordEnd);
+        const lines = block.split('\n');
+        const commandIndices: number[] = [];
+        lines.forEach((ln, i) => {
+            if (ln.match(/^\s*[A-Z]+(\s[A-Z]+)*\s*$/)) {
+                commandIndices.push(i);
+            }
+        });
+
+        if (commandIndices.length === 0) {
+            return;
+        }
+
+        const urls = parseArray(lines.slice(0, commandIndices[0]).join('\n'));
+        const index = leafs.length;
+        for (const url of urls) {
+            // TODO: make sure this is correct
+            const domain = url.split('/')[0];
+            const labels = domain.split('.');
+            let node = root;
+            for (let i = labels.length - 1; i >= 0; i--) {
+                const label = labels[i];
+                if (!node.children) {
+                    node.children = {};
+                }
+                if (!node.children[label]) {
+                    node.children[label] = {};
+                }
+                node = node.children[label];
+            }
+            if (node.records) {
+                if (typeof node.records === 'number') {
+                    node.records = [node.records, index];
+                } else {
+                    // node.records is number[]
+                    node.records.push(index);
+                }
+            } else {
+                node.records = index;
+            }
+            
+        }
+        leafs.push({
+            start: recordStart,
+            end: recordEnd
+        });
+    }
+
+    let recordStart = 0;
+    // Delimiter between two blocks
+    const delimiterRegex = /\r?\s*={2,}\s*\r?/gm;
+    while (true) {
+        const delimiter = delimiterRegex.exec(text);
+        const nextDelimiterStart = delimiter ? delimiter.index : text.length;
+        const nextDelimiterEnd = delimiter ? delimiter.index + delimiter[0].length : text.length;
+
+        processBlock(recordStart, nextDelimiterStart);
+
+        recordStart = nextDelimiterEnd;
+        if (delimiter === null) {
+            break;
+        }
+    }
+
+    return {root, leafs, cache: new Map<number, T>()};
+}
+
+export function parseSiteFixConfig<T extends SiteProps>(text: string, options: SitesFixesParserOptions<T>, indexRecord: SitePropsIndexRecord): T {
+    const block = text.substring(indexRecord.start, indexRecord.end);
+    return parseSitesFixesConfig<T>(block, options)[0];
+}
+
+export function getSitesFixesFor<T extends SiteProps>(url: string, frameURL: string, text: string, index: SitePropsIndex<T>, options: SitesFixesParserOptions<T>): T[] {
+    const labels = (frameURL || url).split('.');
+    let recordIds: number[] = [];
+    const stack: Array<[number, SitePropsIndexRecordRecursive<T>]> = [[
+        labels.length - 1,
+        index.root,
+    ]];
+    while (stack.length) {
+        const task = stack.pop();
+        const index = task[0];
+        const node = task[1];
+        const label = labels[index];
+
+        if (node.records) {
+            // TODO: make sure there is no GC waste
+            recordIds = recordIds.concat(node.records);
+        }
+
+        // Explore wildcard match
+        if (node.children && node.children['*']) {
+            stack.push([
+                index - 1,
+                node.children['*'],
+            ]);
+        }
+
+        // Explore exact label match
+        if (node.children && node.children[label]) {
+            stack.push([
+                index - 1,
+                node.children[label],
+            ]);
+        }
+    }
+
+    const records: T[] = [];
+    for (const id of recordIds) {
+        if (index.cache.has(id)) {
+            records.push(index.cache.get(id));
+        } else {
+            const record = parseSiteFixConfig<T>(text, options, index.leafs[id]);
+            index.cache.set(id, record);
+            records.push(record);
+        }
+    }
+
+    return records;
 }

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -66,7 +66,7 @@ function getDomain(url: string) {
 }
 
 /*
- * Encode all offsets into a string, where each record is 6 bytes long:
+ * Encode all offsets into a string, where each record is 7 bytes long:
  *  - 4 bytes for start offset
  *  - 3 bytes for record length (end offset - start offset)
  * Both values are stored in base 36 (radix 36) notation.
@@ -130,11 +130,11 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
                 continue;
             }
 
-            if (!domains[domain]) {
+            if (!domainPatterns[domain]) {
                 domainPatterns[domain] = index;
-            } else if (typeof domains[domain] === 'number' && domains[domain] !== index) {
+            } else if (typeof domainPatterns[domain] === 'number' && domainPatterns[domain] !== index) {
                 domainPatterns[domain] = [(domainPatterns[domain] as number), index];
-            } else if (typeof domains[domain] === 'object' && !((domains[domain] as number[]).includes(index))) {
+            } else if (typeof domainPatterns[domain] === 'object' && !((domainPatterns[domain] as number[]).includes(index))) {
                 (domainPatterns[domain] as number[]).push(index);
             }
         }

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -31,7 +31,7 @@ export function parseSitesFixesConfig<T extends SiteProps>(text: string, options
         const lines = block.split('\n');
         const commandIndices: number[] = [];
         lines.forEach((ln, i) => {
-            if (ln.match(/^\s*[A-Z]+(\s[A-Z]+)*\s*$/)) {
+            if (ln.match(/^[A-Z]+(\s[A-Z]+){0,2}$/)) {
                 commandIndices.push(i);
             }
         });
@@ -77,7 +77,7 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
         const lines = block.split('\n');
         const commandIndices: number[] = [];
         lines.forEach((ln, i) => {
-            if (ln.match(/^\s*[A-Z]+(\s[A-Z]+)*\s*$/)) {
+            if (ln.match(/^[A-Z]+(\s[A-Z]+){0,2}$/)) {
                 commandIndices.push(i);
             }
         });

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -139,7 +139,7 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
 
     let recordStart = 0;
     // Delimiter between two blocks
-    const delimiterRegex = /\r?\s*={2,}\s*\r?/gm;
+    const delimiterRegex = /\s*={2,}\s*/gm;
     let delimiter: RegExpMatchArray;
     let count = 0;
     while ((delimiter = delimiterRegex.exec(text))) {

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -84,10 +84,10 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
         const urls = parseArray(lines.slice(0, commandIndices[0]).join('\n'));
         const index = offsets.length;
         for (const url of urls) {
-            // TODO: make sure this is correct
+            // URL patterns are guaranteed to not have protocol and leading '/'
             const domain = url.split('/')[0].toLowerCase();
             if (isFullyQualifiedDomain(domain)) {
-                if (typeof domains[domain] === 'undefined') {
+                if (!domains[domain]) {
                     domains[domain] = index;
                 } else if (typeof domains[domain] === 'number') {
                     domains[domain] = [(domains[domain] as number), index];
@@ -97,7 +97,7 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
                 continue;
             }
 
-            if (typeof domains[domain] === 'undefined') {
+            if (!domains[domain]) {
                 domainPatterns[domain] = index;
             } else if (typeof domains[domain] === 'number') {
                 domainPatterns[domain] = [(domainPatterns[domain] as number), index];

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -135,7 +135,7 @@ export function parseSiteFixConfig<T extends SiteProps>(text: string, options: S
     return parseSitesFixesConfig<T>(block, options)[0];
 }
 
-export function getSitesFixesFor<T extends SiteProps>(url: string, frameURL: string, text: string, index: SitePropsIndex<T>, options: SitesFixesParserOptions<T>): T[] {
+export function getSitesFixesFor<T extends SiteProps>(url: string, text: string, index: SitePropsIndex<T>, options: SitesFixesParserOptions<T>): T[] {
     const records: T[] = [];
     let recordIds: number[] = [];
     const domain = url.split('/')[0];

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -85,7 +85,7 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
         const index = offsets.length;
         for (const url of urls) {
             // TODO: make sure this is correct
-            const domain = url.split('/')[0];
+            const domain = url.split('/')[0].toLowerCase();
             if (isFullyQualifiedDomain(domain)) {
                 if (typeof domains[domain] === 'undefined') {
                     domains[domain] = index;
@@ -138,7 +138,7 @@ export function parseSiteFixConfig<T extends SiteProps>(text: string, options: S
 export function getSitesFixesFor<T extends SiteProps>(url: string, text: string, index: SitePropsIndex<T>, options: SitesFixesParserOptions<T>): T[] {
     const records: T[] = [];
     let recordIds: number[] = [];
-    const domain = url.split('/')[0];
+    const domain = url.split('/')[0].toLowerCase();
     if (index.domains[domain]) {
         recordIds = recordIds.concat(index.domains[domain]);
     }

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -61,6 +61,11 @@ export function parseSitesFixesConfig<T extends SiteProps>(text: string, options
     return sites;
 }
 
+// URL patterns are guaranteed to not have protocol and leading '/'
+function getDomain(url: string) {
+    return url.split('/')[0].toLowerCase();
+}
+
 export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePropsIndex<T> {
     const domains: {[domain: string]: number | number[]} = {};
     const domainPatterns: {[domainPattern: string]: number | number[]} = {};
@@ -84,8 +89,7 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
         const urls = parseArray(lines.slice(0, commandIndices[0]).join('\n'));
         const index = offsets.length;
         for (const url of urls) {
-            // URL patterns are guaranteed to not have protocol and leading '/'
-            const domain = url.split('/')[0].toLowerCase();
+            const domain = getDomain(url);
             if (isFullyQualifiedDomain(domain)) {
                 if (!domains[domain]) {
                     domains[domain] = index;
@@ -138,7 +142,7 @@ export function parseSiteFixConfig<T extends SiteProps>(text: string, options: S
 export function getSitesFixesFor<T extends SiteProps>(url: string, text: string, index: SitePropsIndex<T>, options: SitesFixesParserOptions<T>): T[] {
     const records: T[] = [];
     let recordIds: number[] = [];
-    const domain = url.split('/')[0].toLowerCase();
+    const domain = getDomain(url);
     if (index.domains[domain]) {
         recordIds = recordIds.concat(index.domains[domain]);
     }

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -58,7 +58,11 @@ export function parseSitesFixesConfig<T extends SiteProps>(text: string, options
 
 // URL patterns are guaranteed to not have protocol and leading '/'
 function getDomain(url: string) {
-    return url.split('/')[0].toLowerCase();
+    try {
+        return (new URL(url)).hostname.toLowerCase();
+    } catch (error) {
+        return url.split('/')[0].toLowerCase();
+    }
 }
 
 /*

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -118,18 +118,16 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
     let recordStart = 0;
     // Delimiter between two blocks
     const delimiterRegex = /\r?\s*={2,}\s*\r?/gm;
-    while (true) {
-        const delimiter = delimiterRegex.exec(text);
-        const nextDelimiterStart = delimiter ? delimiter.index : text.length;
-        const nextDelimiterEnd = delimiter ? delimiter.index + delimiter[0].length : text.length;
+    let delimiter: RegExpMatchArray;
+    while ((delimiter = delimiterRegex.exec(text))) {
+        const nextDelimiterStart = delimiter.index;
+        const nextDelimiterEnd = delimiter.index + delimiter[0].length;
 
         processBlock(recordStart, nextDelimiterStart);
 
         recordStart = nextDelimiterEnd;
-        if (delimiter === null) {
-            break;
-        }
     }
+    processBlock(recordStart, text.length);
 
     return {offsets, domains, domainPatterns, cache: {}};
 }

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -66,7 +66,7 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
     const domainPatterns: {[domainPattern: string]: number | number[]} = {};
     const offsets: number[] = [];
 
-    function processBlock(recordStart: number, recordEnd: number) {
+    function processBlock(recordStart: number, recordEnd: number, index: number) {
         // TODO: more formal definition of URLs and delimiters
         const block = text.substring(recordStart, recordEnd);
         const lines = block.split('\n');
@@ -82,7 +82,6 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
         }
 
         const urls = parseArray(lines.slice(0, commandIndices[0]).join('\n'));
-        const index = offsets.length / 2;
         for (const url of urls) {
             const domain = getDomain(url);
             if (isFullyQualifiedDomain(domain)) {
@@ -111,15 +110,17 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
     // Delimiter between two blocks
     const delimiterRegex = /\r?\s*={2,}\s*\r?/gm;
     let delimiter: RegExpMatchArray;
+    let count = 0;
     while ((delimiter = delimiterRegex.exec(text))) {
         const nextDelimiterStart = delimiter.index;
         const nextDelimiterEnd = delimiter.index + delimiter[0].length;
 
-        processBlock(recordStart, nextDelimiterStart);
+        processBlock(recordStart, nextDelimiterStart, count);
 
         recordStart = nextDelimiterEnd;
+        count++;
     }
-    processBlock(recordStart, text.length);
+    processBlock(recordStart, text.length, count);
 
     return {offsets, domains, domainPatterns, cache: {}};
 }

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -118,9 +118,9 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
             if (isFullyQualifiedDomain(domain)) {
                 if (!domains[domain]) {
                     domains[domain] = index;
-                } else if (typeof domains[domain] === 'number') {
+                } else if (typeof domains[domain] === 'number' && domains[domain] !== index) {
                     domains[domain] = [(domains[domain] as number), index];
-                } else if (typeof domains[domain] === 'object') {
+                } else if (typeof domains[domain] === 'object' && !((domains[domain] as number[]).includes(index))) {
                     (domains[domain] as number[]).push(index);
                 }
                 continue;
@@ -128,9 +128,9 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
 
             if (!domains[domain]) {
                 domainPatterns[domain] = index;
-            } else if (typeof domains[domain] === 'number') {
+            } else if (typeof domains[domain] === 'number' && domains[domain] !== index) {
                 domainPatterns[domain] = [(domainPatterns[domain] as number), index];
-            } else if (typeof domains[domain] === 'object') {
+            } else if (typeof domains[domain] === 'object' && !((domains[domain] as number[]).includes(index))) {
                 (domainPatterns[domain] as number[]).push(index);
             }
         }
@@ -152,7 +152,6 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
         count++;
     }
     processBlock(recordStart, text.length, count);
-
 
     return {offsets: encodeOffsets(offsets), domains, domainPatterns, cache: {}};
 }

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -64,24 +64,27 @@ function getDomain(url: string) {
 /*
  * Encode all offsets into a string, where each record is 6 bytes long:
  *  - 4 bytes for start offset
- *  - 2 bytes for record length (end offset - start offset)
+ *  - 3 bytes for record length (end offset - start offset)
  * Both values are stored in base 36 (radix 36) notation.
  * Maximum supported numbers:
  *  - start offset must be no more than parseInt('zzzz', 36) = 1679615
- *  - length must be no more than parseInt('zzzz', 36) = 1295
+ *  - length must be no more than parseInt('zzz', 36) = 46655
+ *
+ * We have to encode offsets into a string to be able to save them in
+ * chrome.storage.local for use in non-persistent background contexts.
  */
 function encodeOffsets(offsets: Array<[number, number]>): string {
     return offsets.map(([offset, length]) => {
         const stringOffset = offset.toString(36);
         const stringLength = length.toString(36);
-        return '0'.repeat(4 - stringOffset.length) + stringOffset + '0'.repeat(2 - stringLength.length) + stringLength;
+        return '0'.repeat(4 - stringOffset.length) + stringOffset + '0'.repeat(3 - stringLength.length) + stringLength;
     }).join('');
 }
 
 function decodeOffset(offsets: string, index: number): [number, number] {
-    const base = (4 + 2) * index;
+    const base = (4 + 3) * index;
     const offset = parseInt(offsets.substring(base + 0, base + 4), 36);
-    const length = parseInt(offsets.substring(base + 4, base + 4 + 2), 36);
+    const length = parseInt(offsets.substring(base + 4, base + 4 + 3), 36);
     return [
         offset,
         offset + length,

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -12,7 +12,7 @@ export interface SitePropsIndex<T extends SiteProps> {
     cache: {[offsetId: number]: T};
 }
 
-interface SitesFixesParserOptions<T> {
+export interface SitesFixesParserOptions<T> {
     commands: string[];
     getCommandPropName: (command: string) => keyof T;
     parseCommandValue: (command: string, value: string) => any;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -199,3 +199,7 @@ export function isURLEnabled(url: string, userSettings: UserSettings, {isProtect
     }
     return (!isInDarkList && !isURLInUserList);
 }
+
+export function isFullyQualifiedDomain(candidate: string) {
+    return /^[a-z0-9.-]+$/.test(candidate);
+}

--- a/tests/generators/utils/jest.config.js
+++ b/tests/generators/utils/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+    verbose: true,
+    testEnvironment: 'jsdom',
+    transform: {
+        '^.+\\.ts$': 'ts-jest'
+    },
+    testRegex: 'tests/generators/utils/.*\\.tests\\.ts$',
+    moduleFileExtensions: [
+        'ts',
+        'js'
+    ],
+    rootDir: '../../../',
+    collectCoverage: false,
+    coverageDirectory: 'tests/coverage',
+    collectCoverageFrom: [
+        '<rootDir>/src/**/*.ts',
+    ],
+    globals: {
+        'ts-jest': {
+            tsconfig: './tests/generators/utils/tsconfig.json'
+        }
+    }
+};

--- a/tests/generators/utils/parse.tests.ts
+++ b/tests/generators/utils/parse.tests.ts
@@ -1,0 +1,46 @@
+import {indexSitesFixesConfig, getSitesFixesFor} from '../../../src/generators/utils/parse';
+
+test('Index config', () => {
+    const record1 =
+    '*\n' +
+    '\n' +
+    'DIRECTIVE\n' +
+    'hi\n' +
+    '\n' +
+    'MULTILINEDIRECTIVE\n' +
+    'hello\n' +
+    'world\n';
+
+    const record2 =
+    'example.com\n' +
+    '\n' +
+    'CSS\n' +
+    'div {\n' +
+    '  color: green;\n' +
+    '}\n';
+
+    const config = `${record1}\
+    \n\
+    =====================\n\
+    \n\
+    ${record2}`;
+
+    const options = {
+        commands: ['DIRECTIVE1', 'MULTILINEDIRECTIVE'],
+        getCommandPropName: (command) => command,
+        parseCommandValue: (_, value) => value.trim(),
+    };
+    const index = indexSitesFixesConfig(config);
+
+    const fixes = getSitesFixesFor('example.com', null, config, index, options);
+    expect(fixes).toEqual([
+        {
+            'url': ['example.com'],
+            'CSS': 'div {\n  color: green;\n}'
+        }, {
+            'url': ['*'],
+            'DIRECTIVE': 'hi',
+            'MULTILINEDIRECTIVE':
+            'hello\nworld'
+        }]);
+});

--- a/tests/generators/utils/parse.tests.ts
+++ b/tests/generators/utils/parse.tests.ts
@@ -1,4 +1,5 @@
 import {indexSitesFixesConfig, getSitesFixesFor} from '../../../src/generators/utils/parse';
+import type {SitesFixesParserOptions} from '../../../src/generators/utils/parse';
 
 test('Index config', () => {
     const record1 =
@@ -25,7 +26,7 @@ test('Index config', () => {
     \n\
     ${record2}`;
 
-    const options = {
+    const options: SitesFixesParserOptions<any> = {
         commands: ['DIRECTIVE1', 'MULTILINEDIRECTIVE'],
         getCommandPropName: (command) => command,
         parseCommandValue: (_, value) => value.trim(),

--- a/tests/generators/utils/parse.tests.ts
+++ b/tests/generators/utils/parse.tests.ts
@@ -32,7 +32,7 @@ test('Index config', () => {
     };
     const index = indexSitesFixesConfig(config);
 
-    const fixes = getSitesFixesFor('example.com', null, config, index, options);
+    const fixes = getSitesFixesFor('example.com', config, index, options);
     expect(fixes).toEqual([
         {
             'url': ['example.com'],

--- a/tests/generators/utils/parse.tests.ts
+++ b/tests/generators/utils/parse.tests.ts
@@ -45,3 +45,31 @@ test('Index config', () => {
             'hello\nworld'
         }]);
 });
+
+test('Empty config', () => {
+    const config =
+    '*\n' +
+    '\n' +
+    'DIRECTIVE\n' +
+    'hello world\n' +
+    '\n' +
+    '====================\n' +
+    '\n' +
+    'invalid.example\n' +
+    '\n';
+
+    const options: SitesFixesParserOptions<any> = {
+        commands: ['DIRECTIVE'],
+        getCommandPropName: (command) => command,
+        parseCommandValue: (_, value) => value.trim(),
+    };
+    const index = indexSitesFixesConfig(config);
+
+    const fixesGeneric = getSitesFixesFor('example.com', config, index, options);
+    const fixesInvalid = getSitesFixesFor('invalid.example', config, index, options);
+    expect(fixesGeneric).toEqual([{
+        'url': ['*'],
+        'DIRECTIVE': 'hello world',
+    }]);
+    expect(fixesInvalid).toEqual(fixesGeneric);
+});

--- a/tests/generators/utils/tsconfig.json
+++ b/tests/generators/utils/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../src/tsconfig",
+    "compilerOptions": {
+        "module": "commonjs",
+        "outDir": "",
+        "types": [
+            "jest",
+            "node"
+        ]
+    }
+}

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
     projects: [
         'tests/config/jest.config.js',
         'tests/utils/jest.config.js',
+        'tests/generators/utils/jest.config.js',
     ],
     verbose: true,
 };

--- a/tests/utils/url.tests.ts
+++ b/tests/utils/url.tests.ts
@@ -1,4 +1,4 @@
-import {isURLEnabled, isURLMatched, isPDF, getURLHostOrProtocol, getAbsoluteURL} from '../../src/utils/url';
+import {isURLEnabled, isURLMatched, isPDF, isFullyQualifiedDomain, getURLHostOrProtocol, getAbsoluteURL} from '../../src/utils/url';
 import type {UserSettings} from '../../src/definitions';
 
 test('URL is enabled', () => {
@@ -278,4 +278,9 @@ test('Absolute URL', () => {
     expect(getAbsoluteURL('https://www.google.com/path/page.html', '../image.jpg')).toBe('https://www.google.com/image.jpg');
     expect(getAbsoluteURL('path/index.html', 'image.jpg')).toBe(`${location.origin}/path/image.jpg`);
     expect(getAbsoluteURL('path/index.html', '/image.jpg?size=128')).toBe(`${location.origin}/image.jpg?size=128`);
+});
+
+test('Fully qualified domain', () => {
+    expect(isFullyQualifiedDomain('www.google.com')).toBe(true);
+    expect(isFullyQualifiedDomain('*.google.com')).toBe(false);
 });


### PR DESCRIPTION
As discussed earlier, current parser implementation is suboptimal. This PR aims to:
 - decrease memory usage by storing only rule offsets for unused rules, and
 - improve performance by creating one more cache for used rules

This optimisation takes advantage of the following observations:
 1. Most users visits only a tiny subset of sites which have configs
 2. Storing two numbers (indecies of rule start and end) is cheaper than storing the whole parsed rule
 
This PR also should improve performance because prior to this `getDynamicThemeFixesFor(...)` calculated `sortedBySpecificity` by iterating over all rules each time. After this commit, it iterates only over url patterns with `*` and looks up exact domain in a map.

This is still a draft because I have a few more questions (below).

Before this patch, heap snapshot was 2.7 MB, after it is 1.9MB.