### PR TITLE
Refactor parsing colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Correctly open static theme editor on Mobile.
 - Migrate automation settings to it's own object. WARNING: this can lead to data loss of currently used automation settings due to browser behavior.
 - Correctly handle empty URL's in `background-image` property.
+- Make parsing colors use cache.
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/background/window-theme.ts
+++ b/src/background/window-theme.ts
@@ -1,5 +1,5 @@
 import type {RGBA} from '../utils/color';
-import {parse} from '../utils/color';
+import {parseColorWithCache} from '../utils/color';
 import {modifyBackgroundColor, modifyForegroundColor, modifyBorderColor} from '../generators/modify-colors';
 import type {FilterConfig} from '../definitions';
 
@@ -77,7 +77,7 @@ export function setWindowTheme(filter: FilterConfig) {
             'text': modifyForegroundColor,
             'border': modifyBorderColor,
         }[type];
-        const rgb = parse(value);
+        const rgb = parseColorWithCache(value);
         const modified = modify(rgb, filter);
         obj[key] = modified;
         return obj;

--- a/src/generators/modify-colors.ts
+++ b/src/generators/modify-colors.ts
@@ -1,6 +1,6 @@
 import type {FilterConfig, Theme} from '../definitions';
 import type {RGBA, HSLA} from '../utils/color';
-import {parse, rgbToHSL, hslToRGB, rgbToString, rgbToHexString} from '../utils/color';
+import {parseToHSLWithCache, rgbToHSL, hslToRGB, rgbToString, rgbToHexString} from '../utils/color';
 import {scale} from '../utils/math';
 import {applyColorMatrix, createFilterMatrix} from './utils/matrix';
 
@@ -21,21 +21,9 @@ function getFgPole(theme: Theme) {
 }
 
 const colorModificationCache = new Map<ColorFunction, Map<string, string>>();
-const colorParseCache = new Map<string, HSLA>();
-
-function parseToHSLWithCache(color: string) {
-    if (colorParseCache.has(color)) {
-        return colorParseCache.get(color);
-    }
-    const rgb = parse(color);
-    const hsl = rgbToHSL(rgb);
-    colorParseCache.set(color, hsl);
-    return hsl;
-}
 
 export function clearColorModificationCache() {
     colorModificationCache.clear();
-    colorParseCache.clear();
 }
 
 const rgbCacheKeys: Array<keyof RGBA> = ['r', 'g', 'b', 'a'];

--- a/src/inject/detector.ts
+++ b/src/inject/detector.ts
@@ -1,11 +1,11 @@
-import {parse, getSRGBLightness} from '../utils/color';
+import {getSRGBLightness, parseColorWithCache} from '../utils/color';
 
 function hasBuiltInDarkTheme() {
     const drStyles = document.querySelectorAll('.darkreader') as NodeListOf<HTMLStyleElement & {disabled: boolean}>;
     drStyles.forEach((style) => style.disabled = true);
 
-    const rootColor = parse(getComputedStyle(document.documentElement).backgroundColor);
-    const bodyColor = document.body ? parse(getComputedStyle(document.body).backgroundColor) : {r: 0, g: 0, b: 0, a: 0};
+    const rootColor = parseColorWithCache(getComputedStyle(document.documentElement).backgroundColor);
+    const bodyColor = document.body ? parseColorWithCache(getComputedStyle(document.body).backgroundColor) : {r: 0, g: 0, b: 0, a: 0};
     const rootLightness = (1 - rootColor.a) + rootColor.a * getSRGBLightness(rootColor.r, rootColor.g, rootColor.b);
     const finalLightness = (1 - bodyColor.a) * rootLightness + bodyColor.a * getSRGBLightness(bodyColor.r, bodyColor.g, bodyColor.b);
     const darkThemeDetected = finalLightness < 0.5;

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -1,6 +1,6 @@
 import {overrideInlineStyle, getInlineOverrideStyle, watchForInlineStyles, stopWatchingForInlineStyles, INLINE_STYLE_SELECTOR} from './inline-style';
 import {changeMetaThemeColorWhenAvailable, restoreMetaThemeColor} from './meta-theme-color';
-import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, getSelectionColor, tryParseColor} from './modify-css';
+import {getModifiedUserAgentStyle, getModifiedFallbackStyle, cleanModificationCache, getSelectionColor} from './modify-css';
 import type {StyleElement, StyleManager} from './style-manager';
 import {manageStyle, getManageableStyles, cleanLoadingLinks} from './style-manager';
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
@@ -18,7 +18,7 @@ import type {AdoptedStyleSheetManager} from './adopted-style-manger';
 import {createAdoptedStyleSheetOverride} from './adopted-style-manger';
 import {isFirefox} from '../../utils/platform';
 import {injectProxy} from './stylesheet-proxy';
