### PR TITLE
Added my sites, which are already dark.

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -562,6 +562,9 @@ nfspolska.pl
 ngplus.net
 nh-server.github.io/switch-guide/
 nheko-reborn.github.io
+nicholemattera.com
+nicholemattera.gay
+nicholemattera.lgbt
 niebezpiecznik.pl
 nitter.13ad.de
 nitter.42l.fr


### PR DESCRIPTION
Added:

- https://nicholemattera.com
- https://nicholemattera.gay
- https://nicholemattera.lgbt

Currently, Dark Reader does the opposite and blinds you when visiting these pages.