### PR TITLE
Add a Immediate modify option

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -34,6 +34,7 @@ export const DEFAULT_THEME: Theme = {
     styleSystemControls: !isCSSColorSchemePropSupported,
     lightColorScheme: 'Default',
     darkColorScheme: 'Default',
+    immediateModify: false,
 };
 
 export const DEFAULT_COLORSCHEME: ParsedColorSchemeConfig = {

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -64,6 +64,7 @@ export interface Theme {
     styleSystemControls: boolean;
     lightColorScheme: string;
     darkColorScheme: string;
+    immediateModify: boolean;
 }
 
 export type FilterConfig = Theme;

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -5,7 +5,7 @@ import type {StyleElement, StyleManager} from './style-manager';
 import {manageStyle, getManageableStyles, cleanLoadingLinks} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
 import {forEach, push, toArray} from '../../utils/array';
-import {removeNode, watchForNodePosition, iterateShadowHosts, isDOMReady, removeDOMReadyListener, cleanReadyStateCompleteListeners, addDOMReadyListener} from '../utils/dom';
+import {removeNode, watchForNodePosition, iterateShadowHosts, isDOMReady, removeDOMReadyListener, cleanReadyStateCompleteListeners, addDOMReadyListener, setIsDOMReady} from '../utils/dom';
 import {logInfo, logWarn} from '../../utils/log';
 import {throttle} from '../../utils/throttle';
 import {clamp} from '../../utils/math';
@@ -321,7 +321,7 @@ function createThemeAndWatchForUpdates() {
         watchForUpdates();
     }
 
-    if (document.hidden) {
+    if (document.hidden && !filter.immediateModify) {
         watchForDocumentVisibility(runDynamicStyle);
     } else {
         runDynamicStyle();
@@ -426,6 +426,13 @@ export function createOrUpdateDynamicTheme(filterConfig: FilterConfig, dynamicTh
         ignoredImageAnalysisSelectors = [];
         ignoredInlineSelectors = [];
     }
+
+    if (filter.immediateModify) {
+        setIsDOMReady(() => {
+            return true;
+        });
+    }
+
     isIFrame = iframe;
     if (document.head) {
         if (isAnotherDarkReaderInstanceActive()) {

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -192,8 +192,12 @@ export function iterateShadowHosts(root: Node, iterator: (host: Element) => void
     }
 }
 
-export function isDOMReady() {
+export let isDOMReady = () => {
     return document.readyState === 'complete' || document.readyState === 'interactive';
+};
+
+export function setIsDOMReady(newFunc: () => boolean) {
+    isDOMReady = newFunc;
 }
 
 const readyStateListeners = new Set<() => void>();

--- a/src/ui/popup/theme/controls/immediate-modify.tsx
+++ b/src/ui/popup/theme/controls/immediate-modify.tsx
@@ -1,0 +1,16 @@
+import {m} from 'malevic';
+import {DropDown} from '../../../controls';
+import ThemeControl from './theme-control';
+
+export default function ImmediateModify(props: {value: boolean; onChange: (value: boolean) => void}) {
+    const options = [{id: true, content: 'Yes'}, {id: false, content: 'No'}];
+    return (
+        <ThemeControl label="Immediate modify">
+            <DropDown
+                options={options}
+                onChange={props.onChange}
+                selected={props.value}
+            />
+        </ThemeControl>
+    );
+}

--- a/src/ui/popup/theme/controls/index.tsx
+++ b/src/ui/popup/theme/controls/index.tsx
@@ -4,6 +4,7 @@ import Contrast from './contrast';
 import ColorSchemeDropDown from './color-scheme';
 import FontPicker from './font-picker';
 import Grayscale from './grayscale';
+import ImmediateModify from './immediate-modify';
 import Mode from './mode';
 import ResetButton from './reset-button';
 import Scheme from './scheme';
@@ -22,6 +23,7 @@ export {
     ColorSchemeDropDown,
     FontPicker,
     Grayscale,
+    ImmediateModify,
     Mode,
     ResetButton,
     Scheme,

--- a/src/ui/popup/theme/page/index.tsx
+++ b/src/ui/popup/theme/page/index.tsx
@@ -3,7 +3,7 @@ import {DEFAULT_SETTINGS, DEFAULT_THEME, DEFAULT_COLORS} from '../../../../defau
 import type {Theme} from '../../../../definitions';
 import type {ParsedColorSchemeConfig} from '../../../../utils/colorscheme-parser';
 import type {ViewProps} from '../../types';
-import {BackgroundColor, Brightness, Contrast, FontPicker, Grayscale, Mode, ResetButton, Scheme, Scrollbar, SelectionColorEditor, Sepia, TextColor, TextStroke, UseFont, StyleSystemControls, ColorSchemeDropDown} from '../controls';
+import {BackgroundColor, Brightness, Contrast, FontPicker, Grayscale, Mode, ResetButton, Scheme, Scrollbar, SelectionColorEditor, Sepia, TextColor, TextStroke, UseFont, StyleSystemControls, ColorSchemeDropDown, ImmediateModify} from '../controls';
 import ThemePresetPicker from '../preset-picker';
 import {getCurrentThemePreset} from '../utils';
 import Collapsible from './collapsible-panel';
@@ -125,6 +125,10 @@ function FontGroup({theme, fonts, change}: FontGroupsProps) {
             <StyleSystemControls
                 value={theme.styleSystemControls}
                 onChange={(styleSystemControls) => change({styleSystemControls})}
+            />
+            <ImmediateModify
+                value={theme.immediateModify}
+                onChange={(immediateModify) => change({immediateModify})}
             />
         </Array>
     );


### PR DESCRIPTION
- Add a per-site option to enable "Immediate modify", within this mode(only useable for dynamic theme), Dark Reader will modify the page without waiting for it to be shown to the user. With this mode you can open a new tab in the background and switch to it and notice it's already been modified by Dark Reader.
- Because users(myself included to a certain extend) might find this behavior unexpected and prefer to let Dark Reader wait until the tab is shown, this option is disabled by default. And because it has chances it will break certain sites, it's implemented to be a per-site toggle(Under `font & more`).
- Resolves #7682.