### PR TITLE
Add dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -160,7 +160,6 @@ cinema-city.pl
 cl00e9ment.gitlab.io/kingdom-blazon-generator/
 clash3d.com
 clashofstats.com
-clowncore.computer
 clt.gg
 codepen.io
 codesandbox.io
@@ -690,7 +689,6 @@ polsatboxgo.pl
 polsatgo.pl
 pony.tube
 pool.pm
-pornhub.com
 powercord.dev
 ppluss.de
 pr0gramm.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -13,6 +13,7 @@
 absolucy.moe
 account.bhvr.com
 accounts.pubg.com
+aceship.github.io
 acm.sdut.edu.cn/onlinejudge3/
 addictinggames.com
 adridoesthings.com
@@ -159,6 +160,7 @@ cinema-city.pl
 cl00e9ment.gitlab.io/kingdom-blazon-generator/
 clash3d.com
 clashofstats.com
+clowncore.computer
 clt.gg
 codepen.io
 codesandbox.io
@@ -317,6 +319,7 @@ flooxer.com
 florr.io
 fluxpoint.dev
 flyordie.io
+fmovies.to
 fortnite-api.com
 forum.cswarzone.com
 forum.lastos.org
@@ -661,6 +664,7 @@ piped.kavin.rocks
 piracybank.org
 piskelapp.com
 pitokmm.it
+platinumgod.co.uk
 play.geforcenow.com
 play.hbogo.com
 play.mubert.com
@@ -686,6 +690,7 @@ polsatboxgo.pl
 polsatgo.pl
 pony.tube
 pool.pm
+pornhub.com
 powercord.dev
 ppluss.de
 pr0gramm.com
@@ -880,6 +885,8 @@ throwbacks-music.com
 thunix.net
 tilde.club
 tilde.team
+tilde.town
+tildegit.org
 tildeverse.org
 tinyzonetv.to
 tio.run
@@ -941,6 +948,7 @@ vixlatio.com
 vizality.com
 vortetty.k3live.com
 vrv.co
+vscodethemes.com
 vtcdirectory.com
 vuecinemas.nl
 w0rp.com


### PR DESCRIPTION
note: aceship.github.io has two images that take up half of the screen, both link to pages that are dark