### PR TITLE
Fix for thereader.mitpress.mit.edu

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12672,6 +12672,13 @@ INVERT
 
 ================================
 
+thereader.mitpress.mit.edu
+
+INVERT
+#logo
+
+================================
+
 theregister.*
 theregister.*.*
 


### PR DESCRIPTION
- Invert logo.