### PR TITLE
Remove non-dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -410,7 +410,6 @@ kbhgames.com
 keezersquest.nl
 kernel.fish
 kfocus.org
-killabee-gaming.com
 kimbatt.github.io/js-Z
 kingdom-leaks.com
 kittybot.de
@@ -418,8 +417,6 @@ kiwifarms.cc
 kiwifarms.net
 knockout.chat
 kodenames.io
-kreatea.space
-kreato.cf
 krisoneil.com/home
 kristal.cc
 krunker.io


### PR DESCRIPTION
Removed killabee-gaming.com - Invalid URL
Removed kreatea.space - URL Redirect
Removed kreato.cf - URL Redirect. Possible malicious and adult content redirects.