### PR TITLE
Add "cerber.re" to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -164,6 +164,7 @@ cascadr.co
 catvibers.me
 cdkeys.com
 cdnnow.pro
+cerber.re
 channel4.com
 chat.ryzom.com
 cheat.sh


### PR DESCRIPTION
Hello my website already support light and dark theme depending the OS configuration DarkReader break my footer img and maybe other things for later.