### PR TITLE
Fixed tables in spanish.kwiziq.com having black text on black background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12323,7 +12323,9 @@ INVERT
 spanish.kwiziq.com
 
 CSS
-.table-scroll-shadow-wrapper table td, .table-scroll-shadow-wrapper table th, .table-scroll-shadow-wrapper table tr {
+.table-scroll-shadow-wrapper table td,
+.table-scroll-shadow-wrapper table th,
+.table-scroll-shadow-wrapper table tr {
     mix-blend-mode: normal !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12320,6 +12320,15 @@ INVERT
 
 ================================
 
+spanish.kwiziq.com
+
+CSS
+.table-scroll-shadow-wrapper table td, .table-scroll-shadow-wrapper table th, .table-scroll-shadow-wrapper table tr {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
 speed.cloudflare.com
 
 INVERT


### PR DESCRIPTION
See how tables look right now:
https://spanish.kwiziq.com/my-languages/spanish/review/5653/2110430

This fix updates the text to be white (it was technically previously white as well, except it multiplied with the background resulting in a faint gray)