### PR TITLE
fix images on roscidus.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12110,6 +12110,15 @@ CSS
 
 ================================
 
+roscidus.com
+
+CSS
+span.caption-wrapper img {
+  background-color: white !important;
+}
+
+================================
+
 roskomsvoboda.org
 
 INVERT


### PR DESCRIPTION
adds a white background to [images.](https://roscidus.com/blog/blog/2021/10/30/xwayland/#:~:text=easy%20as%20I%27d%20hoped.%20Ideally%2C%20Xwayland%20would%20completely%20isolate%20the%20Wayland%20compositor%20from%20needing%20to%20know%20anything%20about%20X11%3A)
![image](https://user-images.githubusercontent.com/72410860/147056808-ca918de4-a7a3-47fb-a9fa-6062e76bdc05.png)
