### PR TITLE
Fix for ditu.baidu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3775,6 +3775,7 @@ INVERT
 #message-panel
 .more-device
 #nearby-searchbox-hint
+#nearby-searchbox-hint-center
 .pass-forceverify-wrapper
 .pass-form-item
 .route-button


### PR DESCRIPTION
- Invert nearby searchbox hint center text