### PR TITLE
gamerant.com is dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -366,6 +366,7 @@ fusengine.github.io/apaxy-v2
 gamebanana.com
 gamejolt.com
 gameloop.fun
+gamerant.com
 gaming.amazon.com
 garamlee500.github.io
 garudalinux.org


### PR DESCRIPTION
https://gamerant.com/stranger-things-duffer-brothers-movies-homework/

![20220519-1652975926](https://user-images.githubusercontent.com/9846948/169345068-aaeb6d96-a140-4cc8-978c-46e7f03d7cb2.png)
