### PR TITLE
Build process: add option to save logs to disk

### DIFF
--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -6,7 +6,7 @@ import type {InversionFix, StaticTheme, DynamicThemeFix} from '../definitions';
 import type {SitePropsIndex} from '../generators/utils/parse';
 import type {ParsedColorSchemeConfig} from '../utils/colorscheme-parser';
 import {ParseColorSchemeConfig} from '../utils/colorscheme-parser';
-import {logWarn} from '../utils/log';
+import {logWarn} from './utils/log';
 import {DEFAULT_COLORSCHEME} from '../defaults';
 
 const CONFIG_URLs = {

--- a/src/background/content-script-manager.ts
+++ b/src/background/content-script-manager.ts
@@ -1,4 +1,4 @@
-import {logWarn} from '../utils/log';
+import {logWarn} from './utils/log';
 
 declare const __MV3__: boolean;
 

--- a/src/background/devtools.ts
+++ b/src/background/devtools.ts
@@ -1,4 +1,4 @@
-import {logInfo, logWarn} from '../utils/log';
+import {logInfo, logWarn} from './utils/log';
 import {parseInversionFixes, formatInversionFixes} from '../generators/css-filter';
 import {parseDynamicThemeFixes, formatDynamicThemeFixes} from '../generators/dynamic-theme';
 import {parseStaticThemes, formatStaticThemes} from '../generators/static-theme';

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -19,7 +19,7 @@ import type {ExtensionData, FilterConfig, Shortcuts, UserSettings, TabInfo, TabD
 import {isSystemDarkModeEnabled, runColorSchemeChangeDetector} from '../utils/media-query';
 import {isFirefox, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
-import {logInfo, logWarn} from '../utils/log';
+import {logInfo, logWarn} from './utils/log';
 import {PromiseBarrier} from '../utils/promise-barrier';
 import {StateManager} from '../utils/state-manager';
 import {debounce} from '../utils/debounce';
@@ -75,7 +75,7 @@ export class Extension {
             autoState: '',
             wasEnabledOnLastCheck: null,
             registeredContextMenus: null,
-        });
+        }, logWarn);
 
         chrome.alarms.onAlarm.addListener(this.alarmListener);
 
@@ -103,7 +103,7 @@ export class Extension {
         if (!this.systemColorStateManager) {
             this.systemColorStateManager = new StateManager<SystemColorState>(Extension.SYSTEM_COLOR_LOCAL_STORAGE_KEY, this, {
                 isDark,
-            });
+            }, logWarn);
         }
         if (isDark === null) {
             // Attempt to restore data from storage

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,8 +4,9 @@ import {canInjectScript} from '../background/utils/extension-api';
 import type {ExtensionData, Message, UserSettings} from '../definitions';
 import {MessageType} from '../utils/message';
 import {makeChromiumHappy} from './make-chromium-happy';
-import {logInfo} from '../utils/log';
 import DevTools from './devtools';
+import {logInfo} from './utils/log';
+import {sendLog} from './utils/sendLog';
 
 type TestMessage = {
     type: 'changeSettings';
@@ -53,6 +54,7 @@ console.log(welcome);
 
 declare const __DEBUG__: boolean;
 declare const __WATCH__: boolean;
+declare const __LOG__: string | false;
 declare const __PORT__: number;
 declare const __TEST__: number;
 declare const __MV3__: number;
@@ -185,6 +187,14 @@ if (__TEST__) {
             respond({type: 'error', data: String(err)});
         }
     };
+}
+
+if (__DEBUG__ && __LOG__) {
+    chrome.runtime.onMessage.addListener((message: Message) => {
+        if (message.type === 'cs-log') {
+            sendLog(message.data.level, message.data.log);
+        }
+    });
 }
 
 makeChromiumHappy();

--- a/src/background/newsmaker.ts
+++ b/src/background/newsmaker.ts
@@ -3,7 +3,7 @@ import {getDurationInMinutes} from '../utils/time';
 import type {News} from '../definitions';
 import {readSyncStorage, readLocalStorage, writeSyncStorage, writeLocalStorage} from './utils/extension-api';
 import {StateManager} from '../utils/state-manager';
