### PR TITLE
Remove fix for thesaurus.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18157,15 +18157,6 @@ INVERT
 
 ================================
 
-thesaurus.com
-
-INVERT
-img[alt^="Grammar Coach"]
-[data-grammar-coach-hero="true"] + [data-promotion-page="true"]
-[data-grammar-coach-hero="true"] + [data-promotion-page="true"] > div
-
-================================
-
 theverge.com
 
 INVERT


### PR DESCRIPTION
The Grammar Coach section of the website (https://www.thesaurus.com/grammarcoach), which I reported needed fixing, has been redesigned, and the existing fix is no longer needed.