### PR TITLE
Fix: do not open install/uninstall pages during testing

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -18,6 +18,7 @@ const welcome = `  /''''\\
 Welcome to Dark Reader!`;
 console.log(welcome);
 
+declare const __DEBUG__: boolean;
 declare const __WATCH__: boolean;
 declare const __PORT__: number;
 const WATCH = __WATCH__;
@@ -71,7 +72,7 @@ if (WATCH) {
         };
     };
     listen();
-} else {
+} else if (!__DEBUG__){
     chrome.runtime.onInstalled.addListener(({reason}) => {
         if (reason === 'install') {
             chrome.tabs.create({url: getHelpURL()});


### PR DESCRIPTION
I want to make E2E tests more automatic and, may be, even run them on CI. This commit prevents DR from opening extra tabs not used in testing.