### PR TITLE
allegro.pl smart logo fix in order details area

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -699,6 +699,7 @@ allegro.pl
 INVERT
 i[title="Smart!"]
 div[class="mpof_ki m389_6m"]
+img[alt="Zakup z pakietem Smart"]
 
 CSS
 #opbox-listing--base i,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -700,6 +700,7 @@ INVERT
 i[title="Smart!"]
 div[class="mpof_ki m389_6m"]
 img[alt="Zakup z pakietem Smart"]
+.so15i8
 
 CSS
 #opbox-listing--base i,


### PR DESCRIPTION
If you have "Smart!" delivery enabled, in details about your order is visible `Smart!` logo.
I removed sensitive details from screenshot
![20211126-1637933442](https://user-images.githubusercontent.com/9846948/143589346-66146a00-ec50-4aca-80dd-b28cb5a1dcce.png)

`Dostawa Smart!` from polish language to english is just: `Delivery Smart!`