### PR TITLE
40ton.net header logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -214,6 +214,13 @@ img[alt="Zespół 300Gospodarki"]
 
 ================================
 
+40ton.net
+
+INVERT
+.td-main-logo
+
+================================
+
 4pda.ru
 
 CSS


### PR DESCRIPTION
https://40ton.net/

![20220204-1643988507](https://user-images.githubusercontent.com/9846948/152555887-b117b04e-46ef-450b-844c-3bddd21b8b03.png)
