### PR TITLE
fix: correctly implement box-shadow raw value handling

### DIFF
--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -1,7 +1,7 @@
 import {modifyBackgroundColor, modifyBorderColor, modifyForegroundColor} from '../../generators/modify-colors';
 import {getParenthesesRange} from '../../utils/text';
 import {iterateCSSRules, iterateCSSDeclarations} from './css-rules';
-import {tryParseColor, getBgImageModifier, getShadowModifier} from './modify-css';
+import {tryParseColor, getBgImageModifier, getShadowModifierWithInfo} from './modify-css';
 import type {CSSValueModifier} from './modify-css';
 import type {Theme} from '../../definitions';
 
@@ -265,8 +265,11 @@ export class VariablesStore {
                     );
                     // Check if property is box-shadow and if so, do a pass-trough to modify the shadow
                     if (property === 'box-shadow') {
-                        const shadowModifier = getShadowModifier(variableReplaced);
-                        return shadowModifier(theme) || variableReplaced;
+                        const shadowModifier = getShadowModifierWithInfo(variableReplaced);
+                        const modifiedShadow = shadowModifier(theme);
+                        if (modifiedShadow.unparseableMatchesLength !== modifiedShadow.matchesLength) {
+                            return modifiedShadow.result;
+                        }
                     }
                     return variableReplaced;
                 };

--- a/tests/inject/dynamic/variables.tests.ts
+++ b/tests/inject/dynamic/variables.tests.ts
@@ -1212,4 +1212,24 @@ describe('CSS VARIABLES OVERRIDE', () => {
 
         expect(elementStyle.boxShadow).toBe('rgb(0, 0, 0) -9px 0px 0px 0px');
     });
+
+    it(`shouldn't modify the raw value of box-shadow when their is no color`, async () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 {',
+            '        --color-border-muted: green;',
+            '    }',
+            '    h1 {',
+            '        box-shadow: inset 0 -1px 0 var(--color-border-muted)',
+            '    }',
+            '</style>',
+            '<h1>COmplicated shit :(</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(0);
+        const elementStyle = getComputedStyle(container.querySelector('h1'));
+
+        expect(elementStyle.boxShadow).toBe('rgb(0, 102, 0) 0px -1px 0px 0px inset');
+    });
 });


### PR DESCRIPTION
- Fixes a regression from #6931
- This should ignore when box-shadow's don't have any color within the value and just should be handled by the variable implementation.
- Resolves the box shadow of github's nav bar.