### PR TITLE
Fix for liveuamap.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10102,6 +10102,21 @@ div.icoShare.iconSprite
 
 ================================
 
+liveuamap.com
+
+INVERT
+.comment-link::after
+.leaflet-pane > .leaflet-layer
+.logo
+.top-bright > label::after
+
+CSS
+.head-news {
+    background-image: none !important;
+}
+
+================================
+
 lkml.org
 
 INVERT


### PR DESCRIPTION
- Darken map theme
- Invert comment, share, and logo icons
- Remove bright background gradient behind the Live News header