### PR TITLE
tygodnikkrag.pl header logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15809,6 +15809,13 @@ header {
 
 ================================
 
+tygodnikkrag.pl
+
+INVERT
+#header-logo-image
+
+================================
+
 typescriptlang.org
 
 CSS


### PR DESCRIPTION
https://tygodnikkrag.pl/

![20220204-1643988043](https://user-images.githubusercontent.com/9846948/152554822-b790ca4f-661b-4683-9631-7555c5be9395.png)
