### PR TITLE
Add darkreader-lock meta 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Don't manage styles that have a empty `href` attribute.
 - Use `navigator.UserAgentData` when possible.
+- Add a `<meta name="darkreader-lock">` detector, to disable Dark Reader when detected (only dynamic theme).
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -431,6 +431,18 @@ function stopWatchingForUpdates() {
     cleanReadyStateCompleteListeners();
 }
 
+let metaObserver: MutationObserver;
+
+function addMetaListener() {
+    metaObserver = new MutationObserver(() => {
+        if (document.querySelector('meta[name="darkreader-lock"]')) {
+            metaObserver.disconnect();
+            removeDynamicTheme();
+        }
+    });
+    metaObserver.observe(document.head, {childList: true, subtree: true});
+}
+
 function createDarkReaderInstanceMarker() {
     const metaElement: HTMLMetaElement = document.createElement('meta');
     metaElement.name = 'darkreader';
@@ -439,6 +451,10 @@ function createDarkReaderInstanceMarker() {
 }
 
 function isAnotherDarkReaderInstanceActive() {
+    if (document.querySelector('meta[name="darkreader-lock"]')) {
+        return true;
+    }
+
     const meta: HTMLMetaElement = document.querySelector('meta[name="darkreader"]');
     if (meta) {
         if (meta.content !== INSTANCE_ID) {
@@ -447,6 +463,7 @@ function isAnotherDarkReaderInstanceActive() {
         return false;
     }
     createDarkReaderInstanceMarker();
+    addMetaListener();
     return false;
 }
 
@@ -532,6 +549,8 @@ export function removeDynamicTheme() {
         manager.destroy();
     });
     adoptedStyleManagers.splice(0);
+
+    metaObserver && metaObserver.disconnect();
 }
 
 export function cleanDynamicThemeCache() {

--- a/tests/inject/dynamic/fixes.tests.ts
+++ b/tests/inject/dynamic/fixes.tests.ts
@@ -81,8 +81,8 @@ describe('FIXES', () => {
     });
 
     it('should ignore styling when darkreader-lock detected', async () => {
-        document.head.innerHTML = multiline(
-            '<meta name="darkreader-lock"></meta>',
+        document.head.innerHTML = '<meta name="darkreader-lock"></meta>',
+        container.innerHTML = multiline(
             '<style>',
             '    body {',
             '        background-color: pink !important;',
@@ -95,7 +95,7 @@ describe('FIXES', () => {
     });
 
     it('should ignore styling when delayed darkreader-lock detected', async () => {
-        document.head.innerHTML = multiline(
+        container.innerHTML = multiline(
             '<style>',
             '    body {',
             '        background-color: pink !important;',

--- a/tests/inject/dynamic/fixes.tests.ts
+++ b/tests/inject/dynamic/fixes.tests.ts
@@ -1,9 +1,10 @@
 import '../support/polyfills';
 import {DEFAULT_THEME} from '../../../src/defaults';
 import {createOrUpdateDynamicTheme, removeDynamicTheme} from '../../../src/inject/dynamic-theme';
-import {multiline} from '../support/test-utils';
+import {multiline, timeout} from '../support/test-utils';
 import type {DynamicThemeFix} from '../../../src/definitions';
 import {FilterMode} from '../../../src/generators/css-filter';
+import {removeNode} from '../../../src/inject/utils/dom';
 
 let container: HTMLElement;
 
@@ -15,6 +16,7 @@ beforeEach(() => {
 afterEach(() => {
     removeDynamicTheme();
     container.innerHTML = '';
+    removeNode(document.head.querySelector('meta[name="darkreader-lock"]'));
 });
 
 describe('FIXES', () => {
@@ -76,5 +78,38 @@ describe('FIXES', () => {
         };
         createOrUpdateDynamicTheme(DEFAULT_THEME, fixes, false);
         expect(getComputedStyle(container.querySelector('.text')).backgroundColor).toBe('rgb(128, 0, 128)');
+    });
+
+    it('should ignore styling when darkreader-lock detected', async () => {
+        document.head.innerHTML = multiline(
+            '<meta name="darkreader-lock"></meta>',
+            '<style>',
+            '    body {',
+            '        background-color: pink !important;',
+            '    }',
+            '</style>',
+        );
+        createOrUpdateDynamicTheme(DEFAULT_THEME, null, false);
+
+        expect(getComputedStyle(document.body).backgroundColor).toBe('rgb(255, 192, 203)');
+    });
+
+    it('should ignore styling when delayed darkreader-lock detected', async () => {
+        document.head.innerHTML = multiline(
+            '<style>',
+            '    body {',
+            '        background-color: pink !important;',
+            '    }',
+            '</style>',
+        );
+        createOrUpdateDynamicTheme(DEFAULT_THEME, null, false);
+
+        expect(getComputedStyle(container).backgroundColor).toBe('rgb(89, 0, 16)');
+        const metaElement: HTMLMetaElement = document.createElement('meta');
+        metaElement.name = 'darkreader-lock';
+        document.head.appendChild(metaElement);
+        await timeout(100);
+
+        expect(getComputedStyle(container).backgroundColor).toBe('rgb(255, 192, 203)');
     });
 });


### PR DESCRIPTION
- Add `<meta name="darkreader-lock">` to look for and if available remove Dark Reader.
- Resolves https://github.com/darkreader/darkreader/issues/4325
- Resolves https://github.com/darkreader/darkreader/issues/4330