### PR TITLE
Fix typo for atlassian.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1502,7 +1502,7 @@ code:first-of-type {
     background-color: ${rgba(3, 9, 15, 0.02)} !important;
 }
 #ak-main-content {
-    background-color: var(--darkreader-neutal-background) !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 #jira-issue-header, #jira-issue-header-actions {
     background-color: rgb(29, 32, 33) !important;


### PR DESCRIPTION
The issue #8566 hasn't been fully resolved due to a small typo. The variabel`darkreader-neual-background` should be `dark-reader-neutral-background` to make the white background on top of the page dark.