### PR TITLE
Fix for tribunemag.co.uk

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13445,6 +13445,14 @@ INVERT
 
 ================================
 
+tribunemag.co.uk
+
+INVERT
+.si-hr-nv__toggle--menu
+.si-hr-sm__item
+
+================================
+
 trip101.com
 
 INVERT


### PR DESCRIPTION
Fixes icons on top banner (as seen when scrolling down an article).

Before:
![1](https://user-images.githubusercontent.com/6563728/138560629-3489f835-15cd-4bb3-927e-dd1008a07cba.png)

After:
![2](https://user-images.githubusercontent.com/6563728/138560635-2ccc7067-f56a-45d7-9215-ddf4f4f8530f.png)