### PR TITLE
Fix for yelp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14713,7 +14713,8 @@ header a[href="/q/"] svg
 yelp.com
 
 INVERT
-#logo
+#logo:not(.homepage-hero_logo)
+img[src$="40x40_food_v2.svg"]
 .gm-style img[role="presentation"]:not([src*="v="])
 
 ================================


### PR DESCRIPTION
Fix to only invert the Yelp logo on the results pages (not on the homepage where it's not needed). Also an inversion for a one-off dark icon in the homepage header.