### PR TITLE
Fix for overleaf.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13088,7 +13088,7 @@ div.o365cs-base > span.ms-Icon--WaffleOffice36
 overleaf.com
 
 INVERT
-.mwe-math-element
+.canvasWrapper
 
 ================================
 


### PR DESCRIPTION
It seems like overleaf.com has made some changes due to which the PDF preview is no longer inverted. This is a simple fix for that.