### PR TITLE
Fixes side panel shopping cart overlaying items

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -114,7 +114,6 @@ CSS
 #nav-flyout-ewc {
     margin-right: -220px;
 }
-
 .nav-flyout-body {
     height: 100% !important;
 }

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -115,6 +115,10 @@ CSS
     margin-right: -220px;
 }
 
+.nav-flyout-body {
+    height: 100% !important;
+}
+
 ================================
 
 anankeiot.com


### PR DESCRIPTION
In all 4 filters (I primarily use Filter or Filter+), when you have an item or more in your cart, the "Saved For Later" button is on the right will overlap the items in your cart and you can't view them. That is because the nav-flyout-body has an inner style of a hardcoded height. Giving it 100% lets it re-inherit a style it had from another css class and fixes the issue.

Example: Add this item to your cart and then go to any item. Without the CSS, you won't be able to scroll or quickly view your items currently in your cart. With the added fix, you will be able to as it removes the hardcoded size for the height of the side panel.

https://www.amazon.com/Nirvana-Poster-Promo-Concert-Germany/dp/B01EGR4BAW/ref=pd_day0fbt_img_1/141-8784869-0283737?pd_rd_w=twlyZ&pf_rd_p=bcb8482a-3db5-4b0b-9f15-b86e24acdb00&pf_rd_r=YRBJRW91TNZ3K5HR0276&pd_rd_r=09b8ff46-99d8-45d2-a091-1d5380299ad7&pd_rd_wg=tt3bv&pd_rd_i=B01EGR4BAW&psc=1

https://smile.amazon.com/Nirvana-Poster-Promo-Concert-Germany/dp/B01EGR4BAW/ref=pd_day0fbt_img_1/141-8784869-0283737?pd_rd_w=twlyZ&pf_rd_p=bcb8482a-3db5-4b0b-9f15-b86e24acdb00&pf_rd_r=YRBJRW91TNZ3K5HR0276&pd_rd_r=09b8ff46-99d8-45d2-a091-1d5380299ad7&pd_rd_wg=tt3bv&pd_rd_i=B01EGR4BAW&psc=1