### PR TITLE
Remove white background in TON logo in codeforces.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3904,7 +3904,7 @@ CSS
 .highlighted-row th{
     background-color: ${rgb(195, 205, 215)} !important;
 }
-#footer img[alt="Telegram"] {
+#footer img[alt="TON"] {
     border-radius: 50%;
 }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/30190448/181161636-eef2f939-b93e-474c-a6fa-c7cba2ccac9d.png) |  ![image](https://user-images.githubusercontent.com/30190448/181161574-1e654802-d9ee-4ccb-9f4e-e02ca56a502a.png) |

The same problem used to exist in a telegram logo which was recently removed so removed corresponding fix