### PR TITLE
linuxcompatible.org is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -496,6 +496,7 @@ lightweightpdf.com
 limeshark.dev/editor
 link.brawlstars.com/invite
 linux.org.ru
+linuxcompatible.org
 lipu-linku.github.io
 liquidplus.com
 listen.moe


### PR DESCRIPTION
https://linuxcompatible.org

![20211228-1640693200](https://user-images.githubusercontent.com/9846948/147564825-7833a1c1-4660-4ecd-9095-3bc82517b52c.png)
