### PR TITLE
Fix Cloudflare Community forums

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2871,8 +2871,8 @@ CSS
 community.cloudflare.com
 
 CSS
-.visited {
-  background-color: #262626;
+:root {
+    --darkreader-text--primary-medium: ${gray} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2868,6 +2868,15 @@ CSS
 
 ================================
 
+community.cloudflare.com
+
+CSS
+.visited {
+  background-color: #262626;
+}
+
+================================
+
 community.notepad-plus-plus.org
 
 INVERT


### PR DESCRIPTION
On the community forums, you cannot see visited posts because the background colour does not change. This adds a lighter dark to distinguish between visited and non-visited. 

Without fix:
![image](https://user-images.githubusercontent.com/8492901/140605189-768613ad-7ce2-46b7-803c-aedb6db9ee61.png)

With fix:
![image](https://user-images.githubusercontent.com/8492901/140605210-5de8c6e8-56e9-4fac-8767-4dbff74227e8.png)
