### PR TITLE
Refactor: use unique message ID for WS test messages

### DIFF
--- a/src/ui/devtools/index.tsx
+++ b/src/ui/devtools/index.tsx
@@ -27,24 +27,24 @@ if (DEBUG) {
     const socket = new WebSocket(`ws://localhost:8894`);
     socket.onmessage = (e) => {
         const respond = (message: any) => socket.send(JSON.stringify(message));
+        const message = JSON.parse(e.data);
         try {
-            const message = JSON.parse(e.data);
             const textarea: HTMLTextAreaElement = document.querySelector('textarea#editor');
             const [buttonReset, buttonApply] = document.querySelectorAll('button');
             switch (message.type) {
                 case 'debug-devtools-paste':
                     textarea.value = message.data;
                     buttonApply.click();
-                    respond({type: 'debug-devtools-paste-response'});
+                    respond({type: 'debug-devtools-paste-response', id: message.id});
                     break;
                 case 'debug-devtools-reset':
-                    respond({type: 'debug-devtools-reset-response'});
+                    respond({type: 'debug-devtools-reset-response', id: message.id});
                     buttonReset.click();
                     (document.querySelector('button.message-box__button-ok') as HTMLButtonElement).click();
                     break;
             }
         } catch (err) {
-            respond({type: 'error', data: String(err)});
+            respond({type: 'error', id: message.id, data: String(err)});
         }
     };
 }

--- a/src/ui/popup/index.tsx
+++ b/src/ui/popup/index.tsx
@@ -76,16 +76,16 @@ if (DEBUG) {
                 const selector = message.data;
                 const element = document.querySelector(selector);
                 element.click();
-                respond({type: 'click-response'});
+                respond({type: 'click-response', id: message.id});
             } else if (message.type === 'exists') {
                 const selector = message.data;
                 const element = document.querySelector(selector);
-                respond({type: 'exists-response', data: element != null});
+                respond({type: 'exists-response', id: message.id, data: element != null});
             } else if (message.type === 'rect') {
                 const selector = message.data;
                 const element = document.querySelector(selector);
                 const rect = (element as HTMLElement).getBoundingClientRect();
-                respond({type: 'rect-response', data: {left: rect.left, top: rect.top, width: rect.width, height: rect.height}});
+                respond({type: 'rect-response', id: message.id, data: {left: rect.left, top: rect.top, width: rect.width, height: rect.height}});
             }
         } catch (err) {
             respond({type: 'error', data: String(err)});


### PR DESCRIPTION
Previously, resolvers and rejecters were keyed on message type, which is not unique. After this patch, they are keyed on unique ID (which is just a simple counter). This is part of work which will allow us to run more tests simultaneously.

Also, previously error handling was messed up. It was:
```
if (message.type === 'error') {
    const reject = rejectors.get(message.type);
    reject(message.data);
```
But there was not any value in `rejectors` map with key `'error'`. This bug was never triggered since there are no tests which are expected to error out.