### PR TITLE
Restore bg color of citation needed text on Chinese Wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16168,6 +16168,9 @@ body.mediawiki,
 #dialogEngineContainer #dialogEngineDialog {
     background-color: var(--darkreader-neutral-background) !important;
 }
+.template-facttext {
+    background-color: #eaecf0 !important;
+}
 
 IGNORE INLINE STYLE
 .legend-color


### PR DESCRIPTION
Citation needed template: https://zh.wikipedia.org/zh-cn/Template:Citation_needed

Example page: https://zh.wikipedia.org/zh-cn/%E4%B8%AD%E6%96%87%E7%BB%B4%E5%9F%BA%E7%99%BE%E7%A7%91#%E5%8F%83%E8%88%87%E8%80%85