### PR TITLE
Only send messages to affected tabs when toggling current site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Migrate automation settings to it's own object. WARNING: this can lead to data loss of currently used automation settings due to browser behavior.
 - Correctly handle empty URL's in `background-image` property.
 - Make parsing colors use cache.
+- Only send updates to the affected tabs when toggling sites.
 
 ## 4.9.52 (June 28, 2022)
 

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -459,7 +459,7 @@ export class Extension {
         }
     };
 
-    changeSettings($settings: Partial<UserSettings>) {
+    changeSettings($settings: Partial<UserSettings>, onlyUpdateActiveTab = false) {
         const prev = {...this.user.settings};
 
         this.user.set($settings);
@@ -498,7 +498,7 @@ export class Extension {
                 chrome.contextMenus.removeAll();
             }
         }
-        this.onSettingsChanged();
+        this.onSettingsChanged(onlyUpdateActiveTab);
     }
 
     private setTheme($theme: Partial<FilterConfig>) {
@@ -537,12 +537,12 @@ export class Extension {
         const darkThemeDetected = !settings.applyToListedOnly && settings.detectDarkTheme && tab.isDarkThemeDetected;
         if (isInDarkList || darkThemeDetected || settings.siteListEnabled.includes(host)) {
             const toggledList = getToggledList(settings.siteListEnabled);
-            this.changeSettings({siteListEnabled: toggledList});
+            this.changeSettings({siteListEnabled: toggledList}, true);
             return;
         }
 
         const toggledList = getToggledList(settings.siteList);
-        this.changeSettings({siteList: toggledList});
+        this.changeSettings({siteList: toggledList}, true);
     }
 
     //------------------------------------
@@ -568,13 +568,13 @@ export class Extension {
         }
     }
 
-    private async onSettingsChanged() {
+    private async onSettingsChanged(onlyUpdateActiveTab = false) {
         if (!this.user.settings) {
             await this.user.loadSettings();
         }
         await this.stateManager.loadState();
         this.wasEnabledOnLastCheck = this.isExtensionSwitchedOn();
-        this.tabs.sendMessage();
+        this.tabs.sendMessage(onlyUpdateActiveTab);
         this.saveUserSettings();
         this.reportChanges();
         this.stateManager.saveState();

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -6,7 +6,7 @@ import {isFirefox, isOpera, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
 import {logWarn} from '../utils/log';
 import {StateManager} from '../utils/state-manager';
-import {getURLHostOrProtocol, parseURL} from 'utils/url';
+import {getURLHostOrProtocol} from '../utils/url';
 
 declare const __MV3__: boolean;
 

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -6,6 +6,7 @@ import {isFirefox, isOpera, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
 import {logWarn} from '../utils/log';
 import {StateManager} from '../utils/state-manager';
+import {getURLHostOrProtocol, parseURL} from 'utils/url';
 
 declare const __MV3__: boolean;
 
@@ -286,8 +287,16 @@ export default class TabManager {
         });
     }
 
-    async sendMessage() {
+    // sendMessage will send a tab messages to all active tabs and their frames.
+    // If onlyUpdateActiveTab is specified, it will only send a new message to any
+    // tab that matches the active tab's hostname. This is to ensure that when a user
+    // has multiple tabs of the same website, it will ensure that every tab will receive
+    // the new message and not just that tab as Dark Reader currently doesn't have per-tab
+    // operations, this should be the expected behavior.
+    async sendMessage(onlyUpdateActiveTab = false) {
         this.timestamp++;
+
+        const activeTabHostname = onlyUpdateActiveTab ? getURLHostOrProtocol(await this.getActiveTabURL()) : null;
 
         (await queryTabs({}))
             .filter((tab) => Boolean(this.tabs[tab.id]))
@@ -296,7 +305,13 @@ export default class TabManager {
                 Object.entries(frames)
                     .filter(([, {state}]) => state === DocumentState.ACTIVE || state === DocumentState.PASSIVE)
                     .forEach(([, {url}], frameId) => {
-                        const message = this.getTabMessage(this.getTabURL(tab), frameId === 0 ? null : url);
+                        const tabURL = this.getTabURL(tab);
+                        // Check if hostname are equal when we only want to update active tab.
+                        if (onlyUpdateActiveTab && getURLHostOrProtocol(tabURL) !== activeTabHostname) {
+                            return;
+                        }
+
+                        const message = this.getTabMessage(tabURL, frameId === 0 ? null : url);
                         if (tab.active && frameId === 0) {
                             chrome.tabs.sendMessage<Message>(tab.id, message, {frameId});
                         } else {


### PR DESCRIPTION
- Currently if you toggle a site, a new tabmessage would be sent to all tabs, this is inefficient as most sites will just reprocess the whole site without any changes in the output. This PR fixes that by currently hardcoding to only send tabmessages to tabs that have the same hostname as the active tab, when toggling the current site.
- This behavior can later extended to other functionality, however this requires processing of presets, themes etc. Which require the more complex URL matching.
- Resolves #9336