### PR TITLE
Fix for whatsapp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14219,10 +14219,6 @@ span[data-icon="tail-in"] {
 span[data-icon="tail-out"] {
     color: rgb(4, 57, 51) !important;
 }
-body#top-of-page > div#hide_till_load > div > div:nth-child(2):not([data-testid="whatsapp_www_header"]) > div:not(#subheader) > div:nth-child(1) > :nth-child(1):not(h1) {
-    background-image: url(https://static.whatsapp.net/rsrc.php/v1/y_/r/oqWQjtJbOPM.jpg) !important;
-    background-size: 100% !important;
-}
 div#subheader {
     background-image: url(https://static.whatsapp.net/rsrc.php/v1/yQ/r/dPFl9fRFF9u.jpg) !important;
     background-size: 100% !important;


### PR DESCRIPTION
- Remove obsolete rule.

Since it breaks the styles at https://api.whatsapp.com/send?phone=79262033131. And if you look at the commits from #4419, this rule was intended for https://www.whatsapp.com/security/, but at the moment this page is displayed correctly without this rule.