### PR TITLE
Update `rollup-plugin-typescript2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "puppeteer-core": "10.4.0",
         "rollup": "2.59.0",
         "rollup-plugin-istanbul2": "2.0.2",
-        "rollup-plugin-typescript2": "0.30.0",
+        "rollup-plugin-typescript2": "0.31.1",
         "ts-jest": "27.0.7",
         "ts-node": "10.4.0",
         "tsconfig-paths": "3.11.0",
@@ -1249,6 +1249,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@ts-type/package-dts": {
+      "version": "1.0.53",
+      "resolved": "https://registry.npmjs.org/@ts-type/package-dts/-/package-dts-1.0.53.tgz",
+      "integrity": "sha512-P8bMcjqaUsaBbXOCxBtzT4/pvhQSHTMc91WrpErVfB52zpNRVw2evOYWMe6q3c087+wpvITB7HtppYDnQe1RwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/semver": "^7.3.9",
+        "ts-type": "^1.2.40"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -1313,6 +1323,13 @@
       "dependencies": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "node_modules/@types/bluebird": {
+      "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/chrome": {
       "version": "0.0.162",
@@ -1505,6 +1522,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -1751,6 +1774,91 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@yarn-tool/resolve-package/-/resolve-package-1.0.38.tgz",
+      "integrity": "sha512-WmYM/Znh/vPQw7PBfbH2PmZSrzCF0AfGMfpA4z3SbNa2UUcdpqq9yD9pYKcHY1FP3yjMB7KwcVD8mhojROXCQQ==",
+      "dev": true,
+      "dependencies": {
+        "@ts-type/package-dts": "^1.0.53",
+        "pkg-dir": "< 6 >= 5",
+        "tslib": "^2.3.1",
+        "upath2": "^3.1.10"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@yarn-tool/resolve-package/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/abab": {
@@ -9448,6 +9556,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-is-network-drive": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/path-is-network-drive/-/path-is-network-drive-1.0.10.tgz",
+      "integrity": "sha512-D6kJYPUSKGZBpTM2nv10sOWNdC056p4JDx0y7ARe6gop0aXXm5G86Gn/SyKvaf0Ce8c9Guctf+J+qoFmzuhDQg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -9462,6 +9579,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-strip-sep": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-strip-sep/-/path-strip-sep-1.0.7.tgz",
+      "integrity": "sha512-9xDVZPblHde4lTuTDnwqBKr9LTbPZW+Iae63ho500+BpEiZe3X6wvLInHgbB6FSMtwCTvztljw3k2zcNDNESzg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -10377,16 +10503,17 @@
       }
     },
     "node_modules/rollup-plugin-typescript2": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz",
-      "integrity": "sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.1.tgz",
+      "integrity": "sha512-sklqXuQwQX+stKi4kDfEkneVESPi3YM/2S899vfRdF9Yi40vcC50Oq4A4cSZJNXsAQE/UsBZl5fAOsBLziKmjw==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.1.0",
+        "@yarn-tool/resolve-package": "^1.0.36",
         "find-cache-dir": "^3.3.1",
         "fs-extra": "8.1.0",
         "resolve": "1.20.0",
-        "tslib": "2.1.0"
+        "tslib": "2.2.0"
       },
       "peerDependencies": {
         "rollup": ">=1.26.3",
@@ -10417,9 +10544,9 @@
       }
     },
     "node_modules/rollup-plugin-typescript2/node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
       "dev": true
     },
     "node_modules/rollup-plugin-typescript2/node_modules/universalify": {
@@ -11673,6 +11800,28 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ts-toolbelt": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-8.4.0.tgz",
+      "integrity": "sha512-hnGJXIgC49ZuF5g5oDthoge8t4cvT0dYg2pYO5C6yV/HmUUy1koooU2U/5K2N+Uw++hcXQpJAToLRa+GRp28Sg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/ts-type": {
+      "version": "1.2.40",
+      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-1.2.40.tgz",
+      "integrity": "sha512-Ux5e7Frys5pX7w8gYchEd0KfhG1H5puXOQC8yOBgMJ1aEwDSypeHLwxIUpKjecni1IGwtLI3JrxCVZaQO9JKmw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0",
+        "typedarray-dts": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/bluebird": "*",
+        "@types/node": "*",
+        "ts-toolbelt": "^8.0.7"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
@@ -11803,6 +11952,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "node_modules/typedarray-dts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
+      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==",
+      "dev": true
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -11908,6 +12063,21 @@
       "engines": {
         "node": ">=4",
         "yarn": "*"
+      }
+    },
+    "node_modules/upath2": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/upath2/-/upath2-3.1.10.tgz",
+      "integrity": "sha512-7ph3GzTaVbQX+oIoMsGtM+9BAWQr+6Mn28TJKPu28+yGpZ+J4am590CPDBlDG0zyuo9T9T7o21ciqNzwIp/q0A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "path-is-network-drive": "^1.0.10",
+        "path-strip-sep": "^1.0.7",
+        "tslib": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/update-notifier": {
@@ -12498,6 +12668,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zip-dir": {
@@ -13490,6 +13672,16 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@ts-type/package-dts": {
+      "version": "1.0.53",
+      "resolved": "https://registry.npmjs.org/@ts-type/package-dts/-/package-dts-1.0.53.tgz",
+      "integrity": "sha512-P8bMcjqaUsaBbXOCxBtzT4/pvhQSHTMc91WrpErVfB52zpNRVw2evOYWMe6q3c087+wpvITB7HtppYDnQe1RwA==",
+      "dev": true,
+      "requires": {
+        "@types/semver": "^7.3.9",
+        "ts-type": "^1.2.40"
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
@@ -13554,6 +13746,13 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/bluebird": {
+      "version": "3.5.36",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
+      "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
+      "dev": true,
+      "peer": true
     },
     "@types/chrome": {
       "version": "0.0.162",
@@ -13746,6 +13945,12 @@
         "@types/node": "*"
       }
     },
+    "@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -13896,6 +14101,66 @@
       "requires": {
         "@typescript-eslint/types": "5.3.0",
         "eslint-visitor-keys": "^3.0.0"
+      }
+    },
+    "@yarn-tool/resolve-package": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/@yarn-tool/resolve-package/-/resolve-package-1.0.38.tgz",
+      "integrity": "sha512-WmYM/Znh/vPQw7PBfbH2PmZSrzCF0AfGMfpA4z3SbNa2UUcdpqq9yD9pYKcHY1FP3yjMB7KwcVD8mhojROXCQQ==",
+      "dev": true,
+      "requires": {
+        "@ts-type/package-dts": "^1.0.53",
+        "pkg-dir": "< 6 >= 5",
+        "tslib": "^2.3.1",
+        "upath2": "^3.1.10"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        }
       }
     },
     "abab": {
@@ -19923,6 +20188,15 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-is-network-drive": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/path-is-network-drive/-/path-is-network-drive-1.0.10.tgz",
+      "integrity": "sha512-D6kJYPUSKGZBpTM2nv10sOWNdC056p4JDx0y7ARe6gop0aXXm5G86Gn/SyKvaf0Ce8c9Guctf+J+qoFmzuhDQg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -19934,6 +20208,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-strip-sep": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-strip-sep/-/path-strip-sep-1.0.7.tgz",
+      "integrity": "sha512-9xDVZPblHde4lTuTDnwqBKr9LTbPZW+Iae63ho500+BpEiZe3X6wvLInHgbB6FSMtwCTvztljw3k2zcNDNESzg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -20627,16 +20910,17 @@
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz",
-      "integrity": "sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.31.1.tgz",
+      "integrity": "sha512-sklqXuQwQX+stKi4kDfEkneVESPi3YM/2S899vfRdF9Yi40vcC50Oq4A4cSZJNXsAQE/UsBZl5fAOsBLziKmjw==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.1.0",
+        "@yarn-tool/resolve-package": "^1.0.36",
         "find-cache-dir": "^3.3.1",
         "fs-extra": "8.1.0",
         "resolve": "1.20.0",
-        "tslib": "2.1.0"
+        "tslib": "2.2.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -20660,9 +20944,9 @@
           }
         },
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==",
           "dev": true
         },
         "universalify": {
@@ -21641,6 +21925,23 @@
         }
       }
     },
+    "ts-toolbelt": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-8.4.0.tgz",
+      "integrity": "sha512-hnGJXIgC49ZuF5g5oDthoge8t4cvT0dYg2pYO5C6yV/HmUUy1koooU2U/5K2N+Uw++hcXQpJAToLRa+GRp28Sg==",
+      "dev": true,
+      "peer": true
+    },
+    "ts-type": {
+      "version": "1.2.40",
+      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-1.2.40.tgz",
+      "integrity": "sha512-Ux5e7Frys5pX7w8gYchEd0KfhG1H5puXOQC8yOBgMJ1aEwDSypeHLwxIUpKjecni1IGwtLI3JrxCVZaQO9JKmw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.0",
+        "typedarray-dts": "^1.0.0"
+      }
+    },
     "tsconfig-paths": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
@@ -21745,6 +22046,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedarray-dts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
+      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA==",
+      "dev": true
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -21815,6 +22122,18 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
       "dev": true
+    },
+    "upath2": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/upath2/-/upath2-3.1.10.tgz",
+      "integrity": "sha512-7ph3GzTaVbQX+oIoMsGtM+9BAWQr+6Mn28TJKPu28+yGpZ+J4am590CPDBlDG0zyuo9T9T7o21ciqNzwIp/q0A==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "path-is-network-drive": "^1.0.10",
+        "path-strip-sep": "^1.0.7",
+        "tslib": "^2.3.1"
+      }
     },
     "update-notifier": {
       "version": "5.1.0",
@@ -22274,6 +22593,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     },
     "zip-dir": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "puppeteer-core": "10.4.0",
     "rollup": "2.59.0",
     "rollup-plugin-istanbul2": "2.0.2",
-    "rollup-plugin-typescript2": "0.30.0",
+    "rollup-plugin-typescript2": "0.31.1",
     "ts-jest": "27.0.7",
     "ts-node": "10.4.0",
     "tsconfig-paths": "3.11.0",


### PR DESCRIPTION
- Fixes compiling the master on node v17.0+
- See https://github.com/ezolenko/rollup-plugin-typescript2/issues/286