### PR TITLE
Fix for canvas.oregonstate.edu

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2945,6 +2945,15 @@ INVERT
 
 ================================
 
+canvas.oregonstate.edu
+
+CSS
+.ic-app-header__menu-list-item.ic-app-header__menu-list-item--active .ic-app-header__menu-list-link {
+    background-color: white;
+}
+
+================================
+
 canvas.usask.ca
 
 CSS


### PR DESCRIPTION
Fixed active category icon wrongfully inverting color.