### PR TITLE
Add some inverts for Finn.no

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6551,6 +6551,10 @@ header.ant-layout-header img
 
 finn.no
 
+INVERT
+finn-footer
+article.ads__unit overflowmenu-active
+
 IGNORE INLINE STYLE
 svg *
 


### PR DESCRIPTION
Main page ads and site footer.

Ads are dynamically loaded and are therefore usually light.
A toggle / reapplication of style fixes them. Does darkreader have a mechanism to handle these cases?