### PR TITLE
Fix: check sender.tab.id before using it

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -57,12 +57,7 @@ export class Extension {
         this.messenger = new Messenger(this.getMessengerAdapter());
         this.news = new Newsmaker((news) => this.onNewsUpdate(news));
         this.tabs = new TabManager({
-            getConnectionMessage: ({url, frameURL, unsupportedSender}) => {
-                if (unsupportedSender) {
-                    return this.getUnsupportedSenderMessage();
-                }
-                return this.getConnectionMessage(url, frameURL);
-            },
+            getConnectionMessage: ({url, frameURL}) => this.getConnectionMessage(url, frameURL),
             getTabMessage: this.getTabMessage,
             onColorSchemeChange: this.onColorSchemeChange,
         });
@@ -347,10 +342,6 @@ export class Extension {
         return new Promise<TabData>((resolve) => {
             this.user.loadSettings().then(() => resolve(this.getTabMessage(url, frameURL)));
         });
-    }
-
-    private getUnsupportedSenderMessage() {
-        return {type: MessageType.BG_UNSUPPORTED_SENDER};
     }
 
     private onColorSchemeChange = ({isDark}: {isDark: boolean}) => {

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -16,7 +16,6 @@ async function queryTabs(query: chrome.tabs.QueryInfo) {
 interface ConnectionMessageOptions {
     url: string;
     frameURL: string;
-    unsupportedSender?: boolean;
 }
 
 interface TabManagerOptions {
@@ -99,7 +98,15 @@ export default class TabManager {
                         // NOTE: Vivaldi and Opera can show a page in a side panel,
                         // but it is not possible to handle messaging correctly (no tab ID, frame ID).
                         if (isFirefox) {
-                            reply({url: sender.url, frameURL: null, unsupportedSender: true});
+                            if (sender && sender.tab && typeof sender.tab.id === 'number') {
+                                chrome.tabs.sendMessage<Message>(sender.tab.id,
+                                    {
+                                        type: MessageType.BG_UNSUPPORTED_SENDER
+                                    },
+                                    {
+                                        frameId: sender && typeof sender.frameId === 'number' ? sender.frameId : undefined
+                                    });
+                            }
                         } else {
                             sendResponse('unsupportedSender');
                         }


### PR DESCRIPTION
This commit add a check `sender && sender.tab && typeof sender.tab.id === 'number'` before using `sender.tab.id`. This avoids logging an error `sender.tab is undefined`.