### PR TITLE
Fix for distrowatch.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4383,7 +4383,8 @@ distrowatch.com
 
 INVERT
 img[src="images/cpxtu/dwbanner.png"]
-.NewsLogo > a
+.NewsLogo > a:first-of-type
+.TablesTitle > img
 
 CSS
 .NavMenu, 


### PR DESCRIPTION
- Don't invert the screenshots under the distro logos on home page list.
- Invert distro logo within details summary page.