### PR TITLE
Fix for understandingwar.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17665,6 +17665,28 @@ a.logo[title="United Nations"]
 
 ================================
 
+understandingwar.org
+
+CSS
+#edit-search-block-form--2,
+#nice-menu-1 > li > a {
+    color: #665c39 !important;
+    text-shadow: none !important;
+}
+#mainwrap,
+.secondarybox,
+.content,
+.view-filters {
+    background-image: none !important;
+}
+img[src*="ISW\%20LOGO"] {
+    background-color: white !important;
+}
+
+IGNORE IMAGE ANALYSIS
+*
+================================
+
 uokik.gov.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17679,7 +17679,7 @@ CSS
 .view-filters {
     background-image: none !important;
 }
-img[src*="ISW\%20LOGO"] {
+img[src*="LOGO"] {
     background-color: white !important;
 }
 


### PR DESCRIPTION
- Ignore image analysis throughout site to fix images.
- Set text in header search bar and top menu to be the correct color. Not using ${color} to avoid messing with the site's color scheme.
- Remove bright background images from posts and various other areas of the site.
- Force white background behind transparent ISW logos on home page and publications sections.