### PR TITLE
Added a value to the variable used for the background of the course list.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2110,6 +2110,15 @@ section + img {
 
 ================================
 
+brightspace.avans.nl
+
+CSS
+:root {
+    --darkreader-bg--d2l-dropdown-background-color: #1D1F20;
+}
+
+================================
+
 bugreplay.com
 
 INVERT


### PR DESCRIPTION
The variable "--darkreader-bg--d2l-dropdown-background-color" was used on the "background-color" property of the selector ".d2l-dropdown-content-width" while the variable had no value. This caused the the course list to have a transparent background. I gave this variable a fitting color that's also used in other parts of the page.