### PR TITLE
Fix editing static theme on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Use `navigator.UserAgentData` when possible.
 - Add a `<meta name="darkreader-lock">` detector, to disable Dark Reader when detected (only dynamic theme).
 - Fix filter theme for Firefox v102+
+- Correctly open static theme editor on Mobile.
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/ui/popup/settings-page/devtools.tsx
+++ b/src/ui/popup/settings-page/devtools.tsx
@@ -5,6 +5,7 @@ import {NavButton} from '../../controls';
 import ControlGroup from '../control-group';
 import type {ViewProps} from '../types';
 import {isMobile, isFirefox} from '../../../utils/platform';
+import {openExtensionPage} from 'ui/utils';
 
 function getExistingDevToolsObject(): Promise<chrome.windows.Window> | Promise<chrome.tabs.Tab> {
     if (isMobile) {
@@ -37,27 +38,7 @@ function getExistingDevToolsObject(): Promise<chrome.windows.Window> | Promise<c
 }
 
 async function openDevTools() {
-    const devToolsObject = await getExistingDevToolsObject();
-    if (isMobile) {
-        if (devToolsObject) {
-            chrome.tabs.update(devToolsObject.id, {'active': true});
-            window.close();
-        } else {
-            chrome.tabs.create({
-                url: '../devtools/index.html',
-            });
-            window.close();
-        }
-    } else if (devToolsObject) {
-        chrome.windows.update(devToolsObject.id, {'focused': true});
-    } else {
-        chrome.windows.create({
-            type: 'popup',
-            url: isFirefox ? '../devtools/index.html' : 'ui/devtools/index.html',
-            width: 600,
-            height: 600,
-        });
-    }
+    await openExtensionPage('devtools/index.html');
 }
 
 export default function DevToolsGroup(props: ViewProps) {

--- a/src/ui/popup/settings-page/devtools.tsx
+++ b/src/ui/popup/settings-page/devtools.tsx
@@ -1,41 +1,10 @@
 import {m} from 'malevic';
+import {openExtensionPage} from '../../utils';
 import ThemeEngines from '../../../generators/theme-engines';
 import {getLocalMessage} from '../../../utils/locales';
 import {NavButton} from '../../controls';
 import ControlGroup from '../control-group';
 import type {ViewProps} from '../types';
-import {isMobile, isFirefox} from '../../../utils/platform';
-import {openExtensionPage} from 'ui/utils';
-
-function getExistingDevToolsObject(): Promise<chrome.windows.Window> | Promise<chrome.tabs.Tab> {
-    if (isMobile) {
-        return new Promise<chrome.tabs.Tab>((resolve) => {
-            chrome.tabs.query({}, (t) => {
-                for (const tab of t) {
-                    if (tab.url.endsWith('ui/devtools/index.html')) {
-                        resolve(tab);
-                        return;
-                    }
-                }
-                resolve(null);
-            });
-        });
-    }
-    return new Promise<chrome.windows.Window>((resolve) => {
-        chrome.windows.getAll({
-            populate: true,
-            windowTypes: ['popup']
-        }, (w) => {
-            for (const window of w) {
-                if (window.tabs[0].url.endsWith('ui/devtools/index.html')) {
-                    resolve(window);
-                    return;
-                }
-            }
-            resolve(null);
-        });
-    });
-}
 
 async function openDevTools() {
     await openExtensionPage('devtools/index.html');

--- a/src/ui/popup/theme/controls/mode.tsx
+++ b/src/ui/popup/theme/controls/mode.tsx
@@ -3,16 +3,11 @@ import ThemeEngines from '../../../../generators/theme-engines';
 import {getLocalMessage} from '../../../../utils/locales';
 import {DropDown} from '../../../controls';
 import ThemeControl from './theme-control';
-import {isFirefox} from '../../../../utils/platform';
+import {openExtensionPage} from '../../../utils';
 
 export default function Mode(props: {mode: string; onChange: (mode: string) => void}) {
-    function openCSSEditor() {
-        chrome.windows.create({
-            type: 'panel',
-            url: isFirefox ? '../stylesheet-editor/index.html' : 'ui/stylesheet-editor/index.html',
-            width: 600,
-            height: 600,
-        });
+    async function openCSSEditor() {
+        await openExtensionPage('stylesheet-editor/index.html');
     }
 
     const modes = [

--- a/src/ui/stylesheet-editor/index.html
+++ b/src/ui/stylesheet-editor/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <title>Dark Reader CSS editor</title>
     <meta name="theme-color" content="#0B2228" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="style.css" />
     <link rel="shortcut icon" href="../assets/images/darkreader-icon-256x256.png" />
     <script src="index.js" defer></script>


### PR DESCRIPTION
- Unify the code to correctly query existing tabs/windows as well the code to open a new tab/window(with the correct URL).
- Move the opening of the static theme to this code so it will work on mobile.
- Supersede #3335
- Resolves #3272