### PR TITLE
Fix edge-case for webkitMask

### DIFF
--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -254,7 +254,7 @@ function getColorModifier(prop: string, value: string, rule: CSSStyleRule): stri
     if (prop.includes('background')) {
         if (
             (rule.style.webkitMaskImage && rule.style.webkitMaskImage !== 'none') ||
-            (rule.style.webkitMask && rule.style.webkitMask !== 'none') ||
+            (rule.style.webkitMask && !rule.style.webkitMask.startsWith('none')) ||
             (rule.style.mask && rule.style.mask !== 'none') ||
             (rule.style.getPropertyValue('mask-image') && rule.style.getPropertyValue('mask-image') !== 'none')
         ) {


### PR DESCRIPTION
- The default value isn't `none` for Chromium, but has a bunch of other values. So instead use `startsWith('none')`.