### PR TITLE
tvn24.pl header icons fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14231,6 +14231,14 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+tvn24.pl
+
+INVERT
+.header-menu__more-button
+.hamburger-icon
+
+================================
+
 tvrain.ru
 
 INVERT


### PR DESCRIPTION
https://tvn24.pl/
![20211207-1638861702](https://user-images.githubusercontent.com/9846948/144984557-ff1f0abc-0a0f-4acf-9570-dc125dac13b6.png)
