### PR TITLE
Refactor: build JS for every platform individually

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -34,7 +34,7 @@ async function build({platforms, debug, watch}) {
     try {
         await runTasks(debug ? standardTask : buildTask, {platforms, debug, watch});
         if (watch) {
-            standardTask.forEach((task) => task.watch());
+            standardTask.forEach((task) => task.watch(platforms));
             reload({type: reload.FULL});
             log.ok('Watching...');
         } else {

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -162,13 +162,13 @@ module.exports = createTask(
         watchFiles = getWatchFiles();
         return watchFiles;
     },
-    async (changedFiles, watcher) => {
+    async (changedFiles, watcher, platforms) => {
         const entries = jsEntries.filter((entry) => {
             return changedFiles.some((changed) => {
                 return entry.watchFiles?.includes(changed);
             });
         });
-        await Promise.all(hydrateTask(entries, true, true));
+        await Promise.all(hydrateTask(entries, platforms, true, true));
 
         const newWatchFiles = getWatchFiles();
         watcher.unwatch(

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -70,6 +70,7 @@ const jsEntries = [
             await writeFile(mv3DestPath, patchedCodeMV3);
             await copyFile(ffDestPath, tbDestPath);
         },
+        platform: PLATFORM.CHROME,
         watchFiles: null,
     },
     {

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -86,6 +86,9 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, {debug, watch}) {
     switch (platform) {
         case PLATFORM.FIREFOX:
         case PLATFORM.THUNDERBIRD:
+            if (entry.src === 'src/ui/popup/index.tsx') {
+                break;
+            }
             replace = {
                 'chrome.fontSettings.getFontList': `chrome['font' + 'Settings']['get' + 'Font' + 'List']`,
                 'chrome.fontSettings': `chrome['font' + 'Settings']`

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -34,7 +34,7 @@ const jsEntries = [
             if (platform !== PLATFORM.CHROME_MV3) {
                 return;
             }
-            const destPath = `${getDestDir({debug, platform: PLATFORM.CHROME})}/${this.dest}`;
+            const destPath = `${getDestDir({debug, platform: PLATFORM.CHROME_MV3})}/${this.dest}`;
             // Prior to Chrome 93, background service worker had to be in top-level directory
             const mv3DestPath = `${getDestDir({debug, platform: PLATFORM.CHROME_MV3})}/background.js`;
             const code = await readFile(destPath);

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -184,7 +184,9 @@ let watchFiles;
 module.exports = createTask(
     'bundle-js',
     async ({debug, watch}) => await Promise.all(
-        jsEntries.map((entry) => bundleJS(entry, {debug, watch}))
+        jsEntries.map((entry) => {
+            return [bundleJS(entry, {debug, watch})];
+        }).flat()
     ),
 ).addWatcher(
     () => {
@@ -198,7 +200,9 @@ module.exports = createTask(
             });
         });
         await Promise.all(
-            entries.map((e) => bundleJS(e, {debug: true, watch: true}))
+            entries.map((entry) => {
+                return [bundleJS(entry, {debug: true, watch: true})];
+            }).flat()
         );
 
         const newWatchFiles = getWatchFiles();

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -141,19 +141,22 @@ function getWatchFiles() {
 /** @type {string[]} */
 let watchFiles;
 
-function hydrateTask(/** @type {JSEntry[]} */entries, /** @type {boolean} */debug, /** @type {boolean} */watch) {
+function hydrateTask(/** @type {JSEntry[]} */entries, platforms, /** @type {boolean} */debug, /** @type {boolean} */watch) {
     return entries.map((entry) => {
         if (entry.platform) {
-            return [bundleJS(entry, entry.platform, {debug, watch})];
+            if (platforms[entry.platform]) {
+                return [bundleJS(entry, entry.platform, {debug, watch})];
+            }
+            return [];
         }
-        return Object.values(PLATFORM).map((platform) =>
+        return Object.values(PLATFORM).filter((platform) => platforms[platform]).map((platform) =>
             bundleJS(entry, platform, {debug, watch}));
     }).flat();
 }
 
 module.exports = createTask(
     'bundle-js',
-    async ({debug, watch}) => await Promise.all(hydrateTask(jsEntries, debug, watch)),
+    async ({platforms, debug, watch}) => await Promise.all(hydrateTask(jsEntries, platforms, debug, watch)),
 ).addWatcher(
     () => {
         watchFiles = getWatchFiles();

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -112,7 +112,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, {debug, watch}) {
                 preventAssignment: true,
                 ...replace,
                 '__DEBUG__': debug ? 'true' : 'false',
-                '__MV3__':  platform === PLATFORM.CHROME_MV3,
+                '__MV3__': platform === PLATFORM.CHROME_MV3,
                 '__PORT__': watch ? String(PORT) : '-1',
                 '__TEST__': 'false',
                 '__WATCH__': watch ? 'true' : 'false',

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -13,7 +13,6 @@ const reload = require('./reload');
 const {PORT} = reload;
 const {createTask} = require('./task');
 
-process.setMaxListeners(50);
 
 /**
  * @typedef JSEntry

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -13,6 +13,8 @@ const reload = require('./reload');
 const {PORT} = reload;
 const {createTask} = require('./task');
 
+process.setMaxListeners(50);
+
 /**
  * @typedef JSEntry
  * @property {string} src
@@ -144,7 +146,7 @@ function hydrateTask(/** @type {JSEntry[]} */entries, /** @type {boolean} */debu
         if (entry.platform) {
             return [bundleJS(entry, entry.platform, {debug, watch})];
         }
-        return [PLATFORM.CHROME, PLATFORM.CHROME_MV3, PLATFORM.FIREFOX, PLATFORM.THUNDERBIRD].map((platform) =>
+        return Object.values(PLATFORM).map((platform) =>
             bundleJS(entry, platform, {debug, watch}));
     }).flat();
 }

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -191,7 +191,11 @@ module.exports = createTask(
         });
         await Promise.all(
             entries.map((entry) => {
-                return [bundleJS(entry, {debug: true, watch: true})];
+                if (entry.platform) {
+                    return [bundleJS(entry, entry.platform, {debug, watch})];
+                }
+                return [PLATFORM.CHROME, PLATFORM.CHROME_MV3, PLATFORM.FIREFOX, PLATFORM.THUNDERBIRD].map((platform) =>
+                    bundleJS(entry, platform, {debug, watch}));
             }).flat()
         );
 

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -141,18 +141,12 @@ function getWatchFiles() {
 /** @type {string[]} */
 let watchFiles;
 
-function hydrateTask(/** @type {JSEntry[]} */entries, platforms, /** @type {boolean} */debug, /** @type {boolean} */watch) {
-    return entries.map((entry) => {
-        if (entry.platform) {
-            if (platforms[entry.platform]) {
-                return [bundleJS(entry, entry.platform, {debug, watch})];
-            }
-            return [];
-        }
-        return Object.values(PLATFORM).filter((platform) => platforms[platform]).map((platform) =>
-            bundleJS(entry, platform, {debug, watch}));
-    }).flat();
-}
+const hydrateTask = (/** @type {JSEntry[]} */entries, platforms, /** @type {boolean} */debug, /** @type {boolean} */watch) =>
+    entries.map((entry) =>
+        (entry.platform ? [entry.platform] : Object.values(PLATFORM))
+            .filter((platform) => platforms[platform])
+            .map((platform) => bundleJS(entry, platform, {debug, watch}))
+    ).flat();
 
 module.exports = createTask(
     'bundle-js',

--- a/tasks/task.js
+++ b/tasks/task.js
@@ -20,7 +20,7 @@ class Task {
 
     /**
      * @param {string[] | (() => string[])} files
-     * @param {(changedFiles: string[], watcher: import('chokidar').FSWatcher) => void | Promise<void>} onChange
+     * @param {(changedFiles: string[], watcher: import('chokidar').FSWatcher) => void | Promise<void>, platforms: object} onChange
      */
     addWatcher(files, onChange) {
         this._watchFiles = files;
@@ -47,7 +47,7 @@ class Task {
         );
     }
 
-    watch() {
+    watch(platforms) {
         if (!this._watchFiles || !this._onChange) {
             return;
         }
@@ -58,7 +58,7 @@ class Task {
                 this._watchFiles,
             onChange: async (files) => {
                 await this._measureTime(
-                    this._onChange(files, watcher)
+                    this._onChange(files, watcher, platforms)
                 );
             },
         });

--- a/tasks/task.js
+++ b/tasks/task.js
@@ -3,6 +3,7 @@ const watch = require('./watch');
 
 /**
  * @typedef TaskOptions
+ * @property {object} platforms
  * @property {boolean} debug
  * @property {boolean} watch
  */


### PR DESCRIPTION
Use proper rollup plugins/methods for building extension. This will permit rollup to eliminate some dead code from builds. Also, this makes building for a single target faster. There is a speed regression in building for all platforms at once, but this is compensated with new flags which let us pick which exact platforms we want to build for: `--chrome`, `--chrome-mv3`, `--firefox`, `--thunderbird` (choose one or more, choose none to build all).