### PR TITLE
Use Shunting-Yard algorithm for lowering calc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix CSS imports that contains `url(...)` and ends with `screen`.
 - Send network response to the correct frame in tab.
+- Handle more cases lowering `calc(...)` by using [Shunting Yard algorithm](https://en.wikipedia.org/wiki/Shunting_yard_algorithm).
 
 ## 4.9.50 (May 1, 2022)
 

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -257,23 +257,30 @@ export function lowerCalcExpression(color: string): string {
     // the calc(...) expression.
     let searchIndex = 0;
 
+    // Replace the content between two indices.
     const replaceBetweenIndices = (start: number, end: number, replacement: string) => {
         color = color.substring(0, start) + replacement + color.substring(end);
     };
 
+    // Run this code until it doesn't find any `calc(...)`.
     while ((searchIndex = color.indexOf('calc(')) !== -1) {
+        // Get the parantheses ranges of `calc(...)`
         const range = getParenthesesRange(color, searchIndex);
         if (!range) {
             break;
         }
 
-
+        // Get the content between the parentheses.
         let slice = color.slice(range.start + 1, range.end - 1);
+        // Does the content include a percentage?
         const includesPercentage = slice.includes('%');
+        // Remove all percentages.
         slice = slice.split('%').join('');
 
+        // Pass the content to the evalMath library and round it's output.
         const output = Math.round(evalMath(slice));
 
+        // Replace `calc(...)` with the result.
         replaceBetweenIndices(range.start - 4, range.end, output + (includesPercentage ? '%' : ''));
     }
     return color;

--- a/src/utils/math-eval.ts
+++ b/src/utils/math-eval.ts
@@ -1,7 +1,7 @@
 // evalMath is a function that's able to evaluates a mathematical expression and return it's ouput.
 //
 // Internally it uses the Shunting Yard algoritm. First it produces a reverse polish notation(RPN) stack.
-// Example: 1 + 2 * 3 -> [1, 2, 3, *, +]
+// Example: 1 + 2 * 3 -> [1, 2, 3, *, +] which with parentheses means 1 (2 3 *) +
 //
 // Then it evaluates the RPN stack and returns the output.
 export function evalMath(expression: string): number {
@@ -15,43 +15,57 @@ export function evalMath(expression: string): number {
     for (let i = 0, len = expression.length; i < len; i++) {
         const token = expression[i];
 
+        // Skip if the token is empty or a whitespace.
         if (!token || token === ' ') {
             continue;
         }
 
+        // Is the token a operator?
         if (operators.has(token)) {
             const op = operators.get(token);
 
+            // Go trough the workingstack and determine it's place in the workingStack
             while (workingStack.length) {
                 const currentOp = operators.get(workingStack[0]);
                 if (!currentOp) {
                     break;
                 }
 
+                // Is the current operation equal or less than the current operation?
+                // Then move that operation to the rpnStack.
                 if (op.lessOrEqualThan(currentOp)) {
                     rpnStack.push(workingStack.shift());
                 } else {
                     break;
                 }
             }
+            // Add the operation to the workingStack.
             workingStack.unshift(token);
+        // Otherwise was the last token a operator?
         } else if (!lastToken || operators.has(lastToken)) {
             rpnStack.push(token);
+        // Otherwise just append the result to the last token(e.g. multiple digits numbers).
         } else {
             rpnStack[rpnStack.length - 1] += token;
         }
+        // Set the last token.
         lastToken = token;
     }
 
+    // Push the working stack on top of the rpnStack.
     rpnStack.push(...workingStack);
 
+    // Now evaluate the rpnStack.
     const stack: number[] = [];
     for (let i = 0, len = rpnStack.length; i < len; i++) {
         const op = operators.get(rpnStack[i]);
         if (op) {
+            // Get the arguments of for the operation(first two in the stack).
             const args = stack.splice(0, 2);
+            // Excute it, because of reverse notation we first pass second item then the first item.
             stack.push(op.exec(args[1], args[0]));
         } else {
+            // Add the number to the stack.
             stack.unshift(parseFloat(rpnStack[i]));
         }
     }

--- a/src/utils/math-eval.ts
+++ b/src/utils/math-eval.ts
@@ -1,0 +1,86 @@
+// evalMath is a function that's able to evaluates a mathematical expression and return it's ouput.
+//
+// Internally it uses the Shunting Yard algoritm. First it produces a reverse polish notation(RPN) stack.
+// Example: 1 + 2 * 3 -> [1, 2, 3, *, +]
+//
+// Then it evaluates the RPN stack and returns the output.
+export function evalMath(expression: string): number {
+    // Stack where operators & numbers are stored in RPN.
+    const rpnStack: string[] = [];
+    // The working stack where new tokens are pushed.
+    const workingStack: string[] = [];
+
+    let lastToken: string;
+    // Iterate over the expression.
+    for (let i = 0, len = expression.length; i < len; i++) {
+        const token = expression[i];
+
+        if (!token || token === ' ') {
+            continue;
+        }
+
+        if (operators.has(token)) {
+            const op = operators.get(token);
+
+            while (workingStack.length) {
+                const currentOp = operators.get(workingStack[0]);
+                if (!currentOp) {
+                    break;
+                }
+
+                if (op.lessOrEqualThan(currentOp)) {
+                    rpnStack.push(workingStack.shift());
+                } else {
+                    break;
+                }
+            }
+            workingStack.unshift(token);
+        } else if (!lastToken || operators.has(lastToken)) {
+            rpnStack.push(token);
+        } else {
+            rpnStack[rpnStack.length - 1] += token;
+        }
+        lastToken = token;
+    }
+
+    rpnStack.push(...workingStack);
+
+    const stack: number[] = [];
+    for (let i = 0, len = rpnStack.length; i < len; i++) {
+        const op = operators.get(rpnStack[i]);
+        if (op) {
+            const args = stack.splice(0, 2);
+            stack.push(op.exec(args[1], args[0]));
+        } else {
+            stack.unshift(parseFloat(rpnStack[i]));
+        }
+    }
+
+    return stack[0];
+}
+
+// Operator class  defines a operator that can be parsed & evaluated by evalMath.
+class Operator {
+    private precendce: number;
+    private execMethod: (left: number, right: number) => number;
+
+    constructor(precedence: number, method: (left: number, right: number) => number) {
+        this.precendce = precedence;
+        this.execMethod = method;
+    }
+
+    public exec(left: number, right: number): number {
+        return this.execMethod(left, right);
+    }
+
+    public lessOrEqualThan(op: Operator) {
+        return this.precendce <= op.precendce;
+    }
+}
+
+const operators: Map<string, Operator> = new Map([
+    ['+', new Operator(1, (left: number, right: number): number => left + right)],
+    ['-', new Operator(1, (left: number, right: number): number => left - right)],
+    ['*', new Operator(2, (left: number, right: number): number => left * right)],
+    ['/', new Operator(2, (left: number, right: number): number => left / right)],
+]);

--- a/tests/inject/dynamic/color.tests.ts
+++ b/tests/inject/dynamic/color.tests.ts
@@ -100,4 +100,15 @@ describe('COLOR PARSING', () => {
         createOrUpdateDynamicTheme(theme, null, false);
         expect(getComputedStyle(container.querySelector('h1')).backgroundImage).toBe('-webkit-linear-gradient(bottom, rgb(24, 26, 27) 15%, rgb(29, 32, 33) 85%)');
     });
+
+    it('should handle complex calc(...) cases', () => {
+        container.innerHTML = multiline(
+            '<style>',
+            '    h1 { background-color: rgb(calc(216.75 + 153 * .15), calc(216.75 + 205 * .15), calc(216.75 + 255 * .15)) }',
+            '</style>',
+            '<h1>Weird color <strong>Power</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        expect(getComputedStyle(container.querySelector('h1')).backgroundColor).toBe('rgb(28, 31, 32)');
+    });
 });

--- a/tests/unit/utils/color.tests.ts
+++ b/tests/unit/utils/color.tests.ts
@@ -98,4 +98,5 @@ test('Color conversion', () => {
 test('Lower calc expressions', () => {
     expect(lowerCalcExpression('hsl(0, 0%, calc(95% - 3%))')).toEqual('hsl(0, 0%, 92%)');
     expect(lowerCalcExpression('hsl(0, calc(25% + 12%), calc(95% - 3%))')).toEqual('hsl(0, 37%, 92%)');
+    expect(lowerCalcExpression('rgb(calc(216.75 + 153 * .15), calc(216.75 + 205 * .15), calc(216.75 + 255 * .15))')).toEqual('rgb(240, 248, 255)');
 });


### PR DESCRIPTION
- Currently we were using a hacky made up parser(made by me) to handle simple cases of `calc(...)` and safely evaluate them. However this doesn't handle all cases and updating this hacky function to also handle precede is not great for maintenance.
- This patch fixes that by using the [Shunting-Yard algorithm](https://en.wikipedia.org/wiki/Shunting_yard_algorithm). Which is a small but powerful parser & evaluator which converts infix notation and transform it into RPN(which is really really easy and fast to evaluate).
- Resolves #8894