### PR TITLE
Fix for vjudge.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19887,6 +19887,15 @@ INVERT
 
 ================================
 
+vjudge.net
+
+CSS
+body {
+    background: none !important;
+}
+
+================================
+
 vk.com
 
 CSS


### PR DESCRIPTION
Background is a grayish noise-like image, need to set it to none for proper dark theming.

Before:
![image](https://user-images.githubusercontent.com/43037910/186076212-8fd189b8-113f-40f5-a8ed-b60f3c08a6e7.png)

After:
![image](https://user-images.githubusercontent.com/43037910/186076317-20304acb-202e-4f9a-8f8f-03b2f76ae49d.png)
