### PR TITLE
Added galacticabot.vercel.app to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -374,6 +374,7 @@ gaming.amazon.com
 garamlee500.github.io
 garudalinux.org
 gatsbyjs.org
+galacticabot.vercel.app
 geekabit.nl
 geektyper.com
 gekri.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -366,6 +366,7 @@ freespeechextremist.com
 frozensand.com
 funnyjunk.com
 fusengine.github.io/apaxy-v2
+galacticabot.vercel.app
 gamebanana.com
 gamejolt.com
 gameloop.fun
@@ -373,7 +374,6 @@ gaming.amazon.com
 garamlee500.github.io
 garudalinux.org
 gatsbyjs.org
-galacticabot.vercel.app
 geekabit.nl
 geektyper.com
 gekri.com


### PR DESCRIPTION
This is a website of mine which contains the documentation of my Discord bot named galactica, all the pages use dark mode by default and here is the domain you can use for checking if the website meets your guidelines: https://galacticabot.vercel.app