### PR TITLE
Fix for cnn.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2601,7 +2601,7 @@ CSS
 cnn.com
 
 INVERT
-[data-test="section-link"] > svg
+[data-test="section-link"] > svg:not(.politics-logo-icon)
 img.metadata-header__logo
 
 CSS


### PR DESCRIPTION
Prevent inverting one of the section link logos that is already light.