### PR TITLE
Fix checkboxes on signulous.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15682,6 +15682,18 @@ img[alt="Niantic"]
 
 ================================
 
+signulous.com
+
+INVERT
+.checkbox input:checked
+
+CSS
+.checkbox input:checked {
+    background-color: white;
+}
+
+================================
+
 simepar.br
 
 CSS


### PR DESCRIPTION
Note: Did not use `${black}` on purpose because that messes with the invert in light mode.