### PR TITLE
Adding Vercel in default dark site

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -955,6 +955,7 @@ valvestore.forfansbyfans.com
 vancedapp.com
 vanillatweaks.net
 vcjhwebdev.github.io/useless-translator/
+vercel.com
 verify.bots.gg
 vexbot.tk
 vid.puffyan.us


### PR DESCRIPTION
vercel.com has default darkmode