### PR TITLE
Fix: work around Vivaldi erroneously injecting CS into panes

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -33,7 +33,15 @@ function sendMessage(message: Message) {
         return;
     }
     try {
-        chrome.runtime.sendMessage<Message>(message);
+        chrome.runtime.sendMessage<Message>(message, (response) => {
+            // Vivaldi bug workaround. See TabManager for details.
+            if (response === 'unsupportedSender') {
+                removeStyle();
+                removeSVGFilter();
+                removeDynamicTheme();
+                cleanup();
+            }
+        });
     } catch (e) {
         /*
          * Background can be unreachable if:


### PR DESCRIPTION
Fixes #6842.

Vivaldi can display pages in a "sidebar" and sometimes erroneously injects CS into them, but does not handle messaging properly. This causes a Dark Reader to inject partial styles and break the page. This bug has been observed since [2017](https://forum.vivaldi.net/topic/16098/some-extensions-are-not-working-in-web-panels), but started affecting Dark Reader only [recently](https://forum.vivaldi.net/topic/50265/dark-reader-effects-web-panels-uncontrollably).

@mateuszkozakiewicz If you have time, please run this more complete manual testing:
1. Delete or disable all versions of Dark Reader
2. [Download](https://github.com/darkreader/darkreader/releases/download/v4.9.36/darkreader-chrome.zip) and install from source v4.9.36. Open a pane (it should be messed up)
3. Remove v4.9.36
4. [Download](https://github.com/bershanskiy/darkreader/actions/runs/1260859038) and install from source new version. Open pane (it should be fine).

This more holistic test plan verifies that it's the patch fixing the bug and not some other random factor (like installing from source).