### PR TITLE
Add "cerber.re" to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -165,6 +165,7 @@ catvibers.me
 cdkeys.com
 cdn.minlor.net
 cdnnow.pro
+cerber.re
 channel4.com
 chat.ryzom.com
 cheat.sh


### PR DESCRIPTION
I made the changes in my css to remove the light theme and offer the dark mode only. Is it possible to add "cerber.re"?