### PR TITLE
Fix urbandecay.com swatches

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13330,6 +13330,14 @@ CSS
 
 ================================
 
+urbandecay.com
+
+IGNORE INLINE STYLE
+.c-select__icon
+.c-swatch
+
+================================
+
 urbandictionary.com
 
 INVERT


### PR DESCRIPTION
Corrects color of swatches on urbandecay.com

Example:

No Dark Reader
<img width="387" alt="Screen Shot 2021-09-24 at 3 19 19 PM" src="https://user-images.githubusercontent.com/17729260/134735436-eecd6482-9883-43a2-9f94-06c7eddd75b8.png">

Default Dark Reader
<img width="396" alt="Screen Shot 2021-09-24 at 3 19 03 PM" src="https://user-images.githubusercontent.com/17729260/134735476-467336b1-056b-4a9b-9b64-e410591d11ed.png">

Dark Reader with fix
<img width="394" alt="Screen Shot 2021-09-24 at 3 20 05 PM" src="https://user-images.githubusercontent.com/17729260/134735497-be343ed1-2772-41d6-8ffb-fcc5ab349121.png">

