### PR TITLE
Fix for habitica.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7491,6 +7491,9 @@ habitica.com
 INVERT
 .logo path:nth-child(2)
 
+IGNORE IMAGE ANALYSIS
+*
+
 ================================
 
 habr.com


### PR DESCRIPTION
- Fix inverted images everywhere

Before:
<img width="323" alt="2022-03-11-01-50-47" src="https://user-images.githubusercontent.com/1006477/157775149-2f104ab5-8489-403f-b210-8cec33f08fc9.png">

After:
<img width="328" alt="2022-03-11-01-51-18" src="https://user-images.githubusercontent.com/1006477/157775163-1f5af0fd-aa69-483b-a5c8-9eee2872cd5d.png">

Also this makes the web page much smoother as it contains a large number of small image pieces.