-import {logWarn} from '../utils/log';
+import {logWarn} from './utils/log';
 import IconManager from './icon-manager';
 
 interface NewsmakerState {
@@ -27,7 +27,7 @@ export default class Newsmaker {
             logWarn('Attempting to re-initialize Newsmaker. Doing nothing.');
             return;
         }
-        Newsmaker.stateManager = new StateManager<NewsmakerState>(Newsmaker.LOCAL_STORAGE_KEY, this, {latest: [], latestTimestamp: null});
+        Newsmaker.stateManager = new StateManager<NewsmakerState>(Newsmaker.LOCAL_STORAGE_KEY, this, {latest: [], latestTimestamp: null}, logWarn);
         Newsmaker.latest = [];
         Newsmaker.latestTimestamp = null;
     }

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -4,7 +4,7 @@ import type {FetchRequestParameters} from './utils/network';
 import type {Message} from '../definitions';
 import {isChromium, isFirefox, isThunderbird} from '../utils/platform';
 import {MessageType} from '../utils/message';
-import {logWarn} from '../utils/log';
+import {logWarn} from './utils/log';
 import {StateManager} from '../utils/state-manager';
 import {getURLHostOrProtocol} from '../utils/url';
 import {isPanel} from './utils/tab';
@@ -63,7 +63,7 @@ export default class TabManager {
     private static LOCAL_STORAGE_KEY = 'TabManager-state';
 
     static init({getConnectionMessage, onColorSchemeChange, getTabMessage}: TabManagerOptions) {
-        this.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0});
+        this.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0}, logWarn);
         this.tabs = {};
         this.getTabMessage = getTabMessage;
 

--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -3,7 +3,7 @@ import {debounce} from '../utils/debounce';
 import {isURLMatched} from '../utils/url';
 import type {UserSettings} from '../definitions';
 import {readSyncStorage, readLocalStorage, writeSyncStorage, writeLocalStorage} from './utils/extension-api';
-import {logWarn} from '../utils/log';
+import {logWarn} from './utils/log';
 import {PromiseBarrier} from '../utils/promise-barrier';
 import {validateSettings} from '../utils/validation';
 

--- a/src/background/utils/log.ts
+++ b/src/background/utils/log.ts
@@ -1,12 +1,20 @@
+import {sendLog} from './sendLog';
+
 declare const __DEBUG__: boolean;
 const DEBUG = __DEBUG__;
 
 export function logInfo(...args: any[]) {
-    DEBUG && console.info(...args);
+    if (DEBUG) {
+        console.info(...args);
+        sendLog('info', args);
+    }
 }
 
 export function logWarn(...args: any[]) {
-    DEBUG && console.warn(...args);
+    if (DEBUG) {
+        console.warn(...args);
+        sendLog('warn', args);
+    }
 }
 
 export function logInfoCollapsed(title: any, ...args: any[]) {
@@ -14,5 +22,6 @@ export function logInfoCollapsed(title: any, ...args: any[]) {
         console.groupCollapsed(title);
         console.log(...args);
         console.groupEnd();
+        sendLog('info', args);
     }
 }

--- a/src/background/utils/sendLog.ts
+++ b/src/background/utils/sendLog.ts
@@ -1,0 +1,29 @@
+declare const __DEBUG__: boolean;
+const DEBUG = __DEBUG__;
+declare const __LOG__: 'info' | 'warn';
+
+let socket: WebSocket = null;
+let messageQueue: string[] | null = [];
+function createSocket() {
+    if (socket) {
+        return;
+    }
+    socket = new WebSocket(`ws://localhost:${9000}`);
+    socket.addEventListener('open', () => {
+        messageQueue.forEach((message) => socket.send(message));
+        messageQueue = null;
+    });
+}
+
+export function sendLog(level: 'info' | 'warn', ...args: any[]) {
+    if (!__DEBUG__ || !__LOG__) {
+        return;
+    }
+    const message = JSON.stringify({level, log: args});
+    if (socket && socket.readyState === socket.OPEN) {
+        socket.send(message);
+    } else {
+        createSocket();
+        messageQueue.push(message);
+    }
+}

