### PR TITLE
fix for text-based music symbols on wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17861,6 +17861,7 @@ div.post-content.footer-content > h2 > img
 body > .oo-ui-windowManager .vega .marks
 .minerva-footer-logo img
 .music-symbol
+.music-symbol > span
 .tool.tool-button[src$="background-image:"]
 .mw-kartographer-map
 .mw-kartographer-mapDialog-map


### PR DESCRIPTION
Hi!

I'm not exactly sure why, but despite the presence of the class inverter .music-symbol, text based music symbols are missed (it successfully inverts images however). This change allows both to correctly be inverted. If there's a better way to notate this change (i.e. stick it all the .music-symbol hacks on to one line) I'm all ears.

Here's an example of a breaking page: https://en.wikipedia.org/wiki/String_Quartet_No._14_(Beethoven) (note the table!)

Cheers,
Aaron.