### PR TITLE
Fix for chessprogramming.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2819,6 +2819,17 @@ INVERT
 
 ================================
 
+chessprogramming.org
+
+INVERT
+img:not(.thumbimage):not(.thumbborder)
+.mw-wiki-logo
+
+IGNORE IMAGE ANALYSIS
+.mw-wiki-logo
+
+================================
+
 chilkatsoft.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2822,7 +2822,7 @@ INVERT
 chessprogramming.org
 
 INVERT
-img:not(.thumbimage):not(.thumbborder)
+.mw-parser-output div[class^='float'] > a > img:not(.thumbimage):not(.thumbborder)
 .mw-wiki-logo
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
- Correctly invert logo
- Invert embedded images

Example page: [https://www.chessprogramming.org/Texel's_Tuning_Method](https://www.chessprogramming.org/Texel%27s_Tuning_Method)

Before:
![20220306_12h14m56s_grim](https://user-images.githubusercontent.com/34682885/156920674-34e46452-1ab9-4b63-834b-94091cd71e6c.png)

After:
![20220306_12h09m23s_grim](https://user-images.githubusercontent.com/34682885/156920530-6be3889e-4803-4b9c-96e3-5d2ba64fddb6.png)
