### PR TITLE
info.wyborcza.biz header logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7477,6 +7477,13 @@ img[src$="boardreader.ico"]
 
 ================================
 
+info.wyborcza.biz
+
+INVERT
+.imgw
+
+================================
+
 inforlex.pl
 
 INVERT
@@ -16952,7 +16959,6 @@ INVERT
 .header-cap-holder > a > img
 .header-headline
 .header > .header-content > .header-items
-.imgw
 .paywall-widget-svg-wrapper
 .vin-img
 .tools

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16952,6 +16952,7 @@ INVERT
 .header-cap-holder > a > img
 .header-headline
 .header > .header-content > .header-items
+.imgw
 .paywall-widget-svg-wrapper
 .vin-img
 .tools


### PR DESCRIPTION
Sample https://info.wyborcza.biz/szukaj/gospodarka/udzia%C5%82owcy+daimlera

![20220105-1641404742](https://user-images.githubusercontent.com/9846948/148264258-a9e982f9-ed34-47e2-b2a1-32863e43f94b.png)
