### PR TITLE
Fix for bestchange.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1828,7 +1828,11 @@ body,
 #content_table thead td,
 .content .intro,
 .c-block,
-#content_table tbody td {
+#content_table tbody td,
+#content_reviews,
+.review_header,
+.review_middle,
+.review_bottom {
     background-image: none !important;
 }
 


### PR DESCRIPTION
- Remove background image for reviews.

Example of site page: https://www.bestchange.ru/365cash-exchanger.html