### PR TITLE
Fix for developer.android.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4154,14 +4154,15 @@ CSS
 devsite-search .devsite-searchbox::before {
     background-color: unset;
 }
-.devsite-wrapper {
-    background-color: inherit;
-}
+.devsite-wrapper,
 button {
     background-color: inherit;
 }
 code {
     background-color: rgba(255, 255, 255, 0.05);
+}
+.devsite-breadcrumb-list {
+    background: none !important;
 }
 
 ================================


### PR DESCRIPTION
- Remove background for category information.

Example of site page: https://developer.android.com/guide/topics/ui/look-and-feel/darktheme