### PR TITLE
fix: assume default fill value at `<path d="...">`

### DIFF
--- a/tests/inject/dynamic/inline-override.tests.ts
+++ b/tests/inject/dynamic/inline-override.tests.ts
@@ -82,4 +82,12 @@ describe('INLINE STYLES', () => {
         const rect = container.querySelector('rect');
         expect(getComputedStyle(rect).fill).toBe('rgb(255, 26, 26)');
     });
+
+    it('should assume default value for <path> without fill', () => {
+        container.innerHTML = `<svg> <path d="M1,4 l2,2 l4,-4 v1 l-4,4 l-2,-2 Z"> </path> </svg>`;
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        const path = container.querySelector('path');
+        expect(getComputedStyle(path).fill).toBe('rgb(255, 255, 255)');
+    });
 });


### PR DESCRIPTION
- Assume a default fill value, when none is specified. This is safe to assume and safe to set(even if it's not used). 
- Resolves #7209