### PR TITLE
Invert GitHub icon for bugs.python.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2362,6 +2362,14 @@ th {
 
 ================================
 
+bugs.python.org
+
+INVERT
+img[title="has PR"]
+img[title="GitHub"]
+
+================================
+
 build-electronic-circuits.com
 
 INVERT


### PR DESCRIPTION
Invert GitHub icon inside the home page and issue page(login icon).