### PR TITLE
Fix: catch and re-throw error in getImageDetails

### DIFF
--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -20,24 +20,28 @@ export interface ImageDetails {
 const imageManager = new AsyncQueue();
 
 export async function getImageDetails(url: string) {
-    return new Promise<ImageDetails>(async (resolve) => {
-        let dataURL: string;
-        if (url.startsWith('data:')) {
-            dataURL = url;
-        } else {
-            dataURL = await getImageDataURL(url);
-        }
+    return new Promise<ImageDetails>(async (resolve, reject) => {
+        try {
+            let dataURL: string;
+            if (url.startsWith('data:')) {
+                dataURL = url;
+            } else {
+                dataURL = await getImageDataURL(url);
+            }
 
-        const image = await urlToImage(dataURL);
-        imageManager.addToQueue(() => {
-            resolve({
-                src: url,
-                dataURL,
-                width: image.naturalWidth,
-                height: image.naturalHeight,
-                ...analyzeImage(image),
+            const image = await urlToImage(dataURL);
+            imageManager.addToQueue(() => {
+                resolve({
+                    src: url,
+                    dataURL,
+                    width: image.naturalWidth,
+                    height: image.naturalHeight,
+                    ...analyzeImage(image),
+                });
             });
-        });
+        } catch (error) {
+            reject(error);
+        }
     });
 }
 

--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -21,14 +21,14 @@ const imageManager = new AsyncQueue();
 
 export async function getImageDetails(url: string) {
     return new Promise<ImageDetails>(async (resolve, reject) => {
-        try {
-            let dataURL: string;
-            if (url.startsWith('data:')) {
-                dataURL = url;
-            } else {
-                dataURL = await getImageDataURL(url);
-            }
+        let dataURL: string;
+        if (url.startsWith('data:')) {
+            dataURL = url;
+        } else {
+            dataURL = await getImageDataURL(url);
+        }
 
+        try {
             const image = await urlToImage(dataURL);
             imageManager.addToQueue(() => {
                 resolve({


### PR DESCRIPTION
`urlToImage` can throw error `Unable to load image ${url}` which was not previously caught by `getImageDetails()` and could invalidate the whole context. After this commit, this error is properly caught and re-thrown.