### PR TITLE
gazetaprawna.pl new selectors fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5973,13 +5973,10 @@ CSS
 gazetaprawna.pl
 
 INVERT
-.logoHeading
+.bubbleMenuHamburger
 .homePageUrl
-
-CSS
-#menuTrigger {
-    background-color: var(--darkreader-neutral-background) !important;
-}
+.serviceLogo
+.servicesMenu #menuTrigger span
 
 ================================
 


### PR DESCRIPTION
https://serwisy.gazetaprawna.pl/emerytury-i-renty/artykuly/8321923,rosna-kryteria-dochodowe-w-pomocy-spolecznej.html
https://www.gazetaprawna.pl/

![20211228-1640712256](https://user-images.githubusercontent.com/9846948/147591378-a6e250df-88df-48fa-80a9-e903e7eb7af9.png)
![20211228-1640712251](https://user-images.githubusercontent.com/9846948/147591380-0ec30d6a-3906-418d-8c90-e87a6b4236cc.png)
![20211228-1640712223](https://user-images.githubusercontent.com/9846948/147591383-174e0c10-c1c1-4bbf-ba8e-3155855c7242.png)
![20211228-1640712217](https://user-images.githubusercontent.com/9846948/147591385-1b3618f0-5632-465d-b8b1-0ca9381632e7.png)
