### PR TITLE
Add lichess.org to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -436,6 +436,7 @@ lecantiche.com
 lemmi.no
 letterboxd.com
 libreboot.org
+lichess.org
 lightweightpdf.com
 limeshark.dev/editor
 link.brawlstars.com/invite


### PR DESCRIPTION
Defaults to dark since https://github.com/lichess-org/lila/pull/10081