### PR TITLE
perf: faster color parsing

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -1,6 +1,6 @@
 import {overrideInlineStyle, getInlineOverrideStyle, watchForInlineStyles, stopWatchingForInlineStyles, INLINE_STYLE_SELECTOR} from './inline-style';
 import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-theme-color';
-import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache, getSelectionColor} from './modify-css';
+import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, parseColorWithCache, getSelectionColor, tryParseColor} from './modify-css';
 import type {StyleElement, StyleManager} from './style-manager';
 import {manageStyle, getManageableStyles, cleanLoadingLinks} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
@@ -171,14 +171,13 @@ function createShadowStaticStyleOverrides(root: ShadowRoot) {
 }
 
 function replaceCSSTemplates($cssText: string) {
-    return $cssText.replace(/\${(.+?)}/g, (m0, $color) => {
-        try {
-            const color = parseColorWithCache($color);
+    return $cssText.replace(/\${(.+?)}/g, (_, $color) => {
+        const color = tryParseColor($color);
+        if (color) {
             return modifyColor(color, filter);
-        } catch (err) {
-            logWarn(err);
-            return $color;
         }
+        logWarn("Couldn't parse CSSTemplate's color.");
+        return $color;
     });
 }
 


### PR DESCRIPTION
- Partially resolves #6814
- This should remove the old slow regex splitter and replace it by a simple parser.
- Tests are passing and seems to be all good and working.
- Perf results on Firefox Nightly | Arch Linux | (Split functionallity)
Old: 873,027 ops/sec ±1.54% (95 runs sampled) 
New: 1,598,297 ops/sec ±0.63% (97 runs sampled)