### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14473,6 +14473,20 @@ a[title="Google apps"]
 
 ================================
 
+play.google.com/store/paymentmethods
+
+CSS
+.TedqDf,
+.O9PNUb,
+.HgYqic,
+.IguNCd,
+.tyYshb,
+.pCS3ec {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 plotkibiznesowe.pl
 
 INVERT


### PR DESCRIPTION
Adding a fix for play store payment method texts and gift card balance messages appearing in black in dark theme