### PR TITLE
Fix for ditu.baidu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4421,10 +4421,7 @@ INVERT
 .more-device
 #nearby-searchbox-hint
 #nearby-searchbox-hint-center
-.pass-forceverify-wrapper
-.pass-form-item
 .route-button
-.tang-foreground
 .tang-pass-qrcode-title
 #userSignPanel
 


### PR DESCRIPTION
- Remove some outdated fixes for login form

These are no longer the case now. Tested on both 4.9.45 and master.