-import {parse} from '../../utils/color';
+import {clearColorCache, parseColorWithCache} from '../../utils/color';
 import {parsedURLCache} from '../../utils/url';
 import {variablesStore} from './variables';
 
@@ -133,8 +133,8 @@ function createStaticStyleOverrides() {
     const {darkSchemeBackgroundColor, darkSchemeTextColor, lightSchemeBackgroundColor, lightSchemeTextColor, mode} = filter;
     let schemeBackgroundColor = mode === 0 ? lightSchemeBackgroundColor : darkSchemeBackgroundColor;
     let schemeTextColor = mode === 0 ? lightSchemeTextColor : darkSchemeTextColor;
-    schemeBackgroundColor = modifyBackgroundColor(parse(schemeBackgroundColor), filter);
-    schemeTextColor = modifyForegroundColor(parse(schemeTextColor), filter);
+    schemeBackgroundColor = modifyBackgroundColor(parseColorWithCache(schemeBackgroundColor), filter);
+    schemeTextColor = modifyForegroundColor(parseColorWithCache(schemeTextColor), filter);
     variableStyle.textContent = [
         `:root {`,
         `   --darkreader-neutral-background: ${schemeBackgroundColor};`,
@@ -191,7 +191,7 @@ function createShadowStaticStyleOverrides(root: ShadowRoot) {
 
 function replaceCSSTemplates($cssText: string) {
     return $cssText.replace(/\${(.+?)}/g, (_, $color) => {
-        const color = tryParseColor($color);
+        const color = parseColorWithCache($color);
         if (color) {
             return modifyColor(color, filter);
         }
@@ -561,4 +561,5 @@ export function cleanDynamicThemeCache() {
     cancelRendering();
     stopWatchingForUpdates();
     cleanModificationCache();
+    clearColorCache();
 }

--- a/src/inject/dynamic-theme/meta-theme-color.ts
+++ b/src/inject/dynamic-theme/meta-theme-color.ts
@@ -1,4 +1,4 @@
-import {parse} from '../../utils/color';
+import {parseColorWithCache} from '../../utils/color';
 import {modifyBackgroundColor} from '../../generators/modify-colors';
 import {logWarn} from '../../utils/log';
 import type {FilterConfig} from '../../definitions';
@@ -10,12 +10,12 @@ let observer: MutationObserver = null;
 
 function changeMetaThemeColor(meta: HTMLMetaElement, theme: FilterConfig) {
     srcMetaThemeColor = srcMetaThemeColor || meta.content;
-    try {
-        const color = parse(srcMetaThemeColor);
-        meta.content = modifyBackgroundColor(color, theme);
-    } catch (err) {
-        logWarn(err);
+    const color = parseColorWithCache(srcMetaThemeColor);
+    if (!color) {
+        logWarn('Invalid meta color', color);
+        return;
     }
+    meta.content = modifyBackgroundColor(color, theme);
 }
 
 export function changeMetaThemeColorWhenAvailable(theme: FilterConfig) {

--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -1,10 +1,11 @@
 import {modifyBackgroundColor, modifyBorderColor, modifyForegroundColor} from '../../generators/modify-colors';
 import {getParenthesesRange} from '../../utils/text';
 import {iterateCSSRules, iterateCSSDeclarations} from './css-rules';
-import {tryParseColor, getBgImageModifier, getShadowModifierWithInfo} from './modify-css';
+import {getBgImageModifier, getShadowModifierWithInfo} from './modify-css';
 import type {CSSValueModifier} from './modify-css';
 import type {Theme} from '../../definitions';
 import type {RGBA} from '../../utils/color';
+import {parseColorWithCache} from '../../utils/color';
 
 export interface ModifiedVarDeclaration {
     property: string;
@@ -361,7 +362,7 @@ export class VariablesStore {
         }
         this.definedVars.add(varName);
 
-        const color = tryParseColor(value);
+        const color = parseColorWithCache(value);
         if (color) {
             this.unknownColorVars.add(varName);
         } else if (
@@ -654,7 +655,7 @@ function parseRawValue(color: string) {
 function handleRawValue(color: string, theme: Theme, modifyFunction: (rgb: RGBA, theme: Theme) => string) {
     const {isRaw, color: newColor} = parseRawValue(color);
 
-    const rgb = tryParseColor(newColor);
+    const rgb = parseColorWithCache(newColor);
     if (rgb) {
         const outputColor = modifyFunction(rgb, theme);
 
@@ -662,7 +663,7 @@ function handleRawValue(color: string, theme: Theme, modifyFunction: (rgb: RGBA,
         if (isRaw) {
             // This should techincally never fail(returning empty string),
             // but just to be safe we will return outputColor.
-            const outputInRGB = tryParseColor(outputColor);
+            const outputInRGB = parseColorWithCache(outputColor);
             return outputInRGB ? `${outputInRGB.r}, ${outputInRGB.g}, ${outputInRGB.b}` : outputColor;
         }
         return outputColor;

--- a/src/ui/controls/color-dropdown/index.tsx
+++ b/src/ui/controls/color-dropdown/index.tsx
@@ -2,7 +2,7 @@ import {m} from 'malevic';
 import {getContext} from 'malevic/dom';
 import ColorPicker from '../color-picker';
 import DropDown from '../dropdown';
-import {parse} from '../../../utils/color';
+import {parseColorWithCache} from '../../../utils/color';
 
 interface ColorDropDownProps {
     class?: string;
@@ -49,14 +49,7 @@ export default function ColorDropDown(props: ColorDropDownProps) {
         props.onChange(result);
     }
 
-    let isPickerVisible: boolean;
-
-    try {
-        parse(props.value);
-        isPickerVisible = true;
-    } catch (err) {
-        isPickerVisible = false;
-    }
+    const isPickerVisible = Boolean(parseColorWithCache(props.value));
 
     const prevValue = context.prev ? context.prev.props.value : null;
     const shouldFocusOnPicker = (

--- a/src/ui/controls/color-picker/hsb-picker.tsx
+++ b/src/ui/controls/color-picker/hsb-picker.tsx
@@ -1,7 +1,7 @@
 import {m} from 'malevic';
 import {getContext} from 'malevic/dom';
 import type {RGBA} from '../../../utils/color';
-import {rgbToHSL, parse, hslToString, rgbToHexString} from '../../../utils/color';
+import {parseColorWithCache, rgbToHSL, hslToString, rgbToHexString} from '../../../utils/color';
 import {clamp, scale} from '../../../utils/math';
 import {createSwipeHandler} from '../../utils';
 import {isElementHidden} from '../utils';
@@ -122,7 +122,7 @@ export default function HSBPicker(props: HSBPickerProps) {
     const didColorChange = props.color !== prevColor && props.color !== prevActiveColor;
     let activeHSB: HSB;
     if (didColorChange) {
-        const rgb = parse(props.color);
+        const rgb = parseColorWithCache(props.color);
         activeHSB = rgbToHSB(rgb);
         store.activeHSB = activeHSB;
     } else {
@@ -134,7 +134,7 @@ export default function HSBPicker(props: HSBPickerProps) {
             return;
         }
         const hue = activeHSB.h;
-        const prevHue = prevColor && rgbToHSB(parse(prevColor)).h;
+        const prevHue = prevColor && rgbToHSB(parseColorWithCache(prevColor)).h;
         if (store.wasPrevHidden || hue !== prevHue) {
             renderSB(hue, canvas);
         }

--- a/src/ui/controls/color-picker/index.tsx
+++ b/src/ui/controls/color-picker/index.tsx
@@ -1,6 +1,6 @@
 import {m} from 'malevic';
 import {getContext} from 'malevic/dom';
-import {parse} from '../../../utils/color';
+import {parseColorWithCache} from '../../../utils/color';
 import TextBox from '../textbox';
 import HSBPicker from './hsb-picker';
 
@@ -13,12 +13,7 @@ interface ColorPickerProps {
 }
 
 function isValidColor(color: string) {
-    try {
-        parse(color);
-        return true;
-    } catch (err) {
-        return false;
-    }
+    return Boolean(parseColorWithCache(color));
 }
 
 const colorPickerFocuses = new WeakMap<Node, () => void>();

--- a/tests/unit/utils/color.tests.ts
+++ b/tests/unit/utils/color.tests.ts
@@ -60,9 +60,9 @@ test('Color parsing', () => {
     expect(parse('InfoBackground')).toEqual({r: 251, g: 252, b: 197, a: 1});
     expect(parse('-webkit-focus-ring-color')).toEqual({r: 229, g: 151, b: 0, a: 1});
 
-    expect(() => parse('sponge')).toThrow('Unable to parse sponge');
-    expect(() => parse('hsl(0, 0%, 0%) rgb(0, 0, 0)')).toThrow('Unable to parse hsl(0, 0%, 0%) rgb(0, 0, 0)');
-    expect(() => parse('#hello')).toThrow('Unable to parse #hello');
+    expect(parse('sponge')).toBeNull();
+    expect(parse('hsl(0, 0%, 0%) rgb(0, 0, 0)')).toBeNull();
+    expect(parse('#hello')).toBeNull();
 });
 
 test('Stringify color', () => {


### PR DESCRIPTION
- Use parse with cache where possible.
- Don't throw errors, instead return null.
- Resolves https://github.com/darkreader/darkreader/issues/9334