### PR TITLE
Remove joinmastodon.org

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -396,7 +396,6 @@ jhey.dev
 jigsawpuzzles.io
 jmoore.dev
 joeydrewstudios.com
-joinmastodon.org
 jonahsnider.com
 jqbx.fm
 jsben.ch


### PR DESCRIPTION
They have recently revamped the project's website which now includes most of the explainer content being on a white background

https://joinmastodon.org/

*note: this will also cause the new graphics at the top of page (see photos) to be completely blanked out*

![image](https://user-images.githubusercontent.com/63261955/187919154-d18a6149-ac50-4f21-a82e-782212cd634e.png)
![image](https://user-images.githubusercontent.com/63261955/187919261-f051b00e-fba8-47fc-a5ed-91ea09dbee36.png)
