### PR TITLE
fix for facebook.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5529,7 +5529,7 @@ a[role="link"] > i.hu5pjgll, ._3w97 {
 ._2yu8 {
     background-color: rgba(255, 255, 255, .5) !important;
 }
-.leaflet-map-pane img[src*="theme=default"], [style*="map"],
+.leaflet-map-pane img[src*="theme=default"], [style*="map"][style*="theme=default"],
 ._8bb_ img[src*="/map"], ._8bb_ [style*="map"],
 img[src*="mapy.cz"], ._8bb_ img[src*="mapy.cz"],
 img[src*="%2Fmap"], ._8bb_ img[src*="%2Fmap"],

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5529,7 +5529,7 @@ a[role="link"] > i.hu5pjgll, ._3w97 {
 ._2yu8 {
     background-color: rgba(255, 255, 255, .5) !important;
 }
-img[src*="/map"], [style*="map"],
+.leaflet-map-pane img[src*="theme=default"], [style*="map"],
 ._8bb_ img[src*="/map"], ._8bb_ [style*="map"],
 img[src*="mapy.cz"], ._8bb_ img[src*="mapy.cz"],
 img[src*="%2Fmap"], ._8bb_ img[src*="%2Fmap"],


### PR DESCRIPTION
Fix for white maps in Place Editor when dark mode enabled on facebook site.
Now only maps with default theme are inverted. If theme=dark then map is not touched.