### PR TITLE
Update dynamic theme with cb2.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19398,3 +19398,10 @@ CSS
 .zyimage {
     background-color: var(--darkreader-neutral-text) !important;
 }
+
+================================
+
+cb2.com
+
+INVERT
+.menu-button


### PR DESCRIPTION
Updating to include cb2.com. The proposed change inverts the menu buttons to be white on the dark background (black previously)