### PR TITLE
Fix for theregister.* (DevClass logo inversion)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16340,6 +16340,7 @@ theregister.*.*
 INVERT
 .row_label.title_rhs_line
 .blocksandfiles_logo
+.devclass_logo
 #sitpub_logo
 
 ================================


### PR DESCRIPTION
Inverting `.devclass_logo`

![image](https://user-images.githubusercontent.com/10338703/163510322-040738aa-afe2-4021-a407-024c684df3ed.png)
![image](https://user-images.githubusercontent.com/10338703/163510256-0eb687f7-d394-4e10-94c1-ffe64b50661c.png)
