### PR TITLE
perf: improve getCacheId

### DIFF
--- a/src/generators/modify-colors.ts
+++ b/src/generators/modify-colors.ts
@@ -42,9 +42,14 @@ const rgbCacheKeys: Array<keyof RGBA> = ['r', 'g', 'b', 'a'];
 const themeCacheKeys: Array<keyof Theme> = ['mode', 'brightness', 'contrast', 'grayscale', 'sepia', 'darkSchemeBackgroundColor', 'darkSchemeTextColor', 'lightSchemeBackgroundColor', 'lightSchemeTextColor'];
 
 function getCacheId(rgb: RGBA, theme: Theme) {
-    return rgbCacheKeys.map((k) => rgb[k] as any)
-        .concat(themeCacheKeys.map((k) => theme[k]))
-        .join(';');
+    let resultId = '';
+    rgbCacheKeys.forEach((key) => {
+        resultId += `${rgb[key]};`;
+    });
+    themeCacheKeys.forEach((key) => {
+        resultId += `${theme[key]};`;
+    });
+    return resultId;
 }
 
 function modifyColorWithCache(rgb: RGBA, theme: Theme, modifyHSL: (hsl: HSLA, pole?: HSLA, anotherPole?: HSLA) => HSLA, poleColor?: string, anotherPoleColor?: string) {


### PR DESCRIPTION
- `getCacheId` is called on every modifyColor-related call.
- Partially resolves #6814
- It's a simple but effective object to string method with separation character of `;`.
- Due to array's handling and the way `map` works within the javascript engine it's rather slow. Switching to `forEach` and a simple variable with the resultCacheId it's 2x faster.
- Perf results on Firefox Nightly | Arch Linux
Old: 472,906 ops/sec ±0.60% (95 runs sampled)
New: 900,465 ops/sec ±0.43% (95 runs sampled)