### PR TITLE
x-kom.pl icon fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16985,9 +16985,12 @@ INVERT
 a[href="/"] img
 a[href="https://x-kom.pl"] img
 a[href="https://www.x-kom.pl"] img
+div[title*="panel"] svg
 img[alt="Menu"]
 img[alt*="Logo"]
 img[src*="Logo_strefy_marek"]
+img[src*="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iM"]
+img[src*="data:image/svg+xml;base64,PHN2ZyB4bWxucz0ia"]
 
 CSS
 .ePVVIv {


### PR DESCRIPTION
https://www.x-kom.pl/p/667881-dysk-zewnetrzny-hdd-seagate-expansion-new-4tb-usb-32-gen-1-czarny.html#Specyfikacja

https://www.x-kom.pl/p/667881-dysk-zewnetrzny-hdd-seagate-expansion-new-4tb-usb-32-gen-1-czarny.html#modal:galeria

![20220106-1641474083](https://user-images.githubusercontent.com/9846948/148387331-e8b5008f-68da-4c2c-b10b-a1f5391ae71d.png)
![20220106-1641473547](https://user-images.githubusercontent.com/9846948/148387334-a6a1fea3-8a58-42c1-8ac1-b926589cd4dc.png)
![20220106-1641474218](https://user-images.githubusercontent.com/9846948/148387410-978fa347-2426-400e-a88b-6826fa9a5ca0.png)

Icons inverted to white in several places. 
