### PR TITLE
czasnastopy.pl logo header fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3602,6 +3602,13 @@ INVERT
 
 ================================
 
+czasnastopy.pl
+
+INVERT
+.brandinglogo-wrap
+
+================================
+
 czypada.pl
 
 INVERT


### PR DESCRIPTION
https://www.czasnastopy.pl/

![20220129-1643463540](https://user-images.githubusercontent.com/9846948/151663268-c4b447dc-4fb2-475d-bbbb-4c229a64f6eb.png)
