### PR TITLE
fix: add mutex to writing

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -72,6 +72,7 @@ export async function writeSyncStorage<T extends {[key: string]: any}>(values: T
         chrome.storage.sync.set(values, () => {
             if (chrome.runtime.lastError) {
                 reject(chrome.runtime.lastError);
+                mutexStorageWriting.unlock();
                 return;
             }
             resolve();

--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -1,5 +1,6 @@
 import {isPDF} from '../../utils/url';
 import {isFirefox, isEdge} from '../../utils/platform';
+import {Mutex} from '../../utils/mutex';
 
 declare const browser: {
     commands: {
@@ -37,7 +38,7 @@ export function canInjectScript(url: string) {
     );
 }
 
-let isWriting = false;
+const mutexStorageWriting = new Mutex();
 
 export async function readSyncStorage<T extends {[key: string]: any}>(defaults: T): Promise<T> {
     return new Promise<T>((resolve) => {
@@ -66,32 +67,32 @@ export async function readLocalStorage<T extends {[key: string]: any}>(defaults:
 }
 
 export async function writeSyncStorage<T extends {[key: string]: any}>(values: T): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-        isWriting = true;
+    return new Promise<void>(async (resolve, reject) => {
+        await mutexStorageWriting.lock();
         chrome.storage.sync.set(values, () => {
             if (chrome.runtime.lastError) {
                 reject(chrome.runtime.lastError);
                 return;
             }
             resolve();
-            setTimeout(() => isWriting = false);
+            setTimeout(() => mutexStorageWriting.unlock(), 500);
         });
     });
 }
 
 export async function writeLocalStorage<T extends {[key: string]: any}>(values: T): Promise<void> {
-    return new Promise<void>((resolve) => {
-        isWriting = true;
+    return new Promise<void>(async (resolve) => {
+        await mutexStorageWriting.lock();
         chrome.storage.local.set(values, () => {
             resolve();
-            setTimeout(() => isWriting = false);
+            setTimeout(() => mutexStorageWriting.unlock(), 500);
         });
     });
 }
 
 export const subscribeToOuterSettingsChange = (callback: () => void) => {
     chrome.storage.onChanged.addListener(() => {
-        if (!isWriting) {
+        if (!mutexStorageWriting.isLocked()) {
             callback();
         }
     });

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -1,6 +1,4 @@
-
 import {logWarn} from './log';
-
 
 /**
   * This is the Mutex(Not to confuse with RW-Mutex).

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -1,0 +1,52 @@
+
+// This is the Mutex(Not to confuse with RW-Mutex). This is to ensure that certain access are only done
+// by 1 callback/operation(a current fallpit of PromiseBarrier). This ensures that their is a global mutex
+// Which can be called by a finite amount of callbacks. We should ensure that the mutex can only be locked
+// by the first callback which has requrested it and only give the next callback the mutex lock once it's
+
+import {logWarn} from './log';
+
+// unlocked by the callback.
+export class Mutex {
+    private awaitingResolves = [] as Array<() => void>;
+    private locked = false;
+
+    public isLocked() {
+        return this.locked;
+    }
+
+    // Request a lock from the mutex.
+    public async lock() {
+        // Easiest path, the mutex is not locked.
+        // We lock the mutex and
+        if (!this.locked) {
+            this.locked = true;
+            return;
+        }
+        return new Promise<void>((resolve) => {
+            // Harder path, we will push the resolve
+            // into the array and let it be for now.
+            this.awaitingResolves.push(resolve);
+        });
+    }
+
+    // Unlock the mutex.
+    public unlock() {
+        if (!this.locked) {
+            logWarn('An unlocked mutex was tried to be unlocked.');
+            return;
+        }
+        this.locked = false;
+        setTimeout(() => this.executeNextOperation());
+    }
+
+    // Execute the next lock actions.
+    private executeNextOperation() {
+        if (this.awaitingResolves.length > 0) {
+            // Get the first entry.
+            const resolve = this.awaitingResolves.shift();
+            // Simply execute the resolve.
+            resolve();
+        }
+    }
+}

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -16,9 +16,11 @@ export class Mutex {
     }
 
     // Request a lock from the mutex.
+    // It should only return/resolve once the lock is granted.
     public async lock() {
         // Easiest path, the mutex is not locked.
-        // We lock the mutex and
+        // We lock the mutex and check if the mutex is locked.
+        // If it is locked, we wait for the mutex to be unlocked.
         if (!this.locked) {
             this.locked = true;
             return;

--- a/src/utils/mutex.ts
+++ b/src/utils/mutex.ts
@@ -1,12 +1,14 @@
 
-// This is the Mutex(Not to confuse with RW-Mutex). This is to ensure that certain access are only done
-// by 1 callback/operation(a current fallpit of PromiseBarrier). This ensures that their is a global mutex
-// Which can be called by a finite amount of callbacks. We should ensure that the mutex can only be locked
-// by the first callback which has requrested it and only give the next callback the mutex lock once it's
-
 import {logWarn} from './log';
 
-// unlocked by the callback.
+
+/**
+  * This is the Mutex(Not to confuse with RW-Mutex).
+  * This is to ensure that certain access are only done by 1 callback(a current fallpit of PromiseBarrier).
+  * This ensures that their is a global mutex which can be called by a finite amount of callbacks.
+  * We should ensure that the mutex can only be locked by the first callback which has requrested it
+  * and only give the next callback the mutex lock once it's been released.
+ */
 export class Mutex {
     private awaitingResolves = [] as Array<() => void>;
     private locked = false;


### PR DESCRIPTION
- This patch fixes 2 issues.
- 1) For some reason it was possible for a data race to occur(I still haven't a clue how this happend) when writing data. So it's now behind a mutex lock which solves this, and could be removed later when I find why the f*ck a data race can occur.
- 2) The mutex provides a method to check if it's locked. And the lock functionallity is async I've added a setTimeout to 500ms(this should be within error or of marigin) so that the call from `subscribeToOuterSettingsChange` can be executed and seen that the mutex is locked and shouldn't overwrite the data with the old data which it previously had.
- Resolves a bunch of issues.
- Resolves #6848
- Resolves #6873

CC @alexanderby And there we go. Only took more than 7 days to find the stupid root cause and fix it properly.