### PR TITLE
my.nextdns.io remove not needed rule

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12819,7 +12819,6 @@ img[src*="/static/media/sonos"]
 .list-group-item > div > img
 .d-flex > .text-break > img
 .d-flex > .flex-grow-1 > div > img
-img[src*="handshake-logo"]
 .d-flex.align-items-center.flex-wrap a img
 
 CSS


### PR DESCRIPTION
Rule `.d-flex.align-items-center.flex-wrap a img` now handle logos in Web3 section in `settings` subpage. 