### PR TITLE
Fix for wikimediastatus.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18078,6 +18078,13 @@ INVERT
 
 ================================
 
+wikimediastatus.net
+
+INVERT
+.logo-container
+
+================================
+
 wikinews.org
 wikiquote.org
 


### PR DESCRIPTION
Inverting `.logo-container`

![Screenshot 2022-04-16 at 04-25-01 Wikimedia Status](https://user-images.githubusercontent.com/10338703/163634233-5dcdb4c9-a6a5-461c-8452-e24e37ba33b8.png)
![Screenshot 2022-04-16 at 04-25-20 Wikimedia Status](https://user-images.githubusercontent.com/10338703/163634241-c1a57a8e-137c-4915-a6c5-3376bbc456bf.png)
