### PR TITLE
Apply fix for header on yettel.rs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18630,6 +18630,13 @@ CSS
 
 ================================
 
+yettel.rs
+
+INVERT
+.header-container
+
+================================
+
 yle.fi
 
 INVERT


### PR DESCRIPTION
yettel.rs is a site of mobile provider in Serbia, previously known as Telenor Serbia.

For start, this pull request makes content in header readable. This isn't perfect, but does the job.