### PR TITLE
Allow API to disable proxy of stylesheets

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,6 +150,13 @@ declare namespace DarkReader {
          * Mostly used for wrongly inverted background-images
          */
         ignoreImageAnalysis: string[];
+
+        /**
+         * A toggle to disable the proxying of `document.styleSheets`.
+         * This is a API-Exclusive option, as it can break legitmate websites,
+         * who are using the Dark Reader API.
+         */
+        disableStyleSheetsProxy: boolean;
     }
 }
 

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -134,6 +134,7 @@ export interface DynamicThemeFix {
     css: string;
     ignoreInlineStyle: string[];
     ignoreImageAnalysis: string[];
+    disableStyleSheetsProxy: boolean;
 }
 
 export interface InversionFix {

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -133,7 +133,7 @@ function createStaticStyleOverrides() {
     document.head.insertBefore(rootVarsStyle, variableStyle.nextSibling);
 
     const proxyScript = createOrUpdateScript('darkreader--proxy');
-    proxyScript.append(`(${injectProxy})()`);
+    proxyScript.append(`(${injectProxy})(!${fixes.disableStyleSheetsProxy})`);
     document.head.insertBefore(proxyScript, rootVarsStyle.nextSibling);
     proxyScript.remove();
 }

--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -1,4 +1,4 @@
-export function injectProxy() {
+export function injectProxy(enableStyleSheetsProxy: boolean) {
     document.dispatchEvent(new CustomEvent('__darkreader__inlineScriptsAllowed'));
 
     const addRuleDescriptor = Object.getOwnPropertyDescriptor(CSSStyleSheet.prototype, 'addRule');
@@ -6,7 +6,8 @@ export function injectProxy() {
     const deleteRuleDescriptor = Object.getOwnPropertyDescriptor(CSSStyleSheet.prototype, 'deleteRule');
     const removeRuleDescriptor = Object.getOwnPropertyDescriptor(CSSStyleSheet.prototype, 'removeRule');
 
-    const documentStyleSheetsDescriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'styleSheets');
+    const documentStyleSheetsDescriptor = enableStyleSheetsProxy ?
+        Object.getOwnPropertyDescriptor(Document.prototype, 'styleSheets') : null;
 
     // Reference:
     // https://github.com/darkreader/darkreader/issues/6480#issuecomment-897696175
@@ -22,7 +23,9 @@ export function injectProxy() {
         Object.defineProperty(CSSStyleSheet.prototype, 'removeRule', removeRuleDescriptor);
         document.removeEventListener('__darkreader__cleanUp', cleanUp);
         document.removeEventListener('__darkreader__addUndefinedResolver', addUndefinedResolver);
-        Object.defineProperty(Document.prototype, 'styleSheets', documentStyleSheetsDescriptor);
+        if (enableStyleSheetsProxy) {
+            Object.defineProperty(Document.prototype, 'styleSheets', documentStyleSheetsDescriptor);
+        }
         if (shouldWrapHTMLElement) {
             Object.defineProperty(Element.prototype, 'getElementsByTagName', getElementsByTagNameDescriptor);
         }
@@ -109,7 +112,9 @@ export function injectProxy() {
     Object.defineProperty(CSSStyleSheet.prototype, 'insertRule', Object.assign({}, insertRuleDescriptor, {value: proxyInsertRule}));
     Object.defineProperty(CSSStyleSheet.prototype, 'deleteRule', Object.assign({}, deleteRuleDescriptor, {value: proxyDeleteRule}));
     Object.defineProperty(CSSStyleSheet.prototype, 'removeRule', Object.assign({}, removeRuleDescriptor, {value: proxyRemoveRule}));
-    Object.defineProperty(Document.prototype, 'styleSheets', Object.assign({}, documentStyleSheetsDescriptor, {get: proxyDocumentStyleSheets}));
+    if (enableStyleSheetsProxy) {
+        Object.defineProperty(Document.prototype, 'styleSheets', Object.assign({}, documentStyleSheetsDescriptor, {get: proxyDocumentStyleSheets}));
+    }
     if (shouldWrapHTMLElement) {
         Object.defineProperty(Element.prototype, 'getElementsByTagName', Object.assign({}, getElementsByTagNameDescriptor, {value: proxyGetElementsByTagName}));
     }


### PR DESCRIPTION
- Allow developers of the API to disable the proxying of `document.styleSheets`.
- Resolves #7536