### PR TITLE
Using `gecko` to define a firefox-based browser (fixing #6955)

### DIFF
--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -3,7 +3,7 @@ const platform = typeof navigator === 'undefined' ? 'some platform' : navigator.
 
 export const isChromium = userAgent.includes('chrome') || userAgent.includes('chromium');
 export const isThunderbird = userAgent.includes('thunderbird');
-export const isFirefox = userAgent.includes('firefox') || userAgent.includes('librewolf') || isThunderbird;
+export const isFirefox = userAgent.includes('gecko') || isThunderbird;
 export const isVivaldi = userAgent.includes('vivaldi');
 export const isYaBrowser = userAgent.includes('yabrowser');
 export const isOpera = userAgent.includes('opr') || userAgent.includes('opera');


### PR DESCRIPTION
Fixing #6955 for all firefox-based browsers, by targeting the Gecko engine and not the browser name.
Tested and working for WaterFox, LibreWolf, Icecat, Dot and Firefox.
I couldn't install the extension on FireDragon, but i didn't spent more than 2 minutes on it to be honest. It should be working just fine.