### PR TITLE
Refactor: avoid extra cast

### DIFF
--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -66,7 +66,7 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, text: str
     const common = {
         url: genericFix.url,
         invert: genericFix.invert || [],
-        css: genericFix.css || [],
+        css: genericFix.css || '',
         ignoreInlineStyle: genericFix.ignoreInlineStyle || [],
         ignoreImageAnalysis: genericFix.ignoreImageAnalysis || [],
     };


### PR DESCRIPTION
`genericFix.css` is a `string` (because it is just `DynamicThemeFix.css`), so it makes more sense to use default `''`.

https://github.com/darkreader/darkreader/blob/f49a2f0156cb5bbd12e525e3d5267fa1ba744942/src/definitions.d.ts#L122-L128