### PR TITLE
Fix for yandex.ru/maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15217,7 +15217,7 @@ yandex.*/maps
 yandex.*/web-maps
 
 INVERT
-.content-panel-header__logo
+.content-panel-header__logo path[d^="M39.64 22.32"]
 .whats-here-preview__control-search-icon
 .close-button._color_black._circle
 .business-social-links-view__icon


### PR DESCRIPTION
- Improve logo inversion.

Example of site page: https://yandex.ru/maps/org/1577395887/