### PR TITLE
Fix for journal.tinkoff.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7873,6 +7873,7 @@ INVERT
 .PwECA
 .best-authors__arrow.best-authors__arrow--active
 .best-authors__arrow
+label[class^="hamburgerMenu"]
 
 ================================
 


### PR DESCRIPTION
- Invert hamburger menu.

Example of site page: https://journal.tinkoff.ru/list/english-with-ted/