### PR TITLE
Refactor: make static attributes private

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -49,8 +49,8 @@ export class Extension {
     private startBarrier: PromiseBarrier<void, void> = null;
     private stateManager: StateManager<ExtensionState> = null;
 
-    static ALARM_NAME = 'auto-time-alarm';
-    static LOCAL_STORAGE_KEY = 'Extension-state';
+    private static ALARM_NAME = 'auto-time-alarm';
+    private static LOCAL_STORAGE_KEY = 'Extension-state';
     constructor() {
         this.config = new ConfigManager();
         this.devtools = new DevTools(this.config, async () => this.onSettingsChanged());

--- a/src/background/newsmaker.ts
+++ b/src/background/newsmaker.ts
@@ -10,9 +10,9 @@ interface NewsmakerState {
 }
 
 export default class Newsmaker {
-    static UPDATE_INTERVAL = getDurationInMinutes({hours: 4});
-    static ALARM_NAME = 'newsmaker';
-    static LOCAL_STORAGE_KEY = 'Newsmaker-state';
+    private static UPDATE_INTERVAL = getDurationInMinutes({hours: 4});
+    private static ALARM_NAME = 'newsmaker';
+    private static LOCAL_STORAGE_KEY = 'Newsmaker-state';
 
     private stateManager: StateManager<NewsmakerState>;
     private latest: News[];

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -55,7 +55,7 @@ export default class TabManager {
     private fileLoader: {get: (params: FetchRequestParameters) => Promise<string>} = null;
     private getTabMessage: (url: string, frameUrl: string) => Message;
     private timestamp: number = null;
-    static LOCAL_STORAGE_KEY = 'TabManager-state';
+    private static LOCAL_STORAGE_KEY = 'TabManager-state';
 
     constructor({getConnectionMessage, onColorSchemeChange, getTabMessage}: TabManagerOptions) {
         this.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0});

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -72,9 +72,9 @@ interface CacheRecord {
 
 class LimitedCacheStorage {
     // TODO: remove any cast once declarations are updated
-    static QUOTA_BYTES = ((navigator as any).deviceMemory || 4) * 16 * 1024 * 1024;
-    static TTL = getDuration({minutes: 10});
-    static ALARM_NAME = 'network';
+    private static QUOTA_BYTES = ((navigator as any).deviceMemory || 4) * 16 * 1024 * 1024;
+    private static TTL = getDuration({minutes: 10});
+    private static ALARM_NAME = 'network';
 
     private bytesInUse = 0;
     private records = new Map<string, CacheRecord>();


### PR DESCRIPTION
These static constants are used by classes internally, they do not need to be exposed outside of their parent classes.