### PR TITLE
Fix for overleaf.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12741,7 +12741,6 @@ div.o365cs-base > span.ms-Icon--WaffleOffice36
 overleaf.com
 
 INVERT
-.pdf-viewer
 .mwe-math-element
 
 ================================


### PR DESCRIPTION
Remove PDF viewer inversion so that the displayed PDF is an accurate view of the finished product.