### PR TITLE
[Dynamic Theme] Fix chart tooltip in AWS console

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1442,6 +1442,7 @@ aws.amazon.com
 
 INVERT
 a.lb-trigger
+.hover .axis-box rect
 .img-wrapper
 img[alt^="WEB_FreeTier"]
 .lb-is-lazyloaded


### PR DESCRIPTION
For tooltips in Cloudwatch and other charts.
Before and after:

![a](https://user-images.githubusercontent.com/787075/141328899-312468cd-9eb3-4a81-a65c-402d768bb7b2.png) ![b](https://user-images.githubusercontent.com/787075/141328908-3f18177d-287e-4e65-9724-a175c0772352.png)

