### PR TITLE
fix: handle invalid URL's

### DIFF
--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -103,7 +103,15 @@ export function getCSSBaseBath(url: string) {
 export function replaceCSSRelativeURLsWithAbsolute($css: string, cssBasePath: string) {
     return $css.replace(cssURLRegex, (match) => {
         const pathValue = getCSSURLValue(match);
-        return `url("${getAbsoluteURL(cssBasePath, pathValue)}")`;
+        // Sites can have any kind of specified URL, thus also invalid ones.
+        // To prevent the whole operation from failing, let's just skip those
+        // invalid URL's and let them be invalid.
+        try {
+            return `url("${getAbsoluteURL(cssBasePath, pathValue)}")`;
+        } catch (err) {
+            logWarn('Not able to replace relative URL with Absolute URL, skipping');
+            return match;
+        }
     });
 }
 

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -170,5 +170,25 @@ describe('LINK STYLES', () => {
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
     });
+
+    it('should handle styles with invalid url(...)', async () => {
+        const importedCSS = 'h1 { background-image: url("freecookies:3https://example.com"); background-color: gray; }';
+        const importedURL = getCSSEchoURL(importedCSS);
+        stubBackgroundFetchResponse(importedURL, importedCSS);
+        stubBackgroundFetchResponse('freecookies:3https://example.com', '');
+        createCorsLink(multiline(
+            `@import "${importedURL}" screen;`,
+            'h1 strong { color: red; }',
+        ));
+        container.innerHTML = multiline(
+            '<h1><strong>Cross-origin import</strong> link override</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(100);
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
+    });
 });
 


### PR DESCRIPTION
- Don't go error and make a big deal about invalid URL's, we just should skip them and still be able to convert all other relative links to absolute ones.
- Resolves #7286