### PR TITLE
Add option to manually dispatch release workflow and upload artifacts

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       retention_days:
-        description: 'Retantion duration (in days)'
+        description: 'Retention duration (in days)'
         required: true
         default: '1'
 

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: 'Retantion duration (in days)'
+        required: true
+        default: '1'
 
 jobs:
   build:
@@ -38,3 +44,9 @@ jobs:
         with:
           files: |
             build/release/darkreader-*
+
+      - name: Upload built artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: build/release/darkreader-*
+          retention-days: ${{ inputs.retention_days }}


### PR DESCRIPTION
This is continuation of #6650, but just for release build workflow. Also, it adds option to store the built files as artifacts (via [`upload-artifact`](https://github.com/actions/upload-artifact)).