### PR TITLE
Use longer timeout for mutex

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -131,7 +131,7 @@ export async function writeSyncStorage<T extends {[key: string]: any}>(values: T
                 return;
             }
             resolve();
-            setTimeout(() => mutexStorageWriting.unlock(), 500);
+            setTimeout(() => mutexStorageWriting.unlock(), 5000);
         });
     });
 }
@@ -141,7 +141,7 @@ export async function writeLocalStorage<T extends {[key: string]: any}>(values: 
         await mutexStorageWriting.lock();
         chrome.storage.local.set(values, () => {
             resolve();
-            setTimeout(() => mutexStorageWriting.unlock(), 500);
+            setTimeout(() => mutexStorageWriting.unlock(), 5000);
         });
     });
 }


### PR DESCRIPTION
- Use a longer mutex in order to take into account for `sync` storage to get notified for a "update".
- Resolves #8056