### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -485,6 +485,7 @@ accounts.zoho.com
 INVERT
 div#product_img.tfa_totp_mode
 span.zoho_logo
+.zwHDots
 
 ================================
 
@@ -4087,6 +4088,13 @@ CSS
 .geDiagramContainer path {
     filter: brightness(60%);
 }
+
+================================
+
+consent.yahoo.com
+
+INVERT
+.consent-wizard-body > .image-container > .image.yahoo
 
 ================================
 
@@ -10929,6 +10937,7 @@ login.yahoo.com
 INVERT
 .social-login
 label[for=persistent]::before
+#password-toggle-button
 
 IGNORE IMAGE ANALYSIS
 .social-login
@@ -11148,6 +11157,7 @@ img[src$="profile_mask2.png"]
 .mixmax-flyout__wrapper
 div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
 form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id])
+img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"]
 
 CSS
 @media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {
@@ -12073,6 +12083,10 @@ monitor.firefox.com
 INVERT
 svg[class="Mozilla-logo"] > path[fill="#ffffff"]
 .fx-bento-app-link.fx-bento-link.fx-mobile > span::before
+img[src="/img/svg/laptop.svg"]
+img[src="/img/svg/globe.svg"]
+img[src="/img/svg/vpn.svg"]
+button[class="vpn-banner-close"]
 
 ================================
 
@@ -13692,20 +13706,6 @@ otomoto.pl
 
 INVERT
 .seller-card__links__link__icon
-
-================================
-
-outline.com
-
-INVERT
-img[src="https://outline.com/images/wordmark.svg"]
-
-================================
-
-outlook.live.com
-
-INVERT
-div.o365cs-base > span.ms-Icon--WaffleOffice36
 
 ================================
 
@@ -15750,6 +15750,7 @@ scribd.com
 
 INVERT
 .logo
+.document_container
 
 ================================
 
@@ -18511,6 +18512,7 @@ body.wmgWiki > i
 .spi.radar
 .spi.recap
 .spi.shoutout
+.spi.webcomic
 .spi.wmg
 .spi.ymmv
 img[src="/img/loading-alt.gif"]


### PR DESCRIPTION
- Zoho: A menu icon
- Yahoo Consent: Images of other companies owned by Yahoo's parent company
- Yahoo Login: Button to toggle the visibility of the password
- Gmail: A close button
- Firefox Monitor: VPN ad at the top
- Scribd: Invert the documents so they are somewhat readable

Removed:
- Outlook: Menu icon now fits the theme
- Outline: No longer exists