### PR TITLE
Fix: context menus on Firefox

### DIFF
--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -10,9 +10,11 @@
     },
     "permissions": [
         "alarms",
+        "contextMenus",
         "storage",
         "tabs",
         "theme",
         "<all_urls>"
-    ]
+    ],
+    "optional_permissions": null
 }

--- a/src/ui/popup/settings-page/context-menus.tsx
+++ b/src/ui/popup/settings-page/context-menus.tsx
@@ -1,11 +1,15 @@
 import {m} from 'malevic';
-import {isMobile} from '../../../utils/platform';
+import {isFirefox, isMobile} from '../../../utils/platform';
 import CheckButton from '../check-button';
 import type {ViewProps} from '../types';
 
 export default function ContextMenusGroup(props: ViewProps) {
     function onContextMenusChange(checked: boolean) {
         if (checked) {
+            if (isFirefox) {
+                props.actions.changeSettings({enableContextMenus: true});
+                return;
+            }
             // We have to request permissions in foreground context in response to user action.
             // 'contextMenus' permission is granted automatically without any permission prompts.
             chrome.permissions.request({permissions: ['contextMenus']}, (hasPermission: boolean) => {

--- a/src/ui/popup/settings-page/context-menus.tsx
+++ b/src/ui/popup/settings-page/context-menus.tsx
@@ -33,7 +33,7 @@ export default function ContextMenusGroup(props: ViewProps) {
             label="Use context menus"
             description={props.data.settings.enableContextMenus ?
                 'Context menu integration is enabled' :
-                `Context menu integration is disabled${isFirefox ? '\nNote: conext menus permission is not used.' : ''}`}
+                `Context menu integration is disabled${isFirefox ? '\nNote: context menus permission is not used.' : ''}`}
             onChange={onContextMenusChange}
         />
     );

--- a/src/ui/popup/settings-page/context-menus.tsx
+++ b/src/ui/popup/settings-page/context-menus.tsx
@@ -33,7 +33,7 @@ export default function ContextMenusGroup(props: ViewProps) {
             label="Use context menus"
             description={props.data.settings.enableContextMenus ?
                 'Context menu integration is enabled' :
-                'Context menu integration is disabled'}
+                `Context menu integration is disabled${isFirefox ? '\nNote: conext menus permission is not used.' : ''}`}
             onChange={onContextMenusChange}
         />
     );


### PR DESCRIPTION
Firefox does not support `contextMenus` as an optional permission. It must be among required `permissions` in manifest.

[MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions).