### PR TITLE
Fix for bloomberg.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2328,7 +2328,7 @@ INVERT
 
 CSS
 .navi {
-    border-color: rgb(140, 130, 115) !important;
+    border-color: var(--darkreader-border--color-black) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2319,6 +2319,20 @@ CSS
 
 ================================
 
+bloomberg.com
+
+INVERT
+.navi-bar__button-icon
+.navi-sections__item--LiveNow::before
+.navi-sections__link--current::after
+
+CSS
+.navi {
+    border-color: rgb(140, 130, 115) !important;
+}
+
+================================
+
 blueberryroasters.pl
 
 INVERT


### PR DESCRIPTION
- Fix top menu bar border color.
- Invert dark magnifying glass icon, Live Now icon, and current tab indicator.