### PR TITLE
Fix: update debug build paths in tests

### DIFF
--- a/tests/browser/paths.js
+++ b/tests/browser/paths.js
@@ -50,8 +50,8 @@ async function getFirefoxPath() {
     return await linuxAppPath('firefox-nightly');
 }
 
-const chromeExtensionDebugDir = path.join(__dirname, '../../debug');
-const firefoxExtensionDebugDir = path.join(__dirname, '../../debug-firefox');
+const chromeExtensionDebugDir = path.join(__dirname, '../../build/debug/chrome');
+const firefoxExtensionDebugDir = path.join(__dirname, '../../build/debug/firefox');
 
 module.exports = {
     getChromePath,


### PR DESCRIPTION
This fixes integration tests broken by commit
3c0a1b26087a7b78f3708dc4bdf2763b58b204e9 which moved build destinations
but did not update paths accordingly.

Thested by running `npm run test:chrome` and `npm run test:firefox` and seeing no errors about browser failing to load extension.