### PR TITLE
downdetector.com xn--allestrungen-9ib.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4449,6 +4449,7 @@ CSS
 ================================
 
 downdetector.*
+xn--allestrungen-9ib.de
 
 INVERT
 img[class="img-fluid lazy"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4448,6 +4448,13 @@ CSS
 
 ================================
 
+downdetector.*
+
+INVERT
+img[class="img-fluid lazy"]
+
+================================
+
 downloads.khinsider.com
 
 CSS


### PR DESCRIPTION
https://downdetector.com
https://xn--allestrungen-9ib.de
https://downdetector.co.uk/

I used `*` mark against many domains for mostly all major countries/languages. German domain is fancy with `ö` in URL name. 

![20211230-1640841767](https://user-images.githubusercontent.com/9846948/147723857-c5aaaac3-7feb-41dd-93ab-ac159642171c.png)


![screencapture-downdetector-pl-2021-12-29-21_37_17](https://user-images.githubusercontent.com/9846948/147723734-569e78bd-61c2-473d-9b75-0bdaca02f7eb.png)
![screencapture-xn-allestrungen-9ib-de-2021-12-30-06_14_28](https://user-images.githubusercontent.com/9846948/147723736-e292ffd4-8c6f-4899-a7f9-9d299b931228.png)
![screencapture-downdetector-co-uk-2021-12-30-06_16_05](https://user-images.githubusercontent.com/9846948/147723739-1bee64c6-41e8-41bf-898e-7f84481fe174.png)
