### PR TITLE
Fix for read.amazon.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10921,7 +10921,8 @@ INVERT
 read.amazon.com
 
 INVERT
-.readerControls
+.header_bar_icon:not(#kindleReader_button_close)
+.header_bar_button
 
 ================================
 


### PR DESCRIPTION
- Invert header controls in the ebook reader.

Before: 
![image](https://user-images.githubusercontent.com/3061769/137044891-25faf2b7-b7d5-4251-9b7d-ddbf70a60762.png)

After:
![image](https://user-images.githubusercontent.com/3061769/137046296-9edebc17-6f8d-4a40-aafc-2de98d870779.png)