--- a/src/background/utils/sendLog.ts
+++ b/src/background/utils/sendLog.ts
@@ -1,5 +1,4 @@
 declare const __DEBUG__: boolean;
-const DEBUG = __DEBUG__;
 declare const __LOG__: 'info' | 'warn';
 
 let socket: WebSocket = null;

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -1,7 +1,7 @@
 import {forEach} from '../../utils/array';
 import {isSafari} from '../../utils/platform';
 import {parseURL, getAbsoluteURL} from '../../utils/url';
-import {logInfo, logWarn} from '../../utils/log';
+import {logInfo, logWarn} from '../utils/log';
 
 export function iterateCSSRules(rules: CSSRuleList, iterate: (rule: CSSStyleRule) => void, onMediaRuleError?: () => void) {
     forEach(rules, (rule) => {

--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -3,7 +3,7 @@ import {bgFetch} from './network';
 import {getSRGBLightness} from '../../utils/color';
 import {loadAsDataURL} from '../../utils/network';
 import type {FilterConfig} from '../../definitions';
-import {logInfo, logWarn} from '../../utils/log';
+import {logInfo, logWarn} from '../utils/log';
 import AsyncQueue from '../../utils/async-queue';
 
 export interface ImageDetails {

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -6,7 +6,7 @@ import {manageStyle, getManageableStyles, cleanLoadingLinks} from './style-manag
 import {watchForStyleChanges, stopWatchingForStyleChanges} from './watch';
 import {forEach, push, toArray} from '../../utils/array';
 import {removeNode, watchForNodePosition, iterateShadowHosts, isDOMReady, removeDOMReadyListener, cleanReadyStateCompleteListeners, addDOMReadyListener, setIsDOMReady} from '../utils/dom';
-import {logInfo, logWarn} from '../../utils/log';
+import {logInfo, logWarn} from '../utils/log';
 import {throttle} from '../../utils/throttle';
 import {clamp} from '../../utils/math';
 import {getCSSFilterValue} from '../../generators/css-filter';

--- a/src/inject/dynamic-theme/meta-theme-color.ts
+++ b/src/inject/dynamic-theme/meta-theme-color.ts
@@ -1,6 +1,6 @@
 import {parseColorWithCache} from '../../utils/color';
 import {modifyBackgroundColor} from '../../generators/modify-colors';
-import {logWarn} from '../../utils/log';
+import {logWarn} from '../utils/log';
 import type {FilterConfig} from '../../definitions';
 
 const metaThemeColorName = 'theme-color';

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -7,7 +7,7 @@ import {cssURLRegex, getCSSURLValue, getCSSBaseBath} from './css-rules';
 import type {ImageDetails} from './image';
 import {getImageDetails, getFilteredImageDataURL, cleanImageProcessingCache} from './image';
 import type {CSSVariableModifier, VariablesStore} from './variables';
-import {logWarn, logInfo} from '../../utils/log';
+import {logWarn, logInfo} from '../utils/log';
 import type {FilterConfig, Theme} from '../../definitions';
 import {isFirefox, isCSSColorSchemePropSupported} from '../../utils/platform';
 import type {parsedGradient} from '../../utils/parsing';

--- a/src/inject/dynamic-theme/mv3-proxy.ts
+++ b/src/inject/dynamic-theme/mv3-proxy.ts
@@ -1,5 +1,5 @@
 import {injectProxy} from './stylesheet-proxy';
-import {logInfo} from '../../utils/log';
+import {logInfo} from '../utils/log';
 
 document.currentScript && document.currentScript.remove();
 

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -3,7 +3,7 @@ import {forEach} from '../../utils/array';
 import {getMatches} from '../../utils/text';
 import {getAbsoluteURL, isRelativeHrefOnAbsolutePath} from '../../utils/url';
 import {watchForNodePosition, removeNode, iterateShadowHosts, addReadyStateCompleteListener} from '../utils/dom';
-import {logInfo, logWarn} from '../../utils/log';
+import {logInfo, logWarn} from '../utils/log';
 import {replaceCSSRelativeURLsWithAbsolute, removeCSSComments, replaceCSSFontFace, getCSSURLValue, cssImportRegex, getCSSBaseBath} from './css-rules';
 import {bgFetch} from './network';
 import {createStyleSheetModifier} from './stylesheet-modifier';

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -2,7 +2,7 @@ import {createOrUpdateStyle, removeStyle} from './style';
 import {createOrUpdateSVGFilter, removeSVGFilter} from './svg-filter';
 import {runDarkThemeDetector, stopDarkThemeDetector} from './detector';
 import {createOrUpdateDynamicTheme, removeDynamicTheme, cleanDynamicThemeCache} from './dynamic-theme';
-import {logWarn, logInfoCollapsed} from '../utils/log';
+import {logWarn, logInfoCollapsed} from './utils/log';
 import {isSystemDarkModeEnabled, runColorSchemeChangeDetector, stopColorSchemeChangeDetector} from '../utils/media-query';
 import {collectCSS} from './dynamic-theme/css-collection';
 import type {Message} from '../definitions';

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -1,4 +1,4 @@
-import {logWarn} from '../../utils/log';
+import {logWarn} from '../utils/log';
 import {throttle} from '../../utils/throttle';
 import {forEach} from '../../utils/array';
 import {getDuration} from '../../utils/time';

--- a/src/inject/utils/log.ts
+++ b/src/inject/utils/log.ts
@@ -1,0 +1,34 @@
+import {MessageType} from '../../utils/message';
+import {Message} from '../../definitions';
+
+declare const __DEBUG__: boolean;
+declare const __WATCH__: boolean;
+declare const __LOG__: 'info' | 'warn';
+
+function sendLogToBG(level: 'info' | 'warn', ...args: any[]) {
+    if (__WATCH__ && __LOG__ && (__LOG__ === 'info' || level === 'warn')) {
+        chrome.runtime.sendMessage<Message>({type: MessageType.CS_LOG, data: {level, log: args}});
+    }
+}
+
+export function logInfo(...args: any[]) {
+    if (__DEBUG__) {
+        console.info(...args);
+        sendLogToBG('info', ...args);
+    }
+}
+
+export function logWarn(...args: any[]) {
+    if (__DEBUG__) {
+        console.warn(...args);
+        sendLogToBG('warn', ...args);
+    }
+}
+
+export function logInfoCollapsed(title: any, ...args: any[]) {
+    if (__DEBUG__) {
+        console.groupCollapsed(title);
+        console.log(...args);
+        console.groupEnd();
+    }
+}

--- a/src/inject/utils/log.ts
+++ b/src/inject/utils/log.ts
@@ -1,5 +1,5 @@
 import {MessageType} from '../../utils/message';
-import {Message} from '../../definitions';
+import type {Message} from '../../definitions';
 
 declare const __DEBUG__: boolean;
 declare const __WATCH__: boolean;

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -41,4 +41,5 @@ export enum MessageType {
     CS_FETCH = 'cs-fetch',
     CS_DARK_THEME_DETECTED = 'cs-dark-theme-detected',
     CS_DARK_THEME_NOT_DETECTED = 'cs-dark-theme-not-detected',
+    CS_LOG = 'cs-log',
 }

--- a/src/utils/state-manager.ts
+++ b/src/utils/state-manager.ts
@@ -9,7 +9,7 @@ import {StateManagerImpl} from './state-manager-impl';
 export class StateManager<T> {
     private stateManager: StateManagerImpl<T> | null;
 
-    constructor(localStorageKey: string, parent: any, defaults: T){
+    constructor(localStorageKey: string, parent: any, defaults: T, logWarn: (log: string) => void){
         if (isNonPersistent()) {
             function addListener(listener: (data: T) => void) {
                 chrome.storage.onChanged.addListener((changes, areaName) => {
@@ -25,7 +25,8 @@ export class StateManager<T> {
                 parent,
                 defaults,
                 chrome.storage.local,
-                addListener
+                addListener,
+                logWarn,
             );
         }
     }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -6,6 +6,7 @@ import bundleLocales from './bundle-locales.js';
 import bundleManifest from './bundle-manifest.js';
 import clean from './clean.js';
 import copy from './copy.js';
+import console from './console.js';
 import * as reload from './reload.js';
 import codeStyle from './code-style.js';
 import zip from './zip.js';
@@ -25,6 +26,7 @@ const standardTask = [
     bundleLocales,
     bundleManifest,
     copy,
+    console,
 ];
 
 const buildTask = [
@@ -33,10 +35,10 @@ const buildTask = [
     zip
 ];
 
-async function build({platforms, debug, watch, test}) {
+async function build({platforms, debug, watch, log: logging, test}) {
     log.ok('BUILD');
     try {
-        await runTasks(debug ? standardTask : buildTask, {platforms, debug, watch, test});
+        await runTasks(debug ? standardTask : buildTask, {platforms, debug, watch, log: logging, test});
         if (watch) {
             standardTask.forEach((task) => task.watch(platforms));
             reload.reload({type: reload.FULL});
@@ -53,7 +55,7 @@ async function build({platforms, debug, watch, test}) {
 async function api() {
     log.ok('API');
     try {
-        await runTasks([bundleAPI], {platforms: {}, debug: false, watch: false, test: false});
+        await runTasks([bundleAPI], {platforms: {}, debug: false, watch: false, log: false, test: false});
         log.ok('MISSION PASSED! RESPECT +');
     } catch (err) {
         console.log(err);
@@ -79,6 +81,14 @@ async function executeChildProcess(args) {
 async function run() {
     const args = process.argv.slice(2);
 
+    // Enable Ctrl+C to cancel the build immediately
+    if (!process.env.BUILD_CHILD) {
+        return executeChildProcess(args);
+    }
+
+    const validArgs = ['--api', '--chrome', '--chrome-mv3', '--firefox', '--thunderbird', '--release', '--debug', '--watch', '--log-info', '--log-warn', '--test'];
+    args.filter((arg) => !validArgs.includes(arg)).forEach((arg) => log.warn(`Unknown argument ${arg}`));
+
     const allPlatforms = !(args.includes('--chrome') || args.includes('--chrome-mv3') || args.includes('--firefox') || args.includes('--thunderbird'));
     const platforms = {
         [PLATFORM.CHROME]: allPlatforms || args.includes('--chrome'),
@@ -87,16 +97,17 @@ async function run() {
         [PLATFORM.THUNDERBIRD]: allPlatforms || args.includes('--thunderbird'),
     };
 
-    // Enable Ctrl+C to cancel the build immediately
-    if (!process.env.BUILD_CHILD) {
-        return executeChildProcess(args);
-    }
 
-    if (args.includes('--release')) {
-        await build({platforms, debug: false, watch: false, test: false});
+    const release = args.includes('--release');
+    const debug = args.includes('--debug');
+    const watch = args.includes('--watch');
+    const logInfo = watch && args.includes('--log-info');
+    const logWarn = watch && args.includes('--log-warn');
+    if (release) {
+        await build({platforms, debug: false, watch: false, log: null, test: false});
     }
-    if (args.includes('--debug')) {
-        await build({platforms, debug: true, watch: args.includes('--watch'), test: args.includes('--test')});
+    if (debug) {
+        await build({platforms, debug, watch, log: logWarn ? 'warn' : (logInfo ? 'info' : null), test: args.includes('--test')});
     }
     if (args.includes('--api')) {
         await api();

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -6,7 +6,7 @@ import bundleLocales from './bundle-locales.js';
 import bundleManifest from './bundle-manifest.js';
 import clean from './clean.js';
 import copy from './copy.js';
-import console from './console.js';
+import saveLog from './log.js';
 import * as reload from './reload.js';
 import codeStyle from './code-style.js';
 import zip from './zip.js';
@@ -26,7 +26,7 @@ const standardTask = [
     bundleLocales,
     bundleManifest,
     copy,
-    console,
+    saveLog,
 ];
 
 const buildTask = [

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -90,7 +90,7 @@ function freeRollupPluginInstance(name, key) {
     }
 }
 
-async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, test) {
+async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log, test) {
     const {src, dest} = entry;
     const rollupPluginTypesctiptInstanceKey = debug;
     const rollupPluginReplaceInstanceKey = `${platform}-${debug}-${watch}-${entry.src === 'src/ui/popup/index.tsx'}`;
@@ -143,6 +143,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, tes
                     '__PORT__': watch ? String(PORT) : '-1',
                     '__TEST__': test ? 'true' : 'false',
                     '__WATCH__': watch ? 'true' : 'false',
+                    '__LOG__': log ? `"${log}"` : 'false',
                 })
             ),
         ].filter((x) => x)
@@ -170,16 +171,16 @@ function getWatchFiles() {
 /** @type {string[]} */
 let watchFiles;
 
-const hydrateTask = (/** @type {JSEntry[]} */entries, platforms, /** @type {boolean} */debug, /** @type {boolean} */watch, test) =>
+const hydrateTask = (/** @type {JSEntry[]} */entries, platforms, /** @type {boolean} */debug, /** @type {boolean} */watch, log, test) =>
     entries.map((entry) =>
         (entry.platform ? [entry.platform] : Object.values(PLATFORM))
             .filter((platform) => platforms[platform])
-            .map((platform) => bundleJS(entry, platform, debug, watch, test))
+            .map((platform) => bundleJS(entry, platform, debug, watch, log, test))
     ).flat();
 
 const bundleJSTask = createTask(
     'bundle-js',
-    async ({platforms, debug, watch, test}) => await Promise.all(hydrateTask(jsEntries, platforms, debug, watch, test)),
+    async ({platforms, debug, watch, log, test}) => await Promise.all(hydrateTask(jsEntries, platforms, debug, watch, log, test)),
 ).addWatcher(
     () => {
         watchFiles = getWatchFiles();

--- a/tasks/console.js
+++ b/tasks/console.js
@@ -1,0 +1,93 @@
+import {createWriteStream} from 'fs';
+import {WebSocketServer} from 'ws';
+import {createTask} from './task.js';
+import {log} from './utils.js';
+
+export const PORT = 9000;
+const WAIT_FOR_CONNECTION = 2000;
+
+/** @type {import('ws').Server} */
+let server = null;
+
+/** @type {Set<WebSocket>} */
+const sockets = new Set();
+const times = new WeakMap();
+
+/**
+ * @param {string} logLevel
+ * @returns {Promise<import('ws').Server>}
+ */
+function createServer(logLevel) {
+    return new Promise((resolve) => {
+        const server = new WebSocketServer({port: PORT});
+        const stream = createWriteStream(`${Date.now()}-${logLevel}.txt`, {flags:'a'});
+        server.on('listening', () => {
+            log.ok('Loggings started');
+            resolve(server);
+        });
+        server.on('connection', async (ws) => {
+            sockets.add(ws);
+            times.set(ws, Date.now());
+            ws.on('message', async (data) => {
+                const message = data.toString();
+                stream.write(message + "\n");
+            });
+            ws.on('close', () => sockets.delete(ws));
+            if (connectionAwaiter != null) {
+                connectionAwaiter();
+            }
+        });
+    });
+}
+
+function closeServer() {
+    server && server.close(() => log.ok('Logging exit'));
+    sockets.forEach((ws) => ws.close());
+    sockets.clear();
+    server = null;
+}
+
+process.on('exit', closeServer);
+process.on('SIGINT', closeServer);
+
+/** @type {() => void} */
+let connectionAwaiter = null;
+
+function waitForConnection() {
+    return new Promise((resolve) => {
+        connectionAwaiter = () => {
+            connectionAwaiter = null;
+            clearTimeout(timeoutId);
+            setTimeout(resolve, WAIT_FOR_CONNECTION);
+        };
+        const timeoutId = setTimeout(() => {
+            log.warn('Auto-reloader did not connect');
+            connectionAwaiter = null;
+            resolve();
+        }, WAIT_FOR_CONNECTION);
+    });
+}
+
+/**
+ * @param {Object} options
+ * @param {string} options.log
+ */
+export async function logging({log}) {
+    if (!log) {
+        return;
+    }
+    if (!server) {
+        server = await createServer(log);
+    }
+    if (sockets.size === 0) {
+        await waitForConnection();
+    }
+}
+
+const loggingTask = createTask(
+    'logging',
+    logging,
+);
+
+export default loggingTask;
+

--- a/tasks/log.js
+++ b/tasks/log.js
@@ -30,7 +30,7 @@ function createServer(logLevel) {
             times.set(ws, Date.now());
             ws.on('message', async (data) => {
                 const message = data.toString();
-                stream.write(message + "\n");
+                stream.write(`${message}\n`);
             });
             ws.on('close', () => sockets.delete(ws));
             if (connectionAwaiter != null) {

--- a/tasks/task.js
+++ b/tasks/task.js
@@ -7,6 +7,7 @@ import watch from './watch.js';
  * @property {boolean} debug
  * @property {boolean} watch
  * @property {boolean} test
+ * @property {string | false} log
  */
 
 class Task {

--- a/tests/unit/utils/state-manager.tests.ts
+++ b/tests/unit/utils/state-manager.tests.ts
@@ -66,7 +66,7 @@ describe('State manager utility', () => {
         const stateManager = new StateManagerImpl(key, parent, {
             fromParent: 'fromDefault',
             fromStorage: 'fromDefault'
-        }, {get, set}, noop);
+        }, {get, set}, noop, noop);
 
         expect(getMock).not.toBeCalled();
         expect(setMock).not.toBeCalled();
@@ -120,7 +120,7 @@ describe('State manager utility', () => {
 
         const stateManager = new StateManagerImpl(key, parent, {
             data: 'fromStorage',
-        }, {get, set: setMock}, noop);
+        }, {get, set: setMock}, noop, noop);
 
         expect(setMock).not.toBeCalled();
         expect(parent).toEqual({
@@ -179,7 +179,7 @@ describe('State manager utility', () => {
 
         const stateManager = new StateManagerImpl(key, parent, {
             count: 0,
-        }, {get, set}, noop);
+        }, {get, set}, noop, noop);
 
         expect(parent).toEqual({
             noSync: true,
@@ -263,7 +263,7 @@ describe('State manager utility', () => {
 
         const stateManager = new StateManagerImpl(key, parent, {
             count: 0,
-        }, {get, set}, noop);
+        }, {get, set}, noop, noop);
 
         expect(parent).toEqual({
             noSync: true,
@@ -344,7 +344,7 @@ describe('State manager utility', () => {
 
         const stateManager = new StateManagerImpl(key, parent, {
             data: 'fromDefault',
-        }, {get, set}, noop);
+        }, {get, set}, noop, noop);
 
         expect(parent).toEqual({
             data: 'fromParent',
@@ -412,7 +412,7 @@ describe('State manager utility', () => {
 
         const stateManager = new StateManagerImpl(key, parent, {
             data: 'fromDefault',
-        }, {get, set}, noop);
+        }, {get, set}, noop, noop);
 
         expect(parent).toEqual({
             data: 'fromParent',
@@ -546,7 +546,7 @@ describe('State manager utility', () => {
 
         const stateManager = new StateManagerImpl(key, parent, {
             data: 'fromDefault',
-        }, {get, set}, (listener) => onChangedListener = listener);
+        }, {get, set}, (listener) => onChangedListener = listener, noop);
 
         const c1 = jest.fn();
         stateManager.addChangeListener(c1);


### PR DESCRIPTION
This will allow us to obtain more detailed logs from users if we can not reproduce a bug locally. For example, like in #9542.
This rudimentary logger works only on Debug Watch Builds with logging enabled.