### PR TITLE
Fix for yandex.ru/maps

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15225,6 +15225,7 @@ INVERT
 .social-share-view_discovery-large
 .orgpage-social-links-view__icon
 .promo-button__promo-image-container
+.orgpage-photos-view__empty
 .map-container > ymaps > ymaps > canvas
 
 CSS


### PR DESCRIPTION
- Invert placeholder photo in organization card.

Example of site page: https://yandex.ru/maps/org/myaso_khalyal/22944680600/