### PR TITLE
Fix inline background-image when `mask` is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix Google calendar.
 - Fix Opera/Vivaldi sidebar's getting modified.
+- Fix incorrect inline background colors when `mask` is explicitly disabled.
 
 ## 4.9.54 (Aug 10, 2022)
 

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -253,10 +253,10 @@ function getColorModifier(prop: string, value: string, rule: CSSStyleRule): stri
 
     if (prop.includes('background')) {
         if (
-            rule.style.webkitMaskImage ||
-            rule.style.webkitMask ||
-            rule.style.mask ||
-            rule.style.getPropertyValue('mask-image')
+            (rule.style.webkitMaskImage && rule.style.webkitMaskImage !== 'none') ||
+            (rule.style.webkitMaskImage && rule.style.webkitMask !== 'none') ||
+            (rule.style.mask && rule.style.mask !== 'none') ||
+            (rule.style.getPropertyValue('mask-image') && rule.style.getPropertyValue('mask-image') !== 'none')
         ) {
             return (filter) => modifyForegroundColor(rgb, filter);
         }

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -254,7 +254,7 @@ function getColorModifier(prop: string, value: string, rule: CSSStyleRule): stri
     if (prop.includes('background')) {
         if (
             (rule.style.webkitMaskImage && rule.style.webkitMaskImage !== 'none') ||
-            (rule.style.webkitMaskImage && rule.style.webkitMask !== 'none') ||
+            (rule.style.webkitMask && rule.style.webkitMask !== 'none') ||
             (rule.style.mask && rule.style.mask !== 'none') ||
             (rule.style.getPropertyValue('mask-image') && rule.style.getPropertyValue('mask-image') !== 'none')
         ) {


### PR DESCRIPTION
- Make sure that the check includes that the value is not set to `none` and instead has a real value that will conclude that the background is used as a foreground.
- Resolves #9512