### PR TITLE
Update dynamic theme for Jira flagged issue cards

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1674,6 +1674,9 @@ code:first-of-type {
 .ProseMirror hr.ak-editor-selected-node {
     background-color: rgb(0, 101, 255) !important;
 }
+.ghx-flagged {
+    background-color: rgb(0, 0, 0) !important;
+}
 
 IGNORE INLINE STYLE
 .ak-editor-content-area *


### PR DESCRIPTION
The dynamic dark theme for Jira doesn't preserve the highlighted state of "flagged" issues very well. 

The purpose of flagged issues is to signal severity, for example that the issue is blocked or has "extreme" priority. 
It needs immediate attention. 

I realize that this is harder to do with a dark theming engine focused on reducing eye strain.
Nevertheless, I think a simple #000 black works very well as a "highlight" color among the grayshades in this instance.

(sorry for the heavy text censoring)

| Original, light theme  | Current dynamic theme | Black highlights for flagged cards |
| ------------- | ------------- | ------------- | 
| ![image](https://user-images.githubusercontent.com/1403548/176752598-d8354908-4be8-439b-9b9b-61f2320a52be.png) |  ![image](https://user-images.githubusercontent.com/1403548/176752317-548722bd-e8ed-4b2b-bea6-3ff85aa6d9d7.png) | ![image](https://user-images.githubusercontent.com/1403548/176752830-1ce7184e-5676-40b3-b77f-62ec0ff10c8f.png) |
