### PR TITLE
Remove 4 sites that no longer exist and one that is no longer dark from dark site exceptions list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -276,9 +276,7 @@ escapefromtarkov.com
 escapefromtarkov.fandom.com
 esportal.com
 etcroot.pw
-eternal.abimon.org
 etlegacy.com
-eveilcorp.github.io
 evewho.com
 evowars.io
 extrememusic.com
@@ -553,7 +551,6 @@ nitter.nixnet.services
 nitter.pussthecat.org
 nitter.snopyta.org
 nitwhiz.xyz
-noblechairs.com
 nodejs.dev
 noisebridge.net
 nomanssky.com
@@ -722,7 +719,6 @@ sheet.host
 sherlock-project.github.io
 showtimeanytime.com
 shpposter.club
-shriram-balaji.github.io
 shrirambalaji.dev
 shsh.host
 shutov.by
@@ -864,7 +860,6 @@ viddit.red
 viduro.xyz
 villains.fandom.com
 vimm.net
-vineethtrv.github.io/loader
 vinesauce.com
 virustotal.com/old-browsers
 visualboxsite.com


### PR DESCRIPTION
4 sites no longer exist (3 of them seem to be deleted GitHub user pages).

noblechairs is no longer dark.