### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21908,6 +21908,17 @@ zhihu.com
 INVERT
 img[eeimg="1"]
 
+CSS
+    div.css-vurnku > div > div.css-1bi2006 {
+    background-color: ${darkgray} !important;
+}
+div.css-vurnku button {
+    color: ${DarkBlue} !important;
+}
+div.css-vurnku button svg {
+    fill: ${DarkBlue} !important;
+}
+
 ================================
 
 zippyshare.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21909,7 +21909,7 @@ INVERT
 img[eeimg="1"]
 
 CSS
-    div.css-vurnku > div > div.css-1bi2006 {
+div.css-vurnku > div > div.css-1bi2006 {
     background-color: ${darkgray} !important;
 }
 div.css-vurnku button {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21913,10 +21913,10 @@ div.css-vurnku > div > div.css-1bi2006 {
     background-color: ${darkgray} !important;
 }
 div.css-vurnku button {
-    color: ${DarkBlue} !important;
+    color: ${darkblue} !important;
 }
 div.css-vurnku button svg {
-    fill: ${DarkBlue} !important;
+    fill: ${darkblue} !important;
 }
 
 ================================


### PR DESCRIPTION
When the user clicks on the notification center and the comment panel pops up, the Zhihu website jumps to the comment automatically.
Fixed highlighted background color for floating comments popped up by notification center and change the button(reply and like) color to light blue.
<img width="1467" alt="Screen Shot 2022-08-15 at 22 39 28" src="https://user-images.githubusercontent.com/23691171/184672287-d0517d58-f9f2-45a5-abe3-cadf118d39d3.png">
