### PR TITLE
Fix for cbpp.org and gizmodo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2285,6 +2285,13 @@ INVERT
 
 ================================
 
+cbpp.org
+
+INVERT
+.navbar-brand
+
+================================
+
 cdc.gov
 
 INVERT
@@ -5805,6 +5812,13 @@ CSS
     background-color: unset !important;
     background-image: unset !important;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
 }
+
+================================
+
+gizmodo.com
+
+INVERT
+[aria-label="Gizmodo logo"]
 
 ================================
 


### PR DESCRIPTION
- Invert logos