### PR TITLE
Add comicfury.com to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2836,6 +2836,15 @@ button
 
 ================================
 
+comicfury.com
+
+CSS
+html {
+    background-color: revert !important;
+}
+
+================================
+
 comixology.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2839,8 +2839,12 @@ button
 comicfury.com
 
 CSS
-html {
-    background-color: revert !important;
+#wrapper {
+    background-color: inherit !important;
+    padding-bottom: 10px !important;
+}
+#footer {
+    margin-top: 0px !important;
 }
 
 ================================


### PR DESCRIPTION
Because of the way Flexbox is used on the site, the `body` tag only has a height of the browser window. The background color extends to the whole page normally because the `html` tag doesn't have a background color, but Dark Reader adds a background color to it. This simply removes the background color from the `html` tag so that the background color works as the website intends.

Honestly, this website is kind of weird, seemingly using a very bright dark mode, so there's probably more that need to be done to get the light mode setting to work right on the site, but this at least fixes the issue of the inconsistent background color.