### PR TITLE
joemonster.org header logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7827,6 +7827,9 @@ CSS
 
 joemonster.org
 
+INVERT
+.logo
+
 CSS
 body {
     background-image: none !important;


### PR DESCRIPTION
https://joemonster.org/

![20211229-1640763169](https://user-images.githubusercontent.com/9846948/147638015-b8f1600d-f38c-45da-bbd0-641aab3c9f34.png)
