### PR TITLE
fix: avoid double invert on chromium

### DIFF
--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -4,6 +4,7 @@ import type {SitePropsIndex} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
 import type {DynamicThemeFix} from '../definitions';
+import {isChromium} from '../utils/platform';
 
 const dynamicThemeFixesCommands: { [key: string]: keyof DynamicThemeFix } = {
     'INVERT': 'invert',
@@ -71,7 +72,11 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, text: str
         ignoreImageAnalysis: genericFix.ignoreImageAnalysis || [],
     };
     if (enabledForPDF) {
-        common.css += '\nembed[type="application/pdf"] { filter: invert(100%) contrast(90%); }';
+        if (isChromium) {
+            common.css += '\nembed[type="application/pdf"][src="about:blank"] { filter: invert(100%) contrast(90%); }';
+        } else {
+            common.css += '\nembed[type="application/pdf"] { filter: invert(100%) contrast(90%); }';
+        }
     }
     const sortedBySpecificity = fixes
         .slice(1)


### PR DESCRIPTION
- Avoid double inverting a pdf on Chromium browsers.
- Resolves #7949