### PR TITLE
Update wikipedia.org for incorrect dynamic styling

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13852,7 +13852,6 @@ body.mediawiki {
     background-color: var(--darkreader-neutral-background) !important;
 }
 
-
 IGNORE INLINE STYLE
 .legend-color
 .infobox > tbody > tr > td[style*="background-color"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13849,9 +13849,6 @@ body.mediawiki,
 #dialogEngineContainer #dialogEngineDialog {
     background-color: var(--darkreader-neutral-background) !important;
 }
-#dialogEngineContainer #dialogEngineDialog {
-    background-color: var(--darkreader-neutral-background) !important;
-}
 
 IGNORE INLINE STYLE
 .legend-color

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13845,7 +13845,8 @@ sup.reference:target {
     background-image: none !important;
 }
 .k-player,
-body.mediawiki {
+body.mediawiki,
+#dialogEngineContainer #dialogEngineDialog {
     background-color: var(--darkreader-neutral-background) !important;
 }
 #dialogEngineContainer #dialogEngineDialog {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13848,6 +13848,10 @@ sup.reference:target {
 body.mediawiki {
     background-color: var(--darkreader-neutral-background) !important;
 }
+#dialogEngineContainer #dialogEngineDialog {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
 
 IGNORE INLINE STYLE
 .legend-color


### PR DESCRIPTION
The dialog boxes for the gadget RedWarn in Wikipedia are not currently styled correctly. This change makes their background uniform and creates contrast with the dialog text.