### PR TITLE
Fix Slack.com dynamic theme

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13408,8 +13408,17 @@ body {
 
 slack.com
 
-INVERT
-.slack_logo > img
+CSS
+.c-slacklogo svg path:first-child {
+    fill: var(--darkreader-selection-text) !important;
+}
+.c-button:not(.v--primary,.v--secondary) {
+    background: inherit !important;
+    color: inherit !important;
+}
+.c-button:not(.v--primary,.v--secondary):hover {
+    text-decoration: underline !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13412,11 +13412,11 @@ CSS
 .c-slacklogo svg path:first-child {
     fill: var(--darkreader-selection-text) !important;
 }
-.c-button:not(.v--primary,.v--secondary) {
+.c-button:not(.v--primary, .v--secondary) {
     background: inherit !important;
     color: inherit !important;
 }
-.c-button:not(.v--primary,.v--secondary):hover {
+.c-button:not(.v--primary, .v--secondary):hover {
     text-decoration: underline !important;
 }
 


### PR DESCRIPTION
There are two issues with Slack.com's current dynamic fixes:
  - The invert logo on the homepage no longer works (the logo is now an SVG, and has a newly named class)
  - Buttons in the actual "app" aren't darkened properly

The first issue is resolved by coloring the first path of the logo's SVG element. This is the only way to select the text part of the logo as they have not named the paths, and the colorful "pips" of the logo are part of the same SVG element.

The second issue is resolved by letting the buttons inherit their text color and background. With that change, there is no indication when hovering, so I added a basic underline decoration for that. I also took care not to enable it for primary and secondary buttons which seem to be handled fine by the dynamic mode. Unfortunately, it does have a side effect - some buttons which were previously "colored" (see example below) are now greyer, but it was the only solution I could find that works in both light and dark schemes.

Fixing only button background works fine in the dark scheme
![Screenshot_2022-01-19_00-58-39](https://user-images.githubusercontent.com/283676/150038453-e5035246-8e66-4844-bdb3-4fad07acd691.png)
but less so in the light scheme:
![Screenshot_2022-01-19_00-58-09](https://user-images.githubusercontent.com/283676/150038597-5dab4083-60a1-4e41-9552-ff909e48d7f7.png)

The result when fixing both looks like this - first in the dark scheme:
![image](https://user-images.githubusercontent.com/283676/150038687-ee8fbb6b-b81f-4336-9621-333c1953ea4f.png)
and in the light scheme:
![image](https://user-images.githubusercontent.com/283676/150038731-407b78f5-89b1-46bb-987c-614cffff87c6.png)

