### PR TITLE
Fix for eapteka.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4707,6 +4707,14 @@ body.origin-com,
 
 ================================
 
+eapteka.ru
+
+INVERT
+ymaps[class$="ground-pane"]
+ymaps[class$="svg-icon-content"] > ymaps
+
+================================
+
 easypost.com
 
 INVERT


### PR DESCRIPTION
- Invert map.

Example of site page: https://www.eapteka.ru/company/pickup/