### PR TITLE
Invert logos on *.lever.co

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9612,6 +9612,14 @@ INVERT
 
 ================================
 
+lever.co
+
+INVERT
+a.main-header-logo
+div.site-branding
+
+================================
+
 lg.com
 
 INVERT


### PR DESCRIPTION
INVERT on a.main-header-logo (for jobs.lever.co) and div.site-branding (for lever.co) to invert default dark logos.