### PR TITLE
Bing Results with summary side panel

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2047,7 +2047,7 @@ CSS
     z-index: 2 !important;
 }
 #b_content {
-    background: none !important
+    background-image: none !important
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2046,6 +2046,9 @@ CSS
 .l_ecrd_imcolheader.gradient {
     z-index: 2 !important;
 }
+#b_content {
+    background: none !important
+}
 
 IGNORE INLINE STYLE
 .b_header_bg


### PR DESCRIPTION
When you search for something that has an extended summary panel, it adds a gradient to the background that was being inverted strangely. This change removes the gradient.