### PR TITLE
onet.pl header logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13870,6 +13870,9 @@ CSS
 .weatherMap .mapLayer .fil0, #weatherChartsHolder .chartValue {
     fill: rgb(128, 128, 128) !important;
 }
+svg path[d^="M50.315,89"] {
+    fill: ${white} !important;      
+}
 
 ================================
 


### PR DESCRIPTION
SITE https://onet.pl
FIX header logo 
![20220818-1660829220](https://user-images.githubusercontent.com/9846948/185406587-28202bb7-9936-4e8f-b52a-7350bbd15c28.png)
