### PR TITLE
Remove text-shadow on developers.arcgis.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3423,6 +3423,15 @@ CSS
 
 ================================
 
+developers.arcgis.com
+
+CSS
+a {
+    text-shadow: none !important;
+}
+
+================================
+
 developers.google.com
 
 INVERT


### PR DESCRIPTION
Removes the white text shadow that obscures <a> tags on developers.arcgis.com, particularly in the API References. For example, https://developers.arcgis.com/javascript/latest/

Before
![arcgis_js_darkreader_default](https://user-images.githubusercontent.com/47948499/132020191-1e75b19e-e2da-4262-b7dd-88f646cecd06.png)

After
![arcgis_js_darkreader_modified](https://user-images.githubusercontent.com/47948499/132020209-fce68d21-1637-4ea1-b250-06bad6a47d5e.png)


