### PR TITLE
Continue rebuilding if debug:watch is run

### DIFF
--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -130,7 +130,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, tes
                     removeComments: debug ? false : true,
                     sourceMap: debug ? true : false,
                     inlineSources: debug ? true : false,
-                    noEmitOnError: true,
+                    noEmitOnError: watch ? false : true,
                     cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache` : undefined,
                 })
             ),


### PR DESCRIPTION
Do not crash `npm run debug:watch` when there are TypeScript errors, continue rebuilding until there are no errors.