### PR TITLE
Refactor: do more work in parallel

### DIFF
--- a/src/background/devtools.ts
+++ b/src/background/devtools.ts
@@ -235,9 +235,18 @@ export default class DevTools {
     }
 
     private async loadConfigOverrides() {
-        this.config.overrides.dynamicThemeFixes = await this.getSavedDynamicThemeFixes() || null;
-        this.config.overrides.inversionFixes = await this.getSavedInversionFixes() || null;
-        this.config.overrides.staticThemes = await this.getSavedStaticThemes() || null;
+        const [
+            dynamicThemeFixes,
+            inversionFixes,
+            staticThemes
+        ] = await Promise.all([
+            this.getSavedDynamicThemeFixes(),
+            this.getSavedInversionFixes(),
+            this.getSavedStaticThemes(),
+        ]);
+        this.config.overrides.dynamicThemeFixes = dynamicThemeFixes || null;
+        this.config.overrides.inversionFixes = inversionFixes || null;
+        this.config.overrides.staticThemes = staticThemes || null;
     }
 
     private async getSavedDynamicThemeFixes() {

--- a/src/background/newsmaker.ts
+++ b/src/background/newsmaker.ts
@@ -61,8 +61,13 @@ export default class Newsmaker {
     }
 
     private async getReadNews(): Promise<string[]> {
-        const sync = await readSyncStorage({readNews: []});
-        const local = await readLocalStorage({readNews: []});
+        const [
+            sync,
+            local
+        ] = await Promise.all([
+            readSyncStorage({readNews: []}),
+            readLocalStorage({readNews: []}),
+        ]);
         return Array.from(new Set([
             ...sync ? sync.readNews : [],
             ...local ? local.readNews : [],
@@ -70,8 +75,13 @@ export default class Newsmaker {
     }
 
     private async getDisplayedNews(): Promise<string[]> {
-        const sync = await readSyncStorage({displayedNews: []});
-        const local = await readLocalStorage({displayedNews: []});
+        const [
+            sync,
+            local
+        ] = await Promise.all([
+            readSyncStorage({displayedNews: []}),
+            readLocalStorage({displayedNews: []}),
+        ]);
         return Array.from(new Set([
             ...sync ? sync.displayedNews : [],
             ...local ? local.displayedNews : [],
@@ -120,9 +130,11 @@ export default class Newsmaker {
             });
             this.onUpdate(this.latest);
             const obj = {readNews: results};
-            await writeLocalStorage(obj);
-            await writeSyncStorage(obj);
-            await this.stateManager.saveState();
+            await Promise.all([
+                writeLocalStorage(obj),
+                writeSyncStorage(obj),
+                this.stateManager.saveState(),
+            ]);
         }
     }
 
@@ -143,9 +155,11 @@ export default class Newsmaker {
             });
             this.onUpdate(this.latest);
             const obj = {displayedNews: results};
-            await writeLocalStorage(obj);
-            await writeSyncStorage(obj);
-            await this.stateManager.saveState();
+            await Promise.all([
+                writeLocalStorage(obj),
+                writeSyncStorage(obj),
+                this.stateManager.saveState(),
+            ]);
         }
     }
 


### PR DESCRIPTION
This PR takes advantage of `Promise.all` to do more work in parallel. In particular, according to the spec, if one has an object like this
```
const o = {o1: await a(), o2: await b()}
```
then browser will await for `a()` to finish before starting on with `b()`. This can be fixed simply by writing:
```
const [o1, o2] = await Promise.all(a(), b());
const o = {o1, o2};
```