### PR TITLE
Fix for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17414,11 +17414,14 @@ body > .oo-ui-windowManager .vega .marks
 .minerva-footer-logo img
 .music-symbol
 .tool.tool-button[src$="background-image:"]
-.oo-ui-iconElement-icon
 #p-personal .mw-echo-notifications-badge
 .mw-ui-icon::before
 .mw-kartographer-map
 .mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 CSS
 .mwe-popups-discreet > svg,


### PR DESCRIPTION
- Invert editor toolbar icons.
- Invert notification icons.
- Invert audio speaker icon.

Example of site page: https://en.wikipedia.org/wiki/Wikipedia?action=edit

Resolves #8384 