### PR TITLE
contacts.google.com fix rotate buttons in wizard

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3268,6 +3268,13 @@ span[style*="background-color: rgb(255, 255, 0)"] {
 
 ================================
 
+contacts.google.com
+
+INVERT
+img[src*="rotate"]
+
+================================
+
 convertio.co
 
 INVERT


### PR DESCRIPTION
In Google Contacts you can add/update images for each one contact. Wizard have additional buttons for rotate images.
Dark Reader does not invert them to white. 
There is the fix for.

![20220106-1641471352](https://user-images.githubusercontent.com/9846948/148381987-29e317bf-20ca-4c7e-b352-4ef8342bc866.png)
