### PR TITLE
Hide long logs

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -2,7 +2,7 @@ import {createOrUpdateStyle, removeStyle} from './style';
 import {createOrUpdateSVGFilter, removeSVGFilter} from './svg-filter';
 import {runDarkThemeDetector, stopDarkThemeDetector} from './detector';
 import {createOrUpdateDynamicTheme, removeDynamicTheme, cleanDynamicThemeCache} from './dynamic-theme';
-import {logInfo, logWarn} from '../utils/log';
+import {logInfo, logWarn, logInfoCollapsed} from '../utils/log';
 import {watchForColorSchemeChange} from './utils/watch-color-scheme';
 import {collectCSS} from './dynamic-theme/css-collection';
 import type {Message} from '../definitions';
@@ -56,7 +56,7 @@ function sendMessage(message: Message) {
 }
 
 function onMessage({type, data}: Message) {
-    logInfo('onMessage', type, data);
+    logInfoCollapsed(`onMessage[${type}]`, data);
     switch (type) {
         case MessageType.BG_ADD_CSS_FILTER:
         case MessageType.BG_ADD_STATIC_THEME: {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -8,3 +8,11 @@ export function logInfo(...args: any[]) {
 export function logWarn(...args: any[]) {
     DEBUG && console.warn(...args);
 }
+
+export function logInfoCollapsed(title: any, ...args: any[]) {
+    if (DEBUG) {
+        console.groupCollapsed(title);
+        console.log(...args);
+        console.groupEnd();
+    }
+}


### PR DESCRIPTION
- The onmessage logs can be quite long in the console is annoying to go trough when you need to debug based of logs(because browser bugs). So, hide them in a collapsed group by default.