### PR TITLE
Fix FreeBSD Found., Khan Acad., Internet Archive

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1386,6 +1386,7 @@ archive.org
 INVERT
 p + fieldset a svg
 .search-field svg
+.ia-wordmark
 
 CSS
 #search-input {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7117,6 +7117,15 @@ INVERT
 
 ================================
 
+freebsdfoundation.org
+
+CSS
+.content-wrapper {
+    background-image: none !important;
+}
+
+================================
+
 freecommander.com
 
 CSS
@@ -9870,6 +9879,14 @@ CSS
 .img-container > img {
     filter: brightness(50%) sepia(40%) !important;
 }
+
+================================
+
+khanacademy.org
+
+INVERT
+.svg-image
+.graphie-label
 
 ================================
 
@@ -19089,14 +19106,12 @@ INVERT
 .sparkline-canvas
 .sparkline-mouse-highlight
 .search-toolbar-logo
+.ia-wordmark
 
 CSS
 .measure {
     z-index: 0 !important;
 }
-
-IGNORE INLINE STYLE
-.ia-wordmark
 
 IGNORE IMAGE ANALYSIS
 .search-toolbar-logo


### PR DESCRIPTION
### [FreeBSD Foundation](https://freebsdfoundation.org/)
 - Remove the bright fixed-size background sidebars; see [this page](https://freebsdfoundation.org/freebsd-project/resources/guide-to-freebsd-desktop-distributions/) for an example

### [Khan Academy](https://www.khanacademy.org/)
 - Invert SVG images containing LaTeX generated by [KaTeX](https://github.com/KaTeX/KaTeX) to white-on-black
 - Invert chart labels generated by [Graphie](https://www.npmjs.com/package/graphie) to white-on-black

### [Internet Archive](https://archive.org/)
 - Invert the Internet Archive wordmark SVG in the header to white-on-black, which prior had been excepted as `IGNORE INLINE STYLE`