### PR TITLE
Upwork darkmode changes (fixed many issues)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17068,6 +17068,9 @@ border-left-color: transparent;
     border-right: var(--darkreader-border--border-base);
 }
 /* border too white */
+
+================================
+
 urbandecay.com
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -230,20 +230,6 @@ div.description > span {
 
 ================================
 
-4t-niagara.com
-
-CSS
-.download_link > h3,
-.buy_link > h3 {
-    color: ${#88c1ff} !important;
-}
-.download_link li,
-.buy_link li {
-    color: ${white} !important;
-}
-
-================================
-
 aad.org
 
 INVERT
@@ -491,18 +477,6 @@ addons.mozilla.org
 IGNORE IMAGE ANALYSIS
 .Icon-youtube
 span.Permission-description:before
-
-================================
-
-adguard-dns.io
-
-INVERT
-.animation__video
-
-CSS
-.animation__video {
-    z-index: 0 !important;
-}
 
 ================================
 
@@ -3168,10 +3142,6 @@ INVERT
 
 cnbc.com
 
-INVERT
-.RenderKeyPoints-list li::before
-.WatchLiveRightRail-logo
-
 CSS
 div[class^="FeaturedStories-styles-makeit-background"]::before {
     opacity: 0.1 !important;
@@ -3202,11 +3172,6 @@ cnn.com
 INVERT
 [data-test="section-link"] > svg:not(.business-logo-icon)
 img.metadata-header__logo
-
-CSS
-#header-nav-container::before {
-    border-bottom-color: transparent !important;
-}
 
 IGNORE INLINE STYLE
 svg.cnn-badge-icon
@@ -3602,7 +3567,7 @@ CSS
 }
 
 IGNORE INLINE STYLE
-#generator *
+#generator*
 
 ================================
 
@@ -3816,7 +3781,7 @@ INVERT
 .owl_item_container img[src*=".gif"]
 .ci-feedback img[src*=".gif"]
 label img[src*=".gif"]
-span.MathJax_SVG g[stroke="black"]
+span.MathJax_SVG
 
 CSS
 .owl_item_container img[src*=".GIF"] {
@@ -3831,9 +3796,6 @@ div.tool-container.gradient > .controlButtons {
 div.tool-container.gradient {
     box-shadow: none;
 }
-
-IGNORE INLINE STYLE
-span.MathJax_SVG g
 
 ================================
 
@@ -4003,18 +3965,6 @@ dawn.com
 
 INVERT
 img[alt="Dawn Logo"]
-
-================================
-
-deadpixeltest.org
-
-CSS
-html {
-    background-color: transparent !important;
-}
-
-IGNORE INLINE STYLE
-body
 
 ================================
 
@@ -4365,15 +4315,6 @@ pre {
 
 ================================
 
-dhmo.org
-
-CSS
-body {
-    background-image: none !important;
-}
-
-================================
-
 di.com.pl
 
 INVERT
@@ -4540,13 +4481,6 @@ html, body {
 
 IGNORE IMAGE ANALYSIS
 body
-
-================================
-
-discuss.pixls.us
-
-INVERT
-#site-logo.logo-big
 
 ================================
 
@@ -5099,7 +5033,7 @@ INVERT
 [data-test="skill-icon"] + div img
 
 CSS
-button[aria-disabled="true"] {
+button[aria-disabled="true"] > span {
     opacity: 0.3 !important;
 }
 
@@ -6611,15 +6545,6 @@ CSS
 
 ================================
 
-gain.tv
-
-CSS
-.body-new-index .hero-img-container {
-    z-index: 0 !important;
-}
-
-================================
-
 garmin.com
 
 INVERT
@@ -7851,18 +7776,6 @@ INVERT
 
 ================================
 
-hp.com
-
-INVERT
-#g-nav .c-logo
-
-CSS
-.pdp-bg {
-    background-image: none !important;
-}
-
-================================
-
 hs.fi
 
 CSS
@@ -8473,13 +8386,6 @@ CSS
 
 ================================
 
-iplocation.net
-
-INVERT
-img[src="/assets/images/logo.png"]
-
-================================
-
 iqiyi.com
 
 INVERT
@@ -8521,15 +8427,6 @@ div.grey-gui-bg,
 .small-purple-heading, 
 .small-navy2-heading {
     background-image: none !important;
-}
-
-================================
-
-istanbulfm.com.tr
-
-CSS
-#jarallax-container-0 {
-    z-index: 0 !important;
 }
 
 ================================
@@ -9742,19 +9639,6 @@ body {
 td.c {
     color: ${white} !important;
 }
-
-================================
-
-loepenshop.com
-bonjourfoto.nl
-
-CSS
-body {
-    background-image: none !important;
-}
-
-IGNORE IMAGE ANALYSIS
-div.art-Header-jpeg
 
 ================================
 
@@ -11809,26 +11693,15 @@ body,
 nymag.com
 
 INVERT
-.article-feed-header svg
+.logo-svg
 .article-nav-top-center
 #latest-feed-title
-.logo-svg
 #site-feed-curbed-title > .feed-title-wrapper
 .tab-trigger > svg
 .tab-trigger > svg > circle
 .tab-trigger > svg > g > circle
-.title-logo
 #vulture-trigger > svg > g > path:nth-child(1)
 #wwwthecut-trigger > svg > .active > path
-
-CSS
-.collection-articles-lede_first-featured .lede-item[data-track-index="0"] .lede-image-wrap {
-    z-index: 0 !important;
-}
-.collection-articles-lede_first-featured .lede-item[data-track-index="0"] .lede-text-wrap {
-    z-index: 1 !important;
-    position: absolute !important;
-}
 
 ================================
 
@@ -11876,21 +11749,6 @@ a[data-testid] > svg {
 }
 #xwd-board rect[class^="Cell-related--"] {
     fill: ${goldenrod} !important;
-}
-#xwd-board rect[class^="xwd__cell--cell"] {
-    fill: ${darkgrey} !important;
-}
-#xwd-board rect[class^="xwd__cell--highlighted"] {
-    fill: ${lightgrey} !important;
-}
-#xwd-board rect[class^="xwd__cell--selected"] {
-    fill: ${white} !important;
-}
-#xwd-board rect[class^="xwd__cell--related"] {
-    fill: ${khaki} !important;
-}
-#xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
-    fill: ${blue} !important;
 }
 
 ================================
