### PR TITLE
Fix hidden elements on alipay

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -621,7 +621,6 @@ svg[class^="ali-kit_Rating__star"]
 alipay.com
 
 INVERT
-.alipay-logo
 #J_logoHomeUrl
 .global-logo
 
@@ -633,7 +632,9 @@ CSS
     z-index: 0 !important;
 }
 .authcenter-head,
-.authcenter-foot {
+.authcenter-foot,
+.authcenter-body-login,
+.authcenter-body-logo > a {
     z-index: 1 !important;
 }
 


### PR DESCRIPTION
Resolves #7674. The issue was some rather funky custom css to continue showing the page background. This meant some elements were ending up too low in z-index to be seen. I don't use alipay, so I don't have an account, nor do I speak chinese - using google translate messes up page layout. For these reasons it would probably be best if someone who meets these criteria could chime in, especially in regards to how this change affects pages after login.

Before: 
![image](https://user-images.githubusercontent.com/72410860/148111231-b4ffb3fb-4c41-4bde-894a-828aef5c40b0.png)
After:
![image](https://user-images.githubusercontent.com/72410860/148111128-2e300cc5-818b-474b-ae58-e92518a4c0b2.png)

Some of the page is illegible / highly inaccessible even without darkreader, like the light text on light colored image. Might make sense to hide the image, but this would be making cosmetic changes... Regardless, this pr prevents ui elements from being hidden.
