### PR TITLE
dark company logos for linkedin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7735,6 +7735,9 @@ div#header a:visited {
 
 linkedin.com
 
+INVERT
+img[src*="logo"]
+
 CSS
 :root {
     --color-text-low-emphasis: ${rgba(0,0,0,0.6)};


### PR DESCRIPTION
Added invert for company logos as most of them are pics with white background.