### PR TITLE
Fix for tails.boum.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14469,8 +14469,17 @@ tails.boum.org
 
 CSS
 body {
-    background-image: none !important; 
+    background-image: none !important;
 }
+#donate-banner p {
+    color: var(--darkreader-neutral-background) !important;
+}
+#donate-banner u {
+    border-bottom-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE IMAGE ANALYSIS
+#donate-banner
 
 ================================
 


### PR DESCRIPTION
Fixes donate banner.

Before:
![1](https://user-images.githubusercontent.com/6563728/149628019-7e7a94da-419e-43ef-b528-6625c4c034ee.png)

After:
![2](https://user-images.githubusercontent.com/6563728/149628021-f8d3e0c9-ee9b-49b1-b2d5-cac88ada99fc.png)