### PR TITLE
fix for otomoto.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10151,6 +10151,13 @@ INVERT
 
 ================================
 
+otomoto.pl
+
+INVERT
+.seller-card__links__link__icon
+
+================================
+
 overleaf.com
 
 INVERT


### PR DESCRIPTION
Added invert for some dark icons on offer page.
![image](https://user-images.githubusercontent.com/56877029/137123732-ff45d2a9-cbac-4d10-835a-54f66cb78e7b.png)

Example page:
https://www.otomoto.pl/oferta/renault-megane-1-5-dci-klima-tempomat-ID6E7LTw.html#d4195329e1