### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12414,7 +12414,7 @@ div[dir="ltr", id="map"] {
     background-color: ${#1b1b1b} !important;
 }
 img.loader {
-	filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5030,7 +5030,7 @@ div[role="button"][aria-disabled="true"] > div {
     filter: invert(50%) !important;
 }
 #request-access-icon {
-	filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
 }
 
 IGNORE INLINE STYLE
@@ -5044,7 +5044,7 @@ INVERT
 div[role="menu"] > div[role="menuitem"] > div > div > div
 div[role="menu"] > div[role="menuitem"] > div > div
 #request-access-icon {
-	filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
+    filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
 }
 
 ================================
@@ -17389,6 +17389,7 @@ vimeo.com
 INVERT
 svg[alt="Vimeo"]
 #header-vimeo-logo
+footer > div > div > a > svg > path[d^="M89.05 23.658a12.087 12.087"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5043,6 +5043,8 @@ drive.google.com/file
 INVERT
 div[role="menu"] > div[role="menuitem"] > div > div > div
 div[role="menu"] > div[role="menuitem"] > div > div
+
+CSS
 #request-access-icon {
     filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -430,6 +430,7 @@ accounts.zoho.com
 
 INVERT
 div#product_img.tfa_totp_mode
+span.zoho_logo
 
 ================================
 
@@ -1544,6 +1545,13 @@ CSS
 body {
      background-color: var(--darkreader-neutral-background) !important;
 }
+
+================================
+
+auth0.com
+
+INVERT
+button[data-handler="authorise-github"] > img.icon.icon-default
 
 ================================
 
@@ -3795,8 +3803,20 @@ crowdin.com
 INVERT
 .crowdin-navbar__logo
 svg.logo-icon-projects
+.nav.pull-right > li > a > i
+.btn-group.pull-right > a > i
+.pull-right.btn-toolbar > button > i
+.pull-right.btn-toolbar > div > button > i
+.btn.btn-small.dropdown-toggle.files-dropmenu.btn-link-2
+.file_type.file_folder.file_branch
+.static-icon.static-icon-star-black.muted.clearfix
 #master-loader > .master-loader-logo
 #master-loader-progress.bar
+
+CSS
+i.notification-placeholder-icon.static-icon.ajax-loader-icon.static-icon-alarm {
+    background-image: url(https://d2srrzh48sp2nh.cloudfront.net/52aa3a4b/images/application-icons/svg/bell-o.svg) !important;
+}
 
 ================================
 
@@ -4694,7 +4714,9 @@ CSS
 img[src="/images/logos/ASALE2.png"],
 img[src="/images/logos/rae.png"],
 img[src="/images/LibroDeEstilo_300.jpg"],
-img[src="/app/doc/es/img/dle.jpg"] {
+img[src="/app/doc/es/img/dle.jpg"],
+a[href="https://dej.rae.es"] > img.img-responsive.b-lazy.b-loaded,
+img[src="/images/logos/BCRAEl.jpg"] {
 	filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
 }
 
@@ -5007,6 +5029,9 @@ div[role="menu"] div[role="menuitem"][class*=" "] > div > div > div,
 div[role="button"][aria-disabled="true"] > div {
     filter: invert(50%) !important;
 }
+#request-access-icon {
+	filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
+}
 
 IGNORE INLINE STYLE
 div[role="presentation"] svg
@@ -5018,6 +5043,9 @@ drive.google.com/file
 INVERT
 div[role="menu"] > div[role="menuitem"] > div > div > div
 div[role="menu"] > div[role="menuitem"] > div > div
+#request-access-icon {
+	filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
+}
 
 ================================
 
@@ -10934,6 +10962,7 @@ monitor.firefox.com
 
 INVERT
 svg[class="Mozilla-logo"] > path[fill="#ffffff"]
+.fx-bento-app-link.fx-bento-link.fx-mobile > span::before
 
 ================================
 
@@ -12384,6 +12413,9 @@ div[dir="ltr", id="map"] {
 .map-layout #map {
     background-color: ${#1b1b1b} !important;
 }
+img.loader {
+	filter: invert(93.7%) hue-rotate(180deg) contrast(90.6%) !important
+}
 
 IGNORE INLINE STYLE
 .ideditor .main-content *
@@ -13438,6 +13470,7 @@ qwant.com
 INVERT
 .background-home__logo
 .home__logo__container .home__logo
+canvas.mapboxgl-canvas
 
 ================================
 
@@ -13769,6 +13802,10 @@ relay.firefox.com
 INVERT
 img.c-landing-hero-brands
 img.c-brand-title
+.fx-bento-app-link.fx-bento-link.fx-mobile > span::before
+.fx-bento-app-link.fx-bento-link.fx-vpn > span::before
+div.glocal-site-options > a > img
+div.glocal-site-options > form > button::before
 
 ================================
 
@@ -16212,6 +16249,21 @@ INVERT
 
 ================================
 
+thefreedictionary.com
+
+INVERT
+strong.i.logo
+a.i.keyboard-link.mobile-hidden
+#regButton::before
+ul.social-networks
+a.i.icon-notif
+div.box > a.i
+div.cprh > span.i.A.cpr
+a.i.popup-opener
+ul.logos-list
+
+================================
+
 theguardian.com
 
 INVERT
@@ -17336,6 +17388,7 @@ vimeo.com
 
 INVERT
 svg[alt="Vimeo"]
+#header-vimeo-logo
 
 ================================
 
@@ -18596,6 +18649,14 @@ www.mayoclinic.org
 INVERT
 .mc-logo
 .logo > a > img[alt="Mayo Clinic"]
+img[src="/-/media/images/mayologo.png"]
+img[src="/styles/img/gbs/logo-mayoclinic-mobile.png"]
+
+CSS
+ul#nav.nav > li.no-image > a,
+ul#nav.nav > li.current > a {
+    background-image: url("/UniversalNav/Styles/img/sprite-globalnavarrows.png") !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Zoho: Main logo in settings page
- A0: Github icon in login page
- Crowdin: Various icons. Not entirely sure if the addition in CSS is correct, but without it the icon inexplicably changes from a bell into a loading gif. It can only be seen when logged in.
- RAE: Images at the bottom
- GDrive: New denied access image, not entirely convinced about the result.
- FFMonitor: Mobile icon in dropdown menu
- FFRelay: Mobile and VPN icons in dropdown menu and icons in profile dropdown menu
- Qwant: Maps
- OSM: Loading icon when searching
- TFD: Various icons
- Vimeo: Header logo when seeing a single video and footer logo on main page
- MC: Various logos and dropdown menu icons