### PR TITLE
fix: remove `screen` after `@import ...`

### DIFF
--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -89,7 +89,7 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
 }
 
 export const cssURLRegex = /url\((('.+?')|(".+?")|([^\)]*?))\)/g;
-export const cssImportRegex = /@import\s*(url\()?(('.+?')|(".+?")|([^\)]*?))\)?;?/g;
+export const cssImportRegex = /@import\s*(url\()?(('.+?')|(".+?")|([^\)]*?))\)? ?(screen)?;?/g;
 
 export function getCSSURLValue(cssURL: string) {
     return cssURL.replace(/^url\((.*)\)$/, '$1').trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -583,7 +583,7 @@ async function linkLoading(link: HTMLLinkElement, loadingId: number) {
 function getCSSImportURL(importDeclaration: string) {
     // substring(7) is used to remove `@import` from the string.
     // And then use .trim() to remove the possible whitespaces.
-    return getCSSURLValue(importDeclaration.substring(7).trim().replace(/;$/, ''));
+    return getCSSURLValue(importDeclaration.substring(7).trim().replace(/;$/, '').replace(/screen$/, ''));
 }
 
 async function loadText(url: string) {

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -151,5 +151,24 @@ describe('LINK STYLES', () => {
         expect(getComputedStyle(h1).backgroundColor).toBe('rgb(102, 102, 102)');
         expect(document.querySelector('.darkreader--fallback').textContent).toBe('');
     });
+
+    it('should handle styles with @import "..." screen;', async () => {
+        const importedCSS = 'h1 { background: gray; }';
+        const importedURL = getCSSEchoURL(importedCSS);
+        stubBackgroundFetchResponse(importedURL, importedCSS);
+        createCorsLink(multiline(
+            `@import "${importedURL}" screen;`,
+            'h1 strong { color: red; }',
+        ));
+        container.innerHTML = multiline(
+            '<h1><strong>Cross-origin import</strong> link override</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(100);
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
+    });
 });
 


### PR DESCRIPTION
- Handle cases whereby imports as `@import 'cookie.css' screen;` would remove `@import 'cookie.css'` but leave behind the `screen` part.
- Resolves #7278