### PR TITLE
Added "djflame.tech" to dark-by-default list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -267,6 +267,7 @@ discourse.disneyheroesgame.com
 discuss.noisebridge.info
 disneyplus.com
 distrotube.com
+djflame.tech
 dlive.tv
 dodi-repacks.site
 doesitarm.com


### PR DESCRIPTION
[djflame.tech](https://djflame.tech/) is dark by default on all pages no matter system defaults, and sometimes gets broken when Dark Reader is enabled on the site.

## Screenshot of Site's Homepage with DarkReader disabled
![image](https://user-images.githubusercontent.com/58677791/166162425-49b22c90-1654-46b1-a11d-e53609571019.png)
