### PR TITLE
Revert "Affect img elements with filters (#6044)"

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -9,7 +9,7 @@ import {removeNode, watchForNodePosition, iterateShadowHosts, isDOMReady, remove
 import {logInfo, logWarn} from '../../utils/log';
 import {throttle} from '../../utils/throttle';
 import {clamp} from '../../utils/math';
-import {FilterMode, getCSSFilterValue} from '../../generators/css-filter';
+import {getCSSFilterValue} from '../../generators/css-filter';
 import {modifyBackgroundColor, modifyColor, modifyForegroundColor} from '../../generators/modify-colors';
 import {createTextStyle} from '../../generators/text-style';
 import type {FilterConfig, DynamicThemeFix} from '../../definitions';
@@ -86,27 +86,18 @@ function createStaticStyleOverrides() {
     setupNodePositionWatcher(textStyle, 'text');
 
     const invertStyle = createOrUpdateStyle('darkreader--invert');
-    let invertStyleContent = '';
     if (fixes && Array.isArray(fixes.invert) && fixes.invert.length > 0) {
-        invertStyleContent += [
+        invertStyle.textContent = [
             `${fixes.invert.join(', ')} {`,
             `    filter: ${getCSSFilterValue({
                 ...filter,
                 contrast: filter.mode === 0 ? filter.contrast : clamp(filter.contrast - 10, 0, 100),
             })} !important;`,
             '}',
-            '',
         ].join('\n');
+    } else {
+        invertStyle.textContent = '';
     }
-    const imageFilter = getCSSFilterValue({
-        ...filter,
-        // Disables the invert() hue-rotate()
-        mode: FilterMode.light
-    });
-    if (imageFilter) {
-        invertStyleContent += `img { filter: ${imageFilter} !important;\n`;
-    }
-    invertStyle.textContent = invertStyleContent;
     document.head.insertBefore(invertStyle, textStyle.nextSibling);
     setupNodePositionWatcher(invertStyle, 'invert');
 


### PR DESCRIPTION
This reverts commit 29a9a12b6f10260040b0a666cdd088ae90b36575.

This is causing by far more issues than I'd anticipated, removing for now and can be merged back in once I'd have a better plan to correctly use those.

- Resolves #8145