### PR TITLE
Fixed spelling errors in color-schemes document

### DIFF
--- a/docs/color-schemes-drconf.spec
+++ b/docs/color-schemes-drconf.spec
@@ -4,11 +4,11 @@ which doesn't really follow the standard for other files.
 Spec:
 - A section is a unique defined colorscheme following the syntax rules.
 - The file must begin with a section, with the name of "Default" which has both a light and dark variant.
-- A seperator must be placed between new sections, the seperator is `'='.repeat(32)`.
-- A new line must be placed before and after the seperator.
-- All but not the first section should start with a new line(this is the same new line after the seperator).
-- The first keywoard in the section(after the possible new line) should be a unique colorscheme name.
-- After 2 new lines of the first keywoard should either be "DARK" or "LIGHT", at least 1 variant should be defined.
+- A separator must be placed between new sections, the separator is `'='.repeat(32)`.
+- A new line must be placed before and after the separator.
+- All but not the first section should start with a new line(this is the same new line after the separator).
+- The first keyword in the section(after the possible new line) should be a unique colorscheme name.
+- After 2 new lines of the first keyword should either be "DARK" or "LIGHT", at least 1 variant should be defined.
 - If a color scheme has both variants the order should start with "DARK" and then "LIGHT" for consistency.
 - Within the variants a background color and text color can be defined, both are required.
 - The syntax of defining background-color and text color should be `{background,text}: #6-or-3-length-hex-color` each on a new line.


### PR DESCRIPTION
Fixed spelling errors in documentation for color-schemes for better readability.