### PR TITLE
Remove unnecessary invert and css for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17620,13 +17620,8 @@ body > .oo-ui-windowManager .vega .marks
 .minerva-footer-logo img
 .music-symbol
 .tool.tool-button[src$="background-image:"]
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
 .mw-kartographer-map
 .mw-kartographer-mapDialog-map
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 CSS
@@ -17682,10 +17677,6 @@ body.mediawiki,
 }
 .template-facttext {
     background-color: #eaecf0 !important;
-}
-.leaflet-bar .oo-ui-icon-close,
-.leaflet-control-zoom a {
-    background-color: white !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
These rules actually make the icons invisibly on v4.9.46 