### PR TITLE
tokfm.pl play button fix right side section

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18605,6 +18605,9 @@ footer {
 
 tokfm.pl
 
+INVERT
+.controls span.play svg
+
 CSS
 div.top_section_bg,
 div.bottom_section_bg {


### PR DESCRIPTION
I removed `.play` rule previously (was too generic), now we need one more fix for proper looking podcast right side play button.

![20220813-1660407815](https://user-images.githubusercontent.com/9846948/184502652-dbd47d09-cb38-4a52-8541-ad335be27ba5.png)
