### PR TITLE
Fix New York Times Crossword text

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10284,6 +10284,9 @@ a[data-testid] > svg {
 #xwd-board rect[class^="Cell-block--"] {
     fill: ${black} !important;
 }
+#xwd-board text[class^="Cell-hidden--"] {
+    color: ${black} !important;
+}
 
 ================================
 


### PR DESCRIPTION
The text for crossword cells no longer inverts correctly with the
existing fixes and results in dark text on dark background. This new
addition restores the inverted text color to bring back light text on
dark background.