### PR TITLE
Fix product images on thomann.de

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2184,7 +2184,7 @@ thomann.de
 
 CSS
 .fx-mix-blend-mode--multiply {
-    mix-blend-mode: unset;
+    mix-blend-mode: unset !important;
 }
 
 ================================

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2183,7 +2183,7 @@ img
 thomann.de
 
 CSS
-.fx-mix-blend-mode--multiply {
+.fx-mix-blend-mode--multiply, .product__image {
     mix-blend-mode: unset !important;
 }
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2183,7 +2183,8 @@ img
 thomann.de
 
 CSS
-.fx-mix-blend-mode--multiply, .product__image {
+.fx-mix-blend-mode--multiply,
+.product__image {
     mix-blend-mode: unset !important;
 }
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2180,6 +2180,15 @@ img
 
 ================================
 
+thomann.de
+
+CSS
+.fx-mix-blend-mode--multiply {
+    mix-blend-mode: unset;
+}
+
+================================
+
 tianchi.aliyun.com
 
 NO INVERT


### PR DESCRIPTION
Thomann.de is a major german/european music retailer. 

This PR fixes the product images on the site.

Before:
![grafik](https://user-images.githubusercontent.com/18742414/176998267-bd1f3683-2a3a-4b79-b2f0-e2cdc72fe71c.png)

After:
![grafik](https://user-images.githubusercontent.com/18742414/176998289-f5557aa2-b49d-4d13-a7f1-45375426cb3d.png)
