### PR TITLE
wtfast.com is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -957,6 +957,7 @@ wormhole.app
 wowaudit.com
 wowhead.com
 wowinterface.com
+wtfast.com
 www.cc.com
 www.chiefdelphi.com
 www.digikam.org


### PR DESCRIPTION
https://wtfast.com

![20211229-1640791385](https://user-images.githubusercontent.com/9846948/147677540-63d48a4f-c3d1-4860-9146-77477919f53e.png)
