### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18045,7 +18045,7 @@ a[aria-label="Tumblr"] > svg {
 nav.FhRnI > ul > li {
     filter: invert(100%) hue-rotate(180deg) contrast(200%) !important;
 }
-footer[role="contentinfo"] {
+footer[role="contentinfo"] > ul > li > a {
     filter: invert(0%) hue-rotate(180deg) contrast(200%) !important;
 }
 ul.AohpR > li > a {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18029,23 +18029,27 @@ INVERT
 div[role="progressbar"]
 
 CSS
-a[data-testid="google-login-button"] {
-    background-color: #0d0d0d !important;
-}
+a[data-testid="google-login-button"],
 a[data-testid="apple-login-button"] {
-    background-color: #0d0d0d !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 a[href="/"] > div > svg {
-    filter: invert(100%) hue-rotate(180deg) contrast(200%) !important;
+    fill: white !important;
 }
 a[href="/explore"] > svg {
-    filter: invert(0%) hue-rotate(180deg) contrast(200%) !important;
+    fill: white !important;
 }
 a[aria-label="Tumblr"] > svg {
-    filter: invert(100%) hue-rotate(180deg) contrast(200%) !important;
+    fill: white !important;
 }
 nav.FhRnI > ul > li {
     filter: invert(100%) hue-rotate(180deg) contrast(200%) !important;
+}
+footer[role="contentinfo"] {
+    filter: invert(0%) hue-rotate(180deg) contrast(200%) !important;
+}
+ul.AohpR > li > a {
+    filter: invert(0%) hue-rotate(180deg) contrast(200%) !important;
 }
 :root {
     --darkreader-bg--white: 23, 23, 23 !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10011,6 +10011,7 @@ medium.com
 INVERT
 .svgIcon
 .svgIcon-use
+div[role="separator"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5685,6 +5685,8 @@ body {
 }
 #mixed-content-footer,
 .community-header-wrapper,
+.top-ads-container,
+.bottom-ads-container,
 .global-footer {
     z-index: 1 !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16990,7 +16990,7 @@ CSS
 weblate.org
 
 INVERT
-h5.list-group-item-heading > svg 
+h5.list-group-item-heading > svg
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18051,6 +18051,7 @@ nav.FhRnI > ul > li {
     --darkreader-text--black: 228, 224, 218 !important;
     --darkreader-bg--secondary-accent: 31, 32, 34 !important;
 }
+
 ================================
 
 www.windy.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3612,6 +3612,7 @@ crowdin.com
 
 INVERT
 .crowdin-navbar__logo
+svg.logo-icon-projects
 #master-loader > .master-loader-logo
 #master-loader-progress.bar
 
@@ -16113,6 +16114,24 @@ INVERT
 
 tvtropes.org
 
+INVERT
+body.darthWiki > i
+body.wmgWiki > i
+.spi.darthwiki
+.spi.sugarwiki
+.spi.film
+.spi.headscratchers
+.spi.laconic-icon
+.spi.lightnovel
+.spi.manga
+.spi.nightmarefuel
+.spi.radar
+.spi.recap
+.spi.shoutout
+.spi.wmg
+.spi.ymmv
+img[src="/img/loading-alt.gif"]
+
 IGNORE IMAGE ANALYSIS
 body.sugarWiki #header-spacer-left::after
 body.sugarWiki #header-spacer-right::after
@@ -16962,6 +16981,13 @@ CSS
 .tile {
     background-color: var(--darkreader-neutral-background);
 }
+
+================================
+
+weblate.org
+
+INVERT
+h5.list-group-item-heading > svg 
 
 ================================
 
@@ -17995,13 +18021,34 @@ a[title="Tinkoff"]
 
 www.tumblr.com
 
+INVERT
+.QnWzN > div
+div[role="progressbar"]
+
 CSS
+a[data-testid="google-login-button"] {
+    background-color: #0d0d0d !important;
+}
+a[data-testid="apple-login-button"] {
+    background-color: #0d0d0d !important;
+}
+a[href="/"] > div > svg {
+    filter: invert(100%) hue-rotate(180deg) contrast(200%) !important;
+}
+a[href="/explore"] > svg {
+    filter: invert(0%) hue-rotate(180deg) contrast(200%) !important;
+}
+a[aria-label="Tumblr"] > svg {
+    filter: invert(100%) hue-rotate(180deg) contrast(200%) !important;
+}
+nav.FhRnI > ul > li {
+    filter: invert(100%) hue-rotate(180deg) contrast(200%) !important;
+}
 :root {
     --darkreader-bg--white: 23, 23, 23 !important;
     --darkreader-text--black: 228, 224, 218 !important;
     --darkreader-bg--secondary-accent: 31, 32, 34 !important;
 }
-
 ================================
 
 www.windy.com


### PR DESCRIPTION
- Crowdin: Logo at the top left when viewing projects
- Fandom: Didn't know if it was right to add these. They are ad sections, but their current absence could also confuse a user who isn't using an ad blocker.
- TVT: Backgrounds of Darth and WMG wikis + subpages icons + loading icon when searching
- Medium: Separator
- Weblate: Icon that indicates a string has a suggestion
- Tumblr: Logos and other elements in the main page, made white because the randomly selected background sometimes has low contrast with those unless they are white + Login with Google/Apple buttons + Video Progress Bar