### PR TITLE
Add fixes for CISCE

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2699,6 +2699,14 @@ INVERT
 
 ================================
 
+cisce.org
+
+INVERT
+.nav-wrapper
+hgroup
+
+================================
+
 citilink.ru
 
 INVERT


### PR DESCRIPTION
This fixes certain issues with the [CISCE website's](cisce.org) header.

The navbar in the header is originally dark with light text, but on inversion becomes light with light text.
The rest of header is originally light with dark text, but on inversion becomes dark with dark text.
Attached are pictures of the original page, the inverted page before the fix, and the inverted page after the fix, in that order
![Screenshot from 2021-12-15 09-48-35](https://user-images.githubusercontent.com/69745509/146123423-b59c2c69-33d4-418a-8454-59ce5ecc6f27.png)
![Screenshot from 2021-12-15 10-01-22](https://user-images.githubusercontent.com/69745509/146123485-41fcd383-f3fd-44cf-ba1b-4eb9eeccd5ac.png)
![Screenshot from 2021-12-15 09-59-56](https://user-images.githubusercontent.com/69745509/146123502-68c4ce16-a614-41fd-8121-84c1b8b9e521.png)
.