### PR TITLE
Improved Canvas PDF Viewer Inversion

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7791,7 +7791,7 @@ instructure.com
 
 INVERT
 .equation_image
-.ef-file-preview-stretch
+.Page-container
 
 ================================
 


### PR DESCRIPTION
More selective CSS class selection for inversion that inverts the pages only, and not the background.

Old / Previous:
![image](https://user-images.githubusercontent.com/29745705/151476863-76211c37-9263-45ba-8fc5-20cffc67b587.png)

New / Proposed:
![image](https://user-images.githubusercontent.com/29745705/151476941-5cc50492-ec1f-4a63-b61c-452641121121.png)
