### PR TITLE
Makes paramountnetwork.com dark

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -45,6 +45,15 @@ div[class^='scrollableList'] {
 
 ================================
 
+*.paramountnetwork.com
+
+CSS
+.module-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 *.screenconnect.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -45,15 +45,6 @@ div[class^='scrollableList'] {
 
 ================================
 
-paramountnetwork.com
-
-CSS
-.module-container {
-    background-color: var(--darkreader-neutral-background) !important;
-}
-
-================================
-
 *.screenconnect.com
 
 CSS
@@ -10904,6 +10895,15 @@ INVERT
 .nav__item--profile
 .search__button
 .search__close
+
+================================
+
+paramountnetwork.com
+
+CSS
+.module-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -45,7 +45,7 @@ div[class^='scrollableList'] {
 
 ================================
 
-*.paramountnetwork.com
+paramountnetwork.com
 
 CSS
 .module-container {


### PR DESCRIPTION
[ParamountNetwork.com](https://www.paramountnetwork.com/) is not dark when DarkReader is active. This change fixes that.

(NOTE: ParamountNetwork.com may not be accessible outside of the US).