### PR TITLE
Fix for machinelearningmastery.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7345,7 +7345,7 @@ img[src*="/img/"]
 
 CSS
 .star-on-png::before {
-    color: #FCAD03 !important; 
+    color: #F$2.34 !important; 
 }
 
 ================================
@@ -8649,6 +8649,13 @@ CSS
 #filler {
     background-image: none !important;
 }
+
+================================
+
+machinelearningmastery.com
+
+INVERT
+img.size-full.wp-image-7676
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7345,7 +7345,7 @@ img[src*="/img/"]
 
 CSS
 .star-on-png::before {
-    color: #F$2.34 !important; 
+    color: #FCAD03 !important; 
 }
 
 ================================


### PR DESCRIPTION
Fixes the dark background of an image in Dark mode. I did INVERT instead of CSS because the CSS I tried made it have a black background in Light mode.