### PR TITLE
Optimize: reuse Rollup plugins

### DIFF
--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -133,33 +133,68 @@ const jsEntries = [
     },
 ];
 
+const rollupPluginCache = {};
+
+function getRollupPluginInstance(name, key, create) {
+    if (!rollupPluginCache[name]) {
+        rollupPluginCache[name] = {};
+    }
+    if (!rollupPluginCache[name][key]) {
+        rollupPluginCache[name][key] = {};
+    }
+    if (!rollupPluginCache[name][key].instance) {
+        rollupPluginCache[name][key].count = 0;
+        rollupPluginCache[name][key].instance = create();
+    }
+    rollupPluginCache[name][key].count++;
+    return rollupPluginCache[name][key].instance;
+}
+
+function freeRollupPluginInstance(name, key) {
+    if (rollupPluginCache[name] && rollupPluginCache[name][key]) {
+        rollupPluginCache[name][key].count--;
+        if (rollupPluginCache[name][key].count === 0) {
+            rollupPluginCache[name][key] = null;
+        }
+    }
+}
+
 async function bundleJS(/** @type {JSEntry} */entry, {debug, watch}) {
     const {src, dest} = entry;
+    const rollupPluginTypesctiptInstanceKey = debug;
+    const rollupPluginReplaceInstanceKey = `${entry.platform}-${debug}-${watch}`;
     const bundle = await rollup.rollup({
         input: rootPath(src),
         plugins: [
-            rollupPluginNodeResolve(),
-            rollupPluginTypescript({
-                rootDir,
-                typescript,
-                tsconfig: rootPath('src/tsconfig.json'),
-                noImplicitAny: debug ? false : true,
-                removeComments: debug ? false : true,
-                sourceMap: debug ? true : false,
-                inlineSources: debug ? true : false,
-                noEmitOnError: true,
-                cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache` : null,
-            }),
-            rollupPluginReplace({
-                preventAssignment: true,
-                '__DEBUG__': debug ? 'true' : 'false',
-                '__MV3__': entry.platform === PLATFORM.CHROME_MV3,
-                '__PORT__': watch ? String(PORT) : '-1',
-                '__TEST__': 'false',
-                '__WATCH__': watch ? 'true' : 'false',
-            }),
+            getRollupPluginInstance('nodeResolve', '', rollupPluginNodeResolve),
+            getRollupPluginInstance('typesctipt', rollupPluginTypesctiptInstanceKey, () =>
+                rollupPluginTypescript({
+                    rootDir,
+                    typescript,
+                    tsconfig: rootPath('src/tsconfig.json'),
+                    noImplicitAny: debug ? false : true,
+                    removeComments: debug ? false : true,
+                    sourceMap: debug ? true : false,
+                    inlineSources: debug ? true : false,
+                    noEmitOnError: true,
+                    cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache` : null,
+                })
+            ),
+            getRollupPluginInstance('replace', rollupPluginReplaceInstanceKey, () =>
+                rollupPluginReplace({
+                    preventAssignment: true,
+                    '__DEBUG__': debug ? 'true' : 'false',
+                    '__MV3__': entry.platform === PLATFORM.CHROME_MV3,
+                    '__PORT__': watch ? String(PORT) : '-1',
+                    '__TEST__': 'false',
+                    '__WATCH__': watch ? 'true' : 'false',
+                })
+            ),
         ].filter((x) => x)
     });
+    freeRollupPluginInstance('nodeResolve', '');
+    freeRollupPluginInstance('typesctipt', rollupPluginTypesctiptInstanceKey);
+    freeRollupPluginInstance('replace', rollupPluginReplaceInstanceKey);
     entry.watchFiles = bundle.watchFiles;
     await bundle.write({
         file: `${getDestDir({debug, platform: entry.platform || PLATFORM.CHROME})}/${dest}`,


### PR DESCRIPTION
Prior to this PR, build script was constructing a new instance of every Rollup plugin for every JS target. This is very inefficient, since this creates copies of every plugin with almost exact configs for every JS file. These plugin instances were not collected in a timely manner and resulted in memory bloat.

It's hard to measure exact memory usage, since it is runtime dependent, but in testing this PR leads to more than halving of peak memory usage on my system. In particular, prior to this PR node would easily surpass 1000 MB, and after it never reaches 500 MB.

The memory footprint is less important for local builds, but it is blocking #9222 because CI simply can run out of memory.

Also, we could reduce the memory footprint a bit further by marking `bundle` for memory collection before `entry.postBuild` completes.