### PR TITLE
Fix for science.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11031,8 +11031,9 @@ IGNORE IMAGE ANALYSIS
 science.org
 
 INVERT
-.navbar-brand
+.navbar-brand > .hidden-on-dark
 .main-header__secondary__logo > img
+h1.news-article__hero__title
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11033,7 +11033,11 @@ science.org
 INVERT
 .navbar-brand > .hidden-on-dark
 .main-header__secondary__logo > img
-h1.news-article__hero__title
+
+CSS
+h1.news-article__hero__title {
+    color: var(--darkreader-neutral-text) !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Fix dark logo in article header
- Fix inconsistently dark `<h1>` element in different areas of the site