### PR TITLE
Fix sending `unsupportedSender`

### DIFF
--- a/src/background/make-chromium-happy.ts
+++ b/src/background/make-chromium-happy.ts
@@ -1,6 +1,7 @@
 import {MessageType} from '../utils/message';
 import type {Message} from '../definitions';
 import {isChromium} from '../utils/platform';
+import {isPanel} from './utils/tab';
 
 declare const __MV3__: boolean;
 
@@ -11,14 +12,15 @@ export function makeChromiumHappy() {
     if (__MV3__ || !isChromium) {
         return;
     }
-    chrome.runtime.onMessage.addListener((message: Message, _, sendResponse) => {
+    chrome.runtime.onMessage.addListener((message: Message, sender, sendResponse) => {
         if (![
             // Messenger
             MessageType.UI_GET_DATA,
             MessageType.UI_APPLY_DEV_DYNAMIC_THEME_FIXES,
             MessageType.UI_APPLY_DEV_INVERSION_FIXES,
             MessageType.UI_APPLY_DEV_STATIC_THEMES,
-        ].includes(message.type)) {
+        ].includes(message.type) &&
+            (message.type !== MessageType.CS_FRAME_CONNECT || !isPanel(sender))) {
             sendResponse({type: '¯\\_(ツ)_/¯'});
         }
     });

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -7,6 +7,7 @@ import {MessageType} from '../utils/message';
 import {logWarn} from '../utils/log';
 import {StateManager} from '../utils/state-manager';
 import {getURLHostOrProtocol} from '../utils/url';
+import {isPanel} from './utils/tab';
 
 declare const __MV3__: boolean;
 
@@ -77,12 +78,7 @@ export default class TabManager {
                         getConnectionMessage(options).then((message) => message && chrome.tabs.sendMessage<Message>(sender.tab.id, message, {frameId: sender.frameId}));
                     };
 
-                    // Workaround for Thunderbird and Vivaldi.
-                    // On Thunderbird, sometimes sender.tab is undefined but accessing it will throw a very nice error.
-                    // On Vivaldi, sometimes sender.tab is undefined as well, but error is not very helpful.
-                    // On Opera, sender.tab.index === -1.
-                    const isPanel = typeof sender === 'undefined' || typeof sender.tab === 'undefined' || (isOpera && sender.tab.index === -1);
-                    if (isPanel) {
+                    if (isPanel(sender)) {
                         // NOTE: Vivaldi and Opera can show a page in a side panel,
                         // but it is not possible to handle messaging correctly (no tab ID, frame ID).
                         if (isFirefox) {

--- a/src/background/utils/tab.ts
+++ b/src/background/utils/tab.ts
@@ -1,0 +1,8 @@
+import {isOpera} from '../../utils/platform';
+
+// On Thunderbird, sometimes sender.tab is undefined but accessing it will throw a very nice error.
+// On Vivaldi, sometimes sender.tab is undefined as well, but error is not very helpful.
+// On Opera, sender.tab.index === -1.
+export function isPanel(sender: chrome.runtime.MessageSender): boolean {
+    return typeof sender === 'undefined' || typeof sender.tab === 'undefined' || (isOpera && sender.tab.index === -1);
+}


### PR DESCRIPTION
- In order to make chromium happy, we use `sendResponse`, however we shouldn't send this when we're planning on sending another message(`unsupportedSender`). This patch adds a extra check to ensure that we don't send a happy chromium message when we plan to use it for other purposes.
- Resolves #9514