### PR TITLE
Fix readability of security support text on endoflife.date

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4708,6 +4708,15 @@ body {
 
 ================================
 
+endoflife.date
+
+CSS
+.bg-green-000, .bg-yellow-200, .bg-red-000 {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 endomondo.com
 
 INVERT


### PR DESCRIPTION
Example: https://endoflife.date/python