### PR TITLE
Fix light backgrounds with light text on dndbeyond

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3783,6 +3783,10 @@ CSS
 body {
      background-image: none !important;
 }
+body {
+    background: none !important;
+}
+.read-aloud-text,
 .more-info::after,
 .details-container::after {
      border-image: none !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3782,9 +3782,7 @@ CSS
 .mon-stat-block::after,
 body {
      background-image: none !important;
-}
-body {
-    background: none !important;
+     background-color: var(--darkreader-neutral-background) !important;
 }
 .read-aloud-text,
 .more-info::after,


### PR DESCRIPTION
Before

<details><summary>No fixes applied</summary>

![image](https://user-images.githubusercontent.com/39424834/133750942-84875f8c-b59c-4b99-ac99-a42235edd70f.png)

</details>

With just the `.body` selector, without adding the `.read-aloud-text` selector:

<details><summary>Without fixing read-aloud-text</summary>

![image](https://user-images.githubusercontent.com/39424834/133751074-69ba929a-19a5-41c1-8ebd-ac1b188726b8.png)

</details>

Fixed:

<details><summary>Both fixes applied</summary>

![image](https://user-images.githubusercontent.com/39424834/133746527-d5a90b7f-e591-4a4b-9df1-4c026ac66173.png)
</details>