### PR TITLE
Fix for keyserver.pgp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8636,6 +8636,30 @@ CSS
 
 ================================
 
+keyserver.pgp.com
+
+INVERT
+a.button-text
+#ImPGPComHelp
+#ImPGPComHome
+[src="images/crystal_button_left.gif"]
+[src="images/crystal_button_left-dark.gif"]
+[src="images/crystal_button_right.gif"]
+[src="images/crystal_button_right-dark.gif"]
+[src="images/global_dir_logo_web.gif"]
+[background="images/crystal_button_fill.gif"]
+[background="images/crystal_button_fill-dark.gif"]
+
+CSS
+.card-top, .card-top-left-corner, .card-top-right-corner,
+.divide-fill,
+.header-bar-left, .header-bar-right,
+.title-left, .title-right {
+    background-image: none !important;
+}
+
+================================
+
 kfccoupons.co.nz
 
 CSS


### PR DESCRIPTION
- Invert logo and buttoms
- Remove half-black-half-white borders

Before:
<img width="468" alt="2022-02-27-15-00-22" src="https://user-images.githubusercontent.com/1006477/155883789-a9b8e616-7b59-4f79-acdb-2f7ea6590ee6.png">

After:
<img width="451" alt="2022-02-27-15-09-13" src="https://user-images.githubusercontent.com/1006477/155883792-99c764fb-9421-47cb-9b69-bfe1cbcf175a.png">
