### PR TITLE
Fix for twitter.com video player

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12822,8 +12822,7 @@ CSS
 twitter.com
 
 INVERT
-[aria-label="Seek slider"]
-[aria-label="Volume slider"]
+[role="slider"]
 [style^="flex-grow"]
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12821,6 +12821,11 @@ CSS
 
 twitter.com
 
+INVERT
+[aria-label="Seek slider"]
+[aria-label="Volume slider"]
+[style^="flex-grow"]
+
 CSS
 main,
 header {


### PR DESCRIPTION
Twitter uses obfuscated class names so I had to get creative to avoid using gibberish CSS selectors.