### PR TITLE
Migrate automation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add a `<meta name="darkreader-lock">` detector, to disable Dark Reader when detected (only dynamic theme).
 - Fix filter theme for Firefox v102+
 - Correctly open static theme editor on Mobile.
+- Migrate automation settings to it's own object. WARNING: this can lead to data loss of currently used automation settings due to browser behavior.
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -144,11 +144,11 @@ export class Extension implements ExtensionState {
     }
 
     private updateAutoState() {
-        const {automation, automationBehaviour: behavior} = this.user.settings;
+        const {mode, behavior, enabled} = this.user.settings.automation;
 
         let isAutoDark: boolean;
         let nextCheck: number;
-        switch (automation) {
+        switch (mode) {
             case 'time': {
                 const {time} = this.user.settings;
                 isAutoDark = isInTimeIntervalLocal(time.activation, time.deactivation);
@@ -186,7 +186,7 @@ export class Extension implements ExtensionState {
         }
 
         let state: AutomationState = '';
-        if (automation) {
+        if (enabled) {
             if (behavior === 'OnOff') {
                 state = isAutoDark ? 'turn-on' : 'turn-off';
             } else if (behavior === 'Scheme') {
@@ -316,7 +316,7 @@ export class Extension implements ExtensionState {
                 logInfo('Toggle command entered');
                 this.changeSettings({
                     enabled: !this.isExtensionSwitchedOn(),
-                    automation: '',
+                    automation: {...this.user.settings.automation, ...{enable: false}},
                 });
                 break;
             case 'addSite': {
@@ -472,7 +472,7 @@ export class Extension implements ExtensionState {
         if (isFirefox) {
             this.wasLastColorSchemeDark = isDark;
         }
-        if (this.user.settings.automation !== 'system') {
+        if (this.user.settings.automation.mode !== 'system') {
             return;
         }
         this.callWhenSettingsLoaded(() => {
@@ -505,8 +505,9 @@ export class Extension implements ExtensionState {
 
         if (
             (prev.enabled !== this.user.settings.enabled) ||
-            (prev.automation !== this.user.settings.automation) ||
-            (prev.automationBehaviour !== this.user.settings.automationBehaviour) ||
+            (prev.automation.enabled !== this.user.settings.automation.enabled) ||
+            (prev.automation.mode !== this.user.settings.automation.mode) ||
+            (prev.automation.behavior !== this.user.settings.automation.behavior) ||
             (prev.time.activation !== this.user.settings.time.activation) ||
             (prev.time.deactivation !== this.user.settings.time.deactivation) ||
             (prev.location.latitude !== this.user.settings.location.latitude) ||

--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -38,6 +38,10 @@ export default class UserStorage {
     // It will move settings.automation & settings.automationBehavior into,
     // settings.automation = { enabled, mode, behavior }.
     // Remove this over two years(mid-2024).
+    // This won't always work, because browsers can decide to instead use the default settings
+    // when they notice a different type being requested for automation, in that case it's a data-loss
+    // and not something we can encouter for, except for doing always two extra requests to explicitly
+    // check for this case which is inefficient usage of requesting storage.
     private migrateAutomationSettings(settings: UserSettings): void {
         if (typeof settings.automation === 'string') {
             const automationMode = settings.automation as any;

--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -39,7 +39,6 @@ export default class UserStorage {
     // settings.automation = { enabled, mode, behavior }.
     // Remove this over two years(mid-2024).
     private migrateAutomationSettings(settings: UserSettings): void {
-        console.log(settings);
         if (typeof settings.automation === 'string') {
             const automationMode = settings.automation as any;
             const automationBehavior = (settings as any).automationBehaviour;
@@ -58,7 +57,6 @@ export default class UserStorage {
             }
             delete (settings as any).automationBehaviour;
         }
-        console.log(settings);
     }
 
     private async loadSettingsFromStorage(): Promise<UserSettings> {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -64,8 +64,11 @@ export const DEFAULT_SETTINGS: UserSettings = {
     changeBrowserTheme: false,
     syncSettings: true,
     syncSitesFixes: false,
-    automation: '',
-    automationBehaviour: 'OnOff',
+    automation: {
+        enabled: false,
+        mode: '',
+        behavior: 'OnOff',
+    },
     time: {
         activation: '18:00',
         deactivation: '9:00',

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -84,6 +84,12 @@ export interface ThemePreset {
     theme: Theme;
 }
 
+export interface Automation {
+    enabled: boolean;
+    mode: '' | 'time' | 'system' | 'location';
+    behavior: 'OnOff' | 'Scheme';
+}
+
 export interface UserSettings {
     enabled: boolean;
     fetchNews: boolean;
@@ -96,8 +102,7 @@ export interface UserSettings {
     changeBrowserTheme: boolean;
     syncSettings: boolean;
     syncSitesFixes: boolean;
-    automation: '' | 'time' | 'system' | 'location';
-    automationBehaviour: 'OnOff' | 'Scheme';
+    automation: Automation;
     time: TimeSettings;
     location: LocationSettings;
     previewNewDesign: boolean;

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -30,8 +30,11 @@ export function getMockData(override = {} as Partial<ExtensionData>): ExtensionD
             enableForPDF: true,
             enableForProtectedPages: false,
             syncSettings: true,
-            automation: '',
-            automationBehaviour: 'OnOff',
+            automation: {
+                enabled: false,
+                behavior: 'OnOff',
+                mode: '',
+            },
             previewNewDesign: false,
             time: {
                 activation: '18:00',

--- a/src/ui/popup/automation-page/index.tsx
+++ b/src/ui/popup/automation-page/index.tsx
@@ -66,7 +66,7 @@ export default function AutomationPage(props: ViewProps) {
     }
 
     function changeAutomationMode(mode: Automation['mode']) {
-        props.actions.changeSettings({automation: {...props.data.settings.automation, ...{mode}}});
+        props.actions.changeSettings({automation: {...props.data.settings.automation, ...{mode, enabled: Boolean(mode)}}});
     }
 
     function changeAutomationBehavior(behavior: Automation['behavior']) {

--- a/src/ui/popup/automation-page/index.tsx
+++ b/src/ui/popup/automation-page/index.tsx
@@ -3,9 +3,10 @@ import {getLocalMessage} from '../../../utils/locales';
 import {CheckBox, TimeRangePicker, TextBox, Button} from '../../controls';
 import type {ViewProps} from '../types';
 import DropDown from '../../controls/dropdown/index';
+import type {Automation} from 'definitions';
 
 export default function AutomationPage(props: ViewProps) {
-    const isSystemAutomation = props.data.settings.automation === 'system';
+    const isSystemAutomation = props.data.settings.automation.mode === 'system';
     const locationSettings = props.data.settings.location;
     const values = {
         'latitude': {
@@ -64,14 +65,22 @@ export default function AutomationPage(props: ViewProps) {
         });
     }
 
+    function changeAutomationMode(mode: Automation['mode']) {
+        props.actions.changeSettings({automation: {...props.data.settings.automation, ...{mode}}});
+    }
+
+    function changeAutomationBehavior(behavior: Automation['behavior']) {
+        props.actions.changeSettings({automation: {...props.data.settings.automation, ...{behavior}}});
+    }
+
     return (
         <div
             class={'automation-page'}
         >
             <div class="automation-page__line">
                 <CheckBox
-                    checked={props.data.settings.automation === 'time'}
-                    onchange={(e: {target: {checked: boolean}}) => props.actions.changeSettings({automation: e.target.checked ? 'time' : ''})}
+                    checked={props.data.settings.automation.mode === 'time'}
+                    onchange={(e: {target: {checked: boolean}}) => changeAutomationMode(e.target.checked ? 'time' : '')}
                 />
                 <TimeRangePicker
                     startTime={props.data.settings.time.activation}
@@ -84,8 +93,8 @@ export default function AutomationPage(props: ViewProps) {
             </p>
             <div class="automation-page__line automation-page__location">
                 <CheckBox
-                    checked={props.data.settings.automation === 'location'}
-                    onchange={(e: {target: {checked: boolean}}) => props.actions.changeSettings({automation: e.target.checked ? 'location' : ''})}
+                    checked={props.data.settings.automation.mode === 'location'}
+                    onchange={(e: {target: {checked: boolean}}) => changeAutomationMode(e.target.checked ? 'location' : '')}
                 />
                 <TextBox
                     class="automation-page__location__latitude"
@@ -121,14 +130,14 @@ export default function AutomationPage(props: ViewProps) {
                 <CheckBox
                     class="automation-page__system-dark-mode__checkbox"
                     checked={isSystemAutomation}
-                    onchange={(e: {target: {checked: boolean}}) => props.actions.changeSettings({automation: e.target.checked ? 'system' : ''})}
+                    onchange={(e: {target: {checked: boolean}}) => changeAutomationMode(e.target.checked ? 'system' : '')}
                 />
                 <Button
                     class={{
                         'automation-page__system-dark-mode__button': true,
                         'automation-page__system-dark-mode__button--active': isSystemAutomation,
                     }}
-                    onclick={() => props.actions.changeSettings({automation: isSystemAutomation ? '' : 'system'})}
+                    onclick={() => changeAutomationMode(isSystemAutomation ? '' : 'system')}
                 >{getLocalMessage('system_dark_mode')}
                 </Button>
             </div>
@@ -136,8 +145,8 @@ export default function AutomationPage(props: ViewProps) {
                 {getLocalMessage('system_dark_mode_description')}
             </p>
             <DropDown
-                onChange={(selected: any) => props.actions.changeSettings({automationBehaviour: selected})}
-                selected={props.data.settings.automationBehaviour}
+                onChange={(selected: any) => changeAutomationBehavior(selected)}
+                selected={props.data.settings.automation.behavior}
                 options={[
                     {id: 'OnOff', content: 'Toggle on/off'},
                     {id: 'Scheme', content: 'Toggle dark/light'},

--- a/src/ui/popup/components/header/index.tsx
+++ b/src/ui/popup/components/header/index.tsx
@@ -20,14 +20,14 @@ function Header({data, actions, onMoreToggleSettingsClick}: HeaderProps) {
     function toggleExtension(enabled: UserSettings['enabled']) {
         actions.changeSettings({
             enabled,
-            automation: '',
+            automation: {...data.settings.automation, ...{enabled: false}},
         });
     }
 
     const tab = data.activeTab;
-    const isAutomation = Boolean(data.settings.automation);
-    const isTimeAutomation = data.settings.automation === 'time';
-    const isLocationAutomation = data.settings.automation === 'location';
+    const isAutomation = data.settings.automation.enabled;
+    const isTimeAutomation = data.settings.automation.mode === 'time';
+    const isLocationAutomation = data.settings.automation.mode === 'location';
     const now = new Date();
 
     return (

--- a/src/ui/popup/components/header/more-toggle-settings.tsx
+++ b/src/ui/popup/components/header/more-toggle-settings.tsx
@@ -69,7 +69,7 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
     }
 
     function changeAutomationMode(mode: Automation['mode']) {
-        actions.changeSettings({automation: {...data.settings.automation, ...{mode}}});
+        actions.changeSettings({automation: {...data.settings.automation, ...{mode, enabled: Boolean(mode)}}});
     }
 
     return (

--- a/src/ui/popup/components/header/more-toggle-settings.tsx
+++ b/src/ui/popup/components/header/more-toggle-settings.tsx
@@ -1,7 +1,7 @@
 import {m} from 'malevic';
 import {Button, CheckBox, TextBox, TimeRangePicker} from '../../../controls';
 import {getLocalMessage} from '../../../../utils/locales';
-import type {ExtWrapper} from '../../../../definitions';
+import type {Automation, ExtWrapper} from '../../../../definitions';
 
 type MoreToggleSettingsProps = ExtWrapper & {
     isExpanded: boolean;
@@ -9,7 +9,7 @@ type MoreToggleSettingsProps = ExtWrapper & {
 };
 
 export default function MoreToggleSettings({data, actions, isExpanded, onClose}: MoreToggleSettingsProps) {
-    const isSystemAutomation = data.settings.automation === 'system';
+    const isSystemAutomation = data.settings.automation.mode === 'system';
     const locationSettings = data.settings.location;
     const values = {
         'latitude': {
@@ -68,6 +68,10 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
         });
     }
 
+    function changeAutomationMode(mode: Automation['mode']) {
+        actions.changeSettings({automation: {...data.settings.automation, ...{mode}}});
+    }
+
     return (
         <div
             class={{
@@ -82,8 +86,8 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
             <div class="header__app-toggle__more-settings__content">
                 <div class="header__app-toggle__more-settings__line">
                     <CheckBox
-                        checked={data.settings.automation === 'time'}
-                        onchange={(e: {target: HTMLInputElement}) => actions.changeSettings({automation: e.target.checked ? 'time' : ''})}
+                        checked={data.settings.automation.mode === 'time'}
+                        onchange={(e: {target: HTMLInputElement}) => changeAutomationMode(e.target.checked ? 'time' : '')}
                     />
                     <TimeRangePicker
                         startTime={data.settings.time.activation}
@@ -96,8 +100,8 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
                 </p>
                 <div class="header__app-toggle__more-settings__line header__app-toggle__more-settings__location">
                     <CheckBox
-                        checked={data.settings.automation === 'location'}
-                        onchange={(e: {target: HTMLInputElement}) => actions.changeSettings({automation: e.target.checked ? 'location' : ''})}
+                        checked={data.settings.automation.mode === 'location'}
+                        onchange={(e: {target: HTMLInputElement}) => changeAutomationMode(e.target.checked ? 'location' : '')}
                     />
                     <TextBox
                         class="header__app-toggle__more-settings__location__latitude"
@@ -133,14 +137,14 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
                     <CheckBox
                         class="header__app-toggle__more-settings__system-dark-mode__checkbox"
                         checked={isSystemAutomation}
-                        onchange={(e: {target: HTMLInputElement}) => actions.changeSettings({automation: e.target.checked ? 'system' : ''})}
+                        onchange={(e: {target: HTMLInputElement}) => changeAutomationMode(e.target.checked ? 'system' : '')}
                     />
                     <Button
                         class={{
                             'header__app-toggle__more-settings__system-dark-mode__button': true,
                             'header__app-toggle__more-settings__system-dark-mode__button--active': isSystemAutomation,
                         }}
-                        onclick={() => actions.changeSettings({automation: isSystemAutomation ? '' : 'system'})}
+                        onclick={() =>changeAutomationMode(isSystemAutomation ? '' : 'system')}
                     >{getLocalMessage('system_dark_mode')}</Button>
                 </div>
                 <p class="header__app-toggle__more-settings__description">

--- a/src/ui/popup/main-page/app-switch.tsx
+++ b/src/ui/popup/main-page/app-switch.tsx
@@ -8,11 +8,11 @@ import SunMoonIcon from './sun-moon-icon';
 import SystemIcon from './system-icon';
 
 export default function AppSwitch(props: ViewProps) {
-    const isOn = props.data.settings.enabled === true && !props.data.settings.automation;
-    const isOff = props.data.settings.enabled === false && !props.data.settings.automation;
-    const isAutomation = Boolean(props.data.settings.automation);
-    const isTimeAutomation = props.data.settings.automation === 'time';
-    const isLocationAutomation = props.data.settings.automation === 'location';
+    const isOn = props.data.settings.enabled === true && !props.data.settings.automation.enabled;
+    const isOff = props.data.settings.enabled === false && !props.data.settings.automation.enabled;
+    const isAutomation = props.data.settings.automation.enabled;
+    const isTimeAutomation = props.data.settings.automation.mode === 'time';
+    const isLocationAutomation = props.data.settings.automation.mode === 'location';
     const now = new Date();
 
     // TODO: Replace messages with some IDs.
@@ -28,16 +28,16 @@ export default function AppSwitch(props: ViewProps) {
         if (index === 0) {
             props.actions.changeSettings({
                 enabled: true,
-                automation: '',
+                automation: {... props.data.settings.automation, ...{enabled: false}},
             });
         } else if (index === 2) {
             props.actions.changeSettings({
                 enabled: false,
-                automation: '',
+                automation:  {... props.data.settings.automation, ...{enabled: false}},
             });
         } else if (index === 1) {
             props.actions.changeSettings({
-                automation: 'system',
+                automation: {... props.data.settings.automation, ...{mode: 'system'}},
             });
         }
     }

--- a/src/ui/popup/main-page/app-switch.tsx
+++ b/src/ui/popup/main-page/app-switch.tsx
@@ -37,7 +37,7 @@ export default function AppSwitch(props: ViewProps) {
             });
         } else if (index === 1) {
             props.actions.changeSettings({
-                automation: {... props.data.settings.automation, ...{mode: 'system'}},
+                automation: {... props.data.settings.automation, ...{mode: 'system', enabled: true}},
             });
         }
     }

--- a/src/ui/popup/theme/utils.ts
+++ b/src/ui/popup/theme/utils.ts
@@ -35,11 +35,10 @@ export function getCurrentThemePreset(props: ViewProps) {
         }
         if (
             config.mode != null &&
-            props.data.settings.automation &&
-            props.data.settings.automationBehaviour === 'Scheme'
+            props.data.settings.automation.behavior === 'Scheme'
         ) {
             props.actions.changeSettings({
-                automation: '',
+                automation: {...props.data.settings.automation, ...{enabled: false}},
             });
         }
     }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -143,7 +143,7 @@ export function validateSettings(settings: Partial<UserSettings>) {
 
         const automationValidator = createValidator();
         automationValidator.validateProperty(automation, 'enabled', isBoolean, automation);
-        automationValidator.validateProperty(automation, 'mode', isOneOf('system', 'time', 'location'), automation);
+        automationValidator.validateProperty(automation, 'mode', isOneOf('system', 'time', 'location', ''), automation);
         automationValidator.validateProperty(automation, 'behavior', isOneOf('OnOff', 'Scheme'), automation);
         return automationValidator.errors.length === 0;
     }, DEFAULT_SETTINGS);

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import {DEFAULT_SETTINGS, DEFAULT_THEME} from '../defaults';
-import type {UserSettings, Theme, ThemePreset, CustomSiteConfig, TimeSettings, LocationSettings} from '../definitions';
+import type {UserSettings, Theme, ThemePreset, CustomSiteConfig, TimeSettings, LocationSettings, Automation} from '../definitions';
 
 function isBoolean(x: any): x is boolean {
     return typeof x === 'boolean';
@@ -136,8 +136,17 @@ export function validateSettings(settings: Partial<UserSettings>) {
     validateProperty(settings, 'changeBrowserTheme', isBoolean, DEFAULT_SETTINGS);
     validateProperty(settings, 'syncSettings', isBoolean, DEFAULT_SETTINGS);
     validateProperty(settings, 'syncSitesFixes', isBoolean, DEFAULT_SETTINGS);
-    validateProperty(settings, 'automation', isOneOf('', 'time', 'system', 'location'), DEFAULT_SETTINGS);
-    validateProperty(settings, 'automationBehaviour', isOneOf('OnOff', 'Scheme'), DEFAULT_SETTINGS);
+    validateProperty(settings, 'automation', (automation: Automation) => {
+        if (!isPlainObject(automation)) {
+            return false;
+        }
+
+        const automationValidator = createValidator();
+        automationValidator.validateProperty(automation, 'enabled', isBoolean, automation);
+        automationValidator.validateProperty(automation, 'mode', isOneOf('system', 'time', 'location'), automation);
+        automationValidator.validateProperty(automation, 'behavior', isOneOf('OnOff', 'Scheme'), automation);
+        return automationValidator.errors.length === 0;
+    }, DEFAULT_SETTINGS);
 
     validateProperty(settings, 'time', (time: TimeSettings) => {
         if (!isPlainObject(time)) {

--- a/tests/unit/utils/validation.tests.ts
+++ b/tests/unit/utils/validation.tests.ts
@@ -100,8 +100,11 @@ test('Settings Validation', () => {
         changeBrowserTheme: 1,
         syncSettings: null as boolean,
         syncSitesFixes: 0,
-        automation: 'off',
-        automationBehaviour: 'Default',
+        automation: {
+            enabled: false,
+            behavior: 'OnOff',
+            mode: '',
+        },
         time: {
             activation: '10:00PM',
             deactivation: '19:00',
@@ -179,8 +182,11 @@ test('Settings Validation', () => {
         changeBrowserTheme: true,
         syncSettings: false,
         syncSitesFixes: true,
-        automation: 'time',
-        automationBehaviour: 'Scheme',
+        automation: {
+            enabled: true,
+            mode: 'location',
+            behavior: 'OnOff',
+        },
         time: {
             activation: '18:00',
             deactivation: '7:00',


### PR DESCRIPTION
- Migrate the automation settings to a object, so it's all unified.
- Don't lose the automation mode when switching between `on`/off`/`automation`.
-  WARNING: this can lead to data loss of currently used automation settings due to browser behavior. So it's possible that users have to configure which automation they used after having this patch(a small annoyance as all other data is still saved). 
- Supersede https://github.com/darkreader/darkreader/pull/3698
- Resolves https://github.com/darkreader/darkreader/issues/1958
- Resolves https://github.com/darkreader/darkreader/issues/3268