### PR TITLE
Correctly handle empty URL's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix filter theme for Firefox v102+
 - Correctly open static theme editor on Mobile.
 - Migrate automation settings to it's own object. WARNING: this can lead to data loss of currently used automation settings due to browser behavior.
+- Correctly handle empty URL's in `background-image` property.
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -88,7 +88,7 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
     }
 }
 
-export const cssURLRegex = /url\((('.+?')|(".+?")|([^\)]*?))\)/g;
+export const cssURLRegex = /url\((('.*?')|(".*?")|([^\)]*?))\)/g;
 export const cssImportRegex = /@import\s*(url\()?(('.+?')|(".+?")|([^\)]*?))\)? ?(screen)?;?/gi;
 
 // First try to extract the CSS URL value.

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -380,6 +380,7 @@ export function getBgImageModifier(
                 return null;
             }
             let url = getCSSURLValue(urlValue);
+            const isURLEmpty = url.length === 0;
             const {parentStyleSheet} = rule;
             const baseURL = (parentStyleSheet && parentStyleSheet.href) ?
                 getCSSBaseBath(parentStyleSheet.href) :
@@ -389,6 +390,9 @@ export function getBgImageModifier(
             const absoluteValue = `url("${url}")`;
 
             return async (filter: FilterConfig) => {
+                if (isURLEmpty) {
+                    return "url('')";
+                }
                 let imageDetails: ImageDetails;
                 if (imageDetailsCache.has(url)) {
                     imageDetails = imageDetailsCache.get(url);

--- a/tests/inject/dynamic/image-analysis.tests.ts
+++ b/tests/inject/dynamic/image-analysis.tests.ts
@@ -4,6 +4,7 @@ import {createOrUpdateDynamicTheme, removeDynamicTheme} from '../../../src/injec
 import {getImageDetails} from '../../../src/inject/dynamic-theme/image';
 import {multiline, waitForEvent} from '../support/test-utils';
 import type {DynamicThemeFix} from '../../../src/definitions';
+import {isChromium} from '../../../src/utils/platform';
 
 const theme = {
     ...DEFAULT_THEME,
@@ -261,5 +262,19 @@ describe('IMAGE ANALYSIS', () => {
         createOrUpdateDynamicTheme(theme, null, false);
         await waitForEvent('__darkreader__test__asyncQueueComplete');
         expect(getComputedStyle(container.querySelector('h1')).backgroundImage).toBe('linear-gradient(rgb(204, 0, 0), rgb(0, 0, 0)), url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iOCIgaGVpZ2h0PSI4Ij48ZGVmcz48ZmlsdGVyIGlkPSJkYXJrcmVhZGVyLWltYWdlLWZpbHRlciI+PGZlQ29sb3JNYXRyaXggdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAuMzMzIC0wLjY2NyAtMC42NjcgMC4wMDAgMS4wMDAgLTAuNjY3IDAuMzMzIC0wLjY2NyAwLjAwMCAxLjAwMCAtMC42NjcgLTAuNjY3IDAuMzMzIDAuMDAwIDEuMDAwIDAuMDAwIDAuMDAwIDAuMDAwIDEuMDAwIDAuMDAwIiAvPjwvZmlsdGVyPjwvZGVmcz48aW1hZ2Ugd2lkdGg9IjgiIGhlaWdodD0iOCIgZmlsdGVyPSJ1cmwoI2RhcmtyZWFkZXItaW1hZ2UtZmlsdGVyKSIgeGxpbms6aHJlZj0iZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhacFpYZENiM2c5SWpBZ01DQTRJRGdpSUhkcFpIUm9QU0k0SWlCb1pXbG5hSFE5SWpnaVBnb2dJQ0FnUEhKbFkzUWdabWxzYkQwaWQyaHBkR1VpSUhkcFpIUm9QU0l4TURBbElpQm9aV2xuYUhROUlqRXdNQ1VpSUM4K0Nqd3ZjM1puUGc9PSIgLz48L3N2Zz4=")');
+    });
+
+    it('should handle background-image with empty URLs', async () => {
+        container.innerHTML = multiline(
+            '<style>',
+            `    h1 { background-image: url(''), url(''), url("${svgToDataURL(images.lightIcon)}");`,
+            '</style>',
+            '<h1>Weird color <strong>Power</strong>!</h1>',
+        );
+        createOrUpdateDynamicTheme(theme, null, false);
+        await waitForEvent('__darkreader__test__asyncQueueComplete');
+        console.log(getComputedStyle(container.querySelector('h1')).backgroundImage);
+        expect(getComputedStyle(container.querySelector('h1')).backgroundImage.startsWith(isChromium ? `url("http://localhost:9876/` : `url("about:invalid"), url("about:invalid")`)).toBeTrue();
+        expect(getComputedStyle(container.querySelector('h1')).backgroundImage.endsWith(`url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iOCIgaGVpZ2h0PSI4Ij48ZGVmcz48ZmlsdGVyIGlkPSJkYXJrcmVhZGVyLWltYWdlLWZpbHRlciI+PGZlQ29sb3JNYXRyaXggdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAuMzMzIC0wLjY2NyAtMC42NjcgMC4wMDAgMS4wMDAgLTAuNjY3IDAuMzMzIC0wLjY2NyAwLjAwMCAxLjAwMCAtMC42NjcgLTAuNjY3IDAuMzMzIDAuMDAwIDEuMDAwIDAuMDAwIDAuMDAwIDAuMDAwIDEuMDAwIDAuMDAwIiAvPjwvZmlsdGVyPjwvZGVmcz48aW1hZ2Ugd2lkdGg9IjgiIGhlaWdodD0iOCIgZmlsdGVyPSJ1cmwoI2RhcmtyZWFkZXItaW1hZ2UtZmlsdGVyKSIgeGxpbms6aHJlZj0iZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhacFpYZENiM2c5SWpBZ01DQTRJRGdpSUhkcFpIUm9QU0k0SWlCb1pXbG5hSFE5SWpnaVBnb2dJQ0FnUEhKbFkzUWdabWxzYkQwaWQyaHBkR1VpSUhkcFpIUm9QU0l4TURBbElpQm9aV2xuYUhROUlqRXdNQ1VpSUM4K0Nqd3ZjM1puUGc9PSIgLz48L3N2Zz4=")`)).toBeTrue();
     });
 });

--- a/tests/inject/dynamic/image-analysis.tests.ts
+++ b/tests/inject/dynamic/image-analysis.tests.ts
@@ -4,7 +4,7 @@ import {createOrUpdateDynamicTheme, removeDynamicTheme} from '../../../src/injec
 import {getImageDetails} from '../../../src/inject/dynamic-theme/image';
 import {multiline, waitForEvent} from '../support/test-utils';
 import type {DynamicThemeFix} from '../../../src/definitions';
-import {isChromium} from '../../../src/utils/platform';
+import {isChromium, isFirefox} from '../../../src/utils/platform';
 
 const theme = {
     ...DEFAULT_THEME,
@@ -273,8 +273,7 @@ describe('IMAGE ANALYSIS', () => {
         );
         createOrUpdateDynamicTheme(theme, null, false);
         await waitForEvent('__darkreader__test__asyncQueueComplete');
-        console.log(getComputedStyle(container.querySelector('h1')).backgroundImage);
-        expect(getComputedStyle(container.querySelector('h1')).backgroundImage.startsWith(isChromium ? `url("http://localhost:9876/` : `url("about:invalid"), url("about:invalid")`)).toBeTrue();
+        expect(getComputedStyle(container.querySelector('h1')).backgroundImage.startsWith(isFirefox ? `url("about:invalid"), url("about:invalid")` : `url("http://localhost`)).toBeTrue();
         expect(getComputedStyle(container.querySelector('h1')).backgroundImage.endsWith(`url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iOCIgaGVpZ2h0PSI4Ij48ZGVmcz48ZmlsdGVyIGlkPSJkYXJrcmVhZGVyLWltYWdlLWZpbHRlciI+PGZlQ29sb3JNYXRyaXggdHlwZT0ibWF0cml4IiB2YWx1ZXM9IjAuMzMzIC0wLjY2NyAtMC42NjcgMC4wMDAgMS4wMDAgLTAuNjY3IDAuMzMzIC0wLjY2NyAwLjAwMCAxLjAwMCAtMC42NjcgLTAuNjY3IDAuMzMzIDAuMDAwIDEuMDAwIDAuMDAwIDAuMDAwIDAuMDAwIDEuMDAwIDAuMDAwIiAvPjwvZmlsdGVyPjwvZGVmcz48aW1hZ2Ugd2lkdGg9IjgiIGhlaWdodD0iOCIgZmlsdGVyPSJ1cmwoI2RhcmtyZWFkZXItaW1hZ2UtZmlsdGVyKSIgeGxpbms6aHJlZj0iZGF0YTppbWFnZS9zdmcreG1sO2Jhc2U2NCxQSE4yWnlCNGJXeHVjejBpYUhSMGNEb3ZMM2QzZHk1M015NXZjbWN2TWpBd01DOXpkbWNpSUhacFpYZENiM2c5SWpBZ01DQTRJRGdpSUhkcFpIUm9QU0k0SWlCb1pXbG5hSFE5SWpnaVBnb2dJQ0FnUEhKbFkzUWdabWxzYkQwaWQyaHBkR1VpSUhkcFpIUm9QU0l4TURBbElpQm9aV2xuYUhROUlqRXdNQ1VpSUM4K0Nqd3ZjM1puUGc9PSIgLz48L3N2Zz4=")`)).toBeTrue();
     });
 });


### PR DESCRIPTION
- Correctly handle empty URL's by not requiring the regex to have any content within `url("...")` and returning a empty URL when URL is empty.
- Resolves #9213