### PR TITLE
Update parrotbot.xyz to parrotbot.gg

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -585,7 +585,7 @@ paimon.moe
 paper-io.com
 parahumans.wordpress.com
 paranoid.email
-parrotbot.xyz
+parrotbot.gg
 parrotsec.org
 passthepopcorn.me
 pastes.dev


### PR DESCRIPTION
Moved domain names. Original PR #9434