### PR TITLE
Fix for codeberg.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2640,6 +2640,15 @@ CSS
   background-image:url("/assets/home/home-screenshot-linux-lg.png");
   padding-bottom:68%
  }
+ 
+================================
+
+codeberg.org
+
+CSS
+input, textarea, [contenteditable] {
+    caret-color: var(--darkreader-neutral-text) !important;
+}
 
 ================================
 


### PR DESCRIPTION
When submitting a bug/pull request on Codeberg, the blinking typing cursor on the title of said bug/pull request was dark, much like the background. This didn't happen on the body of the bug/pull request (it's typing cursor was white), so I'm not sure if it's okay this way.

![imagen](https://user-images.githubusercontent.com/71190696/133917676-f69f6f6a-75ac-4530-97f1-3e080e5bcfa6.png)

I think this would also apply to other Gitea instances?