### PR TITLE
sematext.com fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13288,6 +13288,14 @@ CSS
 
 ================================
 
+sematext.com
+
+INVERT
+#logo
+.sematext-clients-gamma figure
+
+================================
+
 sembr.org
 
 CSS


### PR DESCRIPTION
https://sematext.com/
![20220130-1643531632](https://user-images.githubusercontent.com/9846948/151692615-109fd2a9-62d0-4879-9e99-14135351796c.png)
