### PR TITLE
Fix: run onColorSchemeChange on all builds

### DIFF
--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -70,9 +70,7 @@ export default class TabManager {
         chrome.runtime.onMessage.addListener(async (message: Message, sender, sendResponse) => {
             switch (message.type) {
                 case MessageType.CS_FRAME_CONNECT: {
-                    if (__MV3__) {
-                        onColorSchemeChange(message.data.isDark);
-                    }
+                    onColorSchemeChange(message.data.isDark);
                     await this.stateManager.loadState();
                     const reply = (options: ConnectionMessageOptions) => {
                         getConnectionMessage(options).then((message) => message && chrome.tabs.sendMessage<Message>(sender.tab.id, message, {frameId: sender.frameId}));
@@ -127,9 +125,7 @@ export default class TabManager {
                     break;
                 }
                 case MessageType.CS_FRAME_RESUME: {
-                    if (__MV3__) {
-                        onColorSchemeChange(message.data.isDark);
-                    }
+                    onColorSchemeChange(message.data.isDark);
                     await this.stateManager.loadState();
                     const tabId = sender.tab.id;
                     const frameId = sender.frameId;


### PR DESCRIPTION
This fixes the following bug:
 - open browser on a page where extension can not inject scripts
 - set extension to "system" automation
 - change system color scheme and observe that icon did not update (1)
 - open a new tab where extension can inject
 - notice that page has the wrong color (2)

This fixes (2) but does not fix (1) since I believe there is no way to fix it as far as I know.