### PR TITLE
Add migueldemoura.com to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -537,6 +537,7 @@ memory-alpha.fandom.com
 merklex.io
 metronom.us
 metropool.nl
+migueldemoura.com
 mikemaximus.github.io/gbm-web
 minehut.com
 miniroyale2.io


### PR DESCRIPTION
The whole website has dark mode already.