### PR TITLE
Refactor: make archives reproducible

### DIFF
--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -21,7 +21,7 @@ function archiveFiles({files, dest, cwd, date}) {
         ));
         /** @type {any} */
         const writeStream = fs.createWriteStream(dest);
-        archive.outputStream.pipe(writeStream).on('close', () => resolve());
+        archive.outputStream.pipe(writeStream).on('close', resolve);
         archive.end();
     });
 }
@@ -32,12 +32,9 @@ async function archiveDirectory({dir, dest, date}) {
 }
 
 async function getLastCommitTime() {
-    return new Promise((resolve) => {
-        exec('git log -1 --format=%ct', (error, stdout, stderr) => {
-            let date = new Date(Number(stdout) * 1000);
-            resolve(date);
-        });
-    });
+    return new Promise((resolve) => 
+        exec('git log -1 --format=%ct', (_, stdout) => resolve(new Date(Number(stdout) * 1000)))
+    );
 }
 
 async function zip({platforms, debug}) {

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -17,7 +17,7 @@ function archiveFiles({files, dest, cwd, date}) {
         files.forEach((file) => archive.addFile(
             file,
             file.startsWith(`${cwd}/`) ? file.substring(cwd.length + 1) : file,
-            { mtime: date }
+            {mtime: date}
         ));
         /** @type {any} */
         const writeStream = fs.createWriteStream(dest);
@@ -32,7 +32,7 @@ async function archiveDirectory({dir, dest, date}) {
 }
 
 async function getLastCommitTime() {
-    return new Promise((resolve) => 
+    return new Promise((resolve) =>
         exec('git log -1 --format=%ct', (_, stdout) => resolve(new Date(Number(stdout) * 1000)))
     );
 }

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -13,6 +13,7 @@ const {getPaths} = require('./utils');
 function archiveFiles({files, dest, cwd, date}) {
     return new Promise((resolve) => {
         const archive = new yazl.ZipFile();
+        files.sort();
         files.forEach((file) => archive.addFile(
             file,
             file.startsWith(`${cwd}/`) ? file.substring(cwd.length + 1) : file,


### PR DESCRIPTION
This makes built archives reproducible, which allows us to `diff -r` two build folders, one before refactoring and another after refactoring, and observe no differences. This PR does two things: enforces alphabetical order of files within the archive and substitutes modified timestamps with the timestamp of the latest checked out commit.