### PR TITLE
Add `.log/` to .gitingore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tests/inject/coverage/
 #-----------------------------------
 .idea/
 .vscode/
+.log/
 *.code-workspace
 
 # Cache files


### PR DESCRIPTION
- `.log/` is a folder generated by typescript's server in combination with https://github.com/typescript-language-server/typescript-language-server which is used by https://github.com/emacs-lsp/lsp-mode/