### PR TITLE
Fix icons on bitbucket.org in Pull Request page

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1798,7 +1798,7 @@ span > svg {
 [data-testid="settingsButton"] {
     background-color: ${rgba(33, 53, 89, 0.04)} !important;
 }
-span.code,
+code.code,
 [type="button"][tabindex="0"]:hover,
 [data-testid="settingsButton"]:hover {
     background-color: ${rgba(33, 53, 89, 0.08)} !important;


### PR DESCRIPTION
The icon stroke color was changed to `--darkreader-neutral-text` but they have a light grey background, so they were barely visible.

This revert the color applied by Dark Reader to use the normal color.

Here's a before (top) after (bottom) image:
![image](https://user-images.githubusercontent.com/5566222/138146690-3698ec07-cc45-481b-a95a-b6de69b60342.png)

I also fixed a selector I previously made for the inline code block in comments.