### PR TITLE
Fix toc colors for kitty terminal docs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14014,7 +14014,8 @@ sw.kovidgoyal.net
 
 CSS
 .sidebar-drawer,
-.sidebar-search {
+.sidebar-search,
+.toc-drawer {
   background: var(--darkreader-neutral-background) !important;
 }
 .sidebar-tree a.current,


### PR DESCRIPTION
Fix background of toc in kitty terminal documentation (https://sw.kovidgoyal.net/kitty/graphics-protocol/)

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/30190448/147822234-5dc88490-3179-43cd-86e5-693d1314dff2.png) | ![image](https://user-images.githubusercontent.com/30190448/147822210-4b33456f-e7c2-4864-adf9-4e06bf48434e.png) |