### PR TITLE
Improve sjc.cengagenow.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3548,6 +3548,30 @@ INVERT
 
 ================================
 
+cxp.cengage.com
+
+INVERT
+.owl_item_container img[src*=".gif"]
+.ci-feedback img[src*=".gif"]
+label img[src*=".gif"]
+span.MathJax_SVG
+
+CSS
+.owl_item_container img[src*=".GIF"] {
+    background-color: ${black};
+}
+font[color="white"] {
+    color: transparent !important;
+}
+div.tool-container.gradient > .controlButtons {
+    background-image: none;
+}
+div.tool-container.gradient {
+    box-shadow: none;
+}
+
+================================
+
 cynkra.com
 
 INVERT


### PR DESCRIPTION
This is not a proper fix in the sense that I am not sure it will work on every page - sadly, nobody will ever be sure dark reader will work on every page of this site. For context, this is a homework site. If I didn't know better I would say this pages design was intentionally adversarial to inversion. It is doing a number of *questionable* things, like sectioning the page in iframes, (which is why the targeted domain is different from the domain being fixed) and using font blocks of periods colored white for tabs. Images have no classes, identifiers, or wrappers to distinguish their use as math symbols or photos. Many wild things happen, but only on one question. This leads me to believe the layout of a given page or section is handcrafted, by different people, rather then templated - there are in many cases no good selectors that are specific enough for our use.

This pr works great on the assignments I have done so far, with one example of inverting an image that should get a background instead. All caps .GIF in the url *usually* means a file is not intentionally transparent, and lowercase gif means it is, and should be inverted (math symbols). However, this doesn't always hold true.

I don't know how this sort of site is handled - it seems impossible to fix, but this pr makes it better, usable for me. I can't even go back to the assignment and take screenshots, I don't think you can make an account without a textbook.

As I keep doing assignments, I will keep making fixes where I find the aforementioned heuristics breaking.

How is this sort of thing handled?