### PR TITLE
Improve theme for metrics.torproject.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9853,10 +9853,10 @@ g > line
 
 CSS
 .dot {
-    fill: ${white}  !important;
+    fill: var(--darkreader-neutral-background) !important;
 }
 div > img[src] {
-    filter: invert(90%)  !important;
+    filter: invert(90%) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9847,7 +9847,6 @@ IGNORE IMAGE ANALYSIS
 metrics.torproject.org
 
 INVERT
-img[class="inline"]
 img[src^="/images/flags/"]
 g > text
 g > line

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9844,6 +9844,24 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+metrics.torproject.org
+
+INVERT
+img[class="inline"]
+img[src^="/images/flags/"]
+g > text
+g > line
+
+CSS
+.dot {
+    fill: ${white}  !important;
+}
+div > img[src] {
+    filter: invert(90%)  !important;
+}
+
+================================
+
 mewe.com
 
 CSS


### PR DESCRIPTION
Changes:
- In relay search, apply inversion to the [icons](https://metrics.torproject.org/rs.html#toprelays) (relay flags)
- In relay search [graph history](https://metrics.torproject.org/rs.html#details/18EAE30A4585BEB0D63D36BCFE3F9CA786CB55C7), invert the graph line and text of the graph ticks. Also fill color of dots in the graph.
- The graphs for the [users/servers/traffic](https://metrics.torproject.org/userstats-relay-country.html) etc pages have custom inversion on them. I'm aware this will make the graph have a black background in a light theme. Is there a way to detect dark mode and only apply this there? (i'm not very good at CSS). If not, I can move this to the invert section instead.