### PR TITLE
color.adobe.com isn't dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -150,7 +150,6 @@ codesandbox.io
 codestackr.com
 codingame.com
 coinpot.co
-color.adobe.com
 comicextra.com
 comicpunch.net
 conficturaindustries.com


### PR DESCRIPTION
But it has a dark mode that can be easily activated. Another thing is that this is a page for choosing color palettes, but those colors are altered by DR, as stated in  #1091. So, I'm not exactly sure if it's okay to remove it.