### PR TITLE
Add geoguessr.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -385,6 +385,7 @@ gekri.com
 generated.photos
 genshin.gg
 geocities.restorativland.org
+geoguessr.com
 geometry.best
 getaether.net
 getdweb.net


### PR DESCRIPTION
Geoguessr is a popular site, and its theme is dark by default.