### PR TITLE
Add developer.mozilla.org to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -225,7 +225,6 @@ deadbydaylight.com
 deadbydaylight.fandom.com
 deepweblinks.net
 defcon.org
-del.dog
 deltarune.com
 demonforums.net
 denims.tv
@@ -235,6 +234,7 @@ destiny.gg
 destinytracker.com
 devanbuggay.com
 devart.withgoogle.com
+developer.mozilla.org
 developerinsider.co
 developpement-systeme-exploitation.github.io/documentation
 di.fm


### PR DESCRIPTION
New design for MDN: https://hacks.mozilla.org/2022/03/a-new-year-a-new-mdn/

https://developer.mozilla.org/

Also, I removed a stale link that I happened to check out.