### PR TITLE
Remove unnecessary invert for Wikimedia websites and fix for MediaWiki wordmark on Vector-2022 skin

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3371,11 +3371,6 @@ INVERT
 .mw-mmv-filepage-buttons .mw-mmv-view-expanded .mw-ui-icon::before
 .mw-mmv-filepage-buttons .mw-mmv-view-config .mw-ui-icon::before
 .licensetpl td[style^="width"]
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
@@ -10211,11 +10206,6 @@ mediawiki.org
 
 INVERT
 #p-logo-text
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
@@ -17534,11 +17524,6 @@ INVERT
 .bookend
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 IGNORE INLINE STYLE
@@ -17550,11 +17535,6 @@ wikidata.org
 
 INVERT
 .wd-mp-headerimage
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
@@ -17581,11 +17561,6 @@ wikimedia.org
 INVERT
 img.graphite-graph
 img[src="images/black.png"]
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 CSS
@@ -17606,11 +17581,6 @@ wikiquote.org
 
 INVERT
 .bookend
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 ================================
@@ -17713,11 +17683,6 @@ wikivoyage.org
 INVERT
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 ================================
@@ -17725,11 +17690,6 @@ img[alt="audio speaker icon"]
 wikitech.wikimedia.org
 
 INVERT
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS
@@ -17758,13 +17718,6 @@ wiktionary.org
 INVERT
 .bookend
 .central-featured-logo-text
-#p-personal .mw-echo-notifications-badge
-.mw-ui-icon::before
-.mw-kartographer-map
-.mw-kartographer-mapDialog-map
-.oo-ui-iconElement-icon
-.oo-ui-indicatorElement-indicator
-.mw-echo-notifications-badge
 img[alt="audio speaker icon"]
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10206,6 +10206,7 @@ mediawiki.org
 
 INVERT
 #p-logo-text
+.mw-logo-wordmark
 img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
Follow-up to #8427 for the rest of Wikimedia Foundation websites

commons.wikimedia.org, mediawiki.org, wikibooks.org, wikidata.org, wikimedia.org, wikinews.org, wikiquote.org, wikisource.org, wiktionary.org, wikiversity.org, wikivoyage.org, wikitech.wikimedia.org