### PR TITLE
Fix for journal.tinkoff.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7150,7 +7150,7 @@ CSS
 journal.tinkoff.ru
 
 INVERT
-.g2tvv
+._17-LK > span
 ._3aEco
 ._1Dhxk
 .uVy35.V6dif::before


### PR DESCRIPTION
- Invert hamburger menu instead of the logo.