### PR TITLE
fix: don't set spllited key to undefined

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -113,7 +113,6 @@ function prepareSyncStorage<T extends {[key: string]: any}>(values: T): {[key: s
             (values as any)[key] = {
                 __meta_split_count: minimalKeysNeeded
             };
-            values[key] = undefined;
         }
     }
     return values;


### PR DESCRIPTION
- Don't set the original key of spllited value to `undefined` as it will need to hold `{__meta_split_count}` object.

Thanks for @alexanderby for pointing out.