### PR TITLE
Cleanup Manjaro website fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4928,23 +4928,6 @@ body > div:nth-child(1) > svg:nth-child(1)
 
 ================================
 
-discover.manjaro.org
-
-CSS
-html, body {
-    background-image: url("/static/images/tux.svg") !important;
-    background-repeat: no-repeat !important;
-    background-position: bottom 0 left -12px !important;
-    background-size: 60px !important;
-    background-attachment: fixed !important;
-    background-color: var(--darkreader-neutral-background) !important;
-}
-
-IGNORE IMAGE ANALYSIS
-body
-
-================================
-
 discuss.pixls.us
 
 INVERT
@@ -6931,6 +6914,15 @@ CSS
 .Button--icon {
     color: ${black} !important;
     background: ${#6f7f92} !important;
+}
+
+================================
+
+forum.manjaro.org
+
+CSS
+.custom-footer {
+    background-image: none !important;
 }
 
 ================================
@@ -10939,18 +10931,6 @@ manage.buyvm.net
 
 INVERT
 .legend-container
-
-================================
-
-manjaro.org
-
-CSS
-.page-header-image {
-    z-index: 0 !important;
-}
-.custom-footer {
-    background-image: none !important;
-}
 
 ================================
 


### PR DESCRIPTION
Remove discover.manjaro.org as website is no longer valid.
Remove manjaro.org as website has been completely overhauled and rewritten from scratch.
Update web page footer fix to be specific to forum.manjaro.org as was originally intended (Issue: #8404 / #8408).