### PR TITLE
Remove valh.io from dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1007,7 +1007,6 @@ v3rmillion.net
 v7player.wostreaming.net
 v8.dev
 vakhtangov.ru
-valh.io
 valvestore.forfansbyfans.com
 vancedapp.com
 vanillatweaks.net


### PR DESCRIPTION
My personal site is light by default now and relies on Dark Reader for a dark theme which is why this PR removes it from dark-sites.config.