### PR TITLE
Fix: use null for missing empty node

### DIFF
--- a/src/ui/popup/settings-page/context-menus.tsx
+++ b/src/ui/popup/settings-page/context-menus.tsx
@@ -27,7 +27,7 @@ export default function ContextMenusGroup(props: ViewProps) {
         }
     }
 
-    return !isMobile && (
+    return isMobile ? null : (
         <CheckButton
             checked={props.data.settings.enableContextMenus}
             label="Use context menus"


### PR DESCRIPTION
Fixes #6912.

My earlier commit, #6761 incorrectly returned `false` to denote empty node. Now it correctly returns `null`.