### PR TITLE
Run Dark Reader on Protected Pages

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -76,7 +76,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
     },
     previewNewDesign: false,
     enableForPDF: true,
-    enableForProtectedPages: false,
+    enableForProtectedPages: true,
     enableContextMenus: false,
     detectDarkTheme: false,
 };

--- a/src/manifest-mv3.json
+++ b/src/manifest-mv3.json
@@ -20,6 +20,7 @@
         "unlimitedStorage"
     ],
     "host_permissions": [
-        "*://*/*"
+        "*://*/*",
+        "chrome://*/*"
     ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,8 @@
     "content_scripts": [
         {
             "matches": [
-                "<all_urls>"
+                "<all_urls>",
+                "chrome://*/*"
             ],
             "js": [
                 "inject/fallback.js",


### PR DESCRIPTION
This set of changes causes Dark Reader to run on chrome's protected pages (e.g. [chrome://chrome-urls/]()).