### PR TITLE
fix stackexchange/overflow closed info box, rpg logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13486,8 +13486,11 @@ INVERT
 .h-auto[alt="Theoretical Computer Science"]
 .h-auto[alt="Unix & Linux"]
 .h-auto[alt="Web Applications"]
+.h-auto[alt="Role-playing Games"]
 a.js-gps-track::before
 img[alt="The Stack Exchange Network"]
+aside.s-notice
+aside.s-notice > *
 
 CSS
 body {


### PR DESCRIPTION
This makes the info box readable, and fixes the white outline on the rpg logo.
![image](https://user-images.githubusercontent.com/72410860/147860174-6c6744f2-e66e-4378-b9b9-0f1e97f9b349.png)
I tested the change to the info box on some subdomains, here is a sampling of how they look after the change:
rpg
![image](https://user-images.githubusercontent.com/72410860/147860176-62f6b07c-d4f2-4247-8420-45e3f8855883.png)
meta
![image](https://user-images.githubusercontent.com/72410860/147860198-6e78f9b6-1714-477a-a956-ffbe10f257db.png)
codegolf
![image](https://user-images.githubusercontent.com/72410860/147860209-0592ce43-0aeb-47cf-8fb2-fd227f4a6fc9.png)
![image](https://user-images.githubusercontent.com/72410860/147860214-8560c670-e6bf-44bc-9561-5ecae207e1c1.png)
worldbuilding
![image](https://user-images.githubusercontent.com/72410860/147860242-3130263c-66d1-49de-b28c-cb1d7e35f8b1.png)
and of course, stackoverflow:
![image](https://user-images.githubusercontent.com/72410860/147860274-cafca66b-5eda-4bfa-b989-7226754deffd.png)

before shot of stackoverflow (they all looked like this, approximately):
![image](https://user-images.githubusercontent.com/72410860/147860339-a7c9eb49-32b0-4bc1-ba8f-b81ab19f48d3.png)


Given how many sites this change applies to, I am sure there is a subdomain with particularly crazy styling - please let me know if you know of one I missed.