### PR TITLE
Improve handling to read from sync

### DIFF
--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -69,11 +69,10 @@ export default class UserStorage {
             return local;
         }
 
-        const sync = await readSyncStorage(DEFAULT_SETTINGS);
-        this.fillDefaults(sync);
+        this.fillDefaults($sync);
 
-        this.loadBarrier.resolve(sync);
-        return sync;
+        this.loadBarrier.resolve($sync);
+        return $sync;
     }
 
     async saveSettings() {

--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -45,7 +45,7 @@ export async function readSyncStorage<T extends {[key: string]: any}>(defaults: 
         chrome.storage.sync.get(null, (sync: any) => {
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError.message);
-                resolve(defaults);
+                resolve(null);
                 return;
             }
 
@@ -69,6 +69,8 @@ export async function readSyncStorage<T extends {[key: string]: any}>(defaults: 
                     sync[key] = JSON.parse(string);
                 } catch (error) {
                     console.error(`sync[${key}]: Could not parse record from sync storage: ${string}`);
+                    resolve(null);
+                    return;
                 }
             }
 


### PR DESCRIPTION
- Return `null` when error occured, so the incorrect return value won't be used.
- Dark reader will not use the sync storage anymore.
- Improves situations like #7838