### PR TITLE
Fix for m.motonet.fi unreadable search box and dropdown

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8094,7 +8094,6 @@ form#haku input[type="text"], #select_my_motonet {
     color: var(--darkreader-neutral-text);
 }
 
-
 ================================
 
 m.slashdot.org


### PR DESCRIPTION
This is a fix for the mobile site of a popular auto parts store in Finland

Before:
![image](https://user-images.githubusercontent.com/16839187/138488983-de401c24-553e-49bb-ab1b-8953624f0630.png)

After:
![image](https://user-images.githubusercontent.com/16839187/138488873-71158a83-a83e-4d74-85cb-655c733dd0c7.png)