### PR TITLE
Fix nav bar logo for behance.net & dribbble.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1940,6 +1940,13 @@ body[style] {
 
 ================================
 
+behance.net
+
+INVERT
+div[class^="PrimaryNav-logoWrap"]
+
+================================
+
 berlingske.dk
 
 INVERT
@@ -5269,6 +5276,13 @@ body {
 #faux {
     background-image: none !important;
 }
+
+================================
+
+dribbble.com
+
+INVERT
+.site-nav-desktop-logo
 
 ================================
 


### PR DESCRIPTION
Behance before/after:
<img width="199" alt="Screen Shot 2022-06-06 at 10 45 37 PM" src="https://user-images.githubusercontent.com/5619348/172184954-d0f8db00-2ee9-4447-9bfb-976690638274.png">
<img width="202" alt="Screen Shot 2022-06-06 at 10 47 34 PM" src="https://user-images.githubusercontent.com/5619348/172185004-66159aff-a14f-411e-b69b-3ca075970281.png">


Dribbble before/after:
<img width="257" alt="Screen Shot 2022-06-06 at 10 45 07 PM" src="https://user-images.githubusercontent.com/5619348/172184867-08a9b645-b070-4cdc-9457-5015a94db9df.png">
<img width="244" alt="Screen Shot 2022-06-06 at 10 45 16 PM" src="https://user-images.githubusercontent.com/5619348/172184883-ae998209-e8cb-4fd4-9869-9f064575ad13.png">

