### PR TITLE
Fix for bankofamerica.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1514,6 +1514,18 @@ img[alt="Bankier.TV"]
 
 ================================
 
+bankofamerica.com
+
+CSS
+.fsdnav-sub-nav-left {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.ad-acct-layout,.thrfwl-body,.ad-summary-container,.olb-summary-widget-container {
+    background-image: none !important;
+}
+
+================================
+
 basecamp.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1520,7 +1520,9 @@ CSS
 .fsdnav-sub-nav-left {
     background-color: var(--darkreader-neutral-background) !important;
 }
-.ad-acct-layout,.thrfwl-body,.ad-summary-container,.olb-summary-widget-container {
+.ad-acct-layout,.ad-acct-detail-card-layout,
+.thrfwl-body,
+.ad-summary-container,.olb-summary-widget-container {
     background-image: none !important;
 }
 


### PR DESCRIPTION
The first fix (.fsdnav-sub-nav-left) fixes the hover submenus (Accounts, Bill Pay...) which are otherwise unreadable over a transparent background.
The second section is cosmetic, as the background images of some elements get badly inverted, but that's IMHO. Feel free to just push the first modification if you don't agree.

If needed, I can provide before/after photos from the user dashboard (which is accessible only with an account)