### PR TITLE
Remove parital fix for thunderbird.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18201,11 +18201,6 @@ INVERT
 .w-48
 a[title="Thunderbird"] > svg
 
-CSS
-body {
-    background-image: none !important;
-}
-
 ================================
 
 tianocore.org


### PR DESCRIPTION
This partial fix is no longer needed. The website (https://start.thunderbird.net/) reported in #6026 was redesigned and simplified.

![thunderbird](https://user-images.githubusercontent.com/95879668/180870953-e929ca78-b524-4b65-a88a-8f9d2e77820d.png)