### PR TITLE
omcar.pl is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -598,6 +598,7 @@ ogusers.com
 ohmyz.sh
 oldergeeks.com
 oldfag.org
+omcar.pl
 omgwtfnzbs.me
 onionplay.co
 online.lloydsbank.co.uk


### PR DESCRIPTION
https://omcar.pl/

![20211227-1640621590](https://user-images.githubusercontent.com/9846948/147489221-b10335f5-5a7e-4551-a147-433570bcb615.png)
