### PR TITLE
Fix for washingtonpost.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14633,6 +14633,11 @@ washingtonpost.com
 INVERT
 .masthead_svg__wplogo
 
+CSS
+.flex * {
+    border: none !important;
+}
+
 IGNORE INLINE STYLE
 a[data-sc-c="headerlogo"] path
 


### PR DESCRIPTION
Hides the bugged-out borders that appear in dark mode when viewing articles.