### PR TITLE
Fix for duolingo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5092,7 +5092,7 @@ INVERT
 [data-test="skill-icon"] + div img
 
 CSS
-button[aria-disabled="true"] > span {
+button[aria-disabled="true"] {
     opacity: 0.3 !important;
 }
 


### PR DESCRIPTION
when doing a multiple-choice word pairing exercise, correct matched pairs should be greyed out. This fix enables greying out the entire button rather than the text enclosed in `<span>`s as unfortunately duolingo recently started putting the button text outside a span and with darkeader on the button is not greyed out anymore. This behavior is also closer to what currently happens without DarkReader.

<details><summary>Before the change:</summary>
<img width="636" alt="image" src="https://user-images.githubusercontent.com/29781022/160333249-3c0b5a4c-5cef-4fb5-a1dd-4ba8e291e8e4.png">
</details>

<details><summary>After the change:</summary>
<img width="636" alt="image" src="https://user-images.githubusercontent.com/29781022/160333174-2fe609a3-f456-4c53-b723-1408b8d789ca.png">
</details>

<details><summary>Without DarkReader:</summary>
<img width="636" alt="image" src="https://user-images.githubusercontent.com/29781022/160333301-013d5533-d142-4489-aba0-c09a3ab5ec01.png">
</details>

With the German language it's even worse as neither the left nor the right columns grey out with the current behavior