### PR TITLE
gadzetomania.pl header logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7691,6 +7691,15 @@ span.bstn-hl-summary {
 
 ================================
 
+gadzetomania.pl
+
+CSS
+a svg path[d^="M12.881 14.785v-"] {
+    fill: #fff !important;
+}
+
+================================
+
 gain.tv
 
 CSS


### PR DESCRIPTION
https://gadzetomania.pl/

![20220820-1660966224](https://user-images.githubusercontent.com/9846948/185727314-4803a44e-b478-454c-809c-61e06ae7dc67.png)
