### PR TITLE
Fix overleaf cursor color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10209,7 +10209,6 @@ overleaf.com
 
 INVERT
 .pdf-page-container
-.ace_cursor
 
 ================================
 


### PR DESCRIPTION
Color was dark on dark due to unneeded `INVERT`