### PR TITLE
Fix raspberrypi.com documentation text color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11490,6 +11490,15 @@ td[style^="background:"]
 
 ================================
 
+raspberrypi.com
+
+CSS
+div.paragraph, td.content {
+  color: var(--darkreader-neutral-text);
+}
+
+================================
+
 raspberrypi.org
 
 IGNORE IMAGE ANALYSIS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11494,7 +11494,7 @@ raspberrypi.com
 
 CSS
 div.paragraph, td.content {
-  color: var(--darkreader-neutral-text);
+  color: var(--darkreader-neutral-text) !important;
 }
 
 ================================


### PR DESCRIPTION
Fixes the text color on documentation pages such as https://www.raspberrypi.com/documentation/computers/os.html