### PR TITLE
chat.ryzom.com is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -140,6 +140,7 @@ cascadr.co
 catvibers.me
 cdkeys.com
 cdnnow.pro
+chat.ryzom.com
 cheat.sh
 checkra.in
 chess.com


### PR DESCRIPTION
[chat.ryzom.com](https://chat.ryzom.com) is dark

thanks!