### PR TITLE
Fix for reuters.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13565,6 +13565,8 @@ reuters.com
 
 INVERT
 path[d^="M121.865 50.29c0"]
+svg[class^="nav-bar__arrow"] > path
+svg[class^="nav-dropdown__icon"] > path
 
 ================================
 


### PR DESCRIPTION
Invert dropdown arrows/chevrons in the top navbar and navbar "more" menus.

Using `class^=` because of the random UID at the end of the class names.