### PR TITLE
Fix for apnews.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -955,8 +955,8 @@ apnews.com
 
 INVERT
 .hamburger-box
-.sticky-part > div > * > svg
-.LeftRail > div > * > svg
+.sticky-part > div svg
+.LeftRail > div svg
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -956,6 +956,7 @@ apnews.com
 INVERT
 .hamburger-box
 .sticky-part > div > * > svg
+.LeftRail > div > * > svg
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -951,6 +951,14 @@ CSS
 
 ================================
 
+apnews.com
+
+INVERT
+.hamburger-box
+.sticky-part > div > * > svg
+
+================================
+
 app.codesignal.com
 
 CSS


### PR DESCRIPTION
Fix for dark hamburger menu and dark icons in article left sidebar.