### PR TITLE
Add twnft.vercel.app to list of dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -932,6 +932,7 @@ tuner.ninja
 tusharsadhwani.dev
 twelvesmith.com
 twist.moe
+twnft.vercel.app
 tycrek.com
 tynker.com/ide
 typing.works


### PR DESCRIPTION
Added [https://twnft.vercel.app/](https://twnft.vercel.app/) to list of already dark sites