### PR TITLE
Add "gibbu.github.io/ThemePreview/"

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -389,6 +389,7 @@ ghidra-sre.org
 ghostpgp.com
 giantbomb.com
 gibber.cc
+gibbu.github.io/ThemePreview/
 gifrun.com
 gifyourgame.com
 giggl.app


### PR DESCRIPTION
Dark Reader kinda makes the theme viewer on the BetterDiscord site scuffed. An example with and without Dark Reader on the ClearVision theme. https://gibbu.github.io/ThemePreview/?file=https://cdn.jsdelivr.net/gh/ClearVision/ClearVision-v6/ClearVision_v6.theme.css

With Dark Reader
![image](https://user-images.githubusercontent.com/79660414/167971174-9881da21-ebfa-4044-b84c-e72df43fcaf0.png)

Without Dark Reader/Normal
![image](https://user-images.githubusercontent.com/79660414/167971217-7e3e546f-cb34-4350-ba80-6665f2e802ec.png)
