### PR TITLE
Fix for numpy.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9693,13 +9693,6 @@ CSS
 
 ================================
 
-numpy.org
-
-INVERT
-.MathJax_SVG
-
-================================
-
 nvidia.com
 nvidia.in
 


### PR DESCRIPTION
It seems math changed again on numpy.org, and it gets correctly inverted _before_ the INVERT directive changes it back to dark.