### PR TITLE
Prevent Inversion of Title Text on Webtoons.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15013,6 +15013,15 @@ CSS
 
 ================================
 
+webtoons.com
+
+CSS
+.info {
+    color: rgb(0,0,0) !important;
+}
+
+================================
+
 wego.here.com
 
 INVERT


### PR DESCRIPTION
New / Proposed:
![image](https://user-images.githubusercontent.com/29745705/145333220-081d5638-8c8a-4744-b213-02d530494c66.png)

Old / Current:
![image](https://user-images.githubusercontent.com/29745705/145333249-565b9883-55fe-429c-af5b-a0c51410a7a3.png)

Dark Reader off:
![image](https://user-images.githubusercontent.com/29745705/145333273-78a93951-5528-4306-826f-4b9a8fd5025e.png)

(NOT DONE) Inversion of title cards:
![image](https://user-images.githubusercontent.com/29745705/145333885-6f9b2ac9-0d8d-4fad-9e72-3b0de2b76874.png)

Choice of pure black `rgb(0,0,0)` was selected due to the original website CSS selecting black as title card text. This will prevent Dark Reader from acting on the text located only on the title card. `IGNORE INLINE STYLE` was not used due to the declaration of this black text being inherited from a global font color. Ignoring dark reader's change to this font color would cause the rest of the website's text to break or require custom overrides for all other text using the global font color.