### PR TITLE
added marvil.co

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -473,6 +473,7 @@ mangaplus.shueisha.co.jp
 mango.pdf.zone
 maroon.jonah.pw
 marte.dev
+marvil.co
 mastercomfig.com
 mastodon.online
 mastodon.social


### PR DESCRIPTION
[marvil.co](https://marvil.co/) is dark by default