### PR TITLE
Fix for Google Drive

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4357,7 +4357,6 @@ div[role="dialog"] ~ div[role="menu"] > div[role="menuitem"] > div > div:not([st
 img[src$="type/audio/mp3"]
 div[role="listitem"] > div > div > div > svg[fill="#000000"] > path
 div[role="menu"] > div > div[role="menuitem"] > div > div > div
-div[role="menu"] > div > div[role="menuitem"][class*=" "] > div > :last-child
 div[data-label="nd"] > div > div > svg > path[fill="#000000"]
 div[role="document"] > div[role="button"] .a-b-c
 


### PR DESCRIPTION
Each menu item on the right-click context menu consists of an image, a text label, and (sometimes) another image, arranged horizontally. The selector ```div[role="menu"] > div > div[role="menuitem"][class*=" "] > div > :last-child``` selects and inverts the last of these elements on every menu item. However, when the last element is a text label, the text often seems to be incorrectly inverted.
![image](https://user-images.githubusercontent.com/69745509/147334156-fb870462-b274-4dc4-96aa-488cd2378bac.png) ![image](https://user-images.githubusercontent.com/69745509/147334174-9566d409-ddfb-46d4-a5fb-fbf0813d7aac.png)
In some cases, images also get wrong inversions when they are returned by the selector (notice the little black arrow on the right end of the menu item).
![image](https://user-images.githubusercontent.com/69745509/147334239-b110e4df-3d72-4d60-b651-27a629930bd6.png)
(The images are from the right-click menu for a file in Google Drive)

However, when the selector is removed, things seem to look fine.

For reference, this selector was added in #6311.