### PR TITLE
Fix for Wikipedia map

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17355,9 +17355,8 @@ body > .oo-ui-windowManager .vega .marks
 .minerva-footer-logo img
 .music-symbol
 .tool.tool-button[src$="background-image:"]
-.wikiEditor-ui .oo-ui-iconElement-icon
+.oo-ui-iconElement-icon
 #p-personal .mw-echo-notifications-badge
-.oo-ui-icon-close
 .mw-ui-icon::before
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17413,6 +17413,10 @@ body.mediawiki,
 .template-facttext {
     background-color: #eaecf0 !important;
 }
+.leaflet-bar .oo-ui-icon-close,
+.leaflet-control-zoom a {
+    background-color: white !important;
+}
 
 IGNORE INLINE STYLE
 .legend-color

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17358,6 +17358,8 @@ body > .oo-ui-windowManager .vega .marks
 .oo-ui-iconElement-icon
 #p-personal .mw-echo-notifications-badge
 .mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
 
 CSS
 .mwe-popups-discreet > svg,


### PR DESCRIPTION
Example page: https://en.wikipedia.org/wiki/Zaporizhzhia_Nuclear_Power_Plant
<img width="1180" alt="Screen Shot 2022-03-04 at 13 56 44" src="https://user-images.githubusercontent.com/21101839/156707995-26bccbc7-22d0-4ceb-a976-817fb7ac30e0.png">

`oo-ui-icon-close` was added from #8284, that element also has `oo-ui-iconElement-icon` class, so I deleted it.

Map zoom button in full screen mode:
<img width="368" alt="Screen Shot 2022-03-04 at 14 00 38" src="https://user-images.githubusercontent.com/21101839/156708434-f47d2760-f8f5-452b-8745-902fa88b06f2.png">
