### PR TITLE
Fix for mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7993,6 +7993,9 @@ img[src$="profile_mask2.png"]
 .rY>.sa
 .buh
 .n3 .qr
+.aih + .qj
+.asor
+.aiC
 .mixmax-flyout__wrapper
 div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
 form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id])


### PR DESCRIPTION
- Invert the "Categories" icon.
- Invert the bar with the remaining free space.
- Invert the icons of the last queries in the search history.