### PR TITLE
inversion fixes for math on atlassian

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -165,6 +165,8 @@ INVERT
 .aui-toolbar
 .editor
 .toolbar-item
+.conf-macro.output-inline
+.conf-macro.output-display
 
 ================================
 


### PR DESCRIPTION
Atlassian confluence pages currently don't invert typeset math.
This change fixes that.