### PR TITLE
fix: wrap private function

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -51,9 +51,9 @@ export class Extension {
     static LOCAL_STORAGE_KEY = 'Extension-state';
     constructor() {
         this.config = new ConfigManager();
-        this.devtools = new DevTools(this.config, this.onSettingsChanged);
+        this.devtools = new DevTools(this.config, async () => this.onSettingsChanged());
         this.messenger = new Messenger(this.getMessengerAdapter());
-        this.news = new Newsmaker(this.onNewsUpdate);
+        this.news = new Newsmaker((news) => this.onNewsUpdate(news));
         this.tabs = new TabManager({
             getConnectionMessage: ({url, frameURL, unsupportedSender}) => {
                 if (unsupportedSender) {
@@ -63,7 +63,7 @@ export class Extension {
             },
             onColorSchemeChange: this.onColorSchemeChange,
         });
-        this.user = new UserStorage({onRemoteSettingsChange: this.onRemoteSettingsChange});
+        this.user = new UserStorage({onRemoteSettingsChange: () => this.onRemoteSettingsChange()});
         this.startBarrier = new PromiseBarrier();
         this.stateManager = new StateManager<ExtensionState>(Extension.LOCAL_STORAGE_KEY, this, {
             isEnabled: null,


### PR DESCRIPTION
- This fixes the devtools properly.
- Don't pass a private function as argument, as the functions uses `this` which when passed will correspond to another class instead of the `Extensions` class, by wrapping them as `() =>` this functionality will behave correctly.

CC @alexanderby 