@@ -12090,13 +11948,6 @@ table[style*="/cvir/UI"],
 {
     background-image: none !important
 }
-
-================================
-
-onelook.com
-
-INVERT
-img[alt="OneLook"]
 
 ================================
 
@@ -12773,15 +12624,6 @@ footer > div > div > a > img
 
 ================================
 
-planet.gnome.org
-
-CSS
-div.post {
-    background-image: none !important;
-}
-
-================================
-
 planetagracza.pl
 
 INVERT
@@ -12967,14 +12809,6 @@ CSS
 
 ================================
 
-polymc.org
-polymc.github.io
-
-IGNORE INLINE STYLE
-svg.home *
-
-================================
-
 poradnikzdrowie.pl
 
 INVERT
@@ -12986,13 +12820,6 @@ portal.qiniu.com
 
 INVERT
 .global-loading-content img
-
-================================
-
-portal.saltyfish.io
-
-INVERT
-.logo-img
 
 ================================
 
@@ -13389,13 +13216,6 @@ INVERT
 
 ================================
 
-radeonramdisk.com
-
-INVERT
-#logo
-
-================================
-
 radio17.pl
 
 INVERT
@@ -13622,9 +13442,6 @@ p, li {
     background-color: ${white} !important;
 }
 
-IGNORE INLINE STYLE
-.redhat-logo *
-
 ================================
 
 redpenreviews.org
@@ -13748,8 +13565,6 @@ reuters.com
 
 INVERT
 path[d^="M121.865 50.29c0"]
-svg[class^="nav-bar__arrow"] > path
-svg[class^="nav-dropdown__icon"] > path
 
 ================================
 
@@ -14080,7 +13895,6 @@ samsung.*
 
 INVERT
 .icon
