### PR TITLE
fix calendar icon not readable in Google Mail

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11641,6 +11641,9 @@ div[class*="bym"][role="navigation"] {
 ::-webkit-scrollbar {
     background-color: transparent !important
 }
+.aRg, .aRj {
+  color: var(--darkreader-neutral-background);
+}
 
 IGNORE INLINE STYLE
 .at

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11641,8 +11641,9 @@ div[class*="bym"][role="navigation"] {
 ::-webkit-scrollbar {
     background-color: transparent !important
 }
-.aRg, .aRj {
-  color: var(--darkreader-neutral-background);
+.aRg,
+.aRj {
+  color: ${white} !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
This fixes the calendar icon being not readable when opening a calendar invitation in Google Mail.

Before:
![Screenshot 2022-08-23 at 11 10 34](https://user-images.githubusercontent.com/1742115/186120200-6eee91c4-489a-40e4-b5f4-6a1a000b55a8.png)

After:
![Screenshot 2022-08-23 at 11 10 52](https://user-images.githubusercontent.com/1742115/186120209-d1e0f008-0770-40b7-9bd6-3261f3a1d849.png)

