### PR TITLE
Fix for nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9744,7 +9744,6 @@ nytimes.com
 INVERT
 .svelte-1v1dl99
 #xwd-board
-.wa-share-item
 
 CSS
 .css-oylsik,
@@ -9765,10 +9764,6 @@ a[data-testid] > svg {
 }
 #xwd-board rect[class^="Cell-block--"] {
     fill: ${black} !important;
-}
-.wa-share-item > a > span {
-    background-color: ${rgb(24, 26, 27)} !important;
-    border-color: ${rgb(62, 68, 70)} !important;
 }
 
 ================================


### PR DESCRIPTION
Undoing the inversion for the WhatsApp share icon because it is now being automatically inverted correctly (tested in Firefox and Brave).