### PR TITLE
Add some dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -827,7 +827,6 @@ sauce420.gitlab.io
 saznajnovo.com
 sb.ltn.fi
 science-news.co
-scrap.tf
 seaofthieves.fandom.com
 search.biboumail.fr
 search.nebulacentre.net

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -196,7 +196,8 @@ crackingking.com
 crackwatch.com
 crazygames.com
 crontab.guru
-crowdin.com
+crowdin.com/proofread
+crowdin.com/translate
 cryptowat.ch
 cs.rin.ru
 cssbattle.dev

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -149,7 +149,6 @@ buildbot.orphis.net
 bungie.net
 byte.co
 bytebin.lucko.me
-cl00e9ment.gitlab.io/kingdom-blazon-generator/
 c-saccoccio.fr
 cadence.moe
 caesarshiba.com
@@ -173,6 +172,7 @@ chitownhousemusic.com
 chromatic-tuner.com
 cider.sh
 cinema-city.pl
+cl00e9ment.gitlab.io/kingdom-blazon-generator/
 clash3d.com
 clashofstats.com
 clt.gg

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -2,7 +2,7 @@
 0x00sec.org
 12bytes.org
 1337x-forum.eu
-1337x.*/$
+1337x.*
 1lighty.github.io/BetterDiscordStuff
 1nf.me
 2600.com
@@ -78,6 +78,7 @@ audiolove.club
 audiomass.co
 audioz.download
 augmentedsteam.com
+avatars.alphacoders.com
 avengedsevenfold.com
 axyl-os.github.io
 azeria-labs.com
@@ -105,7 +106,6 @@ betterttv.com
 bherila.net
 bin.disroot.org
 binclub.dev
-bing.com/$
 bip.staszic.waw.pl
 birdie0.github.io
 bitcoinity.org/markets
@@ -149,6 +149,7 @@ buildbot.orphis.net
 bungie.net
 byte.co
 bytebin.lucko.me
+cl00e9ment.gitlab.io/kingdom-blazon-generator/
 c-saccoccio.fr
 cadence.moe
 caesarshiba.com
@@ -172,10 +173,10 @@ chitownhousemusic.com
 chromatic-tuner.com
 cider.sh
 cinema-city.pl
-cl00e9ment.gitlab.io/kingdom-blazon-generator/
 clash3d.com
 clashofstats.com
 clt.gg
+cncnet.org
 codepen.io
 codesandbox.io
 codestackr.com
@@ -195,6 +196,7 @@ crackingking.com
 crackwatch.com
 crazygames.com
 crontab.guru
+crowdin.com
 cryptowat.ch
 cs.rin.ru
 cssbattle.dev
@@ -233,6 +235,7 @@ deltarune.com
 demonforums.net
 denims.tv
 denshi.org
+derpibooru.org
 desktop.github.com
 destiny.gg
 destinytracker.com
@@ -252,12 +255,7 @@ discohook.org
 discord.bio
 discord.boats
 discord.bots.gg
-discord.com/app
-discord.com/channels
-discord.com/developers
-discord.com/invite
-discord.com/login
-discord.com/register
+discord.com
 discordbotlist.com
 discordservers.me
 discordtemplates.com
@@ -355,7 +353,7 @@ forumplayer.dev
 forums.launchbox-app.com
 fox.com
 fpn.firefox.com
-frankerfacez.com/$
+frankerfacez.com
 freespeechextremist.com
 frozensand.com
 funnyjunk.com
@@ -450,11 +448,7 @@ hostedtalk.net
 hotstar.com
 hrmspms.sicorax.mu
 htmlpasta.com
-humblebundle.com/$
-humblebundle.com/accessibility
-humblebundle.com/charities
-humblebundle.com/refer
-humblebundle.com/subscription
+humblebundle.com
 humblegames.com
 hyper.is
 hyperbeam.dev
@@ -544,6 +538,7 @@ lipu-linku.github.io
 liquidplus.com
 listen.moe
 livesplit.org
+loadout.tf
 lolesports.com
 lollilol.cf
 lollilol.ml
@@ -624,6 +619,7 @@ netzhack.de
 neundex.com
 neurocore.xyz
 newgrounds.com
+next.backpack.tf
 nexusmods.com
 nfs.fandom.com
 nfspolska.pl
