### PR TITLE
Fix minesweeper.online (dynamic)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9811,6 +9811,13 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+minesweeper.online
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
 miro.com
 
 INVERT


### PR DESCRIPTION
The game boards cells were broken due to image analysis.