### PR TITLE
Fix wired.com (dynamic mode)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17073,6 +17073,7 @@ wired.com
 
 INVERT
 body a svg
+a[data-testid="Logo"]
 .c-nav__open-icon
 .c-nav__close-icon
 .standard-navigation__logo-image > img


### PR DESCRIPTION
This fixes the logo at the top of the page.  I didn't create the other INVERT rules, so I don't know which (if any) are still needed.  You may want to check.