### PR TITLE
Fixes black text on black Google Translate bubble

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1,7 +1,6 @@
 *
 
 INVERT
-.jfk-bubble.gtx-bubble
 .captcheck_answer_label > input + img
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
 span[data-href^="https://www.hcaptcha.com/"] > #icon


### PR DESCRIPTION
With this line text in Google Translate bubble is black (Google Chrome +  chrome://flags#enable-force-dark "Enabled with selective inversion of non-image elements").