### PR TITLE
Fix for v2ex.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19372,6 +19372,15 @@ INVERT
 
 ================================
 
+v2ex.com
+
+CSS
+#Wrapper {
+    background-image: none !important;
+}
+
+================================
+
 vaccines.gov
 vacunas.gov
 


### PR DESCRIPTION
- Remove background

Some subforums has a bright background. For example: https://www.v2ex.com/go/programmer