### PR TITLE
Fix for Wikimedia websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3364,6 +3364,14 @@ INVERT
 .mw-mmv-filepage-buttons .mw-mmv-view-expanded .mw-ui-icon::before
 .mw-mmv-filepage-buttons .mw-mmv-view-config .mw-ui-icon::before
 .licensetpl td[style^="width"]
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
 .mw-wiki-logo
@@ -10166,6 +10174,14 @@ mediawiki.org
 
 INVERT
 #p-logo-text
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
 .mw.wiki-logo
@@ -17445,6 +17461,14 @@ INVERT
 .bookend
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 IGNORE INLINE STYLE
 .infobox td
@@ -17455,6 +17479,14 @@ wikidata.org
 
 INVERT
 .wd-mp-headerimage
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
 .mw-wiki-logo
@@ -17480,6 +17512,14 @@ wikimedia.org
 INVERT
 img.graphite-graph
 img[src="images/black.png"]
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 CSS
 div.mw-warning-with-logexcerpt,
@@ -17499,6 +17539,14 @@ wikiquote.org
 
 INVERT
 .bookend
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 ================================
 
@@ -17602,14 +17650,33 @@ IGNORE IMAGE ANALYSIS
 
 wikisource.org
 wikiversity.org
+wikivoyage.org
 
 INVERT
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 ================================
 
 wikitech.wikimedia.org
+
+INVERT
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
 .mw.wiki-logo
@@ -17637,6 +17704,14 @@ wiktionary.org
 INVERT
 .bookend
 .central-featured-logo-text
+#p-personal .mw-echo-notifications-badge
+.mw-ui-icon::before
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.oo-ui-iconElement-icon
+.oo-ui-indicatorElement-indicator
+.mw-echo-notifications-badge
+img[alt="audio speaker icon"]
 
 CSS
 div.NavFrame div.NavHead {


### PR DESCRIPTION
Related to #8371 , for the rest of Wikimedia Foundation websites

Example: https://en.wiktionary.org/w/index.php?title=look_after&action=edit

![notification_bar](https://user-images.githubusercontent.com/10338703/157399570-73deb96c-1689-4f3b-bc29-9fee7cb1490b.png)
![toolbar](https://user-images.githubusercontent.com/10338703/157399581-08243719-a307-41ce-9cee-ac75d874b09d.png)

commons.wikimedia.org, mediawiki.org, wikibooks.org, wikidata.org, wikimedia.org, wikinews.org, wikiquote.org, wikisource.org, wiktionary.org, wikiversity.org, wikivoyage.org, wikitech.wikimedia.org