### PR TITLE
Fix for nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9640,6 +9640,7 @@ nytimes.com
 INVERT
 .svelte-1v1dl99
 #xwd-board
+.wa-share-item
 
 CSS
 .css-oylsik,
@@ -9660,6 +9661,10 @@ a[data-testid] > svg {
 }
 #xwd-board rect[class^="Cell-block--"] {
     fill: ${black} !important;
+}
+.wa-share-item > a > span {
+    background-color: ${rgb(24, 26, 27)} !important;
+    border-color: ${rgb(62, 68, 70)} !important;
 }
 
 ================================


### PR DESCRIPTION
Invert WhatsApp share icon. In this edge case, the SVG icon is set as the CSS background-image, so I don't see a way to more elegantly fix this without needing to override the border and background colors as well to match the other share icons.