### PR TITLE
Fix for decisionproblem.com/paperclips

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3577,6 +3577,9 @@ img[src$="logo.png"]
 
 decisionproblem.com
 
+INVERT
+.qChip
+
 CSS
 #giftShopDiv {
   color: ${white} !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3575,6 +3575,18 @@ img[src$="logo.png"]
 
 ================================
 
+decisionproblem.com
+
+CSS
+#giftShopDiv {
+  color: ${white} !important;
+}
+.projectButton:disabled {
+  color: ${gray} !important;
+}
+
+================================
+
 deepl.com
 
 INVERT


### PR DESCRIPTION
Fixes text in the gift shop box (top right) being hard to read and disabled buttons being hard to distinguish from enabled ones.

Note: For giftShopDiv, `${white}` was used because `${darkreader-neutral-text}` is still hard to read.