### PR TITLE
GitHub Actions: add manual trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  workflow_dispatch:
 jobs:
   test:
     name: Run tests


### PR DESCRIPTION
This PR adds `workflow_dispatch` trigger to the CI workflow. Specifically it creates the following "Run workflow" button:
![image](https://user-images.githubusercontent.com/45960703/131478616-fc5e12cf-5b56-43aa-b6a4-536053a10534.png)

[Learn more about this feature here.](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)