### PR TITLE
Updated svt.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12521,6 +12521,16 @@ store.ubi.com
 INVERT
 div.primary-logo
 
+CSS
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a:not(a[href$="/deals"]) .homepage-custom-slide__content .custom-slide-inner h2,
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a:not(a[href$="/deals"]) .homepage-custom-slide__content .custom-slide-inner h3,
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide a {
+    color: var(--darkreader-neutral-background) !important;
+}
+.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a[href$="/deals"] .homepage-custom-slide__content .custom-slide-inner h3 {
+    color: var(--darkreader-neutral-text) !important;
+}
+
 ================================
 
 strava.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12521,16 +12521,6 @@ store.ubi.com
 INVERT
 div.primary-logo
 
-CSS
-.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a:not(a[href$="/deals"]) .homepage-custom-slide__content .custom-slide-inner h2,
-.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a:not(a[href$="/deals"]) .homepage-custom-slide__content .custom-slide-inner h3,
-.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide a {
-    color: var(--darkreader-neutral-background) !important;
-}
-.pt_storefront-homepage #main .homepage-slider-wrapper .homepage-custom-slide > a[href$="/deals"] .homepage-custom-slide__content .custom-slide-inner h3 {
-    color: var(--darkreader-neutral-text) !important;
-}
-
 ================================
 
 strava.com
@@ -12841,8 +12831,11 @@ CSS
 }
 button[class^="PaginationButton"],
 a[class^="PaginationButton"],
-.nyh_screamer {
+.nyh_screamer,
+[class^="_RightNowTeaser__title"],
+[class^="_RightNowTeaser__root"] {
     background: var(--darkreader-bg--nyh-color-white) !important;
+    border-left-color: var(--darkreader-bg--nyh-color-news);
 }
 button[class^="PaginationButton"]:hover,
 a[class^="PaginationButton"]:hover {
@@ -12859,18 +12852,34 @@ a[class^="PaginationButton"]:hover {
 .nyh_navigation .nyh_submenu::before {
     border-bottom-color: var(--darkreader-bg--nyh-color-white) !important;
 }
+.nyh_teaser.nyh_teaser--story-grid,
+.nyh_icons_caret--factbox {
+    border: none;
+}
+.nyh_submenu-menucard,
 [class*="_Post__contentVisitor___"]::after {
     border-right-color: var(--darkreader-bg--nyh-color-grey-lighter) !important;
 }
 [class*="CurrentTopics__item___"],
 [class*="GroupSecondaryTeasers__showMoreButton___"],
 .nyh_mobile-menu__list-item,
+.nyh_menu-card__submenu-item,
 .nyh_submenu-menucard,
 .nyh_submenu {
     border-color: var(--darkreader-border--nyh-color-grey-lighter) !important;
 }
-.nyh_is-open .nyh_menu-card__link--mobile {
-    border: none !important;
+.nyh_fact-box {
+    border-bottom: 1px solid var(--darkreader-border--nyh-color-grey-lighter);
+    border-top: 1px solid var(--darkreader-border--nyh-color-grey-lighter);
+}
+.nyh_fact-box__body--closed::after {
+    background: linear-gradient(to bottom, #1e202180 0%, #1e2021 100%);
+}
+.nyh_regional-widget-regions {
+    background: var(--darkreader-bg--nyh-color-grey-lightest);
+}
+.nyh_submenu-menucard {
+    background-color: var(--darkreader-bg--nyh-color-white);
 }
 
 ================================


### PR DESCRIPTION
This acts as a continuation of my last PR for this site at #6457

# Noteworthy things
| Before | After |
|-|-|
| ![svt1-off] | ![svt1-on] |

The selector for the menu item borders had their classes changed and was in need of an update.

| Before | After |
|-|-|
| ![svt2-off] | ![svt2-on] |

For the gradient covering the infobox found under some articles, I had to enter a HEX code instead of using existing classes. Otherwise the opacity wouldn't work at all.

```css
.nyh_fact-box__body--closed::after {
    background: linear-gradient(to bottom, #1e202180 0%, #1e2021 100%);
}
```

[svt1-off]: https://user-images.githubusercontent.com/17113053/141692647-660394a3-f69b-4c7e-8c5f-bd0e9dbcd91b.png
[svt1-on]: https://user-images.githubusercontent.com/17113053/141692644-bc160362-22db-42a4-ac6b-49cb0a64f153.png
[svt2-off]: https://user-images.githubusercontent.com/17113053/141692645-57ba5179-7ddb-4f5a-ba33-aca45c2baff0.png
[svt2-on]: https://user-images.githubusercontent.com/17113053/141692646-f2e8bde6-dacd-4953-918c-113309e3cd93.png