### PR TITLE
calendar.google.com download addons button fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3177,6 +3177,9 @@ CSS
 
 calendar.google.com
 
+INVERT
+div[style*="gm_add_black"]
+
 CSS
 div[role="checkbox"] > div > div > div {
     border: 1px solid ${black} !important;


### PR DESCRIPTION
SITE https://calendar.google.com/calendar/u/0/r/month

FIX for + mark on right panel side. 
![20220814-1660504659](https://user-images.githubusercontent.com/9846948/184551744-e23862aa-2f4d-49be-ba77-5599dd0ea5ea.png)
