### PR TITLE
Invert MDN logo text and icon

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4165,6 +4165,7 @@ a.external::after
 .breadcrumbs-container li .breadcrumb-penultimate::after
 .breadcrumbs-container li .breadcrumb::after
 ul.main-menu .top-level-entry::before
+span.icon
 
 CSS
 .search-results-list mark {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4154,7 +4154,6 @@ CSS
 developer.mozilla.org
 
 INVERT
-.logo
 .copy-icon
 .bc-browsers > th > span::before
 .bc-platforms > th::before
@@ -4168,6 +4167,7 @@ ul.main-menu .top-level-entry::before
 span.icon
 
 CSS
+.logo-text,
 .search-results-list mark {
     color: var(--darkreader-neutral-text) !important;
 }


### PR DESCRIPTION
<img width="366" alt="Screen Shot 2022-03-03 at 20 02 52" src="https://user-images.githubusercontent.com/21101839/156561149-b238a444-d464-4d1d-b615-6b15eb48fb74.png">

Also invert icons like the theme toggle icon and search icon at the top right corner.