### PR TITLE
Add Tria.ge to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -768,6 +768,7 @@ pr0gramm.com
 pre.fyp.nl
 premid.app
 primevideo.com
+private.tria.ge
 progettosnaps.net
 programsquared.com
 projectdiscovery.io


### PR DESCRIPTION
## Summary

Tria.ge has its own dark mode, and the site is designed around it by default.