### PR TITLE
Fix theme for paste.rs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11713,6 +11713,15 @@ INVERT
 
 ================================
 
+paste.rs
+
+CSS
+pre {
+    --darkreader-inline-bgcolor: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 paulgraham.com
 
 CSS


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/11978847/151934584-a82784f7-d98b-449a-bcf4-6043c7c6e3bf.png)

After:
![grafik](https://user-images.githubusercontent.com/11978847/151934648-1723e49e-f3c5-420b-bb34-ebb280eb3f56.png)

Otherwise with some code highlighting it can get difficult to read.

Not sure if this is the best way to set that background, but due to `--darkreader-inline-bgcolor` I was not able to set it in the normal way.