### PR TITLE
Add protonmail to blacklist

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -508,6 +508,7 @@ m4rtyr.github.io
 macbb.org
 magnetoo.io
 magoware.tv
+mail.protonmail.com
 manen.me
 mangaplus.shueisha.co.jp
 mango.pdf.zone


### PR DESCRIPTION
They have a dark theme available, you just need to activate on settings menu

![image](https://user-images.githubusercontent.com/15145998/140791174-fbe72656-1d00-41a1-a962-44670f978a88.png)
![image](https://user-images.githubusercontent.com/15145998/140791247-c08f80cf-81a9-4dc3-99ba-c7a386ef84ae.png)
