### PR TITLE
Fixes for gog.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6206,14 +6206,58 @@ gog.com
 
 INVERT
 i.icn.icn--close
+svg.icon-wrapper-icon
+svg.big-spot__add-to-cart-icon
+svg.ic-svg:not(.button__icon):not(.productcard-slider__nav-icon)
+.productcard-thumbnails-slider-pagination
+.carousel-pagination__page
+.big-spot__carousel-pages-container
+.big-spots__arrow-icon
+.discover-games-more__icon
 
 CSS
 .product-tile__info:hover {
     background-color: var(--darkreader-neutral-background) !important;
 }
+a.product-tile__content {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.explore-galaxy {
+    border-top: 0 !important;
+}
+.galaxy-tooltip__layer {
+    background: ${#d9d9d9} !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.big-spot__content, .big-spot__text, .big-spot__action {
+    backdrop-filter: brightness(50%) !important;
+}
+.big-spot__title, .big-spot__super-title, .big-spot__action {
+    filter: brightness(130%) !important;
+}
+.wishlist-button, .review__read-more, .review-new__add-button, .review-new__guideline-button {
+    background: none !important;
+}
 
 IGNORE IMAGE ANALYSIS
 .menu-anonymous__shelf
+
+================================
+
+gog.com/promo
+
+CSS
+.wrapper.cf > .content.cf::before {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.5);
+}
+.container.promo-page-header.cf {
+    filter: brightness(100%) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6236,7 +6236,7 @@ a.product-tile__content {
     filter: brightness(130%) !important;
 }
 .wishlist-button, .review__read-more, .review-new__add-button, .review-new__guideline-button {
-    background: none !important;
+    background-image: none !important;
 }
 
 IGNORE IMAGE ANALYSIS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6222,9 +6222,6 @@ CSS
 a.product-tile__content {
     background-color: var(--darkreader-neutral-background) !important;
 }
-.explore-galaxy {
-    border-top: 0 !important;
-}
 .galaxy-tooltip__layer {
     background: ${#d9d9d9} !important;
     color: var(--darkreader-neutral-text) !important;
@@ -6245,6 +6242,7 @@ IGNORE IMAGE ANALYSIS
 ================================
 
 gog.com/promo
+gog.com/partner
 
 CSS
 .wrapper.cf > .content.cf::before {


### PR DESCRIPTION
Fixed things like icons not being inverted, applied overlays for unprocessed background images that were too bright