### PR TITLE
Fix: restore old behavior of implied wildcards

### DIFF
--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -178,8 +178,13 @@ export function getSitesFixesFor<T extends SiteProps>(url: string, text: string,
             recordIds = recordIds.concat(index.domainPatterns[pattern]);
         }
     }
-    if (index.domains[domain]) {
-        recordIds = recordIds.concat(index.domains[domain]);
+
+    const labels = domain.split('.');
+    for (let i = 0; i < labels.length; i++) {
+        const substring = labels.slice(i).join('.');
+        if (index.domains[substring] && isURLMatched(url, substring)) {
+            recordIds = recordIds.concat(index.domains[substring]);
+        }
     }
 
     const set = new Set();

--- a/tests/generators/utils/parse.tests.ts
+++ b/tests/generators/utils/parse.tests.ts
@@ -239,13 +239,90 @@ test('The generic fix appears first', () => {
     const fixesFQD = getSitesFixesFor('long.sub.example.com', config, index, options);
     expect(fixesFQD).toEqual([
         {
-            'url':['*'],
+            'url': ['*'],
             'DIRECTIVE':'hello world'
         }, {
-            'url':['*.example.com'],
+            'url': ['*.example.com'],
             'DIRECTIVE':'wildcard'
         }, {
-            'url':['long.sub.example.com'],
+            'url': ['long.sub.example.com'],
             'DIRECTIVE':'long'
+        }, {
+            'url': ['sub.example.com'],
+            'DIRECTIVE':'sub'
+        }]);
+});
+
+test('Fixes appear only once', () => {
+    const config = [
+        '*',
+        '',
+        'DIRECTIVE',
+        'hello world',
+        '',
+        '====================',
+        '',
+        '*.example.com',
+        'www.example.com',
+        '',
+        'DIRECTIVE',
+        'duplicate',
+        ''
+    ].join('\n');
+
+    const options: SitesFixesParserOptions<any> = {
+        commands: ['DIRECTIVE'],
+        getCommandPropName: (command) => command,
+        parseCommandValue: (_, value) => value.trim(),
+    };
+    const index = indexSitesFixesConfig(config);
+
+    const fixes = getSitesFixesFor('www.example.com', config, index, options);
+    expect(fixes).toEqual([
+        {
+            'url': ['*'],
+            'DIRECTIVE': 'hello world'
+        }, {
+            'url': [
+                '*.example.com',
+                'www.example.com'
+            ],
+            'DIRECTIVE': 'duplicate'
+        }]);
+});
+
+test('Implied wildcards', () => {
+    const config = [
+        '*',
+        '',
+        'DIRECTIVE',
+        'hello world',
+        '',
+        '====================',
+        '',
+        'example.com',
+        '',
+        'DIRECTIVE',
+        'one',
+        ''
+    ].join('\n');
+
+    const options: SitesFixesParserOptions<any> = {
+        commands: ['DIRECTIVE'],
+        getCommandPropName: (command) => command,
+        parseCommandValue: (_, value) => value.trim(),
+    };
+    const index = indexSitesFixesConfig(config);
+
+    const fixes = getSitesFixesFor('www.example.com', config, index, options);
+    expect(fixes).toEqual([
+        {
+            'url': ['*'],
+            'DIRECTIVE': 'hello world'
+        }, {
+            'url': [
+                'example.com',
+            ],
+            'DIRECTIVE': 'one'
         }]);
 });


### PR DESCRIPTION
Fixes #6738.

Commit 2cf54561f7981f243d5d9fafd61e7f3cfd764f80 changed behavior
of getDynamicThemeFixesFor() to require explicit wildcards.
Restore the old bahavior and delegate final URL chack to isURLMatched().