### PR TITLE
konkret24.tvn24.pl fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7927,6 +7927,16 @@ INVERT
 
 ================================
 
+konkret24.tvn24.pl
+
+INVERT
+.header-left-corner__logo
+.menu-button__bars
+.report-toggle-button__icon
+.search-panel-toggle-button__icon
+
+================================
+
 kraken.com
 
 CSS


### PR DESCRIPTION
https://konkret24.tvn24.pl/polska,108/pomnik-kaczynskich-w-bialej-podlaskiej-garazowany-na-noc-to-nieprawda,1087261.html

![20211206-1638820070](https://user-images.githubusercontent.com/9846948/144912463-e6d28bea-696e-4963-9de4-ed4501b9585c.png)
