### PR TITLE
Remove broken fixes for vk.com in inversion-fixes.config

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2446,7 +2446,6 @@ vk.com
 INVERT
 #video_player
 .mv_playlist
-.page_header_cont
 .page_album_title
 .article_snippet__fade
 .article_snippet__info
@@ -2462,12 +2461,6 @@ INVERT
 .vv_summary
 .thumb_map:after
 .input_back_wrap[style*=none] ~ #ts_input
-#ts_cont_wrap
-#ts_cont_wrap img
-#top_notify_wrap
-#top_notify_wrap .feedback_sticky_icon
-#audio_layer_tt
-#audio_layer_tt [style*=background-image]
 .audio_page_player_play .icon
 .page_video_play_icon
 .apps_featured_thumb_content
@@ -2476,7 +2469,6 @@ INVERT
 .apps_frtt_level
 .settings_separated_row_iconed:before
 .owner_photo_bubble_wrap
-#top_profile_menu
 .tt_black
 .tt_w.tt_black
 .box_title
@@ -2494,7 +2486,6 @@ INVERT
 NO INVERT
 #video_player *
 .mv_playlist *
-.page_header_cont *
 #z_photoview img
 .box_grey .box_title
 


### PR DESCRIPTION
Sorry for complex changes, but that's quite related problems:
- Fixes not inverted header
Before
![4_notif](https://user-images.githubusercontent.com/4707112/143691347-a3c507c7-1417-4b1b-a78f-dd4321649987.png)
After
![3_head](https://user-images.githubusercontent.com/4707112/143691355-8dd4b2de-19a9-42f0-b189-82a34f6f2950.png)


- Fixes https://github.com/darkreader/darkreader/issues/5704
Before / After
![1_not](https://user-images.githubusercontent.com/4707112/143691377-7d075db6-7d92-41ab-8d3a-ee20310ccdcc.png) ![2_not](https://user-images.githubusercontent.com/4707112/143691378-22b50ba0-f650-453e-96be-7d98fec38e07.png)


