### PR TITLE
fix: increase timeout of specific test

### DIFF
--- a/tests/inject/dynamic/image-analysis.tests.ts
+++ b/tests/inject/dynamic/image-analysis.tests.ts
@@ -214,7 +214,7 @@ describe('IMAGE ANALYSIS', () => {
             '<h1>Light background</h1>',
         );
         createOrUpdateDynamicTheme(theme, null, false);
-        await timeout(50);
+        await timeout(75);
         const bgImageValue = getComputedStyle(container.querySelector('h1')).backgroundImage;
         expect(bgImageValue).toBe('none');
     });


### PR DESCRIPTION
- This test seems to be on a occasion to fail. This is because the timeout is too low for this image to be properly analyzed.