### PR TITLE
Don't throw errors on invalid Hex.

### DIFF
--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -262,7 +262,7 @@ function parseHex($hex: string) {
             return {r, g, b, a};
         }
     }
-    throw new Error(`Unable to parse ${$hex}`);
+    return null;
 }
 
 function getColorByName($color: string) {


### PR DESCRIPTION
- Make the behavior consistent with #9337