### PR TITLE
Fix for messenger.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9835,6 +9835,9 @@ CSS
 .j7vl6m33, .a8c37x1j, .bp9cbjyn, mask[id*="jsc_c"] > circle {
     fill: var(--always-white) !important;
 }
+.a8c37x1j > rect {
+  fill: var(--darkreader-bg--fds-white) !important;
+}
 :root, .__fb-light-mode {
     --filter-disabled-icon: invert(100%) opacity(30%) !important;
     --filter-placeholder-icon: invert(59%) sepia(11%) saturate(200%) saturate(135%) hue-rotate(176deg) brightness(96%) contrast(94%) !important;


### PR DESCRIPTION
This fixes a part of the input box that isn't styled.

Before:
![before](https://user-images.githubusercontent.com/1844269/151834956-b63aef81-33f1-4936-a259-d8dd4222e270.png)
After:
![after](https://user-images.githubusercontent.com/1844269/151834975-e4e441c9-2c82-4558-b7e1-a3a023b0f548.png)
