### PR TITLE
Fix comments on banki.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1711,6 +1711,11 @@ banki.ru
 INVERT
 .header__logo
 
+CSS
+.comment:nth-child(even) {
+    background-color: ${#f5f5f5} !important;
+}
+
 ================================
 
 bankier.pl


### PR DESCRIPTION
Comments section on banki.ru has white light background for even comments

Example URL: https://www.banki.ru/services/responses/bank/response/10649002/

How it looks without the fix

![image](https://user-images.githubusercontent.com/153191/163716106-a56c568b-86a9-42d9-8eeb-bacd3dcf7b4e.png)


How it looks with the fix

![image](https://user-images.githubusercontent.com/153191/163716050-a32aea28-8e5f-4b78-b894-fad2abc55009.png)
