### PR TITLE
Remove ass.rip & ass.software from dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -65,8 +65,6 @@ asherhe.com
 ashishpanigrahi.xyz
 asoftmurmur.com
 aspenuwu.me
-ass.rip
-ass.software
 assassins-creed.de
 ast4u.me
 astronvim.github.io


### PR DESCRIPTION
Both of these websites are parked domains. Neither are actual real websites.

ass.rip

![Screenshot 2022-06-08 at 00-18-04 ass rip](https://user-images.githubusercontent.com/95879668/172539135-f04ecc9a-0788-40f5-a619-9e61d88a289c.png)

ass.software

![Screenshot 2022-06-08 at 00-18-12 ass software](https://user-images.githubusercontent.com/95879668/172539143-5ebca37a-2427-4823-bbaf-b1078401d493.png)