### PR TITLE
Change to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ It will after making any code changes, the project will be automatically recompi
 
 ## Tips
 
-For editing the code you can use any text editor or web IDE (like [Visual Studio Code](https://code.visualstudio.com), [Atom](https://atom.io/), or [WebStorm](https://www.jetbrains.com/webstorm/)).
+For editing the code you can use any text editor or web IDE (like [Visual Studio Code](https://code.visualstudio.com), or [WebStorm](https://www.jetbrains.com/webstorm/)).
 
 **Please preserve code style** (whitespaces etc).
 This can automatically be done by executing `npm run code-style`.


### PR DESCRIPTION
Atom editor will no longer be supported by the developer and will be archived on December 15, 2022. You can find the original article here: https://github.blog/2022-06-08-sunsetting-atom/.

I assumed that since it will be discontinued, it should be removed as a useable editor.
