### PR TITLE
Add dark site oxide.computer

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -584,6 +584,7 @@ otzdarva.com
 ovagames.com
 overcoder.dev
 overdodactyl.github.io/ShadowFox
+oxide.computer
 oxy.cannot.date
 p4pirate.xyz
 paimon.moe


### PR DESCRIPTION
I clicked around on https://oxide.computer/ and everything seemed dark. I checked https://www.google.com/search?q=site%3Aoxide.computer and everything there looked dark as well.