### PR TITLE
Don't invert wikipedia images.

### DIFF
--- a/src/config/fix_inversion.json
+++ b/src/config/fix_inversion.json
@@ -896,6 +896,10 @@
             "noinvert": [
                 ".mwe-math-fallback-image-inline",
                 ".mwe-math-fallback-image-display"
+            ],
+            "rules": [
+                ".image, .mw-mmv-image { filter: invert(1); }",
+                ".mw-mmv-image { background-color: black; }"
             ]
         },
         {


### PR DESCRIPTION
This also fixes the lightbox element's white background.

Try as I might, I was unsuccessful getting any of the "invert", "noinvert", or "removebg" properties to work for either of these image tags so the custom "rules" was the best I could do.