### PR TITLE
Fix for cnn.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3173,6 +3173,11 @@ INVERT
 [data-test="section-link"] > svg:not(.business-logo-icon)
 img.metadata-header__logo
 
+CSS
+#header-nav-container::before {
+    border-bottom-color: transparent !important;
+}
+
 IGNORE INLINE STYLE
 svg.cnn-badge-icon
 svg.cnn-badge-icon > rect


### PR DESCRIPTION
Turn the white line under the top nav bar transparent since it's not normally visible outside of dark mode.