### PR TITLE
Add rentry.co and rentry.org

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -805,6 +805,8 @@ relay.firefox.com/faq
 remixpacks.ru
 removeddit.com
 renderlab.net
+rentry.co
+rentry.org
 residentevil.net
 restream4me.com
 resurrectionremix.com


### PR DESCRIPTION
Rentry.co and it's mirror, rentry.org now have native dark modes.
![image](https://user-images.githubusercontent.com/79660414/170609735-9a02b3e1-8613-4ae1-aa63-3e04acca016c.png)
