### PR TITLE
Fix CodeQL Failures

### DIFF
--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -220,7 +220,7 @@ function getModifiedScrollbarStyle(theme: Theme) {
 export function getModifiedFallbackStyle(filter: FilterConfig, {strict}: {strict: boolean}) {
     const lines: string[] = [];
     // https://github.com/darkreader/darkreader/issues/3618#issuecomment-895477598
-    const isMicrosoft = location.hostname.endsWith('microsoft.com');
+    const isMicrosoft = ['microsoft.com', 'docs.microsoft.com'].includes(location.hostname);
     lines.push(`html, body, ${strict ? `body :not(iframe)${isMicrosoft ? ':not(div[style^="position:absolute;top:0;left:-"]' : ''}` : 'body > :not(iframe)'} {`);
     lines.push(`    background-color: ${modifyBackgroundColor({r: 255, g: 255, b: 255}, filter)} !important;`);
     lines.push(`    border-color: ${modifyBorderColor({r: 64, g: 64, b: 64}, filter)} !important;`);

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -46,7 +46,7 @@ export function shouldManageStyle(element: Node) {
                 element.rel.toLowerCase().includes('stylesheet') &&
                 !element.disabled &&
                 (isFirefox ? !element.href.startsWith('moz-extension://') : true) &&
-                !element.href.startsWith('https://fonts.googleapis.com')
+                ((new URL(element.href)).hostname != 'fonts.googleapis.com')
             )
         ) &&
         !element.classList.contains('darkreader') &&

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -46,7 +46,7 @@ export function shouldManageStyle(element: Node) {
                 element.rel.toLowerCase().includes('stylesheet') &&
                 !element.disabled &&
                 (isFirefox ? !element.href.startsWith('moz-extension://') : true) &&
-                ((new URL(element.href)).hostname != 'fonts.googleapis.com')
+                ((new URL(element.href)).hostname !== 'fonts.googleapis.com')
             )
         ) &&
         !element.classList.contains('darkreader') &&

--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -11,7 +11,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
 
     // Reference:
     // https://github.com/darkreader/darkreader/issues/6480#issuecomment-897696175
-    const shouldWrapHTMLElement = location.hostname.endsWith('baidu.com');
+    const shouldWrapHTMLElement = ['baidu.com'].includes(location.hostname);
 
     const getElementsByTagNameDescriptor = shouldWrapHTMLElement ?
         Object.getOwnPropertyDescriptor(Element.prototype, 'getElementsByTagName') : null;

--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -11,7 +11,17 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
 
     // Reference:
     // https://github.com/darkreader/darkreader/issues/6480#issuecomment-897696175
-    const shouldWrapHTMLElement = ['baidu.com'].includes(location.hostname);
+    const shouldWrapHTMLElement = [
+        'baidu.com',
+        'baike.baidu.com',
+        'ditu.baidu.com',
+        'map.baidu.com',
+        'maps.baidu.com',
+        'haokan.baidu.com',
+        'pan.baidu.com',
+        'passport.baidu.com',
+        'tieba.baidu.com',
+        'www.baidu.com'].includes(location.hostname);
 
     const getElementsByTagNameDescriptor = shouldWrapHTMLElement ?
         Object.getOwnPropertyDescriptor(Element.prototype, 'getElementsByTagName') : null;


### PR DESCRIPTION
I'm trying to include DarkReader in a Hugo theme I'm working on when the CodeQL scan reported failures. I've created a pull request since it's a security vulnerability and the Security Policy says that I can create a pull request. All three failures are about URL sanitation.

CodeQL result: https://github.com/hugo-toha/toha/pull/595/checks?check_run_id=6810164189
Recommendation from CodeQL: https://codeql.github.com/codeql-query-help/javascript/js-incomplete-url-substring-sanitization/#:~:text=Sanitizing%20untrusted%20URLs%20is%20an,a%20set%20of%20allowed%20hosts.