### PR TITLE
Fix for washingtonpost.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17050,7 +17050,9 @@ CSS
 washingtonpost.com
 
 INVERT
-.masthead_svg__wplogo
+.hp-masthead
+.switch
+.switch::after
 
 CSS
 .flex * {
@@ -17058,7 +17060,7 @@ CSS
 }
 
 IGNORE INLINE STYLE
-a[href="https://washingtonpost.com"][class*="center"] svg path
+.center > svg > path[fill="white"]
 
 ================================
 


### PR DESCRIPTION
- Invert logos
- Invert toggle switch