### PR TITLE
Fix tabletochki.org - Charity to help children with cancer in Ukraine

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15197,6 +15197,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+tabletochki.org
+
+INVERT
+.perekaz__list img
+
+================================
+
 tails.boum.org
 
 CSS


### PR DESCRIPTION
Fixes #8301 

Please accept pull and release right away.  Thanks.

They need our help more than ever. With this fix, people around the world will now be able to see they can also donate to this compassionate charity via multiple methods, including GlobalGiving at https://www.globalgiving.org/projects/war-in-ukraine-help-children-with-cancer/