### PR TITLE
Fix for yandex.ru/maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15187,6 +15187,13 @@ INVERT
 .promo-button__promo-image-container
 .map-container > ymaps > ymaps > canvas
 
+CSS
+span[class$="business-reactions-view__icon"],
+div[class$="business-reactions-view__counter"],
+span[class$="business-reactions-view__icon _dislike"] {
+    color: ${#aba8a8} !important;
+}
+
 ================================
 
 yandex.*/pogoda


### PR DESCRIPTION
- Improve the contrast of user-liked ratings.

Example of site page: https://yandex.ru/maps/90/san-francisco/?ll=-122.451662%2C37.770213&mode=poi&poi%5Bpoint%5D=-122.480848%2C37.769070&poi%5Buri%5D=ymapsbm1%3A%2F%2Forg%3Foid%3D45761080375&tab=reviews&z=13.33 (you need a Yandex account to check it and like the review)