### PR TITLE
perf: optimize `setRule`

### DIFF
--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -138,7 +138,11 @@ export function createStyleSheetModifier() {
                 return `${property}: ${value == null ? sourceValue : value}${important ? ' !important' : ''};`;
             };
 
-            const ruleText = `${selector} { ${declarations.map(getDeclarationText).join(' ')} }`;
+            let cssRulesText = '';
+            declarations.forEach((declarations) => {
+                cssRulesText += `${getDeclarationText(declarations)} `;
+            });
+            const ruleText = `${selector} { ${cssRulesText} }`;
             target.insertRule(ruleText, index);
         }
 


### PR DESCRIPTION
- .map and .join on a lot of elements can be quite slow, by adding a bit more lines and using the `forEach` the code will be a lot more performant.
- Partially resolvess #6799

Before:
![image](https://user-images.githubusercontent.com/25481501/142195018-af3297e6-062f-46cd-a0c8-8549fb31d2ce.png)

After:
![image](https://user-images.githubusercontent.com/25481501/142195062-c13f5918-7e5c-4220-8a4a-e9ccf3ba3a28.png)
