### PR TITLE
Add anishde.dev to the list of already dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -31,6 +31,7 @@ animencodes.com
 animepahe.com
 animixplay.to
 animk.info
+anishde.dev
 anon.sx
 aonprd.com
 app.destinyitemmanager.com


### PR DESCRIPTION
I have added my portfolio site, [https://anishde.dev](https://anishde.dev) to the list of sites that are already dark. It does not have any light mode so it stays dark irrespective of the preferred color scheme