### PR TITLE
Add emoji.supply and ardov.me to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -43,6 +43,7 @@ application.security
 aqtiongame.com
 ara-ara-ufufu.herokuapp.com
 archive.ragtag.moe
+ardov.me
 ari-web.xyz
 arkenfox.github.io/TZP/
 armaforces.com
@@ -238,6 +239,7 @@ elybeatmaker.com
 emanuelemilella.com
 emeraldchat.com/app
 emkc.org
+emoji.supply/kitchen/
 emuparadise.me
 enlightenment.org
 entity.works


### PR DESCRIPTION
https://ardov.me is mostly for https://huetone.ardov.me, but https://ardov.me is dark as well