### PR TITLE
Enable inversion of Overleaf math SVGs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10669,6 +10669,7 @@ overleaf.com
 
 INVERT
 .pdf-viewer
+.mwe-math-element
 
 ================================
 


### PR DESCRIPTION
Just an additional inversion element

Old: 
![image](https://user-images.githubusercontent.com/29745705/144942096-472a9a02-3b48-492b-bccc-13ab2cb0e5e5.png)

New:
![image](https://user-images.githubusercontent.com/29745705/144942126-e981cdba-53ee-4bac-81bc-b1f51dc02448.png)
