### PR TITLE
Fix for pcgamer.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14535,14 +14535,11 @@ li.level0 > a:hover {
 pcgamer.com
 
 INVERT
-img[alt="Best Buy"]
-img[alt="Amazon"]
+img[alt="Best Buy"], [alt="Amazon"]
 
 CSS
 img {
 	mix-blend-mode: normal !important;
-}
-	mix-blend-mode: difference !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14534,11 +14534,14 @@ li.level0 > a:hover {
 
 pcgamer.com
 
+INVERT
+img[alt="Best Buy"]
+img[alt="Amazon"]
+
 CSS
 img {
 	mix-blend-mode: normal !important;
 }
-img[alt="Best Buy"], [alt="Amazon"] {
 	mix-blend-mode: difference !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14536,7 +14536,7 @@ pcgamer.com
 
 INVERT
 img[alt="Best Buy"]
-[alt="Amazon"]
+img[alt="Amazon"]
 
 CSS
 img {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14532,6 +14532,18 @@ li.level0 > a:hover {
 
 ================================
 
+pcgamer.com
+
+CSS
+img {
+	mix-blend-mode: normal !important;
+}
+img[alt="Best Buy"], [alt="Amazon"] {
+	mix-blend-mode: difference !important;
+}
+
+================================
+
 pch24.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14535,7 +14535,8 @@ li.level0 > a:hover {
 pcgamer.com
 
 INVERT
-img[alt="Best Buy"], [alt="Amazon"]
+img[alt="Best Buy"]
+[alt="Amazon"]
 
 CSS
 img {


### PR DESCRIPTION
Fixes darkened product images and store logos on all of the hardware buying guides found on the site
https://www.pcgamer.com/best-gaming-laptop/ for example.