### PR TITLE
Invert glyph origin of Chinese characters on Wiktionary

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20439,6 +20439,7 @@ wiktionary.org
 INVERT
 .bookend
 .central-featured-logo-text
+.zh-glyph img
 img[alt="audio speaker icon"]
 
 CSS


### PR DESCRIPTION
Glyph origin images on Wiktionary are black-on-transparent.
Inverting them makes them more legible on dark background.

For instance: https://en.wiktionary.org/wiki/%E4%BE%83#Glyph_origin

![Screenshot of before proposed changes](https://user-images.githubusercontent.com/50083900/184995772-d05a08f9-f6d5-408a-aca0-d9d5180a66ca.png)

![Screenshot of after proposed changes](https://user-images.githubusercontent.com/50083900/184995750-ff3a4789-b666-4cec-b583-c693b2105ff5.png)
