### PR TITLE
Fix block math display element on Wikiwand

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14550,6 +14550,7 @@ wikiwand.com
 
 INVERT
 img.mwe-math-fallback-image-inline
+img.mwe-math-fallback-image-display
 img.immediate:not(.ntmb)
 .title_icon
 img.logo_img


### PR DESCRIPTION
Before: 
![Screenshot_20211023_164238](https://user-images.githubusercontent.com/13265529/138572521-8378b01c-e8cb-4658-b05a-56cf72656eec.png)

After: 
![Screenshot_20211023_164246](https://user-images.githubusercontent.com/13265529/138572526-aa377f49-ec0d-4cf3-a9e3-7458561555fc.png)
