### PR TITLE
Fix auto-watch when running `npm run test:inject:debug`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-      
+          node-version: 15.x
+
+      - name: Verify NPM version
+        run: npm --version
+
       - name: Set up npm cache
         uses: actions/cache@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Build files
 #-----------------------------------
-build/
+build*/
 darkreader.js
 debug.log
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "karma-coverage": "2.1.0",
         "karma-firefox-launcher": "2.1.2",
         "karma-jasmine": "4.0.1",
-        "karma-rollup-preprocessor": "7.0.7",
+        "karma-rollup-preprocessor": "github:jlmakes/karma-rollup-preprocessor#master",
         "karma-safari-launcher": "1.0.0",
         "less": "4.1.2",
         "malevic": "0.18.6",
@@ -7911,9 +7911,9 @@
     },
     "node_modules/karma-rollup-preprocessor": {
       "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.7.tgz",
-      "integrity": "sha512-Y1QwsTCiCBp8sSALZdqmqry/mWIWIy0V6zonUIpy+0/D/Kpb2XZvR+JZrWfacQvcvKQdZFJvg6EwlnKtjepu3Q==",
+      "resolved": "git+ssh://git@github.com/jlmakes/karma-rollup-preprocessor.git#de386a6a84664391f178bfe5b4a20a504437dde0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.3.1",
         "debounce": "^1.2.0"
@@ -18297,10 +18297,9 @@
       }
     },
     "karma-rollup-preprocessor": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/karma-rollup-preprocessor/-/karma-rollup-preprocessor-7.0.7.tgz",
-      "integrity": "sha512-Y1QwsTCiCBp8sSALZdqmqry/mWIWIy0V6zonUIpy+0/D/Kpb2XZvR+JZrWfacQvcvKQdZFJvg6EwlnKtjepu3Q==",
+      "version": "git+ssh://git@github.com/jlmakes/karma-rollup-preprocessor.git#de386a6a84664391f178bfe5b4a20a504437dde0",
       "dev": true,
+      "from": "karma-rollup-preprocessor@github:jlmakes/karma-rollup-preprocessor#master",
       "requires": {
         "chokidar": "^3.3.1",
         "debounce": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "karma-coverage": "2.1.0",
     "karma-firefox-launcher": "2.1.2",
     "karma-jasmine": "4.0.1",
-    "karma-rollup-preprocessor": "7.0.7",
+    "karma-rollup-preprocessor": "github:jlmakes/karma-rollup-preprocessor#master",
     "karma-safari-launcher": "1.0.0",
     "less": "4.1.2",
     "malevic": "0.18.6",

--- a/tasks/paths.js
+++ b/tasks/paths.js
@@ -8,5 +8,8 @@ module.exports = {
     getDestDir: function ({debug, platform}) {
         const buildTypeDir = `build/${debug ? 'debug' : 'release'}`;
         return `${buildTypeDir}/${platform}`;
-    }
+    },
+    getTestDestDir: function () {
+        return `build-tests`;
+    },
 };

--- a/tests/inject/karma.conf.js
+++ b/tests/inject/karma.conf.js
@@ -5,6 +5,7 @@ const rollupPluginNodeResolve = require('@rollup/plugin-node-resolve').default;
 const rollupPluginReplace = require('@rollup/plugin-replace');
 const rollupPluginTypescript = require('@rollup/plugin-typescript');
 const typescript = require('typescript');
+const {getTestDestDir} = require("../../tasks/paths");
 
 module.exports = (config) => {
     config.set({

--- a/tests/inject/karma.conf.js
+++ b/tests/inject/karma.conf.js
@@ -5,7 +5,7 @@ const rollupPluginNodeResolve = require('@rollup/plugin-node-resolve').default;
 const rollupPluginReplace = require('@rollup/plugin-replace');
 const rollupPluginTypescript = require('@rollup/plugin-typescript');
 const typescript = require('typescript');
-const {getTestDestDir} = require("../../tasks/paths");
+const {getTestDestDir} = require('../../tasks/paths');
 
 module.exports = (config) => {
     config.set({

--- a/tests/inject/karma.conf.js
+++ b/tests/inject/karma.conf.js
@@ -41,6 +41,7 @@ module.exports = (config) => {
                 }),
             ],
             output: {
+                dir: `${getTestDestDir()}`,
                 strict: true,
                 format: 'iife',
                 sourcemap: 'inline',


### PR DESCRIPTION
When running `npm run test:inject:debug`, watching/reloading is done by the karma-rollup-preprocessor plugin. That plugin needed to be upgraded to its prerelease version at master before this was fixed. 

A screencast that shows the problem and the fix:

- [asciicast](https://asciinema.org/a/96heBpMmTJK2VUkZYROfSMc7q)

Side note, [I've left a note](https://github.com/jlmakes/karma-rollup-preprocessor/issues/72#issuecomment-1029080510) over at jlmakes/karma-rollup-preprocessor asking when the new version will be coming out, at which time you would be able to remove the URL from package.json.