### PR TITLE
stardock.com invert text area

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13336,6 +13336,14 @@ html {
 
 ================================
 
+stardock.com
+
+INVERT
+.mid
+.careers
+
+================================
+
 start64.com
 
 INVERT


### PR DESCRIPTION
https://www.stardock.com/

https://www.stardock.com/products/start11/
and any other product sub page with `.mid` area. Dark reader invert text to white there. 

This PR fix readable, not touch backgrounds. 

![20211227-1640612531](https://user-images.githubusercontent.com/9846948/147477521-d07a659c-1632-4251-bed7-a53ae2c81c8f.png)
![20211227-1640612518](https://user-images.githubusercontent.com/9846948/147477524-ee6ebe61-c3a0-4a2e-b9c1-3f0e36bf4f22.png)
![20211227-1640612506](https://user-images.githubusercontent.com/9846948/147477525-020262fb-48df-4655-b337-fe46100d2318.png)
