### PR TITLE
Fix for ultimate-guitar.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13368,6 +13368,8 @@ ultimate-guitar.com
 INVERT
 form[action$="/search.php"] > button
 form[action$="/search.php"] > button:not(:hover) > span
+canvas[style^="height: 72px; width: 84px;"]
+canvas[style^="height: 42px; width: 141px;"]
 
 ================================
 


### PR DESCRIPTION
- Invert chord charts (guitar and piano). There's a bit of obfuscation used on the page, but this latches on well to the appropriate selections due to their unique and consistent `canvas` style.