### PR TITLE
Fix for theatlantic.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16148,8 +16148,9 @@ INVERT
 theatlantic.com
 
 INVERT
-.c-nav__icon--lacroix
-.hamburger-inner
+[class^="NavHamburgerButton_root"]
+[class^="NudgeShared_chevron"]
+[class^="NonMeteredNudge_desktopTextContainer"]::after
 
 ================================
 


### PR DESCRIPTION
- Invert nav hamburger menu
- Invert chevron and divider in subscription prompt area

Looks like the site was recently redesigned to include random strings at the end of most or all class names, so I removed the old inversions and used 'class^=' instead.