### PR TITLE
Fix readability of Levels on Crowns for duolingo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4189,6 +4189,7 @@ duolingo.com
 INVERT
 .Z392z
 ._24NNT
+[data-test="level-crown"]
 
 CSS
 button[aria-disabled="true"] > span {


### PR DESCRIPTION
With the fix:
![grafik](https://user-images.githubusercontent.com/11978847/135729065-89c7b814-afed-4586-8f99-1e74e755da26.png)
Without:
![grafik](https://user-images.githubusercontent.com/11978847/135729083-50eb018e-c13a-4277-8a03-194b369328a9.png)
