### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2,7 +2,6 @@
 
 INVERT
 .jfk-bubble.gtx-bubble
-img[class*="jfk-button-img"]
 .captcheck_answer_label > input + img
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
 span[data-href^="https://www.hcaptcha.com/"] > #icon
@@ -2683,6 +2682,13 @@ INVERT
 .-streamline-chat_bubbles
 .hp-policies-calendar-icon
 .-iconset-moon_crescent
+
+================================
+
+books.google.*
+
+INVERT
+.jfk-button-img
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2,6 +2,7 @@
 
 INVERT
 .jfk-bubble.gtx-bubble
+img[class*="jfk-button-img"]
 .captcheck_answer_label > input + img
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
 span[data-href^="https://www.hcaptcha.com/"] > #icon


### PR DESCRIPTION
Invert Google's JFK theme button images
Example: buttons at books.google.com, a dynamic pure black bg theme.