### PR TITLE
Add turbowarp links to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -219,6 +219,7 @@ demonforums.net
 denims.tv
 denshi.org
 desktop.github.com
+desktop.turbowarp.org
 destiny.gg
 destinytracker.com
 devanbuggay.com
@@ -252,6 +253,7 @@ discuss.noisebridge.info
 disneyplus.com
 distrotube.com
 dlive.tv
+docs.turbowarp.org
 dodi-repacks.site
 dood.la
 doodstream.com
@@ -639,6 +641,7 @@ overcoder.dev
 overdodactyl.github.io/ShadowFox
 oxy.cannot.date
 p4pirate.xyz
+packager.turbowarp.org
 paimon.moe
 paper-io.com
 parahumans.wordpress.com
@@ -911,6 +914,7 @@ ttf.tf
 ttrms.io
 tube.kdy.ch
 tuner.ninja
+turbowarp.org
 tusharsadhwani.dev
 twelvesmith.com
 twist.moe


### PR DESCRIPTION
Added the following sites to `dark-sites.config`: 

[turbowarp](https://turbowarp.org) (has a dark mode toggle)
[turbowarp desktop](https://desktop.turbowarp.org) & [turbowarp packager](https://packager.turbowarp.org) (both have dark mode only)
[turbowarp docs](https://docs.turbowarp.org) (has a dark mode toggle)