### PR TITLE
msi.com support page del img bckd

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10322,7 +10322,9 @@ a.logo
 .flickity-button-icon
 
 CSS
-#MSI_Support .top-headBg {
+#MSI_Support .top-headBg,
+#MSI_Support .top-head,
+#MSI_Support .main-contact-support {
     background-image: none !important;
 }
 .related__link > .related__title,


### PR DESCRIPTION
https://www.msi.com/support (global site)

![Przechwytywanie zawartości sieci Web_1-2-2022_182447_www msi com](https://user-images.githubusercontent.com/9846948/152018717-6ab8053b-8336-4fd8-add8-a9de6329ed00.jpeg)
