### PR TITLE
Fixes for Wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17184,6 +17184,7 @@ body > .oo-ui-windowManager .vega .marks
 .wikiEditor-ui .oo-ui-iconElement-icon
 #p-personal .mw-echo-notifications-badge
 .oo-ui-icon-close
+.mw-ui-icon::before
 
 CSS
 .mwe-popups-discreet > svg,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17242,7 +17242,6 @@ body.mediawiki,
 
 IGNORE INLINE STYLE
 .legend-color
-.infobox > tbody > tr > td.infobox-subheader[style*="background-color"]
 #on_image_elements span
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
- The background color of the infobox header shouldn't be ignored, for example, https://en.wikipedia.org/wiki/Revolution_of_Dignity :
  <img width="1209" alt="Screen Shot 2022-02-27 at 11 31 58" src="https://user-images.githubusercontent.com/21101839/155867043-1cfb1aa9-ff07-481f-9f24-9d6eaaa98eed.png">

  The ignore rule was added for #7756, but this rule doesn't affect the pages mentioned in that issue anymore.

- The second commit inverts the icons like the language icon and contents expend icon on mobile page.