### PR TITLE
Fix for freetp.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6394,6 +6394,22 @@ INVERT
 
 ================================
 
+freetp.org
+
+CSS
+html,
+body,
+.wmid,
+.wfoot {
+    background-image: none !important;
+}
+html,
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 fritz.box
 
 INVERT


### PR DESCRIPTION
- Remove background image.

Example of site pages: https://freetp.org/po-seti/4638-valheim-po-seti-igrati-besplatno.html, https://freetp.org/getfile-5977