### PR TITLE
Fix for getpocket.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1108,13 +1108,6 @@ svg text.time_cursor {
 
 ================================
 
-app.getpocket.com
-
-IGNORE IMAGE ANALYSIS
-*
-
-================================
-
 app.grammarly.com
 
 CSS
@@ -7046,8 +7039,9 @@ login-container {
 getpocket.com
 
 CSS
-a .title span {
+a[rel="noopener noreferrer"] {
     text-shadow: none !important;
+    background-image: linear-gradient(to top,transparent,transparent 1px,var(--darkreader-text--color-canvas) 1px,var(--darkreader-text--color-canvas) 2px,transparent 2px) !important;
 }
 
 ================================


### PR DESCRIPTION
- Remove obsolete rules.
- Fix inversion of in-article links.

Maybe the rule for `background-image` could be simpler, but I just use original CSS code with other variables.