### PR TITLE
Remove useless statement

### DIFF
--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -50,7 +50,6 @@ export function parseGradient(value: string): parsedGradient[] {
         });
 
         if (!typeGradient) {
-            startIndex = index + conicGradientLength;
             break;
         }
 


### PR DESCRIPTION
- It's only used in the loop, but the loop is being aborted.