### PR TITLE
Fix for hyperskill.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6496,6 +6496,15 @@ hyperskill.org
 INVERT
 .html-preview
 
+CSS
+.monaco-editor .margin,
+.monaco-editor-background {
+    background-color: #181A1B !important;
+}
+.monaco-editor .cursor {
+    background-color: ${#000000} !important;
+}
+
 ================================
 
 hypixel.net


### PR DESCRIPTION
- Fix background for editor.
- Invert editor cursor.

About the background: I tried with `var(--darkreader-neutral-background)` and with `${}`, but when using them, the color does not match the rest of the background (although without using Dark Reader it does match).