### PR TITLE
Get correct frameId in `sendMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix iframes not getting modified when settings were changed.
+
 ## 4.9.56 (Aug 16, 2022)
 
 - Fix browser theme not changing when automation + scheme behavior was enabled.

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -302,7 +302,8 @@ export default class TabManager {
                 const frames = this.tabs[tab.id];
                 Object.entries(frames)
                     .filter(([, {state}]) => state === DocumentState.ACTIVE || state === DocumentState.PASSIVE)
-                    .forEach(([, {url}], frameId) => {
+                    .forEach(([id, {url}]) => {
+                        const frameId = Number(id);
                         const tabURL = this.getTabURL(tab);
                         // Check if hostname are equal when we only want to update active tab.
                         if (onlyUpdateActiveTab && getURLHostOrProtocol(tabURL) !== activeTabHostname) {


### PR DESCRIPTION
- The current frameId was actually the index of the item within the `frames` array. This patch fixes that by changing the position of `frameId`, so it will get the actually stored frameId variable from the array, instead of the index.
- Resolves #9575