### PR TITLE
fix amazon.* video titles

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -750,6 +750,9 @@ img[src*="smile-logo"]
 .a-icon-popover
 .a-link-nav-icon
 .currencyINR
+div.vse-video-title
+div.vse-video-labels
+i.a-icon-search
 
 CSS
 .banner-border {


### PR DESCRIPTION
Fixes video titles and search icon:
![image](https://user-images.githubusercontent.com/72410860/149701835-96170401-eb91-407b-9e50-0ca20b68f57e.png)
![image](https://user-images.githubusercontent.com/72410860/149701856-ec087e86-dcfe-413d-aa2a-e1891279d1f5.png)

before:
![image](https://user-images.githubusercontent.com/72410860/149701886-f42c4630-5273-48b8-80f4-166a3d50c1cc.png)
![image](https://user-images.githubusercontent.com/72410860/149701903-6edb78a8-17a6-4adf-8346-d2284bae4a11.png)
