### PR TITLE
Use `navigator.UserAgentData` when possible

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -184,6 +184,7 @@ config.overrides.push({
     settings: {
         polyfills: [
             'navigator.deviceMemory',
+            'navigator.userAgentData',
         ],
     },
     overrides: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Don't manage styles that have a empty `href` attribute.
+- Use `navigator.UserAgentData` when possible.
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -9,6 +9,15 @@ import {bgFetch} from './network';
 import {createStyleSheetModifier} from './stylesheet-modifier';
 import {isShadowDomSupported, isSafari, isThunderbird, isFirefox} from '../../utils/platform';
 
+interface UserAgentData {
+    brands: Array<{
+        brand: string;
+        version: string;
+    }>;
+    mobile: boolean;
+    platform: string;
+}
+
 declare global {
     interface Document {
         adoptedStyleSheets: CSSStyleSheet[];
@@ -18,6 +27,9 @@ declare global {
     }
     interface CSSStyleSheet {
         replaceSync(text: string): void;
+    }
+    interface NavigatorID {
+        userAgentData: UserAgentData;
     }
 }
 

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -9,15 +9,6 @@ import {bgFetch} from './network';
 import {createStyleSheetModifier} from './stylesheet-modifier';
 import {isShadowDomSupported, isSafari, isThunderbird, isFirefox} from '../../utils/platform';
 
-interface UserAgentData {
-    brands: Array<{
-        brand: string;
-        version: string;
-    }>;
-    mobile: boolean;
-    platform: string;
-}
-
 declare global {
     interface Document {
         adoptedStyleSheets: CSSStyleSheet[];
@@ -27,9 +18,6 @@ declare global {
     }
     interface CSSStyleSheet {
         replaceSync(text: string): void;
-    }
-    interface NavigatorID {
-        userAgentData: UserAgentData;
     }
 }
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,5 +1,10 @@
-const userAgent = typeof navigator === 'undefined' ? 'some useragent' : navigator.userAgent.toLowerCase();
-const platform = typeof navigator === 'undefined' ? 'some platform' : navigator.platform.toLowerCase();
+const userAgent = typeof navigator === 'undefined' ? 'some useragent' : navigator.userAgentData ?
+    navigator.userAgentData.brands.map((brand) => `${brand.brand.toLowerCase()} ${brand.version}`).join(' ')
+    : navigator.userAgent.toLowerCase();
+
+const platform = typeof navigator === 'undefined' ? 'some platform' : navigator.userAgentData ?
+    navigator.userAgentData.platform.toLowerCase()
+    : navigator.platform.toLowerCase();
 
 export const isChromium = userAgent.includes('chrome') || userAgent.includes('chromium');
 export const isThunderbird = userAgent.includes('thunderbird');
@@ -19,7 +24,7 @@ export const isMatchMediaChangeEventListenerSupported = (
 );
 
 export const chromiumVersion = (() => {
-    const m = userAgent.match(/chrom[e|ium]\/([^ ]+)/);
+    const m = userAgent.match(/chrom[e|ium](\/| )([^ ]+)/);
     if (m && m[1]) {
         return m[1];
     }

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -16,7 +16,7 @@ export const isEdge = userAgent.includes('edg');
 export const isSafari = userAgent.includes('safari') && !isChromium;
 export const isWindows = platform.startsWith('win');
 export const isMacOS = platform.startsWith('mac');
-export const isMobile = userAgent.includes('mobile');
+export const isMobile = navigator.userAgentData ? navigator.userAgentData.mobile : userAgent.includes('mobile');
 export const isShadowDomSupported = typeof ShadowRoot === 'function';
 export const isMatchMediaChangeEventListenerSupported = (
     typeof MediaQueryList === 'function' &&

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,10 +1,26 @@
-const userAgent = typeof navigator === 'undefined' ? 'some useragent' : navigator.userAgentData ?
-    navigator.userAgentData.brands.map((brand) => `${brand.brand.toLowerCase()} ${brand.version}`).join(' ')
-    : navigator.userAgent.toLowerCase();
+interface UserAgentData {
+    brands: Array<{
+        brand: string;
+        version: string;
+    }>;
+    mobile: boolean;
+    platform: string;
+}
 
-const platform = typeof navigator === 'undefined' ? 'some platform' : navigator.userAgentData ?
-    navigator.userAgentData.platform.toLowerCase()
-    : navigator.platform.toLowerCase();
+declare global {
+    interface NavigatorID {
+        userAgentData: UserAgentData;
+    }
+}
+
+const isNavigatorDefined = typeof navigator !== 'undefined';
+const userAgent = isNavigatorDefined ? navigator.userAgentData ?
+    navigator.userAgentData.brands.map((brand) => `${brand.brand.toLowerCase()} ${brand.version}`).join(' ') : navigator.userAgent.toLowerCase()
+    : 'some useragent';
+
+const platform = isNavigatorDefined ? navigator.userAgentData ?
+    navigator.userAgentData.platform.toLowerCase() : navigator.platform.toLowerCase()
+    : 'some platform';
 
 export const isChromium = userAgent.includes('chrome') || userAgent.includes('chromium');
 export const isThunderbird = userAgent.includes('thunderbird');
@@ -16,7 +32,7 @@ export const isEdge = userAgent.includes('edg');
 export const isSafari = userAgent.includes('safari') && !isChromium;
 export const isWindows = platform.startsWith('win');
 export const isMacOS = platform.startsWith('mac');
-export const isMobile = navigator.userAgentData ? navigator.userAgentData.mobile : userAgent.includes('mobile');
+export const isMobile = (isNavigatorDefined && navigator.userAgentData) ? navigator.userAgentData.mobile : userAgent.includes('mobile');
 export const isShadowDomSupported = typeof ShadowRoot === 'function';
 export const isMatchMediaChangeEventListenerSupported = (
     typeof MediaQueryList === 'function' &&
@@ -24,7 +40,7 @@ export const isMatchMediaChangeEventListenerSupported = (
 );
 
 export const chromiumVersion = (() => {
-    const m = userAgent.match(/chrom[e|ium](\/| )([^ ]+)/);
+    const m = userAgent.match(/chrom(?:e|ium)(?:\/| )([^ ]+)/);
     if (m && m[1]) {
         return m[1];
     }


### PR DESCRIPTION
- Make chromium happy by using `navigator.UserAgentData` when available. It currently convert the data into a string so it can be used via `.includes(...)` and co-exist with the older `navigator.userAgent`.
- Resolves #9142