### PR TITLE
Fix: make browser tests run entirely automatically

### DIFF
--- a/tests/browser/environment.js
+++ b/tests/browser/environment.js
@@ -34,7 +34,12 @@ class PuppeteerEnvironment extends JestNodeEnvironment {
         this.assignTestGlobals();
 
         // Close sentinel about:blank page created by Puppeteer but not used in tests.
-        (await this.browser.pages())[0].close();
+        this.browser.pages().then((pages) => {
+            const sentinel = pages[0];
+            if (sentinel._target._targetInfo.url === 'about:blank') {
+                sentinel.close();
+            }
+        });
     }
 
     async launchBrowser() {

--- a/tests/browser/environment.js
+++ b/tests/browser/environment.js
@@ -32,6 +32,9 @@ class PuppeteerEnvironment extends JestNodeEnvironment {
         this.global.page = this.page;
 
         this.assignTestGlobals();
+
+        // Close sentinel about:blank page created by Puppeteer but not used in tests.
+        (await this.browser.pages())[0].close();
     }
 
     async launchBrowser() {


### PR DESCRIPTION
This makes browser tests run entirely automatically. This change closes `about:blank` page created by Puppeteer which was preventing browser shutdown. Now, at the end of every set of tests all tabs are closed automatically, allowing Puppeteer to close the whole browser and start the next set of tests.