### PR TITLE
Fix for investopedia.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7993,6 +7993,14 @@ INVERT
 
 ================================
 
+investopedia.com
+
+INVERT
+.widget-ticker-container
+.mntl-dotdash-universal-nav__logo
+
+================================
+
 invisioncommunity.com
 
 INVERT


### PR DESCRIPTION
- Invert home page's stock ticker
- Invert Dotdash logo icon in footer