### PR TITLE
Fix for dominos.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5689,6 +5689,9 @@ CSS
 
 dominos.*
 
+INVERT
+.card--overlay > .card__header .card--overlay__close
+
 CSS
 svg.trackerbarimage:not(.complete svg.trackerbarimage) {
     fill: var(--darkreader-neutral-background) !important;


### PR DESCRIPTION
Fixes close icon on certain pages.

Before:
![1](https://user-images.githubusercontent.com/6563728/185753188-aa1edf08-3d08-4c75-9478-7fd2a0afc892.png)

After:
![2](https://user-images.githubusercontent.com/6563728/185753189-a84c13d6-09b0-451f-9daf-e7569b6efc04.png)