### PR TITLE
Fix dark mode on googleprojectzero for images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6578,6 +6578,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+googleprojectzero.blogspot.com
+
+CSS
+.c5 a img {
+  background-color: white !important;
+}
+
+================================
+
 goplay.anontpp.com
 
 INVERT


### PR DESCRIPTION
adds a white background to images on google project zero.
this makes images readable - I did not use ${white} or ${black} because they continue to not work in the opposite mode.
[images taken from here](https://googleprojectzero.blogspot.com/2021/12/a-deep-dive-into-nso-zero-click.html#:~:text=but%20the%20returned%20type%20will%20now%20not%C2%A0be%20equal%20to%20jbig2SegSymbolDict%C2%A0thus%20causing%20further%20writes%20at%20(4)%C2%A0to%20not%20be%20reached%20and%20bounding%20the%20extent%20of%20the%20memory%20corruption.)
before: 
![image](https://user-images.githubusercontent.com/72410860/146281527-4d2e86fb-f26a-4b72-928d-d27b2cf8fb27.png)
after:
![image](https://user-images.githubusercontent.com/72410860/146281482-93386a8b-b6e7-4f94-9d94-198996d0a0ca.png)
I think there might be a way to automatically detect images with high transparency ratios (greater then 70%?), lots of dark colored pixels, on dark backgrounds, and automatically give them a white background if they exceed a certain percentage of the vmin? This combination of rules would select images but not icons, and only if the image needs the background, at least in my head. Definitely out of scope for this pr.

