### PR TITLE
Change Hacker News BG to --darkreader-neutral-bg

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10026,6 +10026,11 @@ news.ycombinator.com
 INVERT
 .votearrow
 
+CSS
+#hnmain {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
 ================================
 
 newyorker.com


### PR DESCRIPTION
The inverted background colour of Hacker News (news.ycombinator.com) was a sickly green. I've changed it to `--darkreader-neutral-background` instead, and it looks much better.