### PR TITLE
fix: correct implement variable box-shadow

### DIFF
--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -444,10 +444,10 @@ export function getBgImageModifier(
     }
 }
 
-function getShadowModifier(value: string): CSSValueModifier {
+export function getShadowModifier(value: string): CSSValueModifier {
     try {
         let index = 0;
-        const colorMatches = getMatches(/(^|\s)([a-z]+\(.+?\)|#[0-9a-f]+|[a-z]+)(.*?(inset|outset)?($|,))/ig, value, 2);
+        const colorMatches = getMatches(/(^|\s)(?!calc)([a-z]+\(.+?\)|#[0-9a-f]+|[a-z]+)(.*?(inset|outset)?($|,))/ig, value, 2);
         const modifiers = colorMatches.map((match, i) => {
             const prefixIndex = index;
             const matchIndex = value.indexOf(match, index);

--- a/tests/inject/dynamic/variables.tests.ts
+++ b/tests/inject/dynamic/variables.tests.ts
@@ -1192,4 +1192,24 @@ describe('CSS VARIABLES OVERRIDE', () => {
 
         expect(elementStyle.caretColor).toBe('rgb(140, 255, 140)');
     });
+
+    it('should modify the box-shadow actual color values in a variable', async () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 {',
+            '        --offset: 8px;',
+            '    }',
+            '    h1 {',
+            '        box-shadow: calc(var(--offset)*-1 - 1px) 0 0 0 #fff',
+            '    }',
+            '</style>',
+            '<h1>COmplicated shit :(</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(0);
+        const elementStyle = getComputedStyle(container.querySelector('h1'));
+
+        expect(elementStyle.boxShadow).toBe('rgb(0, 0, 0) -9px 0px 0px 0px');
+    });
 });


### PR DESCRIPTION
- Ensure that shadow modifier doesn't catch any `calc(...)`.
- Ensures that for the box-shadow a pass-trough the shadow modifier is done.
- Resolves #6928