### PR TITLE
Remove white background images in caf.fr website

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2842,6 +2842,16 @@ CSS
 
 ================================
 
+caf.fr
+
+CSS
+#theme-contenu-cnaf .row[class*="conteneur-"][class*="-cnaf"] > [class*="col-"],
+#theme-contenu-menu-background-cnaf {
+    background-image: none !important;
+}
+
+================================
+
 caiyunapp.com
 
 INVERT


### PR DESCRIPTION
In account management, the site is adding white background images (visible also on login page), that are not removed by default by the extension. This fix correct that.
Before:
![2022-06-07_00-58](https://user-images.githubusercontent.com/31049012/172263109-bc279b8a-cbb4-4f18-8ad6-88db4f085477.png)
After:
![2022-06-07_01-00](https://user-images.githubusercontent.com/31049012/172263139-c4a0d22e-150d-42f1-86b3-8537270842ac.png)
Screenshots are taken on subdomain https://connect.caf.fr that once your are logged in redirects to https://wwwd.caf.fr

This is the site of a French public institution.
