### PR TITLE
Upgrade TypeScript from 4.6.4 to 4.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "rollup-plugin-istanbul2": "2.0.2",
         "ts-jest": "28.0.7",
         "tslib": "2.4.0",
-        "typescript": "4.6.4",
+        "typescript": "4.7.4",
         "web-ext": "7.1.1",
         "ws": "8.8.1",
         "yazl": "2.5.1"
@@ -10625,9 +10625,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -19407,9 +19407,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "rollup-plugin-istanbul2": "2.0.2",
     "ts-jest": "28.0.7",
     "tslib": "2.4.0",
-    "typescript": "4.6.4",
+    "typescript": "4.7.4",
     "web-ext": "7.1.1",
     "ws": "8.8.1",
     "yazl": "2.5.1"

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -57,7 +57,7 @@ function createValidator() {
         if (!obj.hasOwnProperty(key) || validator(obj[key])) {
             return;
         }
-        errors.push(`Unexpected value for "${key}": ${JSON.stringify(obj[key])}`);
+        errors.push(`Unexpected value for "${key as string}": ${JSON.stringify(obj[key])}`);
         obj[key] = fallback[key];
     }
 
@@ -75,7 +75,7 @@ function createValidator() {
             }
         }
         if (wrongValues.size > 0) {
-            errors.push(`Array "${key}" has wrong values: ${Array.from(wrongValues).map((v) => JSON.stringify(v)).join('; ')}`);
+            errors.push(`Array "${key as string}" has wrong values: ${Array.from(wrongValues).map((v) => JSON.stringify(v)).join('; ')}`);
         }
     }
 


### PR DESCRIPTION
Note to self: TypeScript was throwing a mysterious error about implicit conversion of symbol to string, the following patch helped locate the problematic file:
```diff
diff --git a/tasks/bundle-js.js b/tasks/bundle-js.js
index fb0e9ab2..2c08bae9 100644
--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -6,7 +6,8 @@ import rollupPluginNodeResolve from '@rollup/plugin-node-resolve';
 /** @type {any} */
 import rollupPluginReplace from '@rollup/plugin-replace';
 /** @type {any} */
-import rollupPluginTypescript from '@rollup/plugin-typescript';
+import rollupPluginTypescript from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
 import paths from './paths.js';
 import * as reload from './reload.js';
@@ -132,6 +133,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, tes
                     inlineSources: debug ? true : false,
                     noEmitOnError: watch ? false : true,
                     cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache` : undefined,
+                    verbosity: 3,
                 })
             ),
             getRollupPluginInstance('replace', rollupPluginReplaceInstanceKey, () =>

```

This PR does not alter `build/` output.