### PR TITLE
Fix for bulbagarden.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2375,6 +2375,15 @@ CSS
 
 ================================
 
+bulbagarden.net
+
+CSS
+body  {
+    background-image: none !important;
+}
+
+================================
+
 bulk.com
 
 INVERT


### PR DESCRIPTION
Background image wasn't inverted. More noticeable in bulbapedia.bulbagarden.net.