### PR TITLE
THLW Tierlist charname invert fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6929,6 +6929,15 @@ CSS
 
 ================================
 
+gamepress.gg
+
+CSS
+.TLW-tier-charname {
+    color: #000 !important;
+}
+
+================================
+
 gameranx.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6933,7 +6933,7 @@ gamepress.gg
 
 CSS
 .TLW-tier-charname {
-    color: #000 !important;
+    color: ${black} !important;
 }
 
 ================================


### PR DESCRIPTION
in https://gamepress.gg/lostword/list/touhou-lostword-tier-list, character names would get inverted from its original color #000 to white but the white background doesn't change color, so i made it that the text is not inverted similar to the background