### PR TITLE
Remove background clouds on spanish.kwiziq.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13980,6 +13980,9 @@ INVERT
 spanish.kwiziq.com
 
 CSS
+.bg-clouds {
+    background-image: none !important;
+}
 .table-scroll-shadow-wrapper table td,
 .table-scroll-shadow-wrapper table th,
 .table-scroll-shadow-wrapper table tr {


### PR DESCRIPTION
The website was recently updated with white, light gray, and light blue clouds behind the header element. Since the text is also light gray, it makes it almost impossible to make out.