### PR TITLE
Some extra commits for PR 8266: Remove log4js, Jest snapshot update, ...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "karma-rollup-preprocessor": "github:jlmakes/karma-rollup-preprocessor#master",
         "karma-safari-launcher": "1.0.0",
         "less": "4.1.2",
-        "log4js": "6.4.1",
         "malevic": "0.18.6",
         "prettier": "2.5.1",
         "puppeteer-core": "13.0.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "karma-rollup-preprocessor": "github:jlmakes/karma-rollup-preprocessor#master",
     "karma-safari-launcher": "1.0.0",
     "less": "4.1.2",
-    "log4js": "6.4.1",
     "malevic": "0.18.6",
     "prettier": "2.5.1",
     "puppeteer-core": "13.0.1",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,14 +1,14 @@
 {
     "compilerOptions": {
-        "target": "es2019",
+        "target": "ES2019",
         "baseUrl": ".",
-        "module": "es2015",
+        "module": "ES2015",
         "moduleResolution": "node",
         "lib": [
-            "es2015",
-            "es2017",
-            "dom",
-            "dom.iterable"
+            "ES2015",
+            "ES2017",
+            "Dom",
+            "DOM.Iterable"
         ],
         "types": [
             "chrome",

--- a/tests/browser/tsconfig.json
+++ b/tests/browser/tsconfig.json
@@ -1,11 +1,10 @@
 {
-    "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
         "target": "ES2019",
         "module": "CommonJS",
         "lib": [
-            "es2015",
-            "dom"
+            "ES2015",
+            "Dom"
         ],
         "types": [
             "chrome",

--- a/tests/inject/run.js
+++ b/tests/inject/run.js
@@ -1,5 +1,4 @@
 // @ts-check
-const {getLogger, levels: {DEBUG, INFO}} = require('log4js');
 const karma = require('karma');
 const path = require('path');
 const {createEchoServer} = require('./echo-server');
@@ -12,10 +11,11 @@ async function run() {
     const args = process.argv.slice(2);
     const debug = args.includes('--debug');
 
-    // Default logger is not set if config file doesn't load, so config errors are swallowed
-    getLogger().level = debug ? DEBUG : INFO;
-
-    const karmaConfig = karma.config.parseConfig(path.join(__dirname, './karma.conf.js'), /** @type {any} */({debug}));
+    const configFilePath = path.join(__dirname, './karma.conf.js');
+    /** @type {Object} */
+    const cliOptions = {debug};
+    const parseOptions = {throwErrors: true};
+    const karmaConfig = await karma.config.parseConfig(configFilePath, cliOptions, parseOptions);
 
     const echoServer = await createEchoServer(ECHO_SERVER_PORT);
     const karmaServer = new karma.Server(/** @type {any} */(karmaConfig), () => {

--- a/tests/project/__snapshots__/tsconf.tests.ts.snap
+++ b/tests/project/__snapshots__/tsconf.tests.ts.snap
@@ -17,17 +17,14 @@ Object {
     ],
     "module": "es6",
     "moduleResolution": "node",
-    "noEmit": true,
     "noImplicitAny": true,
+    "resolveJsonModule": true,
     "target": "es2019",
     "types": Array [
       "chrome",
       "offscreencanvas",
     ],
   },
-  "exclude": Array [
-    "node_modules",
-  ],
   "files": Array [
     "./defaults.ts",
     "./definitions.d.ts",
@@ -228,17 +225,14 @@ Object {
     ],
     "module": "es6",
     "moduleResolution": "node",
-    "noEmit": true,
     "noImplicitAny": true,
+    "resolveJsonModule": true,
     "target": "es5",
     "types": Array [
       "chrome",
       "offscreencanvas",
     ],
   },
-  "exclude": Array [
-    "../node_modules",
-  ],
   "files": Array [
     "./chrome.ts",
     "./fetch.ts",
@@ -252,7 +246,6 @@ Object {
   "compileOnSave": false,
   "compilerOptions": Object {
     "allowJs": true,
-    "baseUrl": "../../src",
     "downlevelIteration": true,
     "esModuleInterop": true,
     "jsx": "react",
@@ -265,7 +258,6 @@ Object {
     "moduleResolution": "node",
     "noEmit": true,
     "noImplicitAny": true,
-    "outDir": "./",
     "target": "es2019",
     "types": Array [
       "chrome",
@@ -274,17 +266,11 @@ Object {
       "puppeteer-core",
     ],
   },
-  "exclude": Array [
-    "../../src/node_modules",
-  ],
   "files": Array [
     "./coverage.js",
     "./environment.js",
     "./globals.d.ts",
-    "./jest.config.chrome.js",
-    "./jest.config.firefox.js",
     "./jest.config.js",
-    "./jest.config.shared.js",
     "./paths.js",
     "./server.js",
     "./dynamic/inline-override.tests.ts",
@@ -298,86 +284,13 @@ Object {
 }
 `;
 
-exports[`TypeScript project config file should parse and resolve correctly: tests/config 1`] = `
-Object {
-  "compileOnSave": false,
-  "compilerOptions": Object {
-    "allowJs": true,
-    "baseUrl": "../../src",
-    "downlevelIteration": true,
-    "jsx": "react",
-    "jsxFactory": "m",
-    "lib": Array [
-      "es6",
-      "es2017",
-      "dom",
-      "dom.iterable",
-    ],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "noImplicitAny": true,
-    "outDir": "./",
-    "target": "es2019",
-    "types": Array [
-      "jest",
-      "node",
-    ],
-  },
-  "exclude": Array [
-    "../../src/node_modules",
-  ],
-  "files": Array [
-    "./config.tests.ts",
-    "./jest.config.js",
-    "./locales.tests.ts",
-  ],
-}
-`;
-
-exports[`TypeScript project config file should parse and resolve correctly: tests/generators/utils 1`] = `
-Object {
-  "compileOnSave": false,
-  "compilerOptions": Object {
-    "allowJs": true,
-    "baseUrl": "../../../src",
-    "downlevelIteration": true,
-    "jsx": "react",
-    "jsxFactory": "m",
-    "lib": Array [
-      "es6",
-      "es2017",
-      "dom",
-      "dom.iterable",
-    ],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "noImplicitAny": true,
-    "outDir": "./",
-    "target": "es2019",
-    "types": Array [
-      "jest",
-      "node",
-    ],
-  },
-  "exclude": Array [
-    "../../../src/node_modules",
-  ],
-  "files": Array [
-    "./jest.config.js",
-    "./parse.tests.ts",
-  ],
-}
-`;
-
 exports[`TypeScript project config file should parse and resolve correctly: tests/inject 1`] = `
 Object {
   "compileOnSave": false,
   "compilerOptions": Object {
     "allowJs": true,
-    "baseUrl": "../../src",
     "downlevelIteration": true,
+    "esModuleInterop": true,
     "jsx": "react",
     "jsxFactory": "m",
     "lib": Array [
@@ -393,19 +306,18 @@ Object {
     "target": "es2019",
     "types": Array [
       "chrome",
-      "jasmine",
       "offscreencanvas",
+      "jasmine",
     ],
   },
   "exclude": Array [
-    "../../src/node_modules",
+    "./coverage",
   ],
   "files": Array [
     "./background-stub.ts",
     "./customize.ts",
     "./echo-client.ts",
     "./echo-server.js",
-    "./jest.config.js",
     "./karma.conf.js",
     "./polyfills.ts",
     "./run.js",
@@ -456,48 +368,6 @@ Object {
     "./utils/text.tests.ts",
     "./utils/time.tests.ts",
     "./utils/uid.tests.ts",
-  ],
-}
-`;
-
-exports[`TypeScript project config file should parse and resolve correctly: tests/utils 1`] = `
-Object {
-  "compileOnSave": false,
-  "compilerOptions": Object {
-    "allowJs": true,
-    "baseUrl": "../../src",
-    "downlevelIteration": true,
-    "jsx": "react",
-    "jsxFactory": "m",
-    "lib": Array [
-      "es6",
-      "es2017",
-      "dom",
-      "dom.iterable",
-    ],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "noImplicitAny": true,
-    "outDir": "./",
-    "target": "es2019",
-    "types": Array [
-      "jest",
-      "node",
-    ],
-  },
-  "exclude": Array [
-    "../../src/node_modules",
-  ],
-  "files": Array [
-    "./color.tests.ts",
-    "./jest.config.js",
-    "./math.tests.ts",
-    "./parsing.tests.ts",
-    "./promise-barrier.tests.ts",
-    "./text.tests.ts",
-    "./time.tests.ts",
-    "./uid.tests.ts",
   ],
 }
 `;


### PR DESCRIPTION
Some little things that I meant to include in PR 8266:

- https://github.com/darkreader/darkreader/pull/8266

---

Delayed test snapshot update for the changes in "Move unit tests" commit 21794ec6

Forgot to update the snapshot after the "Move unit tests" commit: [`ae371dc` (#8266)](https://github.com/darkreader/darkreader/pull/8266/commits/ae371dc0ddc27bf964138e2f40cc2ead3bf90dc2)

---

Remove log4js dependency (pass throwErrors: true to Karma instead)

In reference to [this discussion](https://github.com/darkreader/darkreader/pull/8266#discussion_r815495124)
