### PR TITLE
doodstream.com dood.la are dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -231,6 +231,8 @@ disneyplus.com
 distrotube.com
 dlive.tv
 dodi-repacks.site
+doodstream.com
+dood.la
 dota2.ru
 dotabuff.com
 dotapicker.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -231,8 +231,8 @@ disneyplus.com
 distrotube.com
 dlive.tv
 dodi-repacks.site
-doodstream.com
 dood.la
+doodstream.com
 dota2.ru
 dotabuff.com
 dotapicker.com


### PR DESCRIPTION
https://doodstream.com/
![20210901-1630481236](https://user-images.githubusercontent.com/9846948/131630155-c41bf723-c1bc-4697-a492-5706640a9cf0.png)

dood.la is subdomain used for share links. 
