### PR TITLE
Fix for `acorn.utoronto.ca`

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -431,6 +431,19 @@ CSS
 
 ================================
 
+acorn.utoronto.ca
+
+CSS
+.acorn-classic.page-container .academic-history .sessionHeader,
+.acorn-classic.page-container .academic-history .credit-earned-section,
+.acorn-classic.page-container .academic-history .average-section,
+.acorn-classic.page-container .academic-history .courses,
+.acorn-classic.page-container .academic-history .coursesHeader {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 ad.nl
 
 CSS


### PR DESCRIPTION
Adding a small fix for https://acorn.utoronto.ca, an internal University of Toronto website. This list of selectors was already in their scss, but with `color: initial`. I should have submitted this PR a lot sooner lol, thanks.