### PR TITLE
MV3: add registered CSS proxy injector

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,7 +4,7 @@ import {canInjectScript} from '../background/utils/extension-api';
 import type {ExtensionData, Message, UserSettings} from '../definitions';
 import {MessageType} from '../utils/message';
 import {makeChromiumHappy} from './make-chromium-happy';
-import {logInfo} from 'utils/log';
+import {logInfo} from '../utils/log';
 
 // Initialize extension
 const extension = new Extension();
@@ -33,15 +33,15 @@ if (__MV3__) {
                 (chrome.scripting as any).registerContentScripts([{
                     id: 'proxy',
                     matches: [
-                        "<all_urls>"
+                        '<all_urls>'
                     ],
                     js: [
-                        "inject/proxy.js",
+                        'inject/proxy.js',
                     ],
-                    runAt: "document_start",
+                    runAt: 'document_start',
                     allFrames: true,
                     persistAcrossSessions: true,
-                    world: "MAIN",
+                    world: 'MAIN',
                 }], () => logInfo('Registerd direct CSS proxy injector.'));
             });
         } catch (e) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,6 +4,7 @@ import {canInjectScript} from '../background/utils/extension-api';
 import type {ExtensionData, Message, UserSettings} from '../definitions';
 import {MessageType} from '../utils/message';
 import {makeChromiumHappy} from './make-chromium-happy';
+import {logInfo} from 'utils/log';
 
 // Initialize extension
 const extension = new Extension();
@@ -27,24 +28,25 @@ const WATCH = __WATCH__;
 
 if (__MV3__) {
     chrome.runtime.onInstalled.addListener(async () => {
-        (chrome.scripting as any).unregisterContentScripts(() => {
-            (chrome.scripting as any).registerContentScripts([{
-                id: 'proxy',
-                matches: [
-                    "<all_urls>"
-                ],
-                js: [
-                    "inject/proxy.js",
-                ],
-                runAt: "document_start",
-                allFrames: true,
-                persistAcrossSessions: true,
-                world: "MAIN",
-                // TODO:
-                //"match_about_blank": true
-            }]);
-        });
-
+        try {
+            (chrome.scripting as any).unregisterContentScripts(() => {
+                (chrome.scripting as any).registerContentScripts([{
+                    id: 'proxy',
+                    matches: [
+                        "<all_urls>"
+                    ],
+                    js: [
+                        "inject/proxy.js",
+                    ],
+                    runAt: "document_start",
+                    allFrames: true,
+                    persistAcrossSessions: true,
+                    world: "MAIN",
+                }], () => logInfo('Registerd direct CSS proxy injector.'));
+            });
+        } catch (e) {
+            logInfo('Failed to register direct CSS proxy injector, falling back to other injection methods.');
+        }
     });
 }
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -22,7 +22,31 @@ console.log(welcome);
 declare const __DEBUG__: boolean;
 declare const __WATCH__: boolean;
 declare const __PORT__: number;
+declare const __MV3__: number;
 const WATCH = __WATCH__;
+
+if (__MV3__) {
+    chrome.runtime.onInstalled.addListener(async () => {
+        (chrome.scripting as any).unregisterContentScripts(() => {
+            (chrome.scripting as any).registerContentScripts([{
+                id: 'proxy',
+                matches: [
+                    "<all_urls>"
+                ],
+                js: [
+                    "inject/proxy.js",
+                ],
+                runAt: "document_start",
+                allFrames: true,
+                persistAcrossSessions: true,
+                world: "MAIN",
+                // TODO:
+                //"match_about_blank": true
+            }]);
+        });
+
+    });
+}
 
 if (WATCH) {
     const PORT = __PORT__;

--- a/src/inject/dynamic-theme/mv3-proxy.ts
+++ b/src/inject/dynamic-theme/mv3-proxy.ts
@@ -1,7 +1,7 @@
 import {injectProxy} from './stylesheet-proxy';
 import {logInfo} from '../../utils/log';
 
-document.currentScript.remove();
+document.currentScript && document.currentScript.remove();
 
 const key = 'darkreaderProxyInjected';
 const EVENT_DONE = '__darkreader__stylesheetProxy__done';
@@ -51,7 +51,7 @@ function inject() {
         return;
     }
     logInfo('MV3 proxy injector: proxy attempts to inject...');
-    regularPath();
+    document.currentScript && regularPath();
     dedicatedPath();
 }
 

--- a/src/inject/dynamic-theme/mv3-proxy.ts
+++ b/src/inject/dynamic-theme/mv3-proxy.ts
@@ -28,11 +28,11 @@ function regularPath() {
 function dataReceiver(e: any) {
     document.removeEventListener(EVENT_ARG, dataReceiver);
     if (document.documentElement.dataset[key] !== undefined) {
-        logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd': 'dedicated'} path exits because everything is done.`);
+        logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd' : 'dedicated'} path exits because everything is done.`);
         return;
     }
     document.documentElement.dataset[key] = 'true';
-    logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd': 'dedicated'} path runs injectProxy(${e.detail}).`);
+    logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd' : 'dedicated'} path runs injectProxy(${e.detail}).`);
     injectProxyAndCleanup(e.detail);
 }
 
@@ -42,7 +42,7 @@ function doneReceiver() {
 }
 
 function dedicatedPath() {
-    logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd': 'dedicated'} path setup...`);
+    logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd' : 'dedicated'} path setup...`);
     document.addEventListener(EVENT_ARG, dataReceiver);
     document.addEventListener(EVENT_DONE, doneReceiver);
 }

--- a/src/inject/dynamic-theme/mv3-proxy.ts
+++ b/src/inject/dynamic-theme/mv3-proxy.ts
@@ -7,6 +7,8 @@ const key = 'darkreaderProxyInjected';
 const EVENT_DONE = '__darkreader__stylesheetProxy__done';
 const EVENT_ARG = '__darkreader__stylesheetProxy__arg';
 
+const registerdScriptPath = !document.currentScript;
+
 function injectProxyAndCleanup(arg: boolean) {
     injectProxy(arg);
     doneReceiver();
@@ -26,11 +28,11 @@ function regularPath() {
 function dataReceiver(e: any) {
     document.removeEventListener(EVENT_ARG, dataReceiver);
     if (document.documentElement.dataset[key] !== undefined) {
-        logInfo(`MV3 proxy injector: dedicated path exits because everything is done.`);
+        logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd': 'dedicated'} path exits because everything is done.`);
         return;
     }
     document.documentElement.dataset[key] = 'true';
-    logInfo(`MV3 proxy injector: dedicated path runs injectProxy(${e.detail}).`);
+    logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd': 'dedicated'} path runs injectProxy(${e.detail}).`);
     injectProxyAndCleanup(e.detail);
 }
 
@@ -40,7 +42,7 @@ function doneReceiver() {
 }
 
 function dedicatedPath() {
-    logInfo('MV3 proxy injector: dedicated path setup...');
+    logInfo(`MV3 proxy injector: ${registerdScriptPath ? 'registerd': 'dedicated'} path setup...`);
     document.addEventListener(EVENT_ARG, dataReceiver);
     document.addEventListener(EVENT_DONE, doneReceiver);
 }


### PR DESCRIPTION
This is a third method of injecting CSS stylesheet proxy. It is available only for Chromium 102 and above, but in testing it appears to win the race consistently.