### PR TITLE
Fix svg inversion in specific cases on OWL

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3781,7 +3781,7 @@ INVERT
 .owl_item_container img[src*=".gif"]
 .ci-feedback img[src*=".gif"]
 label img[src*=".gif"]
-span.MathJax_SVG
+span.MathJax_SVG g[stroke="black"]
 
 CSS
 .owl_item_container img[src*=".GIF"] {
@@ -3796,6 +3796,9 @@ div.tool-container.gradient > .controlButtons {
 div.tool-container.gradient {
     box-shadow: none;
 }
+
+IGNORE INLINE STYLE
+span.MathJax_SVG g
 
 ================================
 


### PR DESCRIPTION
With the previous patch I did, some svg on sjc.cengagenow.com would be inverted twice, making them hard to read. I *think* this fixes it? Seems to work for me so far.

before:
![image](https://user-images.githubusercontent.com/72410860/158736804-b73a9ef4-0e84-4786-8c2a-020f221fd402.png)
after:
![image](https://user-images.githubusercontent.com/72410860/158736746-083f771e-087d-4853-8d16-baafc9c99c2c.png)

For some reason it makes the svg slightly blurrier though, as the screenshots show. Am I solving this wrong?