### PR TITLE
Update dynamic-theme-fixes.config for app.grammarly.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1003,7 +1003,7 @@ use.valueCircle_f6otssy {
     --highlight-bg: ${rgba(57, 93, 207, 0.2)};
 }
 .alerts-engagement {
-    --selecetdHighlight: rgb(21, 195, 154, var(--selecetdHighlightOpacity));
+    --highlight-bg: ${rgba(29, 203, 162, 0.2)};
 }
 .alerts-correctness {
     --selecetdHighlight: rgb(234, 21, 55, var(--selecetdHighlightOpacity));

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -997,7 +997,7 @@ use.valueCircle_f6otssy {
     stroke: url(#pb-gradient-0);
 }
 :root {
-    --selecetdHighlight: rgb(255, 255, 255, var(--selecetdHighlightOpacity)); /*fallback folor*/
+    --highlight-bg: ${rgba(0, 0, 0, 0.2)}
 }
 .alerts-clarity {
     --selecetdHighlight: rgb(74, 110, 224, var(--selecetdHighlightOpacity));

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -997,19 +997,19 @@ use.valueCircle_f6otssy {
     stroke: url(#pb-gradient-0);
 }
 :root {
-    --selecetdHighlightOpacity: 0.3;
+    --selecetdHighlightOpacity: 0.2;
     --selecetdHighlight: rgb(255, 255, 255, var(--selecetdHighlightOpacity)); /*fallback folor*/
 }
-[class*="alerts-clarity"] {
+.alerts-clarity {
     --selecetdHighlight: rgb(74, 110, 224, var(--selecetdHighlightOpacity));
 }
-[class*="alerts-engagement"] {
+.alerts-engagement {
     --selecetdHighlight: rgb(21, 195, 154, var(--selecetdHighlightOpacity));
 }
-[class*="alerts-correctness"] {
+.alerts-correctness {
     --selecetdHighlight: rgb(234, 21, 55, var(--selecetdHighlightOpacity));
 }
-[class*="alerts-delivery"] {
+.alerts-delivery {
     --selecetdHighlight: rgb(143, 77, 191, var(--selecetdHighlightOpacity));
 }
 [class*="-alerts-markSelectedHigh"], span[class*="markSelectedFocused"] {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -997,7 +997,6 @@ use.valueCircle_f6otssy {
     stroke: url(#pb-gradient-0);
 }
 :root {
-    --selecetdHighlightOpacity: 0.2;
     --selecetdHighlight: rgb(255, 255, 255, var(--selecetdHighlightOpacity)); /*fallback folor*/
 }
 .alerts-clarity {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1000,7 +1000,7 @@ use.valueCircle_f6otssy {
     --highlight-bg: ${rgba(0, 0, 0, 0.2)}
 }
 .alerts-clarity {
-    --selecetdHighlight: rgb(74, 110, 224, var(--selecetdHighlightOpacity));
+    --highlight-bg: ${rgba(57, 93, 207, 0.2)};
 }
 .alerts-engagement {
     --selecetdHighlight: rgb(21, 195, 154, var(--selecetdHighlightOpacity));

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1006,7 +1006,7 @@ use.valueCircle_f6otssy {
     --highlight-bg: ${rgba(29, 203, 162, 0.2)};
 }
 .alerts-correctness {
-    --selecetdHighlight: rgb(234, 21, 55, var(--selecetdHighlightOpacity));
+    --highlight-bg: ${rgba(255, 69, 103, 0.2)};
 }
 .alerts-delivery {
     --selecetdHighlight: rgb(143, 77, 191, var(--selecetdHighlightOpacity));

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -996,8 +996,24 @@ CSS
 use.valueCircle_f6otssy {
     stroke: url(#pb-gradient-0);
 }
+:root {
+    --selecetdHighlightOpacity: 0.3;
+    --selecetdHighlight: rgb(255, 255, 255, var(--selecetdHighlightOpacity)); /*fallback folor*/
+}
+[class*="alerts-clarity"] {
+    --selecetdHighlight: rgb(74, 110, 224, var(--selecetdHighlightOpacity));
+}
+[class*="alerts-engagement"] {
+    --selecetdHighlight: rgb(21, 195, 154, var(--selecetdHighlightOpacity));
+}
+[class*="alerts-correctness"] {
+    --selecetdHighlight: rgb(234, 21, 55, var(--selecetdHighlightOpacity));
+}
+[class*="alerts-delivery"] {
+    --selecetdHighlight: rgb(143, 77, 191, var(--selecetdHighlightOpacity));
+}
 [class*="-alerts-markSelectedHigh"], span[class*="markSelectedFocused"] {
-    color: rgb(14, 16, 26) !important;
+    background-color: var(--selecetdHighlight) !important;
 }
 [class*="-navigation-counterWrapper"] [class*="-navigation-counterContent"],
 [class*="-paidview-counter"] [class*="-paidview-counterContent"] {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1009,7 +1009,7 @@ use.valueCircle_f6otssy {
     --highlight-bg: ${rgba(255, 69, 103, 0.2)};
 }
 .alerts-delivery {
-    --selecetdHighlight: rgb(143, 77, 191, var(--selecetdHighlightOpacity));
+    --highlight-bg: ${rgba(124, 58, 172, 0.2)};
 }
 [class*="-alerts-markSelectedHigh"], span[class*="markSelectedFocused"] {
     background-color: var(--selecetdHighlight) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1012,7 +1012,7 @@ use.valueCircle_f6otssy {
     --highlight-bg: ${rgba(124, 58, 172, 0.2)};
 }
 [class*="-alerts-markSelectedHigh"], span[class*="markSelectedFocused"] {
-    background-color: var(--selecetdHighlight) !important;
+    background-color: var(--highlight-bg) !important;
 }
 [class*="-navigation-counterWrapper"] [class*="-navigation-counterContent"],
 [class*="-paidview-counter"] [class*="-paidview-counterContent"] {


### PR DESCRIPTION
Fixes the Grammarly editor page, when we click on the suggestion, the highlight is very bright and sometimes the text is unreadable. So, I changed the highlight to be darker instead. And now that the highlight is darker, it no longer needs to change the text to darker tone.