### PR TITLE
Images with dark text and white background chart

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17307,6 +17307,19 @@ INVERT
 
 ================================
 
+stockbit.com
+
+INVERT
+#plotplace canvas
+#landing-logo img
+#header-logo img
+.footer-logo img
+.trending-chart img
+.widget-ihsg-chart img
+.konvajs-content canvas
+
+================================
+
 stolichki.ru
 
 INVERT


### PR DESCRIPTION
Some images are hard to see when dark mode is enabled (black text). The chart background isn't converted into dark mode as well. Here are the changes description:
1. Logo images on main page (https://stockbit.com/)
   - #landing-logo img => logo on top left page
   - .footer-logo img => logo on bottom left page
2. Logo image after being logged in (https://stockbit.com/#/stream)
   - #header-logo img => logo on top left page
3. Charts with white background (https://stockbit.com/#/stream)
   - .trending-chart img => under navigation menu (Trending Stocks)
   - .widget-ihsg-chart img => at the right side of stream posts or above "Trending" section, there is "IHSG" label with small chart
4. Black text on orderbook page (https://stockbit.com/#/orderbook)
   - .konvajs-content canvas => this section contains in depth of individual stocks price information and the amount of shares ordered
5. Fundamental chart (Fundachart) with white background (https://stockbit.com/#/symbol/AALI/fundachart)
   - #plotplace canvas => this chart is useful to analyze stocks with 10 years of historical data

Note:
1. There is no website built-in dark mode
2. You need to log in to see the changes for description no. 2 - 5

If you have any questions, please do not hesitate to ask. I will reply as soon as possible. Thank you for reading this :)