### PR TITLE
subiektywnieofinansach.pl logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14527,6 +14527,13 @@ mark {
 
 ================================
 
+subiektywnieofinansach.pl
+
+INVERT
+.logo
+
+================================
+
 subscene.com
 
 CSS


### PR DESCRIPTION
https://subiektywnieofinansach.pl
![20220205-1644039617](https://user-images.githubusercontent.com/9846948/152630310-23550108-6ad5-426f-9d4b-847ba5909c71.png)
![20220205-1644039730](https://user-images.githubusercontent.com/9846948/152630309-b8aa3a29-4a17-4d52-a44e-98b5e58db41f.png)

Arrows menus are hardcoded CSS `background-image`. Inverted logo only.