### PR TITLE
ebok.enea.pl bckgrd bulb img make black

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5163,6 +5163,10 @@ CSS
 .col-lg-12.col-md-12 > div > div > p {
     color: var(--darkreader-neutral-background) !important;
 }
+.bkg-icon,
+.left-bkg-icon {
+    color: ${white} !important;
+}
 
 ================================
 


### PR DESCRIPTION
Make bulb black. Data about account usage power, stats visible properly again. Removed sensitive identify details from screenshot.
![20220203-1643912758](https://user-images.githubusercontent.com/9846948/152405917-2d4b8f05-d698-4e17-88ec-5b3fe97206ee.png)
