### PR TITLE
whitemad.pl logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16161,6 +16161,14 @@ path[fill="currentColor"]
 
 ================================
 
+whitemad.pl
+
+INVERT
+#logo
+#cb-nav-logo
+
+================================
+
 who.int
 
 INVERT


### PR DESCRIPTION
https://www.whitemad.pl/niemcy-rosja-czechy-pawilony-naszych-sasiadow-na-expo-2020-w-dubaju/

![20220110-1641804619](https://user-images.githubusercontent.com/9846948/148739263-d8d7ffec-7fea-4a34-8a3d-d7d8af5e06ee.png)
![20220110-1641804613](https://user-images.githubusercontent.com/9846948/148739264-167a0c2b-68d4-4f5d-9b1f-237f04f8e627.png)
![20220110-1641804609](https://user-images.githubusercontent.com/9846948/148739266-11398ab4-45a4-40d1-b25c-d64304bfa27a.png)
