### PR TITLE
Add DevTools panels for MV3 builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Correctly handle empty URL's in `background-image` property.
 - Make parsing colors use cache.
 - Only send updates to the affected tabs when toggling sites.
+- Display "Dark Reader" panel in browser DevTools
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -28,6 +28,7 @@ export interface TabData {
 
 export interface ExtensionActions {
     changeSettings(settings: Partial<UserSettings>): void;
+    changeDevTollsPanelSettings(settings: DevToolsPanelSettings): void;
     setTheme(theme: Partial<FilterConfig>): void;
     setShortcut(command: string, shortcut: string): void;
     toggleActiveTab(): void;
@@ -44,6 +45,14 @@ export interface ExtensionActions {
 
 export interface ExtWrapper {
     data: ExtensionData;
+    actions: ExtensionActions;
+}
+
+export interface DevToolsExtWrapper {
+    data: {
+        extensionData: ExtensionData;
+        devToolsPanelSettings: DevToolsPanelSettings;
+    };
     actions: ExtensionActions;
 }
 
@@ -110,6 +119,10 @@ export interface UserSettings {
     enableForProtectedPages: boolean;
     enableContextMenus: boolean;
     detectDarkTheme: boolean;
+}
+
+export interface DevToolsPanelSettings {
+    enabled: boolean;
 }
 
 export interface TimeSettings {

--- a/src/manifest-chrome-mv3.json
+++ b/src/manifest-chrome-mv3.json
@@ -26,6 +26,7 @@
             "match_about_blank": true
         }
     ],
+    "devtools_page": "ui/devtools/loader.html",
     "permissions": [
         "alarms",
         "fontSettings",

--- a/src/ui/devtools/components/body.tsx
+++ b/src/ui/devtools/components/body.tsx
@@ -4,33 +4,34 @@ import {withState, useState} from 'malevic/state';
 import {Button, MessageBox, Overlay} from '../../controls';
 import ThemeEngines from '../../../generators/theme-engines';
 import {DEVTOOLS_DOCS_URL} from '../../../utils/links';
-import type {ExtWrapper} from '../../../definitions';
+import type {DevToolsExtWrapper} from '../../../definitions';
 import {getCurrentThemePreset} from '../../popup/theme/utils';
 import {isFirefox} from '../../../utils/platform';
 
-type BodyProps = ExtWrapper;
+type BodyProps = DevToolsExtWrapper;
 
 function Body({data, actions}: BodyProps) {
     const context = getContext();
     const {state, setState} = useState({errorText: null as string});
     let textNode: HTMLTextAreaElement;
-    const previewButtonText = data.settings.previewNewDesign ? 'Switch to old design' : 'Preview new design';
-    const {theme} = getCurrentThemePreset({data, actions});
+    const previewButtonText = data.extensionData.settings.previewNewDesign ? 'Switch to old design' : 'Preview new design';
+    const integrationButtonText = data.devToolsPanelSettings.enabled ? 'Hide panel' : 'Show panel';
+    const {theme} = getCurrentThemePreset({data: data.extensionData, actions});
 
     const wrapper = (theme.engine === ThemeEngines.staticTheme
         ? {
             header: 'Static Theme Editor',
-            fixesText: data.devtools.staticThemesText,
+            fixesText: data.extensionData.devtools.staticThemesText,
             apply: (text: string) => actions.applyDevStaticThemes(text),
             reset: () => actions.resetDevStaticThemes(),
         } : theme.engine === ThemeEngines.cssFilter || theme.engine === ThemeEngines.svgFilter ? {
             header: 'Inversion Fix Editor',
-            fixesText: data.devtools.filterFixesText,
+            fixesText: data.extensionData.devtools.filterFixesText,
             apply: (text: string) => actions.applyDevInversionFixes(text),
             reset: () => actions.resetDevInversionFixes(),
         } : {
             header: 'Dynamic Theme Editor',
-            fixesText: data.devtools.dynamicFixesText,
+            fixesText: data.extensionData.devtools.dynamicFixesText,
             apply: (text: string) => actions.applyDevDynamicThemeFixes(text),
             reset: () => actions.resetDevDynamicThemeFixes(),
         });
@@ -98,7 +99,11 @@ function Body({data, actions}: BodyProps) {
     }
 
     function toggleDesign() {
-        actions.changeSettings({previewNewDesign: !data.settings.previewNewDesign});
+        actions.changeSettings({previewNewDesign: !data.extensionData.settings.previewNewDesign});
+    }
+
+    function togglDevToolsPanelIntegration() {
+        actions.changeDevTollsPanelSettings({enabled: !data.devToolsPanelSettings.enabled});
     }
 
     return (
@@ -124,6 +129,7 @@ function Body({data, actions}: BodyProps) {
                 </Button>
                 <Button onclick={apply}>Apply</Button>
                 <Button class="preview-design-button" onclick={toggleDesign}>{previewButtonText}</Button>
+                <Button class="preview-design-button" onclick={togglDevToolsPanelIntegration}>{integrationButtonText}</Button>
             </div>
             <p id="description">
                 Read about this tool <strong><a href={DEVTOOLS_DOCS_URL} target="_blank" rel="noopener noreferrer">here</a></strong>.

--- a/src/ui/devtools/index.tsx
+++ b/src/ui/devtools/index.tsx
@@ -2,9 +2,9 @@ import {m} from 'malevic';
 import {sync} from 'malevic/dom';
 import Body from './components/body';
 import Connector from '../connect/connector';
-import type {ExtensionData} from '../../definitions';
+import type {DevToolsPanelSettings, ExtensionData} from '../../definitions';
 
-function renderBody(data: ExtensionData, actions: Connector) {
+function renderBody(data: {extensionData: ExtensionData; devToolsPanelSettings: DevToolsPanelSettings}, actions: Connector) {
     sync(document.body, <Body data={data} actions={actions} />);
 }
 
@@ -12,9 +12,9 @@ async function start() {
     const connector = new Connector();
     window.addEventListener('unload', () => connector.disconnect());
 
-    const data = await connector.getData();
+    const data = await connector.getExtendedData();
     renderBody(data, connector);
-    connector.subscribeToChanges((data) => renderBody(data, connector));
+    connector.subscribeToExtendedChanges((data) => renderBody(data, connector));
 }
 
 start();

--- a/src/ui/devtools/loader.html
+++ b/src/ui/devtools/loader.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+  <body>
+    <script src="loader.js"></script>
+  </body>
+</html>

--- a/src/ui/devtools/loader.ts
+++ b/src/ui/devtools/loader.ts
@@ -1,0 +1,35 @@
+import type {DevToolsPanelSettings} from 'definitions';
+import {DEVTOOLS_PANEL_SETTINGS_STORAGE_KEY} from '../connect/connector';
+
+enum PanelState {
+    NONE,
+    CREATING,
+    EXISTS
+}
+
+let panelState: PanelState = PanelState.NONE;
+
+function createPanelIfNeeded(data: DevToolsPanelSettings | undefined) {
+    if ((data && data.enabled === false) || panelState !== PanelState.NONE) {
+        return;
+    }
+    panelState = PanelState.CREATING;
+    chrome.devtools.panels.create(
+        'Dark Reader',
+        'ui/assets/images/mode-dark-32.svg',
+        'ui/devtools/index.html',
+        () => panelState = PanelState.EXISTS
+    );
+}
+
+chrome.storage.local.get(DEVTOOLS_PANEL_SETTINGS_STORAGE_KEY).then((storage) => {
+    createPanelIfNeeded(storage.DEVTOOLS_PANEL_SETTINGS_STORAGE_KEY);
+});
+
+chrome.storage.onChanged.addListener((changes) => {
+    const change = changes[DEVTOOLS_PANEL_SETTINGS_STORAGE_KEY];
+    if (!change) {
+        return;
+    }
+    createPanelIfNeeded(change.newValue);
+});

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -53,6 +53,12 @@ const jsEntries = [
         reloadType: reload.UI,
     },
     {
+        src: 'src/ui/devtools/loader.ts',
+        dest: 'ui/devtools/loader.js',
+        reloadType: reload.UI,
+        platform: PLATFORM.CHROME_MV3,
+    },
+    {
         src: 'src/ui/popup/index.tsx',
         dest: 'ui/popup/index.js',
         reloadType: reload.UI,

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -46,6 +46,11 @@ const copyEntries = [
         reloadType: reload.UI,
     },
     {
+        src: 'ui/devtools/loader.html',
+        reloadType: reload.FULL,
+        platforms: [PLATFORM.CHROME_MV3],
+    },
+    {
         src: 'ui/stylesheet-editor/index.html',
         reloadType: reload.UI,
     },


### PR DESCRIPTION
This embeds the whole Dark Reader Developer Tools into the browser DevTools UI: 
![image](https://user-images.githubusercontent.com/45960703/176966360-79795556-4845-4864-9c50-cedc67deeaf7.png)

This change is MV3-exclussive since it requires modification to manifest. We could easily extend it to other builds if we wanted.