### PR TITLE
Correct *.azuredatabricks.net modal background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3345,6 +3345,9 @@ span[role="presentation"] {
 .ansiout {
     color: ${rgb(85, 85, 85)} !important;
 }
+.rm-modal {
+    background: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Modal background has inline css for a white background, so I'm correcting with the --darkreader-neutral-background var and making it !important