### PR TITLE
dailyexpose.uk logo header fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3508,6 +3508,13 @@ svg.main-logo.inline-flex g g[fill="#110133"] {
 
 ================================
 
+dailyexpose.uk
+
+INVERT
+.header-image
+
+================================
+
 dailymotion.com
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
https://dailyexpose.uk

![20211229-1640760210](https://user-images.githubusercontent.com/9846948/147634583-935209fc-0922-41c7-8369-ae071e77a2df.png)
