### PR TITLE
Add beta version of Crunchyroll

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -89,6 +89,7 @@ benleggiero.blog
 benleggiero.me
 bequiet.com
 bestblackhatforum.com
+beta.crunchyroll.com
 beta.destinyitemmanager.com
 betterdiscord.app
 betterttv.com


### PR DESCRIPTION
Apparently, the Crunchyroll's website on beta is in a dark theme by default.
After some hours there, i still didn't found a "toggle switch" or anything to change to a "light theme", so I think it's the only theme they made.


Here's some screenshots of this version:

![Screenshot from 2022-01-10 23-19-06](https://user-images.githubusercontent.com/15145998/148876605-44fb5fe9-51b1-4117-8461-4d19ba0c02ba.png)
![Screenshot from 2022-01-10 23-19-53](https://user-images.githubusercontent.com/15145998/148876469-70302cbb-8a7e-44b5-bafa-d86c0485118c.png)
![Screenshot from 2022-01-10 23-20-27](https://user-images.githubusercontent.com/15145998/148876478-4416189d-fc26-448e-8d3e-92fe0e44b7e5.png)