### PR TITLE
Fixes for irishtimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9207,6 +9207,13 @@ INVERT
 
 ================================
 
+irishtimes.com
+
+INVERT
+.masthead-block-logo img
+
+================================
+
 is.muni.cz
 
 INVERT


### PR DESCRIPTION
- Fixed logo inversion on homepage