### PR TITLE
Enable inversion of Instructure.com (Canvas) embedded PDFs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7201,6 +7201,7 @@ instructure.com
 
 INVERT
 .equation_image
+.ef-file-preview-stretch
 
 ================================
 


### PR DESCRIPTION
Adding inversion ability to the embedded PDFs produced by Instructure.com websites (also known as Canvas).

Old:
![image](https://user-images.githubusercontent.com/29745705/144504837-955f44eb-b18e-4a03-9d4f-8eaf52252401.png)

New:
![image](https://user-images.githubusercontent.com/29745705/144504864-2af904f6-dff2-47e6-b650-951ea6a25e68.png)

The background and header of the PDF improperly inverting to a "light" mode is an issue with PDF inversions in general and not in the scope of this pull request.