### PR TITLE
Prevent darkreader on Braze previews

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -45,6 +45,57 @@ div[class^='scrollableList'] {
 
 ================================
 
+*.braze.com
+
+CSS
+.preview-background,
+.iphone-rich-notification-preview,
+.iphone-rich-notification-divider {
+    background-color: #dddde2 !important;
+}
+.iphone-push-preview-title, 
+.iphone-push-preview-message-container,
+.iphone-push-preview-preview-message {
+    color: #ffffff !important;
+}
+.iphone-push-preview-now{
+    color: #788186 !important;
+}
+.tab-pull {
+    background: #aaaaaa !important;
+}
+.push-message-background {
+    background-color: #434343 !important;
+}
+.iphone-rich-notification-top-bar,
+.iphone-rich-notification-message,
+.android-push-preview-holder {
+    background-color: #ffffff !important;
+}
+.iphone-rich-notification-app-name,
+.iphone-rich-notification-message-title,
+.iphone-rich-notification-message-body,
+.iphone-rich-notification-message-text,
+.android-push-preview-message {
+    color: #333335 !important;
+}
+.android-push-preview-header,
+.android-push-preview-name,
+.android-push-preview-header-circle,
+.android-push-preview-summary-text,
+.android-push-preview-time,
+.android-push-preview-expand-icon {
+    color: black !important;
+}
+.android-push-preview-title {
+    color: #212123 !important;
+}
+.android-push-preview-app-icon-background {
+    border-color: #FFFFFF !important;
+}
+
+================================
+
 *.screenconnect.com
 
 CSS


### PR DESCRIPTION
Braze.com has a preview window to see how messages will look on iOS and Android once published. Parts of these previews use static images, and so once darkreader does its thing it's an incomplete conversion.

This change will prevent darkreader from modifying the Braze iOS/Android preview view.