### PR TITLE
Add mermaid live editors

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -504,6 +504,8 @@ melody.ml
 melonds.kuribo64.net
 memory-alpha.fandom.com
 merklex.io
+mermaid.live
+mermaid-js.github.io/mermaid-live-editor/
 metronom.us
 metropool.nl
 mikemaximus.github.io/gbm-web


### PR DESCRIPTION
We have implemented an auto dark mode.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/10703445/136645868-20008471-ec63-407e-a310-34f0c0d9629e.png">

Dark reader's default implementation makes the diagrams not legible.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/10703445/136645863-38426ed2-ea95-4fd9-9a03-a919e8e2d788.png">
