### PR TITLE
komputerswiat.pl logo area fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7704,6 +7704,7 @@ komputerswiat.pl
 INVERT
 .serviceLogoImg
 .serviceIcon
+.secondaryLogoImg
 
 ================================
 


### PR DESCRIPTION
https://www.komputerswiat.pl/
INVERT `onet.pl` logo area. 
![20211120-1637426020](https://user-images.githubusercontent.com/9846948/142734137-af2e1b43-48c2-4b24-84fc-4aba7fa076f9.png)
