### PR TITLE
Fix etsy.com stars when rating item

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4510,7 +4510,7 @@ INVERT
 .secondary-banner-title
 .wt-radio label:before
 .review-star.rating:not(.lit)
-div:not(:hover) > .ss-star
+div.rating.nolit:not(:hover) > .ss-star
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4509,6 +4509,8 @@ INVERT
 .banner-container
 .secondary-banner-title
 .wt-radio label:before
+.review-star.rating:not(.lit)
+div:not(:hover) > .ss-star
 
 ================================
 


### PR DESCRIPTION
Fixes review stars when rating an item. Previously all stars would be marked regardless of what was actually selected.

First fix:
Before:
<img width="189" alt="Screen Shot 2021-09-25 at 4 21 15 PM" src="https://user-images.githubusercontent.com/17729260/134786444-df07dfb7-5e6a-471d-8b92-b843bf990b15.png">

After:
<img width="206" alt="Screen Shot 2021-09-25 at 4 22 01 PM" src="https://user-images.githubusercontent.com/17729260/134786481-d02b53a5-d970-4d2d-a3ad-88083904bc38.png">


Second fix:
Before:
<img width="245" alt="Screen Shot 2021-09-25 at 4 19 36 PM" src="https://user-images.githubusercontent.com/17729260/134786497-a20cb406-b05d-4279-8b9d-45703e9ded6c.png">

After:
<img width="225" alt="Screen Shot 2021-09-25 at 4 20 20 PM" src="https://user-images.githubusercontent.com/17729260/134786501-6416960e-5138-4bea-b447-ca4074355997.png">

