### PR TITLE
Banned dark mode for a .io game

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -368,6 +368,7 @@ gekri.com
 generated.photos
 genshin.gg
 geocities.restorativland.org
+geometry.best
 getaether.net
 getdweb.net
 gethalfmoon.com
@@ -822,6 +823,7 @@ seximal.net
 sharkiller.ddns.net
 shatteredpixel.com
 sheet.host
+shellshock.io
 sherlock-project.github.io
 showtimeanytime.com
 shpposter.club


### PR DESCRIPTION
Added shellshock.io (with its alt geometry.best) in the darkreader blacklist because glitches occur when dark mode is on.