### PR TITLE
fix: correctly remove moves out additions

### DIFF
--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -267,13 +267,13 @@ function getElementsTreeOperations(mutations: MutationRecord[]): ElementsTreeOpe
             if (n instanceof Element) {
                 if (n.isConnected) {
                     moves.add(n);
+                    additions.delete(n);
                 } else {
                     deletions.add(n);
                 }
             }
         });
     });
-    moves.forEach((n) => additions.delete(n));
 
     const duplicateAdditions = [] as Element[];
     const duplicateDeletions = [] as Element[];


### PR DESCRIPTION
- Fix a special case with the `getElementsTreeOperations` function whereby the 
element would first be removed(and still be connected while not) and than 
another element would be back. But the moves.forEach would remove it from the 
additions set because it doesn't take the order into account.
- Moving the .delete call to within the existing loop fixes this issue(as it 
will now take into account the order) and also removes another loop.
- Fixes a github navigation bug.