### PR TITLE
Fix for tiktok.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14901,6 +14901,10 @@ www.tiktok.com
 
 INVERT
 .logo-link
+.seek-bar-container
+.volume-control-container
+div[class*="DivSeekBarContainer"]
+div[class*="DivVolumeControlContainer"]
 
 ================================
 


### PR DESCRIPTION
Invert volume and seek bars. When clicking on a video to enlarge it, the volume and seek bar CSS classes change and include a random string which is why all four of these inversions seem to be necessary.