### PR TITLE
fix for display math on confluence pages

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -167,6 +167,7 @@ INVERT
 .toolbar-item
 .conf-macro.output-inline
 .conf-macro.output-display
+.latexmath-center.confluenceTd
 
 ================================
 


### PR DESCRIPTION
Last PR didn't fix display math. This will