### PR TITLE
Fix for mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8009,6 +8009,7 @@ img[src$="profile_mask2.png"]
 .rY>.sa
 .buh
 .n3 .qr
+.aii + .qj
 .aih + .qj
 .asor
 .aiC


### PR DESCRIPTION
- Invert the "Categories" icon (when the list is collapsed).