### PR TITLE
Fix for khronos.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7618,10 +7618,8 @@ CSS
 
 khronos.org
 
-CSS
-.navbar-brand {
-    content: url("/assets/css/images/khronos-logo-inverted.svg") !important;
-}
+INVERT
+.navbar-brand
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7616,6 +7616,15 @@ CSS
 
 ================================
 
+khronos.org
+
+CSS
+.navbar-brand {
+    content: url("/assets/css/images/khronos-logo-inverted.svg") !important;
+}
+
+================================
+
 kiedyprzyjedzie.pl
 
 INVERT


### PR DESCRIPTION
Replaces top logo with inverted version.

Before:
![1](https://user-images.githubusercontent.com/6563728/142729874-4e7d8775-705f-4716-86a8-880b5dedc67a.png)

After:
![2](https://user-images.githubusercontent.com/6563728/142729875-faea3d2a-7a7a-4954-b607-d0c237290eaf.png)