### PR TITLE
Fixed the images not visible in chem.libretexts.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2703,11 +2703,8 @@ header .logo
 
 chem.libretexts.org
 
-CSS
-.internal {
-    background-image: none !important;
-    background-color: ${black} !important;
-}
+INVERT
+.internal
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2701,6 +2701,16 @@ header .logo
 
 ================================
 
+chem.libretexts.org
+
+CSS
+.internal {
+    background-image: none !important;
+    background-color: ${black} !important;
+}
+
+================================
+
 chilkatsoft.com
 
 CSS


### PR DESCRIPTION
Before this, the images weren't visible. This change fixes it there and now at least images are visible but they have a white background.

Before:
![image](https://user-images.githubusercontent.com/40143545/152044006-1d1ef7fc-eba3-48d5-a0cc-3a613cd1c8a1.png)

After:
![image](https://user-images.githubusercontent.com/40143545/152043884-d945418d-428d-4359-8c82-d04a223ae798.png)
