### PR TITLE
Nit: adhere to RollupTypescriptPluginOptions types

### DIFF
--- a/tasks/bundle-api.js
+++ b/tasks/bundle-api.js
@@ -31,7 +31,7 @@ async function bundleAPI({debug}) {
                 tsconfig: rootPath('src/api/tsconfig.json'),
                 removeComments: true,
                 noEmitOnError: true,
-                cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_api_typescript_cache` : null,
+                cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_api_typescript_cache` : undefined,
             }),
             rollupPluginReplace({
                 preventAssignment: true,

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -137,7 +137,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, {debug, watch}) {
                     sourceMap: debug ? true : false,
                     inlineSources: debug ? true : false,
                     noEmitOnError: true,
-                    cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache` : null,
+                    cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache` : undefined,
                 })
             ),
             getRollupPluginInstance('replace', rollupPluginReplaceInstanceKey, () =>


### PR DESCRIPTION
`cacheDir` is an a `string | undefined` type, so `null` was getting nitpicked for me.