### PR TITLE
Fix browser theme with automation & scheme behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix browser theme not changing when automation + scheme behavior was enabled.
+
 ## 4.9.55 (Aug 10, 2022)
 
 - Fix Google calendar.

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -510,15 +510,17 @@ export class Extension {
                 ContentScriptManager.registerScripts(async () => TabManager.updateContentScript({runOnProtectedPages: UserStorage.settings.enableForProtectedPages}));
             }
             IconManager.setActive();
-            if (UserStorage.settings.changeBrowserTheme) {
-                setWindowTheme(UserStorage.settings.theme);
-            }
         } else {
             if (__MV3__) {
                 ContentScriptManager.unregisterScripts();
             }
             IconManager.setInactive();
-            if (UserStorage.settings.changeBrowserTheme) {
+        }
+
+        if (UserStorage.settings.changeBrowserTheme) {
+            if (this.isExtensionSwitchedOn() && this.autoState !== 'scheme-light') {
+                setWindowTheme(UserStorage.settings.theme);
+            } else {
                 resetWindowTheme();
             }
         }


### PR DESCRIPTION
- When you have the browser theme option enabled and used automation in combination with the scheme behavior, when you got to light mode the browser theme wouldn't update. This patch fixes that.
- Resolves #9538