### PR TITLE
Fix for Overleaf PDF inversion on Dynamic Theme

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10544,7 +10544,7 @@ INVERT
 overleaf.com
 
 INVERT
-.pdf-page-container
+.pdf-viewer
 
 ================================
 


### PR DESCRIPTION
Just a small fix for the PDF inversion on overleaf.com.

Overleaf updated their CSS from `.pdf-page-container` to `.pdf-viewer`.