### PR TITLE
Bundle API build within build/api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Build files
 #-----------------------------------
 build/
-darkreader.js
 debug.log
 
 # Node.js modules

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "debug": "node tasks/build.js --debug",
     "debug:watch": "node tasks/build.js --debug --watch",
     "lint": "eslint --ignore-pattern '!.eslintplugin.js' -- 'src/**/*.ts' 'src/**/*.tsx' 'tasks/**/*.js' 'tests/**/*.ts' 'tests/[!coverage]**/*.js' 'index.d.ts' '.eslintplugin.js'",
-    "lint:bundle": "(node ./tasks/check-exists.js ./build/debug/chrome || node tasks/build.js --debug --api) && eslint -- 'build/debug/chrome/**/*.js' 'darkreader.js'",
+    "lint:bundle": "(node ./tasks/check-exists.js ./build/debug/chrome || node tasks/build.js --debug --api) && eslint -- 'build/debug/chrome/**/*.js' 'build/api/darkreader.js'",
     "prepublishOnly": "npm test && npm run api",
     "release": "npm test && npm run lint && node tasks/build.js --release",
     "test": "npm run test:unit",

--- a/tasks/bundle-api.js
+++ b/tasks/bundle-api.js
@@ -10,18 +10,42 @@ import fs from 'fs';
 import os from 'os';
 import {createTask} from './task.js';
 import paths from './paths.js';
+import {copyFile, readFile, writeFile} from './utils.js';
 const {rootDir, rootPath} = paths;
 
-async function getVersion() {
-    const file = await fs.promises.readFile(new URL('../package.json', import.meta.url));
-    const p = JSON.parse(file);
-    return p.version;
+const getDestDir = (file) => `build/api/${file}`;
+
+async function getPackage() {
+    const file = await readFile('./package.json');
+    return JSON.parse(file);
+}
+
+async function copyStaticFiles() {
+    const files = [
+        'index.d.ts',
+        'LICENSE',
+        'README.md',
+    ];
+    const promises = [];
+    files.forEach((file) => promises.push(copyFile(file, getDestDir(file))));
+    await Promise.all(promises);
+}
+
+async function bundlePackageManifest(packageManifest) {
+    const minimalPackageManifest = {
+        ...packageManifest,
+        type: undefined,
+        scripts: undefined,
+        devDependencies: undefined,
+    };
+    return writeFile(getDestDir('package.json'), JSON.stringify(minimalPackageManifest, null, '  '));
 }
 
 async function bundleAPI({debug}) {
     const src = rootPath('src/api/index.ts');
-    const dest = 'darkreader.js';
-    const bundle = await rollup.rollup({
+    const dest = getDestDir('darkreader.js');
+    const packageManifestPromise = getPackage();
+    const bundlePromise = rollup.rollup({
         input: src,
         plugins: [
             rollupPluginNodeResolve(),
@@ -41,14 +65,18 @@ async function bundleAPI({debug}) {
             }),
         ].filter((x) => x)
     });
-    await bundle.write({
-        banner: `/**\n * Dark Reader v${await getVersion()}\n * https://darkreader.org/\n */\n`,
+    const [packageManifest, bundle] = await Promise.all([packageManifestPromise, bundlePromise]);
+    const bundleWritePromise = bundle.write({
+        banner: `/**\n * Dark Reader v${packageManifest.version}\n * https://darkreader.org/\n */\n`,
         file: dest,
         strict: true,
         format: 'umd',
         name: 'DarkReader',
         sourcemap: false,
     });
+    const bundlePackageManifestPromise = bundlePackageManifest(packageManifest);
+    const copyStaticFilesPromise = copyStaticFiles();
+    await Promise.all([bundleWritePromise, bundlePackageManifestPromise, copyStaticFilesPromise]);
 }
 
 const bundleAPITask = createTask(


### PR DESCRIPTION
This PR has one goal: to let us add `"type": "module"` to top-level `package.json` without adding it to `package.json` published on NPM. We will probably need to add `"type": "module"` to our top-level `package.json` so that node never attempts to run anything with CommonJS module resolution algorithm which will fix most issues described in [this comment](https://github.com/darkreader/darkreader/pull/9373#issuecomment-1193090676).