### PR TITLE
Enable native dark for jw.org

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1000,6 +1000,7 @@ www.chiefdelphi.com
 www.digikam.org
 www.directvnow.com
 www.gotimelinr.com
+www.jw.org
 www.mtv.com
 www.netflix.com
 www.razer.com


### PR DESCRIPTION
https://www.jw.org is now dark-native, as announced in https://www.jw.org/finder?wtlocale=E&docid=702021419&srcid=share