### PR TITLE
Fixed ufora.ugent.be

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16001,6 +16001,24 @@ IGNORE INLINE STYLE
 
 ================================
 
+ufora.ugent.be
+
+CSS
+.d2l-datalist-item-content{
+    background-color: #181a1b;
+}
+.d2l-menu-items{
+    background-color: #181a1b;
+}
+d2l-dropdown-menu{
+    background-color: #181a1b;
+}
+.d2l-course-selector-item-pinned{
+    background-color: #072c52
+}
+
+================================
+
 ultimate-guitar.com
 
 INVERT


### PR DESCRIPTION
ufora.ugent.be would show transparent elements that were supposed to be solid colors. Most of them are fixed now.