### PR TITLE
Fix for newyorker.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9575,6 +9575,7 @@ newyorker.com
 
 INVERT
 [data-testid="Logo"]
+[class*="Logo__logo"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9574,7 +9574,7 @@ INVERT
 newyorker.com
 
 INVERT
-.stacked-navigation__logo-link .responsive-image .responsive-image__image
+[data-testid="Logo"]
 
 ================================
 


### PR DESCRIPTION
- Fix logo inversion.