### PR TITLE
Add router.asus.com to dark sites config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -682,6 +682,7 @@ rocketleagueesports.com
 roleypoly.com
 romefrontend.dev
 roosterteeth.fandom.com
+router.asus.com
 rtbyte.xyz
 runechanger.stirante.com
 runeforge.gg


### PR DESCRIPTION
This is router admin panel of ASUS routers. It is already dark by default:
![image](https://user-images.githubusercontent.com/45960703/133922740-b5a64a2f-1288-41c9-81e0-2431a1274a0b.png)

When Dark Reader is on it looks slightly broken:
![image](https://user-images.githubusercontent.com/45960703/133922808-2a658677-8676-437f-ba4a-f43b730800d8.png)
