### PR TITLE
Move code-related CI tests

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -2,7 +2,7 @@ name: Run browser tests in Karma
 on:
 
   # Runs for pushes and pull requests,
-  #  but if changes are config-only
+  #  but don't run these when only some config is changed.
   push:
     branches:
       - master

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,8 +1,13 @@
-name: Run config tests on Pull Request or Push
+name: Run code tests on Pull Request or Push
 on:
+
+  # Runs for pushes and pull requests,
+  #  but don't run these when only some config is changed.
   push:
     branches:
       - master
+    paths-ignore:
+      - 'src/config/*'
   pull_request:
     branches:
       - master
@@ -11,6 +16,9 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths-ignore:
+      - 'src/config/**'
+
   workflow_dispatch:
 jobs:
   test:
@@ -36,9 +44,12 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.OS }}
-      
+
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Run test against code
-        run: npm run test:ci
+      - name: Lint code for code-style errors
+        run: npm run lint
+
+      - name: Check for compatibility issues
+        run: npm run lint:bundle


### PR DESCRIPTION
- Don't run code-related CI tests when only a config is changed. Move the code-related CI tests to it's own workflow, which only run when a non-config path has been changed. Similar how test-browser.yml operates.