### PR TITLE
Fix TypeError on `isCSSColorSchemePropSupported`

### DIFF
--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -58,5 +58,5 @@ export const isCSSColorSchemePropSupported = (() => {
     }
     const el = document.createElement('div');
     el.setAttribute('style', 'color-scheme: dark');
-    return el.style.colorScheme === 'dark';
+    return el.style && el.style.colorScheme === 'dark';
 })();


### PR DESCRIPTION
- There's a chance that `el.style` can be undefined. We need to account for that.
- Resolves #8368