### PR TITLE
fix: ensure proxy is run immeditally

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -134,12 +134,8 @@ function createStaticStyleOverrides() {
     document.head.insertBefore(rootVarsStyle, variableStyle.nextSibling);
 
     const proxyScript = createOrUpdateScript('darkreader--proxy');
-    const blob = new Blob([`(${injectProxy})()`], {type: 'text/javascript'});
-    const url = URL.createObjectURL(blob);
-    proxyScript.src = url;
-    proxyScript.textContent = '';
+    proxyScript.append(`(${injectProxy})()`);
     document.head.insertBefore(proxyScript, rootVarsStyle.nextSibling);
-    URL.revokeObjectURL(url);
     proxyScript.remove();
 }
 


### PR DESCRIPTION
- Fixes a issue whereby the proxy script would be run as last entry due to the usage of `src` it would be seen as a external link and put on the back of the "stack" before getting it loaded.
- Removing the blob and going back to the old behavior of textContent should be fine for now.
- Resolves #5508