### PR TITLE
Fix for wikipedia.org (Vector-2022 skin)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17582,6 +17582,8 @@ INVERT
 .MathJax:not(span#MathJax_Zoom > .MathJax)
 span#MathJax_Zoom
 .mw-ext-score
+.mw-logo
+#mw-sidebar-button
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17582,7 +17582,8 @@ INVERT
 .MathJax:not(span#MathJax_Zoom > .MathJax)
 span#MathJax_Zoom
 .mw-ext-score
-.mw-logo
+.mw-logo.wordmark
+.mw-logo-tagline
 #mw-sidebar-button
 .mw-wiki-logo
 .central-textlogo__image

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17582,7 +17582,8 @@ INVERT
 .MathJax:not(span#MathJax_Zoom > .MathJax)
 span#MathJax_Zoom
 .mw-ext-score
-.mw-logo.wordmark
+.mw-logo-icon
+.mw-logo-wordmark
 .mw-logo-tagline
 #mw-sidebar-button
 .mw-wiki-logo

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17584,7 +17584,6 @@ span#MathJax_Zoom
 .mw-ext-score
 .mw-logo-wordmark
 .mw-logo-tagline
-#mw-sidebar-button
 .mw-wiki-logo
 .central-textlogo__image
 .svg-Wikimedia-logo_black

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17582,7 +17582,6 @@ INVERT
 .MathJax:not(span#MathJax_Zoom > .MathJax)
 span#MathJax_Zoom
 .mw-ext-score
-.mw-logo-icon
 .mw-logo-wordmark
 .mw-logo-tagline
 #mw-sidebar-button


### PR DESCRIPTION
Inverting Wikipedia text and tagline on Vector-2022 skin

Example: https://en.wikipedia.org/w/index.php?title=Main_Page&useskin=vector-2022

![Screenshot 2022-03-11 at 11-30-28 Wikipedia the free encyclopedia](https://user-images.githubusercontent.com/10338703/157802848-ceffe4bc-a1d5-4ae7-811a-8db06db61d0b.png)
![Screenshot 2022-03-11 at 11-29-22 Wikipedia the free encyclopedia](https://user-images.githubusercontent.com/10338703/157923463-6d390a75-9abb-4000-b774-1f288b8ea72e.png)
