### PR TITLE
Fix: ensure that first fix is generic fix

### DIFF
--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -58,10 +58,10 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, text: str
         },
     });
 
-    if (fixes.length === 0 || fixes[fixes.length - 1].url[0] !== '*') {
+    if (fixes.length === 0 || fixes[0].url[0] !== '*') {
         return null;
     }
-    const genericFix = fixes[fixes.length - 1];
+    const genericFix = fixes[0];
 
     const common = {
         url: genericFix.url,
@@ -74,7 +74,7 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, text: str
         common.invert = common.invert.concat('embed[type="application/pdf"]');
     }
     const sortedBySpecificity = fixes
-        .slice(0, fixes.length - 1)
+        .slice(1)
         .map((theme) => {
             return {
                 specificity: isURLInList(frameURL || url, theme.url) ? theme.url[0].length : 0,

--- a/tests/generators/utils/parse.tests.ts
+++ b/tests/generators/utils/parse.tests.ts
@@ -32,13 +32,13 @@ test('Index config', () => {
     const fixes = getSitesFixesFor('example.com', config, index, options);
     expect(fixes).toEqual([
         {
-            'url': ['example.com'],
-            'CSS': 'div {\n  color: green;\n}'
-        }, {
             'url': ['*'],
             'DIRECTIVE': 'hi',
             'MULTILINEDIRECTIVE':
             'hello\nworld'
+        }, {
+            'url': ['example.com'],
+            'CSS': 'div {\n  color: green;\n}'
         }]);
 });
 
@@ -115,6 +115,9 @@ test('Domain appearing in multiple records', () => {
     const fixesWildcard = getSitesFixesFor('sub.example.net', config, index, options);
     expect(fixesFQD).toEqual([
         {
+            'url': ['*'],
+            'DIRECTIVE': 'hello world'
+        }, {
             'url': ['example.com', '*.example.net'],
             'DIRECTIVE': 'one'
         }, {
@@ -123,9 +126,6 @@ test('Domain appearing in multiple records', () => {
         }, {
             'url': ['example.com', '*.example.net'],
             'DIRECTIVE': 'three'
-        }, {
-            'url': ['*'],
-            'DIRECTIVE': 'hello world'
         }]);
     expect(fixesWildcard).toEqual([
         {
@@ -173,6 +173,9 @@ test('Domain appearing multiple times within the same record', () => {
     const fixesWildcard = getSitesFixesFor('sub.example.net', config, index, options);
     expect(fixesFQD).toEqual([
         {
+            'url': ['*'],
+            'DIRECTIVE': 'hello world'
+        }, {
             'url': [
                 'example.com',
                 '*.example.net',
@@ -180,9 +183,6 @@ test('Domain appearing multiple times within the same record', () => {
                 '*.example.net'
             ],
             'DIRECTIVE': 'one'
-        }, {
-            'url': ['*'],
-            'DIRECTIVE': 'hello world'
         }]);
     expect(fixesWildcard).toEqual([
         {
@@ -196,5 +196,56 @@ test('Domain appearing multiple times within the same record', () => {
                 '*.example.net'
             ],
             'DIRECTIVE': 'one'
+        }]);
+});
+
+test('The generic fix appears first', () => {
+    const config = [
+        '*',
+        '',
+        'DIRECTIVE',
+        'hello world',
+        '',
+        '====================',
+        '',
+        '*.example.com',
+        '',
+        'DIRECTIVE',
+        'wildcard',
+        '',
+        '====================',
+        '',
+        'sub.example.com',
+        '',
+        'DIRECTIVE',
+        'sub',
+        '',
+        '====================',
+        '',
+        'long.sub.example.com',
+        '',
+        'DIRECTIVE',
+        'long',
+        ''
+    ].join('\n');
+
+    const options: SitesFixesParserOptions<any> = {
+        commands: ['DIRECTIVE'],
+        getCommandPropName: (command) => command,
+        parseCommandValue: (_, value) => value.trim(),
+    };
+    const index = indexSitesFixesConfig(config);
+
+    const fixesFQD = getSitesFixesFor('long.sub.example.com', config, index, options);
+    expect(fixesFQD).toEqual([
+        {
+            'url':['*'],
+            'DIRECTIVE':'hello world'
+        }, {
+            'url':['*.example.com'],
+            'DIRECTIVE':'wildcard'
+        }, {
+            'url':['long.sub.example.com'],
+            'DIRECTIVE':'long'
         }]);
 });


### PR DESCRIPTION
Fixes #6739.

This fixes regression introduced in commit
2cf54561f7981f243d5d9fafd61e7f3cfd764f80.
This commit ensures that generic fix appears first in the list
returned by getSitesFixesFor().