### PR TITLE
Fix for math.semestr.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8376,6 +8376,13 @@ INVERT
 
 ================================
 
+math.semestr.ru
+
+INVERT
+.img-online
+
+================================
+
 mathsisfun.com
 
 CSS


### PR DESCRIPTION
- Invert images of formulas.

Example of site page: https://math.semestr.ru/optim/rectangle.php