### PR TITLE
Dynamic dark theme fix for educational french websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12768,6 +12768,22 @@ body {
 
 ================================
 
+pronote.toutatice.fr
+
+INVERT
+.ObjetGrille
+.Cours
+.Insecable
+.Calendrier_Jour_Selection
+
+CSS
+body,
+.ie-chips.tag-style {
+	background: linear-gradient(90deg, #282c2d 0, #282C2D calc(100% - 0.8rem), transparent calc(100% - 0.8rem), transparent 100%);
+}
+
+================================
+
 pronto.io
 
 CSS
@@ -15991,6 +16007,14 @@ CSS
 .hero {
     background-image: none !important;
 }
+
+================================
+
+toutatice.fr
+
+INVERT
+.img-responsive
+.banner
 
 ================================
 


### PR DESCRIPTION
Added fix for two major french school websites (Toutatice and Pronote) (Updated and fixed from #8359 )