### PR TITLE
Don't detect a dark theme on PDF's

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -603,7 +603,7 @@ export class Extension implements ExtensionState {
                 theme = {...theme, mode};
             }
             const isIFrame = frameURL != null;
-            const detectDarkTheme = !isIFrame && settings.detectDarkTheme && !isURLInList(url, settings.siteListEnabled);
+            const detectDarkTheme = !isIFrame && settings.detectDarkTheme && !isURLInList(url, settings.siteListEnabled) && !isPDF(url);
 
             logInfo(`Creating CSS for url: ${url}`);
             logInfo(`Custom theme ${custom ? 'was found' : 'was not found'}, Preset theme ${preset ? 'was found' : 'was not found'}


### PR DESCRIPTION
- PDF's are mysteriously implemented on chrome, they are currently controlled by the PDF option and shouldn't be effected by the detect dark theme option.
- Resoles #8452