### PR TITLE
fix: checkbox backgrounds on doodle.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4023,13 +4023,6 @@ CSS
 
 ================================
 
-doodle.com
-
-INVERT
-svg.d-checkmark .d-background
-
-================================
-
 dominos.*
 
 CSS
@@ -4045,6 +4038,13 @@ svg.trackerbarimage:not(.complete svg.trackerbarimage) {
 .tracker-page-container div.tracker-module.pizza-tracker .tracker-container > div.stage [class^="chevron"] {
     stroke: var(--darkreader-neutral-text) !important;
 }
+
+================================
+
+doodle.com
+
+INVERT
+svg.d-checkmark .d-background
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4023,6 +4023,13 @@ CSS
 
 ================================
 
+doodle.com
+
+INVERT
+svg.d-checkmark .d-background
+
+================================
+
 dominos.*
 
 CSS


### PR DESCRIPTION
They were looking like
![изображение](https://user-images.githubusercontent.com/11363215/139713390-6995e59f-d053-4307-b7bf-6b2608d1d185.png)


Now the look like this
![изображение](https://user-images.githubusercontent.com/11363215/139713300-12d7f62e-fbb7-4811-a953-a02d87f60ec6.png)
