### PR TITLE
Update fix for `acorn.utoronto.ca`

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -465,7 +465,9 @@ CSS
 .acorn-classic.page-container .academic-history .credit-earned-section,
 .acorn-classic.page-container .academic-history .average-section,
 .acorn-classic.page-container .academic-history .courses,
-.acorn-classic.page-container .academic-history .coursesHeader {
+.acorn-classic.page-container .academic-history .coursesHeader,
+.acorn-classic.page-container .academic-history .academic-history-report .gpa-listing,
+.acorn-classic.page-container .academic-history-recent table .emph {
     color: var(--darkreader-neutral-text) !important;
 }
 


### PR DESCRIPTION
Updates the original fix brought in https://github.com/darkreader/darkreader/pull/7847

Just adds more selectors to change the text to white