### PR TITLE
Refactor: disallow \r in config files

### DIFF
--- a/tests/config/config.tests.ts
+++ b/tests/config/config.tests.ts
@@ -34,6 +34,10 @@ function throwIfDifferent(input: string, expected: string, message: string) {
 
 test('Dark Sites list', async () => {
     const file = await readConfig('dark-sites.config');
+
+    // there is no \r character
+    expect(file.indexOf('\r')).toEqual(-1);
+
     const sites = parseArray(file);
 
     // is not empty
@@ -51,6 +55,10 @@ test('Dark Sites list', async () => {
 
 test('Dynamic Theme Fixes config', async () => {
     const file = await readConfig('dynamic-theme-fixes.config');
+
+    // there is no \r character
+    expect(file.indexOf('\r')).toEqual(-1);
+
     const fixes = parseDynamicThemeFixes(file);
 
     // there is a common fix
@@ -89,7 +97,7 @@ test('Dynamic Theme Fixes config', async () => {
         '========',
         'duckduckgo.com',
         'IGNORE IMAGE ANALYSIS', 'img[alt="Logo"]', 'canvas',
-    ].join('\r\n'))).toEqual([
+    ].join('\n'))).toEqual([
         {url: ['inbox.google.com', 'mail.google.com'], invert: ['a', 'b'], css: '.x { color: white !important; }'},
         {url: ['twitter.com'], invert: ['c', 'd']},
         {url: ['wikipedia.org'], ignoreInlineStyle: ['a', 'b']},
@@ -99,6 +107,10 @@ test('Dynamic Theme Fixes config', async () => {
 
 test('Inversion Fixes config', async () => {
     const file = await readConfig('inversion-fixes.config');
+
+    // there is no \r character
+    expect(file.indexOf('\r')).toEqual(-1);
+
     const fixes = parseInversionFixes(file);
 
     // there is a common fix
@@ -119,6 +131,10 @@ test('Inversion Fixes config', async () => {
 
 test('Static Themes config', async () => {
     const file = await readConfig('static-themes.config');
+
+    // there is no \r character
+    expect(file.indexOf('\r')).toEqual(-1);
+
     const themes = parseStaticThemes(file);
 
     // there is a common theme


### PR DESCRIPTION
Follow-up to discussion at #6647 [here](https://github.com/darkreader/darkreader/pull/6647#discussion_r702062492).