### PR TITLE
Fix for cnn.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3068,11 +3068,11 @@ cnn.com
 INVERT
 [data-test="section-link"] > svg:not(.business-logo-icon)
 img.metadata-header__logo
+svg.politics-logo-icon
 
 IGNORE INLINE STYLE
 svg.cnn-badge-icon
 svg.cnn-badge-icon > rect
-svg.politics-logo-icon
 svg.business-logo-icon
 
 ================================


### PR DESCRIPTION
- Invert politics section icon as CNN has switched it to a dark style.