### PR TITLE
Remove fastpath.

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -315,18 +315,6 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
         cancelAsyncOperations = false;
 
         function removeCSSRulesFromSheet(sheet: CSSStyleSheet) {
-            // Check if we can use a fastpath by using sheet.replaceSync.
-            // Because replaceSync can throw DOMExceptions we have to use try-catch.
-            try {
-                if (sheet.replaceSync) {
-                    sheet.replaceSync('');
-                    return;
-                }
-            } catch (err) {
-                logWarn('Could not use fastpath for removing rules from stylesheet', err);
-            }
-            // If we hit this point, the replaceSync didn't work
-            // and we have to iterate over the CSSRules.
             for (let i = sheet.cssRules.length - 1; i >= 0; i--) {
                 sheet.deleteRule(i);
             }


### PR DESCRIPTION
- In only a small subset of scenario's the fastpath is actually used. This isn't worth the performance loss of `try {} catch {}`.