### PR TITLE
onet.pl weather widget tabs icons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11118,6 +11118,7 @@ img[alt="O!Konto"]
 img[alt="Plejada.pl"]
 svg[class="menuIconClose"]
 ul.contentList img.icon
+.weatherExtrasWidget__category-image img
 
 CSS
 .mainBoxBgHolder {


### PR DESCRIPTION
https://pogoda.onet.pl/prognoza-pogody/warszawa-357732

![20220112-1642020224](https://user-images.githubusercontent.com/9846948/149219116-ce7aaa43-f1e6-4a0a-b767-53b9c164656b.png)

`Raport Smogowy` etc. 