### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12975,6 +12975,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+royalbank.com
+
+CSS
+.rbc-select-input {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 rp.pl
 
 INVERT


### PR DESCRIPTION
Fixing the transparent background of the drop-down menus with white text on RBC bank -royalbank.com- website.