### PR TITLE
add atlona.zendesk.com/agent

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1401,6 +1401,34 @@ IGNORE INLINE STYLE
 
 ================================
 
+atlona.zendesk.com/agent
+
+INVERT
+.branding__fill--contrast
+.branding__color--contrast
+#z-icon
+
+CSS
+:root {
+    --atlona-orange: #f63 !important;
+    --darkreader-border-color: rgb(58, 63, 65) !important;
+}
+.rich_text .comment_input:not(.is-public) .zendesk-editor--rich-text-container, .event:not(.is-public) .comment {
+    background-color: #111 !important;
+    border-color: var(--darkreader-border-color) !important;
+}
+nav#main_navigation, .fullConversation.is-selected::after, .publicConversation.is-selected::after, .privateConversation.is-selected::after {
+    background-color: var(--atlona-orange) !important;
+}
+fullConversation.is-selected::after, .publicConversation.is-selected::after, .privateConversation.is-selected::after {
+    color: ${BLACK} !important;
+}
+#main_panes .navigation-item.active, #main_panes .reporting .sub-nav .nav a.active, #main_panes .rich_text .comment-actions .btn.active, #main_panes .c-tab__list__item.c-tab__list__item.is-selected {
+    border-bottom-color: var(--atlona-orange) !important;
+}
+
+================================
+
 audible.com
 
 INVERT


### PR DESCRIPTION
Adjusted some branding and ugly colors on text editors for my company's Zendesk Support Agent platform. It's possible that someone could make a better *.zendesk.com/agent edit that preserves branding, but I just handled ours.
![Darkreader Off](https://user-images.githubusercontent.com/15166975/136072261-8f7023e1-e6cd-42ab-a0b8-1b875011effd.png)
![Darkreader On](https://user-images.githubusercontent.com/15166975/136072320-aac903af-1bac-4f26-8b5e-7c846f7091c2.png)
![Darkreader On with edits](https://user-images.githubusercontent.com/15166975/136072354-93b78f81-fb9e-42c9-b775-68af8d58290e.png)

