### PR TITLE
Fix display of star ratings on sephora.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11132,6 +11132,7 @@ img[src="/img/ufe/icons/stores.svg"]
 img[src="/img/ufe/icons/community.svg"]
 img[src="/img/ufe/icons/me32.svg"]
 svg[data-at="basket_icon_large"]
+div[aria-label$="stars"]
 
 ================================
 


### PR DESCRIPTION
Makes star ratings visible when dark mode is enabled.