### PR TITLE
MV3: update extension icon on browser startup

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -27,6 +27,10 @@ declare const __MV3__: number;
 const WATCH = __WATCH__;
 
 if (__MV3__) {
+    // HACK: Force browser to rewive background context on startup (non-incognito only)
+    // so that it can set the appropriate icon.
+    chrome.runtime.onStartup.addListener(() => { /* noop */ });
+
     chrome.runtime.onInstalled.addListener(async () => {
         try {
             (chrome.scripting as any).unregisterContentScripts(() => {


### PR DESCRIPTION
Browser icon changes are not persisted after browser restart, so background needs to be revived on every startup solely to set the appropriate icon.