### PR TITLE
Adding automated extension submission via github action

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,17 @@
+name: Submit build to extension marketplace
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Github Release Assets
+        uses: plasmo-corp/download-release-asset@v1.0.0
+        with:
+          files: darkreader-*
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ tests/inject/coverage/
 # Cache files
 #-----------------------------------
 .eslintcache
+
+# Secret files
+#-----------------------------------
+keys.json


### PR DESCRIPTION
Hi friends,

Love darkreader, I've been a user since forever. Was looking for some way to contribute, and thought that maybe an automated submission pipeline for the release archive could be helpful. 

I integrated 2 github actions that I created:
- [download-release-asset](https://github.com/plasmo-corp/download-release-asset): this action download release files 
- [bpp](https://github.com/marketplace/actions/browser-plugin-publisher) this action can submit the zip to the Chrome/Firefox (safari in the work) stores automatically 

The action in this PR is set to run manually from the github action tab, but we can tweak it to run as frequent as needed! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key for chrome and firefox:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "zip": "./darkreader-chrome-mv3.zip",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./darkreader-firefox.xpi",
    "extId": "123",
    "apiKey": "abcd",
    "apiSecret": "efgh"
  }
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)