@@ -718,7 +714,7 @@ playartifact.com
 playcanv.as
 playcanvas.com
 playclassic.games
-playcode.io/$
+playcode.io
 playerdb.co
 pleroma.social
 plex.doorcraft.de
@@ -737,6 +733,7 @@ polsatgo.pl
 polychromatic.app
 pony.tube
 pool.pm
+pornhub.com
 powercord.dev
 ppluss.de
 pr0gramm.com
@@ -825,6 +822,7 @@ sauce420.gitlab.io
 saznajnovo.com
 sb.ltn.fi
 science-news.co
+scrap.tf
 seaofthieves.fandom.com
 search.biboumail.fr
 search.nebulacentre.net
@@ -891,6 +889,7 @@ stitches.dev
 stonestyle.co.th
 store.steampowered.com
 storyfire.com
+streamable.com
 streamelements.com
 streamwat.ch
 studiomaertens.com
@@ -924,6 +923,7 @@ teleseer.com
 televizeseznam.cz
 telugucz.com
 terminal.sexy
+term.ooo
 tetr.io
 textfiles.com
 tf2mart.net
@@ -948,6 +948,7 @@ tio.run
 title-case-converter.vercel.app
 tmtheme-editor.herokuapp.com
 toneden.io
+top.gg
 totalwarwarhammer.gamepedia.com
 tracker.fumik0.com
 tracker.gg
@@ -1045,18 +1046,22 @@ wtfast.com
 www.canalplus.com
 www.cc.com
 www.chiefdelphi.com
+www.deviantart.com
 www.digikam.org
 www.directvnow.com
 www.gotimelinr.com
+www.leagueoflegends.com
 www.mtv.com
 www.netflix.com
+www.patuscada.bar
 www.razer.com
+www.redgifs.com
 www.seebham.codes
 www.teamfortress.com
 www.tvnz.co.nz
 www.wickeditor.com/editor/
 www.worldofplayers.de
-x1337x.*/$
+x1337x.*
 x64dbg.com
 xbins.org
 xdox.me

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -925,8 +925,8 @@ telecineplay.com.br
 teleseer.com
 televizeseznam.cz
 telugucz.com
-terminal.sexy
 term.ooo
+terminal.sexy
 tetr.io
 textfiles.com
 tf2mart.net

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -904,6 +904,7 @@ support.steampowered.com
 supremacy1914.com
 surviv.io
 svtplay.se
+sync-tube.de
 szmarczak.com
 t.maisputain.ovh
 tabstats.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -78,7 +78,6 @@ audiolove.club
 audiomass.co
 audioz.download
 augmentedsteam.com
-avatars.alphacoders.com
 avengedsevenfold.com
 axyl-os.github.io
 azeria-labs.com
@@ -1054,10 +1053,8 @@ www.deviantart.com
 www.digikam.org
 www.directvnow.com
 www.gotimelinr.com
-www.leagueoflegends.com
 www.mtv.com
 www.netflix.com
-www.patuscada.bar
 www.razer.com
 www.seebham.codes
 www.teamfortress.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -2,7 +2,7 @@
 0x00sec.org
 12bytes.org
 1337x-forum.eu
-1337x.*
+1337x.*/$
 1lighty.github.io/BetterDiscordStuff
 1nf.me
 2600.com
@@ -196,8 +196,6 @@ crackingking.com
 crackwatch.com
 crazygames.com
 crontab.guru
-crowdin.com/proofread
-crowdin.com/translate
 cryptowat.ch
 cs.rin.ru
 cssbattle.dev
@@ -236,7 +234,6 @@ deltarune.com
 demonforums.net
 denims.tv
 denshi.org
-derpibooru.org
 desktop.github.com
 destiny.gg
 destinytracker.com
@@ -256,7 +253,12 @@ discohook.org
 discord.bio
 discord.boats
 discord.bots.gg
-discord.com
+discord.com/app
+discord.com/channels
+discord.com/developers
+discord.com/invite
+discord.com/login
+discord.com/register
 discordbotlist.com
 discordservers.me
 discordtemplates.com
@@ -354,7 +356,7 @@ forumplayer.dev
 forums.launchbox-app.com
 fox.com
 fpn.firefox.com
-frankerfacez.com
+frankerfacez.com/$
 freespeechextremist.com
 frozensand.com
 funnyjunk.com
