### PR TITLE
Fix cnbc.com (dynamic)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3168,6 +3168,10 @@ INVERT
 
 cnbc.com
 
+INVERT
+.RenderKeyPoints-list li::before
+.WatchLiveRightRail-logo
+
 CSS
 div[class^="FeaturedStories-styles-makeit-background"]::before {
     opacity: 0.1 !important;


### PR DESCRIPTION
Example page:
https://www.cnbc.com/2021/12/29/omicron-not-the-same-disease-as-earlier-covid-strains-oxford-scientist.html

Fixes bullet points and TV logo.