### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10917,6 +10917,15 @@ body {
 
 ================================
 
+pushsquare.com
+
+CSS
+.page {
+    background-image: none !important;
+}
+
+================================
+
 pyszne.pl
 lieferando.*
 justeat.*


### PR DESCRIPTION
Removed a white background image from pushsquare.com to fix the otherwise perfect dynamic dark theme.