### PR TITLE
Fix for theregister.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15947,6 +15947,8 @@ theregister.*.*
 
 INVERT
 .row_label.title_rhs_line
+.blocksandfiles_logo
+#sitpub_logo
 
 ================================
 


### PR DESCRIPTION
Invert .blocksandfiles_logo and #sitpub_logo

![image](https://user-images.githubusercontent.com/10338703/158047128-55aa13d2-104c-4f86-9780-a28152a405f8.png)
![image](https://user-images.githubusercontent.com/10338703/158047138-f51eff59-f3df-4f1c-bf9c-0d4d0d0edfdb.png)

![image](https://user-images.githubusercontent.com/10338703/158047113-082bdafb-7afd-4a4a-b18e-40d3e84e355a.png)
![image](https://user-images.githubusercontent.com/10338703/158047117-d6485c10-b436-4ea9-984f-dc2ee9f4a9f3.png)
