### PR TITLE
Fix for nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10173,7 +10173,11 @@ INVERT
 nytimes.com
 
 INVERT
+div#live-country-map.live-country-map-embed
+div#live-us-map.live-us-map-embed
+g > text
 .svelte-1v1dl99
+.vmap-zoom-buttons
 #xwd-board
 
 CSS


### PR DESCRIPTION
Fixes maps on "Tracking Omicron" page.

![1](https://user-images.githubusercontent.com/6563728/144755517-9b39b6a8-56c7-4795-9aed-aebd2c2d9c35.png)

![2](https://user-images.githubusercontent.com/6563728/144755522-8d7ed759-ef85-4708-a7db-24fe9b4d9445.png)