### PR TITLE
Fix for cnn.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2605,7 +2605,7 @@ CSS
 cnn.com
 
 INVERT
-[data-test="section-link"]
+[data-test="section-link"] > svg
 img.metadata-header__logo
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
Small tweak to ensure that only the dark SVGs in this section get inverted, not normal text like in the US and World categories.