### PR TITLE
Added siddharthray.com to dark-by-default sitelist

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1088,6 +1088,7 @@ www.mtv.com
 www.netflix.com
 www.razer.com
 www.seebham.codes
+www.siddharthray.com
 www.teamfortress.com
 www.tvnz.co.nz
 www.wickeditor.com/editor/


### PR DESCRIPTION
# [Link to website](https://www.siddharthray.com)
Some minor CSS aesthetics of the website do break when Darkreader is enabled.

## Screenshot of website homepage (Darkreader not enabled)
![image](https://user-images.githubusercontent.com/58677791/174691236-61081cb2-a9c5-4a00-92f8-2c0d00b3ad66.png)

##  Example of Breakage: Text Gradient (tested [here](https://www.siddharthray.com/portfolio))
**Darkreader Enabled:**
![image](https://user-images.githubusercontent.com/58677791/174691652-2cdf8c45-5a3b-46c2-aeb1-3b7f511220c4.png)

**Darkreader disabled:**
![image](https://user-images.githubusercontent.com/58677791/174691746-5392aecd-3475-4cda-8d54-6e5f92b81b41.png)

