### PR TITLE
Update the NYT Crossword background colors

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11277,6 +11277,18 @@ a[data-testid] > svg {
 #xwd-board text[class^="Cell-hidden--"] {
     color: ${black} !important;
 }
+#xwd-board rect[class^="Cell-cell--"] {
+    fill: ${darkgrey} !important;
+}
+#xwd-board rect[class^="Cell-highlighted--"] {
+    fill: ${lightgrey} !important;
+}
+#xwd-board rect[class^="Cell-selected--"] {
+    fill: ${white} !important;
+}
+#xwd-board rect[class^="Cell-related--"] {
+    fill: ${goldenrod} !important;
+}
 
 ================================
 


### PR DESCRIPTION
The NYT crossword board's background colors made black text hard to read. This PR updates some of the fill colors to enable more contrast.

New:
![image](https://user-images.githubusercontent.com/11667004/155014185-08b52fd0-9cdc-4b44-8428-0cd4bae6084b.png)

Old:
![image](https://user-images.githubusercontent.com/11667004/155014205-0ac542e8-0368-4b27-9bea-110d6cd89d2c.png)
