### PR TITLE
fix for timeline on google maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6121,7 +6121,8 @@ a[href*="about/products"]
 .cards-rating-star
 .maps-sprite-common-chevron-right
 [role="region"] button[jsaction^="pane.list-item.add"] [class*="icon-background"] [class*="icon"][src*="black"]
-.top-activity-icon, .activity-icon
+.top-activity-icon
+.activity-icon
 
 IGNORE IMAGE ANALYSIS
 .widget-settings-map


### PR DESCRIPTION
fix for activity icons in timeline for google maps
![image](https://user-images.githubusercontent.com/56877029/136973715-4ef81c92-0021-47ea-8583-51852e5b6575.png)
