### PR TITLE
dnscrypt.pl logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4234,6 +4234,13 @@ body {
 
 ================================
 
+dnscrypt.pl
+
+INVERT
+.logo
+
+================================
+
 dnsleaktest.com
 
 INVERT


### PR DESCRIPTION
https://dnscrypt.pl

![20211229-1640766287](https://user-images.githubusercontent.com/9846948/147642054-090ea3b2-3778-4739-9d01-b829064fd2a3.png)
