### PR TITLE
Site logo fixes for chase.com and brilliant.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2584,6 +2584,15 @@ CSS
 
 ================================
 
+brilliant.org
+
+INVERT
+[class*="b-sprite-landing"]
+[class*="b-sprite-publishers"]
+.logo
+
+================================
+
 bsi.bund.de
 
 INVERT
@@ -3111,6 +3120,9 @@ CSS
 ================================
 
 chase.com
+
+INVERT
+.single-logo-icon
 
 CSS
 .menu-button-item {


### PR DESCRIPTION
Chase.com logo: 
1. black text on dark background. Proposed inversion. 

Brilliant.org logos: 
1. Nav bar and Footer logos indiscernible on dark background (black on near-black). Propose inversion.
2. Publisher logos dark on dark background hard to see. Propose inversion.