### PR TITLE
Add livesplit.org to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -474,6 +474,7 @@ link.brawlstars.com/invite
 linux.org.ru
 liquidplus.com
 listen.moe
+livesplit.org
 lolesports.com
 lollilol.cf
 lollilol.ml


### PR DESCRIPTION
Especially the web version of LiveSplit is harmed by Dark Reader, because you can set your own colors there which end up looking different than what you choose if Dark Reader is active.