### PR TITLE
Stability improvements

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -45,7 +45,8 @@ export function shouldManageStyle(element: Node) {
                 element.rel &&
                 element.rel.toLowerCase().includes('stylesheet') &&
                 !element.disabled &&
-                (isFirefox ? !element.href.startsWith('moz-extension://') : true)
+                (isFirefox ? !element.href.startsWith('moz-extension://') : true) &&
+                !element.href.startsWith('https://fonts.googleapis.com')
             )
         ) &&
         !element.classList.contains('darkreader') &&

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -203,7 +203,7 @@ export function setIsDOMReady(newFunc: () => boolean) {
 const readyStateListeners = new Set<() => void>();
 
 export function addDOMReadyListener(listener: () => void) {
-    readyStateListeners.add(listener);
+    isDOMReady() ? listener() : readyStateListeners.add(listener);
 }
 
 export function removeDOMReadyListener(listener: () => void) {
@@ -219,7 +219,7 @@ export function isReadyStateComplete() {
 const readyStateCompleteListeners = new Set<() => void>();
 
 export function addReadyStateCompleteListener(listener: () => void) {
-    readyStateCompleteListeners.add(listener);
+    isReadyStateComplete() ? listener() : readyStateCompleteListeners.add(listener);
 }
 
 export function cleanReadyStateCompleteListeners() {

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -89,7 +89,7 @@ describe('LINK STYLES', () => {
         );
         createOrUpdateDynamicTheme(theme, null, false);
 
-        await timeout(100);
+        await timeout(250);
         expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
@@ -123,13 +123,13 @@ describe('LINK STYLES', () => {
             '<h1>Loaded <strong>cross-origin</strong> link override</h1>',
         );
 
-        await timeout(50);
+        await timeout(250);
         expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(128, 128, 128)');
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(0, 0, 0)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 0, 0)');
 
         createOrUpdateDynamicTheme(theme, null, false);
-        await timeout(50);
+        await timeout(250);
         expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
@@ -184,7 +184,7 @@ describe('LINK STYLES', () => {
         );
         createOrUpdateDynamicTheme(theme, null, false);
 
-        await timeout(100);
+        await timeout(250);
         expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');
@@ -204,7 +204,7 @@ describe('LINK STYLES', () => {
         );
         createOrUpdateDynamicTheme(theme, null, false);
 
-        await timeout(100);
+        await timeout(250);
         expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');

--- a/tests/inject/dynamic/link-override.tests.ts
+++ b/tests/inject/dynamic/link-override.tests.ts
@@ -108,7 +108,7 @@ describe('LINK STYLES', () => {
         );
         createOrUpdateDynamicTheme(theme, null, false);
 
-        await timeout(100);
+        await timeout(250);
         expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(102, 102, 102)');
         expect(getComputedStyle(container.querySelector('h1')).color).toBe('rgb(255, 255, 255)');
         expect(getComputedStyle(container.querySelector('h1 strong')).color).toBe('rgb(255, 26, 26)');


### PR DESCRIPTION
- I've encountered over the years many sites that uses the fonts.googleapis.com to fetch font styles. For Dark Reader, these styles are irrelevant, we don't modify font faces. Avoiding this early in the process will prevent some network activity and lower overhead(very minimal).
- If for some reason the document gets loaded before `addDOMReadyListener` or `addReadyStateCompleteListener` has been called, they wouldn't be executed. Per this change, the functions will first check.
- Increase timeout delays in certain tests which are time sensitive, I'd expect that the Github CI's server CPU are shared and not that high-speed(to avoid abuse of it) so increasing it should give it plenty of time to finish within that window.