### PR TITLE
Small fix for script.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12213,6 +12213,9 @@ INVERT
 .icon
 .monaco-editor .cursors-layer > .cursor
 
+IGNORE INLINE STYLE
+mask > *
+
 ================================
 
 scroll.com


### PR DESCRIPTION
On script.google.com, the dynamic mode inverted and thus broke an image mask on the debugging button. I added an Ignore Inline Style -rule to prevent the inversion on the mask.