### PR TITLE
Fix zendesk.com text box

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20031,6 +20031,15 @@ CSS
 
 ================================
 
+zendesk.com
+
+CSS
+.zendesk-editor--rich-text-container {
+    background-image: none !important;
+}
+
+================================
+
 zenn.dev
 
 INVERT


### PR DESCRIPTION
Zendesk is a customer support ticketing website. This fix removes white bars in the comments box which obstruct the top and bottom lines of text when typing.