### PR TITLE
Fix dynamic: notion.so

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11981,22 +11981,8 @@ CSS
 body {
     background-color: var(--darkreader-neutral-background) !important;
 }
-.notion-page-block,
-div[contenteditable="true"],
-.notion-page-content div {
-    color: var(--darkreader-neutral-text) !important;
-}
 .notion-divider-block div div {
     border-bottom: 1px solid ${rgba(55, 53, 47, 0.4)} !important;
-}
-.header .logo svg > path:nth-child(1),
-nav[aria-label="Main footer navigation"] .logo svg > path:nth-child(1) {
-    fill: var(--darkreader-neutral-background) !important;
-}
-.header .logo svg > path:nth-child(3),
-nav[aria-label="Main footer navigation"] .logo svg > path:nth-child(3),
-.notion-focusable svg {
-    fill: var(--darkreader-neutral-text) !important;
 }
 
 ================================


### PR DESCRIPTION
* The first edit is vital: Currently it was overwriting any colored text back to white/black.
* The other two selectors: were increasing contrast of a few non-important UI icons. So in my opinion it makes sense that these elements have less contrast that the text, right now they were equal. And I think the site looks better overall.