### PR TITLE
Fix: avoid User Agent notifications in extension contexts

### DIFF
--- a/src/ui/popup/compatibility.js
+++ b/src/ui/popup/compatibility.js
@@ -1,10 +1,21 @@
 (function () {
+    var minChromeVersion = 63;
+    var browserBrands = navigator.userAgentData && navigator.userAgentData.brands;
+    if (browserBrands) {
+        for (var brandIndex = 0; brandIndex < browserBrands.length; brandIndex++) {
+            if (browserBrands[brandIndex].brand.includes('Chrom')) {
+                var currVersion = parseInt(browserBrands[brandIndex].version);
+                if (currVersion >= minChromeVersion) {
+                    return;
+                }
+            }
+        }
+    }
     var match = navigator.userAgent.toLowerCase().match(/chrom[e|ium]\/([^ \.]+)/);
     if (!match) {
         return;
     }
     var version = parseInt(match[1]);
-    var minChromeVersion = 63;
     if (version >= minChromeVersion) {
         return;
     }

--- a/src/ui/popup/compatibility.js
+++ b/src/ui/popup/compatibility.js
@@ -1,21 +1,13 @@
 (function () {
-    var minChromeVersion = 63;
-    var browserBrands = navigator.userAgentData && navigator.userAgentData.brands;
-    if (browserBrands) {
-        for (var brandIndex = 0; brandIndex < browserBrands.length; brandIndex++) {
-            if (browserBrands[brandIndex].brand.includes('Chrom')) {
-                var currVersion = parseInt(browserBrands[brandIndex].version);
-                if (currVersion >= minChromeVersion) {
-                    return;
-                }
-            }
-        }
+    if ('userAgentData' in navigator) {
+        return;
     }
     var match = navigator.userAgent.toLowerCase().match(/chrom[e|ium]\/([^ \.]+)/);
     if (!match) {
         return;
     }
     var version = parseInt(match[1]);
+    var minChromeVersion = 63;
     if (version >= minChromeVersion) {
         return;
     }


### PR DESCRIPTION
This is a follow-up to commit 3b6441928546cf76756413c4f3bff838ce9c4544

~~Probably, simple check like this would work too since `userAgentData` exists only in recent Chrome versions, but this way logic is much more obvious.~~
On a second thought, the shorter version is clearer.
```js
if ('userAgentData' in navigator) {
  return;
}
```