### PR TITLE
Fix for cnn.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2598,12 +2598,13 @@ CSS
 cnn.com
 
 INVERT
-[data-test="section-link"] > svg:not(.politics-logo-icon)
+[data-test="section-link"]
 img.metadata-header__logo
 
 IGNORE INLINE STYLE
 svg.cnn-badge-icon
 svg.cnn-badge-icon > rect
+svg.politics-logo-icon
 
 ================================
 


### PR DESCRIPTION
- Fix inconsistent inversion in `svg.politics-logo-icon` in page headers across articles and category page.