### PR TITLE
Duolingo - Fix for inverted animations

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4719,6 +4719,7 @@ button[aria-disabled="true"] > span {
 
 IGNORE INLINE STYLE
 div[data-test="challenge-translate-prompt"] svg *
+div[data-test="challenge challenge-translate"] svg *
 
 ================================
 


### PR DESCRIPTION
Fixed Duolingo SVG incorrectly inverted on animation.
Left old "challenge-translate-prompt" intact incase it is still being used