### PR TITLE
Fix for vanguard.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17749,6 +17749,7 @@ INVERT
 #vgn-searchToggleButtonButton--long-form
 #vgn-searchToggleButtonButton--small-form
 input[id^="buysellForm:"]
+input[id^="HoldingDetailForm:"]
 
 CSS
 .hidePageIfJSdisabled {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17743,6 +17743,13 @@ INVERT
 
 vanguard.com
 
+INVERT
+.vgn-accordionIcon
+.vgn-arrow::after
+#vgn-searchToggleButtonButton--long-form
+#vgn-searchToggleButtonButton--small-form
+input[id^="buysellForm:"]
+
 CSS
 .hidePageIfJSdisabled {
     display: block !important;


### PR DESCRIPTION
Inversions for:
- Dark menu chevrons
- Dark magnifying glass search icons
- Light text on light background buy/sell transaction buttons and "holding detail" buttons