### PR TITLE
Fix message error handling

### DIFF
--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -34,25 +34,21 @@ function sendMessage(message: Message) {
     if (unloaded) {
         return;
     }
-    try {
-        chrome.runtime.sendMessage<Message>(message, (response) => {
-            // Vivaldi bug workaround. See TabManager for details.
-            if (response === 'unsupportedSender') {
-                removeStyle();
-                removeSVGFilter();
-                removeDynamicTheme();
-                cleanup();
-            }
-        });
-    } catch (e) {
+    chrome.runtime.sendMessage<Message>(message, (response) => {
         /*
          * Background can be unreachable if:
          *  - extension was disabled
          *  - extension was uninstalled
          *  - extension was updated and this is the old instance of content script
+         *  - it is a Vivaldi sidebar. See TabManager for details.
          */
-        cleanup();
-    }
+        if (chrome.runtime.lastError || response === 'unsupportedSender') {
+            removeStyle();
+            removeSVGFilter();
+            removeDynamicTheme();
+            cleanup();
+        }
+    });
 }
 
 function onMessage({type, data}: Message) {


### PR DESCRIPTION
THIS IS WIP UNTILL WE DISCUSS IT

Prior to this PR, Dark Reader was not handling `chrome.runtime.sendMessage` errors correctly: it used try-catch when in reality it should have checked `chrome.runtime.lastError`.

HOWEVER, this commit also makes DR clean up all styles on error. I believe we fixed that bug in #9164, but since this is high risk change, I wanted to check up with you guys.

I see few ways to make this change safer:
 - make new behavior debug/beta/development-time only for some time
 - retry to deliver the message multiple times and bail out and clean up only after multiple fails
 - add reporting for this error to track frequency of its occurrences

CC @alexanderby @Gusted 