### PR TITLE
Remove cast for crypto.

### DIFF
--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -4,8 +4,7 @@ function hexify(number: number) {
 
 export function generateUID() {
     if ('randomUUID' in crypto) {
-        // TODO: remove any cast once type declarations are updated
-        const uuid = (crypto as any).randomUUID();
+        const uuid = crypto.randomUUID();
         return uuid.substring(0, 8) + uuid.substring(9, 13) + uuid.substring(14, 18) + uuid.substring(19, 23) + uuid.substring(24);
     }
 


### PR DESCRIPTION
- Type declarations have been updated and we don't need any cast anymore in order to use `randomUUID()`.