### PR TITLE
Removed bright sections of realmadridfin.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12238,8 +12238,7 @@ CSS
 #shoutbox_i,
 #shoutbox_nosound,
 #shoutbox_u,
-#shoutbox_u + img
-{
+#shoutbox_u + img {
     background-image: none !important;
 }
 #shoutbox_message {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12227,6 +12227,27 @@ CSS
 
 ================================
 
+realmadridfin.net
+
+CSS
+.button_submit,
+#content_section,
+#shoutbox_b,
+#shoutbox_color,
+#shoutbox_face,
+#shoutbox_i,
+#shoutbox_nosound,
+#shoutbox_u,
+#shoutbox_u + img
+{
+    background-image: none !important;
+}
+#shoutbox_message {
+    background-color: none !important;
+}
+
+================================
+
 realmicentral.com
 
 INVERT


### PR DESCRIPTION
Realmadridfin.net is a Finnish language fan forum of Real Madrid football club. It is using Simple Machine Forum web application and embedded chat extension.

There were 4 bugs:
- Element surrounding all content (#content_section) had a bright background image.
- Forum search button (.button_submit) had a bright background image. 
- Chat extension's text modification buttons (all ids containing "shoutbox", including one img without either id or class next to #shoutbox_u) had bright background images.
- Chat extension's message input element (#shoutbox_message) had bright background color.