### PR TITLE
Implement StateManager.addChangeListener() and add tests

### DIFF
--- a/src/utils/state-manager.ts
+++ b/src/utils/state-manager.ts
@@ -11,7 +11,22 @@ export class StateManager<T> {
 
     constructor(localStorageKey: string, parent: any, defaults: T){
         if (isNonPersistent()) {
-            this.stateManager = new StateManagerImpl(localStorageKey, parent, defaults, chrome.storage.local.get, chrome.storage.local.set);
+            function addListener(listener: (data: T) => void) {
+                chrome.storage.onChanged.addListener((changes, areaName) => {
+                    if (areaName !== 'local' || !changes[localStorageKey]) {
+                        return;
+                    }
+                    listener(changes[localStorageKey].newValue);
+                });
+            }
+
+            this.stateManager = new StateManagerImpl(
+                localStorageKey,
+                parent,
+                defaults,
+                chrome.storage.local,
+                addListener
+            );
         }
     }
 

--- a/tests/unit/utils/state-manager.tests.ts
+++ b/tests/unit/utils/state-manager.tests.ts
@@ -503,6 +503,7 @@ describe('State manager utility', () => {
             getCallback();
             getCallback = undefined;
         };
+
         const get = (storageKey: string, callback: (data: any) => void) => {
             expect(storageKey).toEqual(key);
             getCount++;
@@ -517,6 +518,7 @@ describe('State manager utility', () => {
             setCallback();
             setCallback = undefined;
         };
+
         const set = (items: any, callback: () => void) => {
             setCount++;
             setCallback = () => {


### PR DESCRIPTION
Previously, StateManager with a particular storage key was usable only within one JS context at a time, so we had to, for example, pass all data to background script which had a "canonical" StateManager instance which would `saveState()` centrally. This is tedious and inefficient, since we had to perform lots of messaging and occasionally we had to resurrect the whole `Extension` class just to change a few values in storage. After this PR, every context is entitled to its own copy of StateManager and all instances of it will automatically sync data with all other StateManagers with the same key. All contexts will be made aware of all data writes as soon as they happen and all contexts will sync up the data in case there is ever a data race (which is a very unlikely case, but still theoretically possible and very unpleasant if it ever happens).

This PR just updates the diagram, adds two StateManager states, ands StateManager.addChangeListener(), and updates tests.