### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -367,6 +367,16 @@ CSS
 
 ================================
 
+accounts.firefox.com
+
+INVERT
+#about-mozilla
+a[data-testid="mobile-link"] > div > img
+a[data-testid="vpn-link"] > div > img
+a[data-testid="link-mozilla"] > svg
+
+================================
+
 accounts.google.com
 
 INVERT
@@ -5336,6 +5346,13 @@ INVERT
 
 ================================
 
+firefox.com
+
+INVERT
+.fx-bento-app-link.fx-bento-link.fx-mobile > span::before
+
+================================
+
 firefox.net.cn
 
 CSS
@@ -6878,6 +6895,13 @@ INVERT
 img[alt="Huba"]
 img[alt="INTERIA.PL"]
 .most-interesting-topics-header:before
+
+================================
+
+hubs.mozilla.com
+
+INVERT
+svg.hmc-logo
 
 ================================
 
@@ -9484,6 +9508,13 @@ a[href$="twitter.com/money_pl"] path:first-of-type {
 
 ================================
 
+monitor.firefox.com
+
+INVERT
+svg[class="Mozilla-logo"] > path[fill="#ffffff"]
+
+================================
+
 monokai.pro
 
 INVERT
@@ -11815,6 +11846,14 @@ CSS
 #upload-github {
     border: 1px solid #dddddd;
 }
+
+================================
+
+relay.firefox.com
+
+INVERT
+img.c-landing-hero-brands
+img.c-brand-title
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -367,16 +367,6 @@ CSS
 
 ================================
 
-accounts.firefox.com
-
-INVERT
-#about-mozilla
-a[data-testid="mobile-link"] > div > img
-a[data-testid="vpn-link"] > div > img
-a[data-testid="link-mozilla"] > svg
-
-================================
-
 accounts.google.com
 
 INVERT


### PR DESCRIPTION
Various Mozilla sites:

- FF Accounts: Logo on login screen and icons of other services in the dropdown menu
- FF.com: Mobile icon in FF subpages that have it in the services dropdown menu
- Moz Hubs: Logo on loading screen
- FF Monitor: Logo at the bottom
- FF Relay: News sites' logos and Relay logos in the payment plans