### PR TITLE
Add parrotbot.xyz to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -592,6 +592,7 @@ paimon.moe
 paper-io.com
 parahumans.wordpress.com
 paranoid.email
+parrotbot.xyz
 parrotsec.org
 passthepopcorn.me
 pastes.dev


### PR DESCRIPTION
Similar to #9427 

Website meets the [listed requirements](https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#adding-a-website-that-is-already-dark) and all pages (including login-protected dashboard) are dark-mode only.