### PR TITLE
corriere.it footer logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4350,6 +4350,13 @@ body {
 
 ================================
 
+corriere.it
+
+INVERT
+.footer__content div div img
+
+================================
+
 corsair.com
 
 INVERT


### PR DESCRIPTION
https://milano.corriere.it

![20220821-1661081927](https://user-images.githubusercontent.com/9846948/185789174-72aba62d-97ca-44ef-9e22-a951b90c2314.png)
