### PR TITLE
Add workaround for closed conduit warning

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,6 +3,7 @@ import {getHelpURL, UNINSTALL_URL} from '../utils/links';
 import {canInjectScript} from '../background/utils/extension-api';
 import type {Message} from '../definitions';
 import {MessageType} from '../utils/message';
+import {makeChromiumHappy} from './make-chromium-happy';
 
 // Initialize extension
 const extension = new Extension();
@@ -81,3 +82,5 @@ if (WATCH) {
 
     chrome.runtime.setUninstallURL(UNINSTALL_URL);
 }
+
+makeChromiumHappy();

--- a/src/background/make-chromium-happy.ts
+++ b/src/background/make-chromium-happy.ts
@@ -9,7 +9,7 @@ export function makeChromiumHappy() {
         if (![
             // TabManager
             MessageType.CS_FRAME_CONNECT,
-            
+
             // Messenger
             MessageType.UI_GET_DATA,
             MessageType.UI_GET_ACTIVE_TAB_INFO,

--- a/src/background/make-chromium-happy.ts
+++ b/src/background/make-chromium-happy.ts
@@ -1,0 +1,23 @@
+import {MessageType} from '../utils/message';
+import type {Message} from '../definitions';
+
+// This function exists to prevent Chrome from logging an error about
+// closed conduit. It just sends a dummy message in response to incomming message
+// to utilise open conduit. This response message is not even used on the other side.
+export function makeChromiumHappy() {
+    chrome.runtime.onMessage.addListener((message: Message, _, sendResponse) => {
+        if (![
+            // TabManager
+            MessageType.CS_FRAME_CONNECT,
+            
+            // Messenger
+            MessageType.UI_GET_DATA,
+            MessageType.UI_GET_ACTIVE_TAB_INFO,
+            MessageType.UI_APPLY_DEV_DYNAMIC_THEME_FIXES,
+            MessageType.UI_APPLY_DEV_INVERSION_FIXES,
+            MessageType.UI_APPLY_DEV_STATIC_THEMES,
+        ].includes(message.type)) {
+            sendResponse({type: '¯\\_(ツ)_/¯'});
+        }
+    });
+}

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -117,6 +117,7 @@ export default class TabManager {
                         frameURL: frameId === 0 ? null : senderURL,
                     });
                     this.stateManager.saveState();
+                    sendResponse({type: '¯\\_(ツ)_/¯'});
                     break;
                 }
                 case MessageType.CS_FRAME_FORGET: {

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -102,7 +102,7 @@ export default class TabManager {
                         } else {
                             sendResponse('unsupportedSender');
                         }
-                        return true;
+                        return;
                     }
 
                     const tabId = sender.tab.id;
@@ -211,8 +211,6 @@ export default class TabManager {
                     break;
                 }
             }
-            sendResponse({type: '¯\\_(ツ)_/¯'});
-            return true;
         });
     }
 


### PR DESCRIPTION
This reverts #6897 and adds a different workaround.

This is necessary because #6897 was causing an error with Popup UI: it would unconditionally call `sendResponse` with dummy string before background had time to answer to 'MessageType.UI_GET_DATA' request. This meant Popup to received this dummy string and not proper data. This new workaround checks message type and sends dummy data only if this message does not require a proper response.