### PR TITLE
dell.com invert white text img areas

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3769,6 +3769,9 @@ CSS
 dell.com
 
 INVERT
+.breadcrumbs
+.cat-banner-text
+.cfsf-ba-content-wrap
 .hpg-cat-item-wrap svg
 
 ================================


### PR DESCRIPTION
Samples

- https://www.dell.com/pl-pl/shop/notebooki-firmy-dell/sc/laptops
- https://www.dell.com/pl-pl/shop/notebooki-firmy-dell/sf/inspiron-laptops
- https://www.dell.com/pl-pl/shop/notebooki-firmy-dell/sf/g-series

Scroll page to see white background with text area and image.

![20220106-1641500309](https://user-images.githubusercontent.com/9846948/148445976-43b2a272-a8e6-4edd-b914-c77c84277108.png)
![20220106-1641499093](https://user-images.githubusercontent.com/9846948/148445937-6ea04bd5-48db-4d6b-a854-3e4b57056dad.png)
![20220106-1641499086](https://user-images.githubusercontent.com/9846948/148445945-e56234b4-44af-44a6-a05c-0f2c73c26476.png)
