### PR TITLE
Refactor: remove responseType from tests

### DIFF
--- a/tests/browser/environment.js
+++ b/tests/browser/environment.js
@@ -182,10 +182,10 @@ class PuppeteerEnvironment extends JestNodeEnvironment {
                 ws.on('message', (data) => {
                     const message = JSON.parse(data);
                     if (message.type === 'error') {
-                        const reject = rejectors.get(message.id).reject;
+                        const reject = rejectors.get(message.id);
                         reject(message.data);
                     } else {
-                        const resolve = resolvers.get(message.id).resolve;
+                        const resolve = resolvers.get(message.id);
                         resolve(message.data);
                     }
                     resolvers.delete(message.id);
@@ -196,9 +196,8 @@ class PuppeteerEnvironment extends JestNodeEnvironment {
 
             function sendToUIPage(message) {
                 return new Promise((resolve, reject) => {
-                    const responseType = `${message.type}-response`;
-                    resolvers.set(idCount, {responseType, resolve});
-                    rejectors.set(idCount, {responseType, reject});
+                    resolvers.set(idCount, resolve);
+                    rejectors.set(idCount, reject);
                     const json = JSON.stringify({...message, id: idCount});
                     sockets.forEach((ws) => ws.send(json));
                     idCount++;


### PR DESCRIPTION
This is a follow-up to #6990. In that PR we moved away from `responseType` to unique query ids. At the time, I contemplated using `responseType` for sanity checks and prettier messages, but now I think we don't really need that.