### PR TITLE
Fix for cnn.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2843,13 +2843,14 @@ CSS
 cnn.com
 
 INVERT
-[data-test="section-link"] > svg
+[data-test="section-link"] > svg:not(.business-logo-icon)
 img.metadata-header__logo
 
 IGNORE INLINE STYLE
 svg.cnn-badge-icon
 svg.cnn-badge-icon > rect
 svg.politics-logo-icon
+svg.business-logo-icon
 
 ================================
 


### PR DESCRIPTION
Ignore inline style of the business section logo so the SVG doesn't flicker every page load.