### PR TITLE
Fix time automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fix PDF inversion when Auto-detect dark theme option was enabled.
+- Fix time automation when user's time zone is non-UTC.
 
 ## 4.9.47 (Mar 14, 2022)
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -57,7 +57,9 @@ export function nextTimeInterval(time0: string, time1: string, date: Date = new 
         date.setHours(a[0]);
         date.setMinutes(a[1]);
         date.setSeconds(0);
-        return date.getTime();
+        date.setMilliseconds(0);
+        // Convert into UTC timezone Unix time.
+        return date.getTime() + date.getTimezoneOffset() * 60 * 1000;
     }
 
     if (compareTime(t, b) < 0) {
@@ -66,7 +68,9 @@ export function nextTimeInterval(time0: string, time1: string, date: Date = new 
         date.setHours(b[0]);
         date.setMinutes(b[1]);
         date.setSeconds(0);
-        return date.getTime();
+        date.setMilliseconds(0);
+        // Convert into UTC timezone Unix time.
+        return date.getTime() + date.getTimezoneOffset() * 60 * 60 * 1000;
     }
 
     // a <= b <= t


### PR DESCRIPTION
- Currently we're sending to the browser the unix time with user's time zone. But we need to adjust for user's timezone offset as the browser expects the unix time to be in UTC timezone.
- Resolves #8515
- Resolves #7143