### PR TITLE
Fix for zorin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16692,6 +16692,7 @@ zorin.com
 INVERT
 .logotype
 .social
+img[alt="GOG logo"]
 img[alt="Windows to Zorin OS"]
 
 ================================


### PR DESCRIPTION
Fixes logo on "Zorin OS" page.

Before:
![1](https://user-images.githubusercontent.com/6563728/145682414-60f8a0b3-5aba-4702-9e16-92bb6dd78a00.png)

After:
![2](https://user-images.githubusercontent.com/6563728/145682416-cf40c991-8eae-4e16-ba4c-8996d1581404.png)