### PR TITLE
Add beepbox.co

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -79,6 +79,7 @@ bbc.co.uk/iplayer
 bdeditor.dev
 beastskills.com
 bedrocklinux.org
+beepbox.co
 beeper.com
 ben-herila.webflow.io
 benfoster.dev


### PR DESCRIPTION
https://www.beepbox.co/
Technically the [synth example](https://www.beepbox.co/synth_example.html) subpage isn't dark theme, but barely anyone visits it (let alone more than once), so I don't think it matters too much?