### PR TITLE
Fix MURAL tabs in dynamic theme

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1060,6 +1060,15 @@ img:not([src*="png"]):not([src*="svg"]) {
 
 ================================
 
+app.mural.co
+
+CSS
+.mural-ui-tabs-tab {
+    background-color: #4e4e5c !important;
+}
+
+================================
+
 app.mysms.com
 
 CSS


### PR DESCRIPTION
Icons were almost impossible to see.

Note: The sidebar is not always open. Just when you are looking for icons or other content. So that it's not fully dark is probably OK, since its not always in your view. Besides, MURALs are generally not dark.

Before:

![image](https://user-images.githubusercontent.com/3143819/137350562-747ad258-9b6d-4901-b643-40fd592db511.png)

After:

![image](https://user-images.githubusercontent.com/3143819/137350482-34169f50-8e88-41c3-ac18-036e96596e78.png)

Open for color suggestions!