### PR TITLE
Revert "Comments on selectors; Added GitHub and GitLab style"

### DIFF
--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -1,27 +1,10 @@
 import type {FilterConfig} from '../definitions';
 
 export function createTextStyle(config: FilterConfig): string {
+    const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-
-    const excludingSelectors: string = [
-        'pre, pre *, code, .glyphicon, [class*="vjs-"], .icofont, .typcn, mu, [class*="mu-"], .glyphicon, .icon',
-
-        // Font Awesome
-        '.fab, .fa-github, .fas',
-
-        // Material Icons
-        '.material',
-
-        // GitHub
-        '.blob-code-inner, .blob-code-inner *',
-
-        // Gitlab
-        '.monaco-editor',
-    ].join(', ');
-
-    const lines: string[] = [];
-    lines.push(`*:not(${ excludingSelectors }) {`);
+    lines.push('*:not(pre, pre *, code, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, .icofont, .typcn, mu, [class*="mu-"], .glyphicon, .icon) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...


### PR DESCRIPTION
Reverts darkreader/darkreader#7288

@Gusted i think this needs to be reverted. I noticed what I think is a regression, with some icons that used to load but don't now. 

I am not able to fix until the end of the week. If you revert this, i will submit a better report, fix, test, and resubmit then. 