### PR TITLE
Removed sverigesradio.se

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -808,6 +808,7 @@ supabase.io
 supinic.com
 support.steampowered.com
 surviv.io
+sverigesradio.se
 svtplay.se
 symfony.com
 szmarczak.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13082,61 +13082,6 @@ CSS
 
 ================================
 
-sverigesradio.se
-
-INVERT
-#sprite-check
-#sprite-facebook
-#sprite-instagram
-#sprite-reddit
-#sprite-twitter
-#sprite-whatsapp
-.circle
-.cross
-.default
-.episode-list-item__controls svg
-.external-link-with-icon__icon
-.gallery-button .icon
-.gallery-button svg g
-.info-teaser-container__title h2
-.link-icon .icon
-.local-weather-item__wind-icon
-.logo
-.menu-icon.icon
-.play-icon__pause-symbol
-.play-icon__play-symbol
-.progress.queue-progress .bar
-.sr-link__svg svg
-.sr-logo-wrapper
-.sound-bars .bar
-.support-info__icon svg
-[data-require="modules/custom-click-tracking"] svg
-[data-require="modules/listen-later"] svg
-[data-require="modules/share-button"] svg
-button.reset
-input[type="range"]::-moz-range-thumb
-input[type="range"]::-moz-range-track
-input[type="range"]::-webkit-slider-runnable-track
-input[type="range"]::-webkit-slider-thumb
-
-CSS
-.weather-icon {
-    filter: invert(1) hue-rotate(180deg) !important;
-}
-.live-marker .dot, 
-.live-label::before,
-.active::before {
-    background-color: var(--darkreader-neutral-text) !important;
-}
-.search-page em, .search-result em, .info-teaser-container__title {
-    color: var(--darkreader-neutral-background) !important;
-}
-#sprite-home path, #sprite-news path, #sprite-podcast path, #sprite-direct path, #sprite-profile path {
-    fill: var(--darkreader-neutral-text);
-}
-
-================================
-
 svt.se
 
 INVERT


### PR DESCRIPTION
Today I discovered that _sverigesradio.se_ - Sweden's national publicly funded radio broadcaster - has a native dark theme when your device has dark mode activated, so I've now removed all code that relates to this site.

![sr](https://user-images.githubusercontent.com/17113053/144120468-83a1de92-5513-4c10-a91b-8dd5ab5d273d.png)

