### PR TITLE
Fix for ci.appveyor.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3577,6 +3577,15 @@ CSS
 
 ================================
 
+ci.appveyor.com
+
+CSS
+select {
+    background-image: none !important;
+}
+
+================================
+
 cinedrome.ch
 
 CSS


### PR DESCRIPTION
- Remove broken background image of select box

Before:
<img width="162" alt="2022-08-17-00-04-23" src="https://user-images.githubusercontent.com/1006477/184985330-e7ba9198-2b9c-43f9-b81f-7a6d6e3f0ce8.png">

After:
<img width="163" alt="2022-08-17-00-06-13" src="https://user-images.githubusercontent.com/1006477/184985356-cc9cc101-2994-4b98-88db-8aa77fd42d88.png">
