### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1371,6 +1371,10 @@ CSS
 
 app.standardnotes.org
 
+INVERT
+[aria-label="Challenge modal"] > svg > circle:first-child
+input[id^="react-tag-"]
+
 CSS
 search-options svg {
     fill: var(--darkreader-neutral-text) !important;
@@ -5760,6 +5764,29 @@ INVERT
 .search__view--empty img
 .plan-status-section__icon img
 .dropbox-logo__type
+iframe[class^="previewhtml _previewContent"]
+.toggle.toggle-block__toggle.dig-Toggle
+.toggle.toggle-block__toggle.dig-Toggle.dig-Toggle--isToggled > span::after
+.shared-with-members.audience-box.u-pad-top-xs.u-pad-bottom-s.u-mar-bottom-xs > .c-loader
+.hp-card-carousel-dots
+.loading-loading > .loading-img
+
+CSS
+.rc-inline-action-bar-container.brws-file-row-inline-action-bar {
+    background: var(--darkreader-bg--color__core__secondary) !important;
+}
+svg.dig-GlyphLogo.dig-Waffle-row-logo path[fill="var(--color__glyph__accent)"] {
+    --darkreader-inline-fill: var(--color__glyph__accent) !important;
+}
+svg.dig-GlyphLogo.dig-Waffle-row-logo path[fill="var(--color__glyph__primary)"] {
+    --darkreader-inline-fill: var(--darkreader-text--color__standard__text) !important;
+}
+.dig-LabelGroup > div > input[aria-checked="false"] {
+    background-color: var(--darkreader-bg--color__core__secondary) !important;
+}
+.dig-LabelGroup > div > input[aria-checked="true"] {
+    background-color: var(--darkreader-text--color__core__secondary) !important;
+}
 
 IGNORE INLINE STYLE
 .home__suggest_image path
@@ -19632,6 +19659,14 @@ weblate.org
 
 INVERT
 h5.list-group-item-heading > svg
+img[src="/static/state/lock.svg"]
+img[src="/static/state/link.svg"]
+img[src="/static/state/source.svg"]
+img[src="/static/auth/password.svg"]
+img[src="/static/auth/email.svg"]
+img[src="/static/auth/github.svg"]
+path[d^="M12,4V2A10,10"]
+img[src="/static/state/link.svg"]
 
 ================================
 


### PR DESCRIPTION
- StandardNotes: Lock symbol when unlocking notes and menu titles
- Dropbox: Menu icons, toggles in settings, checkboxes, file preview, right side of a hovered-over item, loading dots, carousel dots and `.loading-loading > .loading-img`, which is to attempt to invert a loading animation, but since it's a mp4 file, it just erases it, but I'm not exactly sure of the proper way of handling it.
- Weblate: Various icons