### PR TITLE
kopalniawiedzy.pl fix patronite logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8342,6 +8342,13 @@ INVERT
 
 ================================
 
+kopalniawiedzy.pl
+
+INVERT
+img[alt="Patronite"]
+
+================================
+
 korso24.pl
 korsosanockie.pl
 


### PR DESCRIPTION
https://kopalniawiedzy.pl/

Patronite logo fix 

![20220107-1641552845](https://user-images.githubusercontent.com/9846948/148533945-87adccb0-218b-4e5f-96ce-c64118a5a242.png)
