### PR TITLE
Remove non-dark site

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -224,7 +224,6 @@ developpement-systeme-exploitation.github.io/documentation
 di.fm
 diablo3.com
 diep.io
-dietpi.com
 digi77.com
 digital.fashion
 disasm.pro


### PR DESCRIPTION
The documentation on the DietPi website is black text on a white background. There is no option for a dark version of the documentation.