### PR TITLE
Fix for understandingwar.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17665,6 +17665,26 @@ a.logo[title="United Nations"]
 
 ================================
 
+understandingwar.org
+
+CSS
+img[typeof="foaf:Image"] {
+    background-color: white !important;
+}
+input,
+li[class^="menu-"] > a {
+    color: #665c39 !important;
+    text-shadow: none !important;
+}
+#mainwrap {
+    background-image: none !important;
+}
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
 uokik.gov.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17674,7 +17674,7 @@ img[typeof="foaf:Image"] {
 input,
 li[class^="menu-"] > a {
     color: #665c39 !important;
-    text-shadow: none !important;
+    text-shadow: #ebe5d5 0 1px 0 !important;
 }
 #mainwrap {
     background-image: none !important;


### PR DESCRIPTION
- Ignore image analysis throughout site to fix images.
- Force white background behind transparent ISW logo next to posts.
- Force text in header menu and search field to be the correct color. Not using ${color} to avoid messing with the site's color scheme. 
- Remove bright background image from bottom of posts.