### PR TITLE
Add runtothefinish.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15150,6 +15150,15 @@ INVERT
 
 ================================
 
+runtothefinish.com
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 rynekzdrowia.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15153,8 +15153,8 @@ INVERT
 runtothefinish.com
 
 CSS
-body {
-    background-color: var(--darkreader-neutral-background) !important;
+:root {
+    --body-background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
Some elements' (most notably article content) text changed shade correctly while background remained unaffected, making reading difficult.

Tested on front page and several articles, e.g. https://www.runtothefinish.com/half-marathon-training/