### PR TITLE
Fix for jacobinmag.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7078,6 +7078,13 @@ body {
 
 ================================
 
+jacobinmag.com
+
+INVERT
+.si-hr-nv__icon--menu
+
+================================
+
 jailbreak.fce365.info
 
 CSS


### PR DESCRIPTION
Fixes menu button.

Before:
![1](https://user-images.githubusercontent.com/6563728/137590685-08bfafd5-ee33-419e-8bc5-6a7390e47ece.png)

After:
![2](https://user-images.githubusercontent.com/6563728/137590688-1ff8eec3-f648-4201-bad9-0c9076f4d503.png)