### PR TITLE
Remove killtheradio.net from dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -527,7 +527,6 @@ kbhgames.com
 keezersquest.nl
 kfocus.org
 killabee-gaming.com
-killtheradio.net
 kimbatt.github.io/js-Z
 kingdom-leaks.com
 kittybot.de


### PR DESCRIPTION
This website is not dark by default.

![killtheradio net](https://user-images.githubusercontent.com/95879668/178126749-df15a8fc-aa1e-4eeb-a430-c6a26060a5db.png)