### PR TITLE
perf: improve performance in modifySheet

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -464,6 +464,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
 
     function destroy() {
         pause();
+        sheetModifier.destroy();
         removeNode(corsCopy);
         removeNode(syncStyle);
         loadingEnd();

--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -19,7 +19,11 @@ const themeCacheKeys: Array<keyof Theme> = [
 ];
 
 function getThemeKey(theme: Theme) {
-    return themeCacheKeys.map((p) => `${p}:${theme[p]}`).join(';');
+    let resultKey = '';
+    themeCacheKeys.forEach((key) => {
+        resultKey += `${key}:${theme[key]};`;
+    });
+    return resultKey;
 }
 
 const asyncQueue = createAsyncTasksQueue();


### PR DESCRIPTION
Improve `getThemeKey`:
- Partially resolves #6814
- Use a simple `forEach();`
- Perf results on Firefox Nightly | Arch Linux
Old: 262,610 ops/sec ±0.98% (90 runs sampled)
New: 811,644 ops/sec ±0.71% (95 runs sampled)

Improve modifySheet hot-call:
- Remove the usage of `.cssText` which was using ~200ms on big sites(in a good case scenario). 
- The current detection of Rule changes is moved to just storing a copy of `rules` itself and also added a correct destroy function.
- The `caching` rules didn't seems to have a much impact and were rather a big hassle in performance as the only things that got cached was at most 2 small CSSRules.
- Partially resolves #6814
- Increased the performance by around ~200ms-1s+


Ultimately resolves #6814  