### PR TITLE
wyborcza.pl wyborcza.biz CMS 2022 fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21270,27 +21270,19 @@ wyborcza.pl
 wyborcza.biz
 
 INVERT
-#logo-wyborcza
-.header-cap-holder > a > img
-.header-headline
-.header > .header-content > .header-items
-.paywall-widget-svg-wrapper
-.vin-img
-.tools
-img[src*="exchange/staticCharts"]
-img[alt="Giełda"]
-img[alt="Waluty"]
-
-CSS
-.contianer-hp-grid .hp-grid-picture-inner {
-    z-index: 0 !important;
-}
-.plot,
-.prev,
-.sbt {
-    background-image: none !important;
-    color: var(--darkreader-neutral-text) !important;
-}
+#wH_username_wrap img
+.account-cap--logo
+.cap-navigation--back
+.cap-vignette--logo-image
+.header-cap-holder a img
+.nmk_avatar-icon
+.partners-list-item
+.partners-list-item-text
+.podcast-player-control ::after
+.podcast-player-time-progress
+.return-back img
+.wyborcza-logo
+a[title="Aplikacja wyborcza.pl"]
 
 ================================
 


### PR DESCRIPTION
Agora (owner) released new CMS. Here is PR with fixes for `wyborcza.pl` and `wyborcza.biz` portals. 

![20220812-1660320793](https://user-images.githubusercontent.com/9846948/184400989-c36cb8b9-8ef6-4b62-b962-4cf4bf858b02.png)
![20220812-1660320827](https://user-images.githubusercontent.com/9846948/184400996-522b0d6f-be5d-4e78-b610-82565599edd3.png)
![20220812-1660320848](https://user-images.githubusercontent.com/9846948/184401001-5549c2a9-4b3b-46e7-a65d-367bc32d4b19.png)
![20220812-1660320889](https://user-images.githubusercontent.com/9846948/184401004-0c1f8555-429b-47f2-acd1-4a85ce5aa68c.png)
![20220812-1660321134](https://user-images.githubusercontent.com/9846948/184401007-e9761842-4ee8-4717-9c46-861ab0ae1763.png)
![20220812-1660321149](https://user-images.githubusercontent.com/9846948/184401008-bce2fd6d-1a3f-4e17-90ed-fc1142b97790.png)
