### PR TITLE
Add palettte.app and colorbox.io to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -178,6 +178,7 @@ codesandbox.io
 codestackr.com
 codingame.com
 coinpot.co
+colorbox.io
 comicextra.com
 comicpunch.net
 conficturaindustries.com
@@ -667,6 +668,7 @@ overdodactyl.github.io/ShadowFox
 oxy.cannot.date
 p4pirate.xyz
 paimon.moe
+palettte.app
 paper-io.com
 parahumans.wordpress.com
 paranoid.email


### PR DESCRIPTION
Add [palettte.app](https://palettte.app/) and [colorbox.io](https://colorbox.io/) to dark-sites.config.

Kind of important considering they're palette generation sites and darkreader messes with the colors