### PR TITLE
Fix for latimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7273,6 +7273,11 @@ INVERT
 .page-logo
 .page-header-logo
 
+CSS
+.page-header-logo > a > svg > g {
+    --darkreader-inline-fill: ${white} !important;
+}
+
 ================================
 
 launchpad.net

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7272,11 +7272,7 @@ latimes.com
 INVERT
 .page-logo
 .page-header-logo
-
-CSS
-.page-header-logo > a > svg > g {
-    --darkreader-inline-fill: ${white} !important;
-}
+.page-header-logo > a > svg > g
 
 ================================
 


### PR DESCRIPTION
Fix dark logo on dark background when scrolling down home page