### PR TITLE
Fix for openenglishbible.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10042,6 +10042,14 @@ img[src="images/home_banner.png"]
 
 ================================
 
+openenglishbible.org
+
+INVERT
+#logo
+img[src="html-logo.png"]
+
+================================
+
 opengeofiction.net
 openstreetmap.org
 


### PR DESCRIPTION
Invert logos. The second line is for the logo in the "Read" area of the site which doesn't have a CSS id or class.