### PR TITLE
fix: don't remove valid props

### DIFF
--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -340,7 +340,11 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
             setCustomProp(property, property, value);
         } else {
             const overridenProp = normalizedPropList[property];
-            if (overridenProp && (!element.style.getPropertyValue(overridenProp) && !element.hasAttribute(overridenProp))) {
+            if (overridenProp &&
+                (!element.style.getPropertyValue(overridenProp) && !element.hasAttribute(overridenProp))) {
+                if (overridenProp === 'background-color' && element.hasAttribute('bgcolor')) {
+                    return;
+                }
                 element.style.setProperty(property, '');
             }
         }


### PR DESCRIPTION
- Don't remove the `--darkreader-inline-bgcolor` style when `bgcolor` attribute is present.
- Resolves #7192