### PR TITLE
Fix images and buttons on apclassroom

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -947,6 +947,7 @@ INVERT
 a.overview-icon svg
 .Zoom--expander svg
 svg.icon--xmark
+.RI_header__button svg.svg-icon
 
 CSS
 .standalone_image img {


### PR DESCRIPTION
I think the non working selector for the zoom icon that this pr removes was added by me =P
Before and afters...
Fix the zoom icon:
![image](https://user-images.githubusercontent.com/72410860/138578804-2ecf4be1-5314-48a3-beae-38d973a6f841.png) ![image](https://user-images.githubusercontent.com/72410860/138578857-9741ea8c-6548-4a78-86f2-999a1a098067.png)
Fix transparent images:
<img src="https://user-images.githubusercontent.com/72410860/138578812-580ab45a-75a3-4b16-8470-6668c2f9083f.png" width=300/> <img src="https://user-images.githubusercontent.com/72410860/138578872-cc619348-f340-4145-abcc-fef819e7bbb0.png" width=300/>

<img src="https://user-images.githubusercontent.com/72410860/138579137-6e5474d5-96cf-4e72-bc9c-cc96bd2a2997.png" width=300/> <img src="https://user-images.githubusercontent.com/72410860/138579122-0936c18c-fae9-4bf6-99df-f9f45b074680.png" width=300/>

Fix X mark buttons:
![image](https://user-images.githubusercontent.com/72410860/138578819-f586f0e7-5270-4451-904a-8b8437a16e71.png) ![image](https://user-images.githubusercontent.com/72410860/138578883-cf12fdeb-cc51-4d05-9afc-f63dcb9eb6db.png)

Fix back and forward arrows:
![image](https://user-images.githubusercontent.com/72410860/138608766-5542ea6d-246b-4598-af5d-fc5b4816e96d.png) ![image](https://user-images.githubusercontent.com/72410860/138608757-5d3fa6e4-8bde-4604-9c3f-193f7ba44a69.png)
