### PR TITLE
Added a dark site

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -650,6 +650,7 @@ omcar.pl
 omgwtfnzbs.me
 onionplay.co
 online.lloydsbank.co.uk
+onlyformats.netlify.app
 open.spotify.com
 openbase.io
 opendota.com


### PR DESCRIPTION
[Only Formats](https://onlyformats.netlify.app) is a dark mode website by default