### PR TITLE
Fix for tastoid.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14746,6 +14746,15 @@ INVERT
 
 ================================
 
+tastoid.com/
+
+CSS
+.jumbotron.jumbotron-no-bg {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 tcrf.net
 
 CSS


### PR DESCRIPTION
Fixed a white text on white background on certain pages.

Example: https://tastoid.com/person/6357/matthew-mcconaughey/
Before: https://i.imgur.com/XHR0kpz.png
After: https://i.imgur.com/nn8dTIH.png