### PR TITLE
Fix for merriam-webster.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8270,6 +8270,13 @@ INVERT
 
 ================================
 
+merriam-webster.com
+
+INVERT
+circle.outline.Oval
+
+================================
+
 messages.android.com
 
 INVERT


### PR DESCRIPTION
Fixes sound icon.

Before:
![1](https://user-images.githubusercontent.com/6563728/132096199-41448839-e363-4eb6-a291-ffc4811acff2.png)

After:
![2](https://user-images.githubusercontent.com/6563728/132096201-ab4f44f7-2bee-4d5f-82b8-56bfdbcf2ded.png)