-.gnb__logo
 
 CSS
 .feature-full-bleed-text img {
@@ -14228,22 +14042,6 @@ scribd.com
 
 INVERT
 .logo
-
-================================
-
-scribe.rip
-
-CSS
-body {
-    background-color: var(--darkreader-neutral-background) !important;
-}
-
-================================
-
-scribus.net
-
-INVERT
-#site-header img
 
 ================================
 
@@ -14871,35 +14669,10 @@ CSS
 
 ================================
 
-spectrum.com
-
-INVERT
-img[src$="spectrum-logo.svg"]
-
-CSS
-.sp-background-image {
-    background-image: none !important;
-}
-
-================================
-
 spectrum.ieee.org
 
 INVERT
 a[title="Spectrum Logo"] > svg
-
-================================
-
-spectrum.net
-
-INVERT
-.banner-wrapper > .image-container
-img[src$="spectrum-logo.svg"]
-
-CSS
-.unauthenticated-homepage {
-    background-image: none !important;
-}
 
 ================================
 
@@ -16426,14 +16199,6 @@ body {
 
 ================================
 
-torguard.net
-
-INVERT
-img[src$="statusok.gif"]
-img[src$="statusfailed.gif"]
-
-================================
-
 tosdr.org
 
 INVERT
@@ -17009,6 +16774,43 @@ CSS
 
 ================================
 
+upwork.com
+/* fix 1 Remove drop shadow of green botton right column */
+
+CSS
+.profile-completeness-nudges-tiles-alternative .carousel-wrapper .up-icon svg {
+    filter: drop-shadow(0 0 0px var(--white)) drop-shadow(0 0 0px var(--white));
+}
+/* fix 2 REMOVE WHITE GRADIENT HIGHLIGHTS */
+.up-skill-container .up-btn.up-btn-next::before { 
+    opacity: 0;
+}
+.up-skill-container .up-btn.up-btn-prev::before {
+    
+opacity: 0;
+}
+    .up-tab-scroll-hint:after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -30px;
+    z-index: 1;
+    pointer-events: none;
+    width: calc(100% + 60px);
+    height: calc(100% - 1px);
+    background: none;
+    background-repeat: no-repeat;
+    background-size: 15px 100%;
+}
+/* fix 3 Fix skeleton loading from white to dark color in messages page */
+.up-d-skeleton {
+    color: transparent !important;
+    background-color: var(--darkreader-bg--skeleton-color)  !important;
+    background-image: linear-gradient(90deg,var(--darkreader-bg--skeleton-color),#24242400,var(--darkreader-bg--skeleton-color))  !important;
+}
+
+================================
+
 urbandecay.com
 
 IGNORE INLINE STYLE
@@ -17055,7 +16857,7 @@ ul.nav-list > li.qt-nav > div > ul > li > a > img
 uteka.ru
 
 INVERT
-img[src^="/static/img/logo.svg"]
+img[src="/static/img/logo.svg"]
 ymaps[class$="ground-pane"]
 
 ================================
@@ -17232,13 +17034,6 @@ videoman.gr
 INVERT
 #logo-custom span
 .logo-single
-
-================================
-
-vimeo.com
-
-INVERT
-svg[alt="Vimeo"]
 
 ================================
 
@@ -17904,7 +17699,7 @@ div.post-content.footer-content > h2 > img
 #p-logo-text
 body > .oo-ui-windowManager .vega .marks
 .minerva-footer-logo img
-.music-symbol img
+.music-symbol
 .tool.tool-button[src$="background-image:"]
 .mw-kartographer-map
 .mw-kartographer-mapDialog-map
@@ -18605,18 +18400,6 @@ CSS
 }
 .highcharts-text-outline {
     stroke: none !important;
-}
-
-================================
-
-www.stern.de
-
-CSS
-.page {
-    --page-background: var(--darkreader-neutral-background) !important;
-}
-.slide-navigation {
-    background: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -230,6 +230,20 @@ div.description > span {
 
 ================================
 
+4t-niagara.com
+
+CSS
+.download_link > h3,
+.buy_link > h3 {
+    color: ${#88c1ff} !important;
+}
+.download_link li,
+.buy_link li {
+    color: ${white} !important;
+}
+
+================================
+
 aad.org
 
 INVERT
@@ -477,6 +491,18 @@ addons.mozilla.org
 IGNORE IMAGE ANALYSIS
 .Icon-youtube
 span.Permission-description:before
+
+================================
+
+adguard-dns.io
+
+INVERT
+.animation__video
+
+CSS
+.animation__video {
+    z-index: 0 !important;
+}
 
 ================================
 
@@ -2974,6 +3000,16 @@ body {
 
 ================================
 
+circt.llvm.org
+mlir.llvm.org
+
+CSS
+header {
+    background: none !important;
+}
+
+================================
+
 circuit-diagram.org
 
 INVERT
@@ -3142,6 +3178,10 @@ INVERT
 
 cnbc.com
 
+INVERT
+.RenderKeyPoints-list li::before
+.WatchLiveRightRail-logo
+
 CSS
 div[class^="FeaturedStories-styles-makeit-background"]::before {
     opacity: 0.1 !important;
@@ -3172,6 +3212,11 @@ cnn.com
 INVERT
 [data-test="section-link"] > svg:not(.business-logo-icon)
 img.metadata-header__logo
+
+CSS
+#header-nav-container::before {
+    border-bottom-color: transparent !important;
+}
 
 IGNORE INLINE STYLE
 svg.cnn-badge-icon
@@ -3567,7 +3612,7 @@ CSS
 }
 
 IGNORE INLINE STYLE
-#generator*
+#generator *
 
 ================================
 
@@ -3781,7 +3826,7 @@ INVERT
 .owl_item_container img[src*=".gif"]
 .ci-feedback img[src*=".gif"]
 label img[src*=".gif"]
-span.MathJax_SVG
+span.MathJax_SVG g[stroke="black"]
 
 CSS
 .owl_item_container img[src*=".GIF"] {
@@ -3796,6 +3841,9 @@ div.tool-container.gradient > .controlButtons {
 div.tool-container.gradient {
     box-shadow: none;
 }
+
+IGNORE INLINE STYLE
+span.MathJax_SVG g
 
 ================================
 
@@ -3965,6 +4013,18 @@ dawn.com
 
 INVERT
 img[alt="Dawn Logo"]
+
+================================
+
+deadpixeltest.org
+
+CSS
+html {
+    background-color: transparent !important;
+}
+
+IGNORE INLINE STYLE
+body
 
 ================================
 
@@ -4315,6 +4375,15 @@ pre {
 
 ================================
 
+dhmo.org
+
+CSS
+body {
+    background-image: none !important;
+}
+
+================================
+
 di.com.pl
 
 INVERT
@@ -4481,6 +4550,13 @@ html, body {
 
 IGNORE IMAGE ANALYSIS
 body
+
+================================
+
+discuss.pixls.us
+
+INVERT
+#site-logo.logo-big
 
 ================================
 
@@ -5033,7 +5109,7 @@ INVERT
 [data-test="skill-icon"] + div img
 
 CSS
-button[aria-disabled="true"] > span {
+button[aria-disabled="true"] {
     opacity: 0.3 !important;
 }
 
@@ -6545,6 +6621,15 @@ CSS
 
 ================================
 
+gain.tv
+
+CSS
+.body-new-index .hero-img-container {
+    z-index: 0 !important;
+}
+
+================================
+
 garmin.com
 
 INVERT
@@ -7776,6 +7861,18 @@ INVERT
 
 ================================
 
+hp.com
+
+INVERT
+#g-nav .c-logo
+
+CSS
+.pdp-bg {
+    background-image: none !important;
+}
+
+================================
+
 hs.fi
 
 CSS
@@ -8386,6 +8483,13 @@ CSS
 
 ================================
 
+iplocation.net
+
+INVERT
+img[src="/assets/images/logo.png"]
+
+================================
+
 iqiyi.com
 
 INVERT
@@ -8427,6 +8531,15 @@ div.grey-gui-bg,
 .small-purple-heading, 
 .small-navy2-heading {
     background-image: none !important;
+}
+
+================================
+
+istanbulfm.com.tr
+
+CSS
+#jarallax-container-0 {
+    z-index: 0 !important;
 }
 
 ================================
@@ -9642,6 +9755,19 @@ td.c {
 
 ================================
 
+loepenshop.com
+bonjourfoto.nl
+
+CSS
+body {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+div.art-Header-jpeg
+
+================================
+
 login.live.com
 
 INVERT
@@ -10362,7 +10488,7 @@ circle.outline.Oval
 mesa3d.org
 
 INVERT
-.collapsed a svg
+[data-bs-toggle="collapse"] > a > svg
 
 ================================
 
@@ -11693,15 +11819,26 @@ body,
 nymag.com
 
 INVERT
-.logo-svg
+.article-feed-header svg
 .article-nav-top-center
 #latest-feed-title
+.logo-svg
 #site-feed-curbed-title > .feed-title-wrapper
 .tab-trigger > svg
 .tab-trigger > svg > circle
 .tab-trigger > svg > g > circle
+.title-logo
 #vulture-trigger > svg > g > path:nth-child(1)
 #wwwthecut-trigger > svg > .active > path
+
+CSS
+.collection-articles-lede_first-featured .lede-item[data-track-index="0"] .lede-image-wrap {
+    z-index: 0 !important;
+}
+.collection-articles-lede_first-featured .lede-item[data-track-index="0"] .lede-text-wrap {
+    z-index: 1 !important;
+    position: absolute !important;
+}
 
 ================================
 
@@ -11749,6 +11886,21 @@ a[data-testid] > svg {
 }
 #xwd-board rect[class^="Cell-related--"] {
     fill: ${goldenrod} !important;
+}
+#xwd-board rect[class^="xwd__cell--cell"] {
+    fill: ${darkgrey} !important;
+}
+#xwd-board rect[class^="xwd__cell--highlighted"] {
+    fill: ${lightgrey} !important;
+}
+#xwd-board rect[class^="xwd__cell--selected"] {
+    fill: ${white} !important;
+}
+#xwd-board rect[class^="xwd__cell--related"] {
+    fill: ${khaki} !important;
+}
+#xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
+    fill: ${blue} !important;
 }
 
 ================================
@@ -11948,6 +12100,13 @@ table[style*="/cvir/UI"],
 {
     background-image: none !important
 }
+
+================================
+
+onelook.com
+
+INVERT
+img[alt="OneLook"]
 
 ================================
 
@@ -12624,6 +12783,15 @@ footer > div > div > a > img
 
 ================================
 
+planet.gnome.org
+
+CSS
+div.post {
+    background-image: none !important;
+}
+
+================================
+
 planetagracza.pl
 
 INVERT
@@ -12809,6 +12977,14 @@ CSS
 
 ================================
 
+polymc.org
+polymc.github.io
+
+IGNORE INLINE STYLE
+svg.home *
+
+================================
+
 poradnikzdrowie.pl
 
 INVERT
@@ -12820,6 +12996,13 @@ portal.qiniu.com
 
 INVERT
 .global-loading-content img
+
+================================
+
+portal.saltyfish.io
+
+INVERT
+.logo-img
 
 ================================
 
@@ -13216,6 +13399,13 @@ INVERT
 
 ================================
 
+radeonramdisk.com
+
+INVERT
+#logo
+
+================================
+
 radio17.pl
 
 INVERT
@@ -13442,6 +13632,9 @@ p, li {
     background-color: ${white} !important;
 }
 
+IGNORE INLINE STYLE
+.redhat-logo *
+
 ================================
 
 redpenreviews.org
@@ -13565,6 +13758,8 @@ reuters.com
 
 INVERT
 path[d^="M121.865 50.29c0"]
+svg[class^="nav-bar__arrow"] > path
+svg[class^="nav-dropdown__icon"] > path
 
 ================================
 
@@ -13895,6 +14090,7 @@ samsung.*
 
 INVERT
 .icon
+.gnb__logo
 
 CSS
 .feature-full-bleed-text img {
@@ -14042,6 +14238,22 @@ scribd.com
 
 INVERT
 .logo
+
+================================
+
+scribe.rip
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
+scribus.net
+
+INVERT
+#site-header img
 
 ================================
 
@@ -14669,10 +14881,35 @@ CSS
 
 ================================
 
+spectrum.com
+
+INVERT
+img[src$="spectrum-logo.svg"]
+
+CSS
+.sp-background-image {
+    background-image: none !important;
+}
+
+================================
+
 spectrum.ieee.org
 
 INVERT
 a[title="Spectrum Logo"] > svg
+
+================================
+
+spectrum.net
+
+INVERT
+.banner-wrapper > .image-container
+img[src$="spectrum-logo.svg"]
+
+CSS
+.unauthenticated-homepage {
+    background-image: none !important;
+}
 
 ================================
 
@@ -16149,6 +16386,11 @@ to-do.live.com
 INVERT
 span[class^="ms-Toggle-thumb"]
 
+CSS
+.backgroundLines {
+    background-image: linear-gradient(180deg, var(--darkreader-bg--bg-primary), var(--darkreader-bg--bg-primary) 52px, var(--darkreader-bg--bg-separator) 52px, var(--darkreader-bg--bg-separator) 52px) !important;
+}
+
 ================================
 
 todoist.com
@@ -16196,6 +16438,14 @@ body {
     background-image: none !important;
     background-color: var(--darkreader-neutral-background) !important;
 }
+
+================================
+
+torguard.net
+
+INVERT
+img[src$="statusok.gif"]
+img[src$="statusfailed.gif"]
 
 ================================
 
@@ -16773,8 +17023,8 @@ CSS
 }
 
 ================================
-
 upwork.com
+/*---------------Home page fixes-------------------*/
 /* fix 1 Remove drop shadow of green botton right column */
 
 CSS
@@ -16790,17 +17040,9 @@ CSS
 opacity: 0;
 }
     .up-tab-scroll-hint:after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: -30px;
-    z-index: 1;
-    pointer-events: none;
-    width: calc(100% + 60px);
-    height: calc(100% - 1px);
+    
     background: none;
-    background-repeat: no-repeat;
-    background-size: 15px 100%;
+    
 }
 /* fix 3 Fix skeleton loading from white to dark color in messages page */
 .up-d-skeleton {
@@ -16814,9 +17056,18 @@ opacity: 0;
     border:none;
     box-shadow: 0px 0px 1px 2px #101010;                       
 }
-
-================================
-
+/*-----------------Profile page fixes--------------------*/
+.up-tab-scroll-hint:after { /* remove gradient */
+    
+    background: none;
+    opacity: 0;
+}
+.up-sidebar-left {
+border-left-color: transparent;
+    border-left: var(--darkreader-border--border-base);
+    border-right: var(--darkreader-border--border-base);
+}
+/* border too white */
 urbandecay.com
 
 IGNORE INLINE STYLE
@@ -16863,7 +17114,7 @@ ul.nav-list > li.qt-nav > div > ul > li > a > img
 uteka.ru
 
 INVERT
-img[src="/static/img/logo.svg"]
+img[src^="/static/img/logo.svg"]
 ymaps[class$="ground-pane"]
 
 ================================
@@ -17040,6 +17291,13 @@ videoman.gr
 INVERT
 #logo-custom span
 .logo-single
+
+================================
+
+vimeo.com
+
+INVERT
+svg[alt="Vimeo"]
 
 ================================
 
@@ -17705,7 +17963,7 @@ div.post-content.footer-content > h2 > img
 #p-logo-text
 body > .oo-ui-windowManager .vega .marks
 .minerva-footer-logo img
-.music-symbol
+.music-symbol img
 .tool.tool-button[src$="background-image:"]
 .mw-kartographer-map
 .mw-kartographer-mapDialog-map
@@ -18362,7 +18620,7 @@ body > div.t3-wrapper > div > div.section-wrap.bg-wrap1 > div > div > div.custom
 
 ================================
 
-www.soepub.com/discuzx33
+www.soepub.com/discuzx34
 
 CSS
 .c_l,
@@ -18406,6 +18664,18 @@ CSS
 }
 .highcharts-text-outline {
     stroke: none !important;
+}
+
+================================
+
+www.stern.de
+
+CSS
+.page {
+    --page-background: var(--darkreader-neutral-background) !important;
+}
+.slide-navigation {
+    background: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16808,6 +16808,12 @@ opacity: 0;
     background-color: var(--darkreader-bg--skeleton-color)  !important;
     background-image: linear-gradient(90deg,var(--darkreader-bg--skeleton-color),#24242400,var(--darkreader-bg--skeleton-color))  !important;
 }
+.person-avatar-status[data-v-3229f3a5] {
+    background-image: initial;
+    background-color: rgb(78, 84, 87);
+    border:none;
+    box-shadow: 0px 0px 1px 2px #101010;                       
+}
 
 ================================
 


### PR DESCRIPTION
Dark reader did not change Upwork.com into dark mode correctly. There were some minor issues
Here are the fixes I've made:
1-Remove white gradient highlights on the tags sections for each job post.
2-The green button on the right had a white drop shadow and I removed it.
3-in the messages tab, the skeleton loading is white and not dark, so it looks horrible, I changed it to the dark reader skeleton color.

Try it out if you work on upwork (or not, but you need to make a freelance account to try this) and tell me what you think!

![Untitled-1](https://user-images.githubusercontent.com/21056509/161365666-f03dcef4-de5f-4f01-a143-97aff1d6b59f.png)

