### PR TITLE
Adding ruben-p.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -713,6 +713,7 @@ romefrontend.dev
 roosterteeth.fandom.com
 router.asus.com
 rtbyte.xyz
+ruben-p.com
 runechanger.stirante.com
 runeforge.gg
 runicgames.com


### PR DESCRIPTION
I have a dynamic theming system on my website and all of them are already dark. So Darkreader sometimes gets in the way of the styling.