### PR TITLE
Fix tiktok.com, buffer.com vectors and add tracker.gg to dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -949,8 +949,8 @@ title-case-converter.vercel.app
 tmtheme-editor.herokuapp.com
 toneden.io
 totalwarwarhammer.gamepedia.com
-tracker.gg
 tracker.fumik0.com
+tracker.gg
 tracr.co
 training.azeria-labs.com
 trblwlf.tk

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -949,6 +949,7 @@ title-case-converter.vercel.app
 tmtheme-editor.herokuapp.com
 toneden.io
 totalwarwarhammer.gamepedia.com
+tracker.gg
 tracker.fumik0.com
 tracr.co
 training.azeria-labs.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19090,6 +19090,8 @@ div[class*="DivVolumeControlContainer"]
 .volume-control-container-browser
 .seek-bar-container
 .volume-control-container
+svg[class*="StyledLinkLogo"]
+svg[class*="SvgPlayIcon"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2456,6 +2456,13 @@ CSS
 
 ================================
 
+buffer.com
+
+INVERT
+a[class*="BufferLogoWithWords"]
+
+================================
+
 bugreplay.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2458,8 +2458,8 @@ CSS
 
 buffer.com
 
-INVERT
-a[class*="BufferLogoWithWords"]
+IGNORE INLINE STYLE
+div[class^="style__LogoWrapper"] *
 
 ================================
 


### PR DESCRIPTION
Add INVERT on svg.StyledLinkLogo and svg.SvgPlayIcon on TikTok webapp.
Add tracker.gg to collection of already dark sites.