### PR TITLE
List of dark sites: added truckspace.group and vtcdirectory.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -850,6 +850,7 @@ tripleaughtdesign.com
 trojansource.codes
 trovo.live
 truckersmp.com
+truckspace.group
 trustreaming.tv
 tsssaver.1conan.com
 ttf.tf

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -895,6 +895,7 @@ vixlatio.com
 vizality.com
 vortetty.k3live.com
 vrv.co
+vtcdirectory.com
 vuecinemas.nl
 w0rp.com
 w41k3r.com


### PR DESCRIPTION
Added [truckspace.group](https://truckspace.group) and [vtcdirectory.com](https://vtcdirectory.com) to the list of dark sites