### PR TITLE
Fix for ozon.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10110,6 +10110,13 @@ div.comment-op {
 
 ================================
 
+ozon.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+
+================================
+
 p30download.com
 
 CSS


### PR DESCRIPTION
- Invert map.
 
Example of site page: https://www.ozon.ru/info/map/