### PR TITLE
Fix for reddit.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10411,7 +10411,7 @@ reddit.com
 
 INVERT
 [role="slider"]
-[style^="height"]
+video ~ div [style^="height"]
 
 CSS
 [role="slider"] > div:nth-child(4) {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10409,7 +10409,14 @@ div.fly-but-wrap.left.relative > span
 
 reddit.com
 
+INVERT
+[role="slider"]
+[style^="height"]
+
 CSS
+[role="slider"] > div:nth-child(4) {
+    background-color: ${#0079d3} !important;
+}
 [style^="--background"] {
     --background: ${#FFFFFF} !important;
 }


### PR DESCRIPTION
Fix for seekbar and volume controls in the video player.

There's so much obfuscation on new reddit that I couldn't find a better way to target the volume controls other than `[style^="height"]` which seems to be a unique enough fingerprint at least. It's an assumption though that anything with an inline style tag with the first word being "height" (`<style="height: ...">`) must be a volume slider and needs to be inverted... Seems unique enough to fix the dark controls for now though without accidentally targeting other elements.