### PR TITLE
Make Toucan's pinyin field visible

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20,10 +20,8 @@ CSS
 a[href="https://coinmarketcap.com/"] > svg[width="94"][height="16"] > path {
     fill: var(--darkreader-neutral-text) !important;
 }
+#edge-translate-panel-body,
 .MuiTypography-body1 {
-    color: var(--darkreader-neutral-text) !important;
-}
-#edge-translate-panel-body {
     color: var(--darkreader-neutral-text) !important;
 }
 gr-main-header {


### PR DESCRIPTION
When using the Toucan add-on for language learning, at least for Chinese, selecting a translated word provides both the translation and the pronunciation in pinyin. Pinyin section is almost unreadable.

This fix changes the text color to neutral, so pinyin is readable again. Probably works for other languages, but I only tested Chinese.