### PR TITLE
fix for garmin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7821,6 +7821,7 @@ garmin.com
 
 INVERT
 .gh__logo
+.map-controls.player .pause span
 
 ================================
 


### PR DESCRIPTION
invert for black pause icon on activity map during play