### PR TITLE
fix: make `cssImportRegex` case insensitive

### DIFF
--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -89,7 +89,7 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
 }
 
 export const cssURLRegex = /url\((('.+?')|(".+?")|([^\)]*?))\)/g;
-export const cssImportRegex = /@import\s*(url\()?(('.+?')|(".+?")|([^\)]*?))\)? ?(screen)?;?/g;
+export const cssImportRegex = /@import\s*(url\()?(('.+?')|(".+?")|([^\)]*?))\)? ?(screen)?;?/gi;
 
 export function getCSSURLValue(cssURL: string) {
     return cssURL.replace(/^url\((.*)\)$/, '$1').trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1');

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -95,6 +95,25 @@ describe('LINK STYLES', () => {
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
     });
 
+    it('should override cross-origin imports in linked CSS with capital @import', async () => {
+        const importedCSS = 'h1 { background: gray; }';
+        const importedURL = getCSSEchoURL(importedCSS);
+        stubBackgroundFetchResponse(importedURL, importedCSS);
+        createCorsLink(multiline(
+            `@IMPORT "${importedURL}";`,
+            'h1 strong { color: red; }',
+        ));
+        container.innerHTML = multiline(
+            '<h1><strong>Cross-origin import</strong> link override</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+
+        await timeout(100);
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
+        expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
+        expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
+    });
+
     it('should override cross-origin link that has already been loaded', async () => {
         createCorsLink(multiline(
             'h1 { background: gray; }',


### PR DESCRIPTION
- Seems like some links return `@IMPORT ...` with capital import. The original regex `cssImportRegex` does not match them;
- It can be observed in the following page: https://m.post.naver.com/viewer/postView.naver?volumeNo=33377956&memberNo=31740578

Before:
<img width="600" alt="Screen Shot 2022-03-04 at 09 58 29" src="https://user-images.githubusercontent.com/4389280/156768373-d39b0ea1-259b-483d-aa8f-f420e2264de9.png">

After:
<img width="600" alt="Screen Shot 2022-03-04 at 10 02 36" src="https://user-images.githubusercontent.com/4389280/156768423-9a947c33-c761-420a-b22b-88366d56a022.png">