### PR TITLE
In MV3 builds, use promise-based message passing

### DIFF
--- a/src/background/make-chromium-happy.ts
+++ b/src/background/make-chromium-happy.ts
@@ -1,12 +1,12 @@
 import {MessageType} from '../utils/message';
 import type {Message} from '../definitions';
-import {isChromium} from '../utils/platform';
+import {isChromium, isMV3} from '../utils/platform';
 
 // This function exists to prevent Chrome from logging an error about
 // closed conduit. It just sends a dummy message in response to incomming message
 // to utilise open conduit. This response message is not even used on the other side.
 export function makeChromiumHappy() {
-    if (!isChromium) {
+    if (isMV3 || !isChromium) {
         return;
     }
     chrome.runtime.onMessage.addListener((message: Message, _, sendResponse) => {


### PR DESCRIPTION
This is a follow-up to #9164 and #6892.

This commit has effect only of MV3 builds and it does two things:
 - it makes `makeChromiumHappy()` a no-op because it is no longer needed
 - makes content scripts use promise-based message passing API because it does not have bug present in callback-based API

Please note that promise-based API is used exclusively with MV3 for backwards-compatibility of MV2 builds.

Bug explanation:
The error is logged when:
 - user initiates tab navigation (reload)
 - CS receives `pagehide` event and sends message `{type: MessageType.CS_FRAME_FORGET}`. This opens a message channel and lives it open
 - Chrome proceeds with tab context unloading and Chrome closes all active ports, this calling `OneTimeMessageHandler::DisconnectOpener` on CS side. Since no error message is available (there was no real error), the function provides the [this dreaded error message](https://github.com/chromium/chromium/blob/main/extensions/renderer/one_time_message_handler.cc#L461): "The message port closed before a response was received."
 - Chrome finalizes page navigation and logs the error message in console. The order of navigation message and error message in the console is runtime-dependent.

I found out that simply using promise-based API fixes this error without using dummy messages because "for a promise-based channel, not receiving a response is fine". The source is the following [comment in Chromium source code](https://github.com/chromium/chromium/blob/main/extensions/renderer/one_time_message_handler.cc#L447):
```
  // Set the error for the message port. If the browser supplies an error, we
  // always use that. Otherwise, the behavior is different for promise-based vs
  // callback-based channels.
  // For a promise-based channel, not receiving a response is fine (assuming the
  // listener didn't indicate it would send one) - the extension may simply be
  // waiting for confirmation that the message sent.
  // In the callback-based scenario, we use the presence of the callback as an
  // indication that the extension expected a specific response. This is an
  // unfortunate behavior difference that we keep for backwards-compatibility in
  // callback-based API calls.
```

CC @Gusted @alexanderby 