### PR TITLE
Add mail.proton.me as dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -480,6 +480,7 @@ macbb.org
 madiator.com
 magnetoo.io
 magoware.tv
+mail.proton.me
 manen.me
 mangaplus.shueisha.co.jp
 mango.pdf.zone


### PR DESCRIPTION
This is one possible fix for https://github.com/darkreader/darkreader/issues/9300. Let's discuss if we like it. This site is not dark by default, but it has a very good native dark theme which can be activated pretty easily.