### PR TITLE
properly select elements given site changes on apclassroom

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -952,7 +952,7 @@ IGNORE IMAGE ANALYSIS
 apclassroom.collegeboard.org
 
 INVERT
-a.overview-icon svg
+.overview-icon svg
 .Zoom--expander svg
 svg.icon--xmark
 .RI_header__button svg.svg-icon


### PR DESCRIPTION
something about the site html changed, and the previous selector is no longer valid.
before:
![image](https://user-images.githubusercontent.com/72410860/142740141-7c4f659d-908d-4273-95c5-7b520c50be76.png)
after: 
![image](https://user-images.githubusercontent.com/72410860/142740129-d2ca017f-0300-4fc9-9389-7602aeb8af29.png)
