### PR TITLE
iCloud.com site fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9038,6 +9038,8 @@ CSS
 icloud.com
 
 INVERT
+.rm-list-body
+.note-list-item-attachment
 .sc-iujRgT.jxLrRl
 .icloud-text.image
 .img.app-icon-icloud


### PR DESCRIPTION
solved issue #9345 on icloud.com/reminders
solved issue #9349  on icloud.com/notes
experienced another issue preview images/emojis on icloud.com/notes + icloud.com/reminders are converted which should not. tried to fix it i could not i need some help.
For example when having (dark images/emojis/any image) && darkreader dark mode is on -> their colors on the preview are inverted which should not -> i dont know how to fix this issue as it is only one element and not the entire canvas. need some help.
please @c-nagy provide additional information that can help us solve this issue.
screenshots:
Now with this fix preview images color are converted which should not.
<img width="615" alt="image" src="https://user-images.githubusercontent.com/78726445/179833254-a410c45e-1772-4a72-9b13-720ab17e8a81.png">
original image
<img width="240" alt="image" src="https://user-images.githubusercontent.com/78726445/179833289-8dddcc52-4854-4334-9568-6d629074210f.png">
btw only the preview images are converted when clicking the images the images are there.