### PR TITLE
Makes TVLand.com Dark

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -115,16 +115,6 @@ IGNORE INLINE STYLE
 
 ================================
 
-tvland.com
-
-CSS
-.module-container,
-.header-container {
-    background-color: var(--darkreader-neutral-background) !important;
-}
-
-================================
-
 *.ubereats.com
 
 INVERT
@@ -135,15 +125,6 @@ div[class^='c5'] .gm-style
 #wrapper > div:nth-of-type(2) > header
 #wrapper > div:nth-of-type(2) > footer
 #wrapper > div:nth-of-type(2) > #main-content > div:first-child
-
-================================
-
-*.vh1.com
-
-CSS
-.module-container {
-    background-color: var(--darkreader-neutral-background) !important;
-}
 
 ================================
 
@@ -14466,6 +14447,16 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+tvland.com
+
+CSS
+.module-container,
+.header-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 tvn24.pl
 
 INVERT
@@ -14876,6 +14867,15 @@ vg24.pl
 
 INVERT
 img[alt="VG24.PL logo"]
+
+================================
+
+vh1.com
+
+CSS
+.module-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -115,6 +115,16 @@ IGNORE INLINE STYLE
 
 ================================
 
+*.tvland.com
+
+CSS
+.module-container,
+.header-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 *.ubereats.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -115,7 +115,7 @@ IGNORE INLINE STYLE
 
 ================================
 
-*.tvland.com
+tvland.com
 
 CSS
 .module-container,


### PR DESCRIPTION
TVLand.com isn't dark when DarkReader is active. This change fixes that.

(NOTE: TVLand.com may be inaccessible outside of the US)