@@ -449,7 +451,11 @@ hostedtalk.net
 hotstar.com
 hrmspms.sicorax.mu
 htmlpasta.com
-humblebundle.com
+humblebundle.com/$
+humblebundle.com/accessibility
+humblebundle.com/charities
+humblebundle.com/refer
+humblebundle.com/subscription
 humblegames.com
 hyper.is
 hyperbeam.dev
@@ -620,7 +626,6 @@ netzhack.de
 neundex.com
 neurocore.xyz
 newgrounds.com
-next.backpack.tf
 nexusmods.com
 nfs.fandom.com
 nfspolska.pl
@@ -715,7 +720,7 @@ playartifact.com
 playcanv.as
 playcanvas.com
 playclassic.games
-playcode.io
+playcode.io/$
 playerdb.co
 pleroma.social
 plex.doorcraft.de
@@ -734,7 +739,6 @@ polsatgo.pl
 polychromatic.app
 pony.tube
 pool.pm
-pornhub.com
 powercord.dev
 ppluss.de
 pr0gramm.com
@@ -890,7 +894,6 @@ stitches.dev
 stonestyle.co.th
 store.steampowered.com
 storyfire.com
-streamable.com
 streamelements.com
 streamwat.ch
 studiomaertens.com
@@ -1057,13 +1060,12 @@ www.mtv.com
 www.netflix.com
 www.patuscada.bar
 www.razer.com
-www.redgifs.com
 www.seebham.codes
 www.teamfortress.com
 www.tvnz.co.nz
 www.wickeditor.com/editor/
 www.worldofplayers.de
-x1337x.*
+x1337x.*/$
 x64dbg.com
 xbins.org
 xdox.me


### PR DESCRIPTION
This pull request:

- removes some `/$` (I sincerely don't know what they do, but I think they are unnecessary since some sites don't have it);
- removes `bing.com` from the global list (since bing.com is white by default);
- adds several dark sites to the list;
- removes duplicated sites (like `discord.com` being listed multiple times). I think this is unnecessary.

Additional notes:
`leagueoflegends.com` is sometimes white, but for the most part it is black. See, for example:
Main page - https://www.leagueoflegends.com/en-us/ ([a little broken in the start - EXTENSION ON](https://user-images.githubusercontent.com/30274161/166124478-59bf2eeb-569e-4121-8912-0d1164f37c84.png)) -- compare with this image: [not broken at the start - EXTENSION OFF](https://user-images.githubusercontent.com/30274161/166124569-3de9a707-3ebb-479b-bae3-590adc8e3ea9.png)
Patch notes - https://www.leagueoflegends.com/en-us/news/game-updates/patch-12-8-notes/

`crowdin.com` is purely white in its main page, but in the editor it is black. Crowdin is a site for community translations.
[Main page image - EXTENSION OFF](https://user-images.githubusercontent.com/30274161/166124511-ba7ed900-c975-4e29-bacc-5528e1b869a0.png)
[Editor image - EXTENSION OFF](https://user-images.githubusercontent.com/30274161/166124517-df9cfc18-029c-43a1-85de-9b6704204054.png)

[Main page image - EXTENSION ON](https://user-images.githubusercontent.com/30274161/166124588-3cb209a1-703f-4401-9d70-51e9bf64ae72.png)
[Editor image - EXTENSION ON](https://user-images.githubusercontent.com/30274161/166124590-e79ee43a-9f7b-483a-87dc-9209a8fa66a1.png)

EDIT (Crowdin): I implemented these changes with a new commit.

Both the main page and the editor are in `crowdin.com`, but the editor is in `crowdin.com/translate` and `crowdin.com/proofread`. If I add these last two to the list, would it work?

For `avatars.alphacoders.com`, I added it because it looks a little better with the extension off. Compare it by yourselves toggling the extension in these:

https://avatars.alphacoders.com/ -- this is mostly fine, except for the words at the middle-top "_Welcome To Avatar Abyss!
Home To 242298 pfp! (Old people call them Forum Avatars or Profile Photos) / Search For pfp!_", these are a little hard to read

https://avatars.alphacoders.com/avatars/highest_rated -- the blue background doesn't turn black at the start


Please let me know about your review(s).

Thanks in advance.