### PR TITLE
Improve dark mode on icloud.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7271,6 +7271,7 @@ INVERT
 .img.app-icon-icloud
 ui-activity-indicator
 .icloud-text.image.light > svg
+img.icon.status-needs-action
 
 CSS
 .main-pane {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7272,6 +7272,11 @@ INVERT
 ui-activity-indicator
 .icloud-text.image.light > svg
 
+CSS
+.main-pane {
+    background-image: none !important;
+}
+
 ================================
 
 icofont.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7269,6 +7269,7 @@ INVERT
 .sc-iujRgT.jxLrRl
 .icloud-text.image
 .img.app-icon-icloud
+ui-activity-indicator
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7270,6 +7270,7 @@ INVERT
 .icloud-text.image
 .img.app-icon-icloud
 ui-activity-indicator
+.icloud-text.image.light > svg
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7274,7 +7274,8 @@ ui-activity-indicator
 img.icon.status-needs-action
 
 CSS
-.main-pane {
+.main-pane,
+div.atv4.reminders {
     background-image: none !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7272,6 +7272,8 @@ INVERT
 ui-activity-indicator
 .icloud-text.image.light > svg
 img.icon.status-needs-action
+.search-icon
+div.clear-search
 
 CSS
 .main-pane,


### PR DESCRIPTION
This PR intends to fix #6305, or at least improve things. Some parts of icloud.com are composed of canvases, which seemingly cannot have their colors set from darkreader fixes. Other parts can be improved, like the following:

Formatted as:
After pr screenshot
Before pr screenshot

"paper" background image which does not convert well to dark mode is removed
![image](https://user-images.githubusercontent.com/72410860/148116293-cff2aed5-cbd5-4cc3-b7e0-f015d0990b6f.png)
![image](https://user-images.githubusercontent.com/72410860/148117936-a760af0f-8cc4-4cc3-ac07-08672f8da42d.png)
--before--
![image](https://user-images.githubusercontent.com/72410860/148116413-7fd4c36a-8e63-47aa-8e70-c2400449e965.png)
![image](https://user-images.githubusercontent.com/72410860/148117984-ed6d1088-cfce-45a3-8329-0816dc3ea947.png)

search bar
![image](https://user-images.githubusercontent.com/72410860/148118357-97e8c994-a95b-4268-9636-c29f17b3eb47.png)
![image](https://user-images.githubusercontent.com/72410860/148118392-ec464abd-de73-4370-b307-3d2c18bd73d2.png)

ui-activity-indicator
![image](https://user-images.githubusercontent.com/72410860/148114189-ecb94144-4b75-43ea-a455-0827ed2b1b52.png)
![image](https://user-images.githubusercontent.com/72410860/148114257-cbdea9ab-ab22-41e9-b32b-19c609ba852f.png)

icloud text in some circumstances
![image](https://user-images.githubusercontent.com/72410860/148115493-e48f5dc9-c729-487d-a039-9f5caaa66499.png)
![image](https://user-images.githubusercontent.com/72410860/148115572-cfe559c0-f2c6-4718-bbd9-f9f77b76de4c.png)

needs action icon
![image](https://user-images.githubusercontent.com/72410860/148117339-d916ec17-e5bb-4956-9db8-4f75ae57cf35.png)
![image](https://user-images.githubusercontent.com/72410860/148117301-7d07ab7a-49e8-4ebd-b317-02ce57f8139a.png)
