### PR TITLE
avlab.pl selectors fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1870,6 +1870,8 @@ avlab.pl
 INVERT
 img[src*="avlab-logo"]
 img[alt*="logo"]
+.elementor-widget-wrap div div a.elementor-icon svg
+.elementor-social-icons-wrapper
 
 ================================
 


### PR DESCRIPTION
https://avlab.pl/przegladarki-tiktok-instagram-facebook-dzialaja-jak-keylogger/

![20220823-1661245751](https://user-images.githubusercontent.com/9846948/186119398-24838663-53d5-4f73-834e-6f9a6bbb9329.png)
