### PR TITLE
Fix notebooks in iframe, github viewer

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10386,11 +10386,10 @@ IGNORE IMAGE ANALYSIS
 notebooks.githubusercontent.com/view/ipynb*
 
 CSS
-.jp-CodeConsole .CodeMirror.cm-s-jupyter, .jp-Notebook .CodeMirror.cm-s-jupyter {
-    background-color: var(--darkreader-neutral-background) !important;
-}
+.jp-CodeConsole .CodeMirror.cm-s-jupyter,
+.jp-Notebook .CodeMirror.cm-s-jupyter,
 .highlight {
-    background: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10383,6 +10383,18 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+notebooks.githubusercontent.com/view/ipynb*
+
+CSS
+.jp-CodeConsole .CodeMirror.cm-s-jupyter, .jp-Notebook .CodeMirror.cm-s-jupyter {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.highlight {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 notion.so
 
 INVERT


### PR DESCRIPTION
In github, the viewer of notebooks see bad
![image](https://user-images.githubusercontent.com/36548949/147491567-4434521d-adba-465a-85af-8058b92c310d.png)

but if we add a `notebooks.githubusercontent.com/view/ipynb*` expresion then it seen dark
![image](https://user-images.githubusercontent.com/36548949/147491663-67e5ff58-687a-4ffe-b4ae-f716812588a8.png)
