### PR TITLE
Fix time automation

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -56,6 +56,7 @@ export function nextTimeInterval(time0: string, time1: string, date: Date = new 
         // Schedule for todate at time a
         date.setHours(a[0]);
         date.setMinutes(a[1]);
+        date.setSeconds(0);
         return date.getTime();
     }
 
@@ -64,6 +65,7 @@ export function nextTimeInterval(time0: string, time1: string, date: Date = new 
         // Schedule for today at time b
         date.setHours(b[0]);
         date.setMinutes(b[1]);
+        date.setSeconds(0);
         return date.getTime();
     }
 


### PR DESCRIPTION
- Set second to `0`, such that the toggle will happen on the exact minute and not after 30 seconds or so.
- Resolves #7996