### PR TITLE
Update NYT CSS matchers for new puzzle DOM

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11765,6 +11765,21 @@ a[data-testid] > svg {
 #xwd-board rect[class^="Cell-related--"] {
     fill: ${goldenrod} !important;
 }
+#xwd-board rect[class^="xwd__cell--cell"] {
+    fill: ${darkgrey} !important;
+}
+#xwd-board rect[class^="xwd__cell--highlighted"] {
+    fill: ${lightgrey} !important;
+}
+#xwd-board rect[class^="xwd__cell--selected"] {
+    fill: ${white} !important;
+}
+#xwd-board rect[class^="xwd__cell--related"] {
+    fill: ${khaki} !important;
+}
+#xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
+    fill: ${blue} !important;
+}
 
 ================================
 


### PR DESCRIPTION
The New York Times is rolling out a new UI for the crossword puzzle which has different class names for the cells breaking the CSS matchers.

This PR adds matches for the new puzzle layout while maintaining the old format as both versions of the board appear to be live in production.

Some readability issues with penciled text being gray on gray have also been addressed.

![image](https://user-images.githubusercontent.com/11667004/159639893-69d3f11d-4c3c-4b0a-88ee-fb112c3aba79.png)
