### PR TITLE
Fix for washingtonpost.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15324,7 +15324,7 @@ CSS
 }
 
 IGNORE INLINE STYLE
-a[href="https://washingtonpost.com" class*="center"] svg path
+a[href="https://washingtonpost.com"][class*="center"] svg path
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15324,8 +15324,7 @@ CSS
 }
 
 IGNORE INLINE STYLE
-a[data-sc-c="headerlogo"] path
-svg.db path
+a[href="https://washingtonpost.com" class*="center"] svg path
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15325,6 +15325,7 @@ CSS
 
 IGNORE INLINE STYLE
 a[data-sc-c="headerlogo"] path
+svg.db path
 
 ================================
 


### PR DESCRIPTION
Ignore inline style on site logo when scrolling through articles.