### PR TITLE
Fix for reuters.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15143,8 +15143,6 @@ reuters.com
 
 INVERT
 path[d^="M121.865 50.29c0"]
-svg[class^="nav-bar__arrow"] > path
-svg[class^="nav-dropdown__icon"] > path
 
 ================================
 


### PR DESCRIPTION
Remove inversion for chevrons in top menu bar because they are being inverted correctly automatically now.