### PR TITLE
Restore functional colors on Manifold Markets

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11792,6 +11792,48 @@ INVERT
 
 ================================
 
+manifold.markets
+
+CSS
+.bg-primary {
+    --darkreader-bg--tw-bg-opacity: 1 !important;
+    background-color: hsla(var(--p)/var(--darkreader-bg--tw-bg-opacity)) !important;
+}
+.border-primary {
+    --darkreader-border--tw-border-opacity: 1 !important;
+    border-color: hsla(var(--p)/var(--darkreader-border--tw-border-opacity)) !important;
+}
+.btn-outline:hover {
+    --darkreader-bg--tw-bg-opacity: 1 !important;
+    background-color: rgb(255 255 255/var(--darkreader-bg--tw-bg-opacity,1)) !important;
+    --darkreader-border--tw-border-opacity: 1 !important;
+    border-color: rgb(255 255 255/var(--darkreader-border--tw-border-opacity,1)) !important;
+    --darkreader-text--tw-text-opacity: 1 !important;
+    color: rgb(0 0 0/var(--darkreader-text--tw-text-opacity,1)) !important;
+}
+.hover\:bg-primary-focus:hover {
+    --darkreader-bg--tw-bg-opacity: 1 !important;
+    background-color: hsla(var(--pf)/var(--darkreader-bg--tw-bg-opacity)) !important;
+}
+.hover\:text-primary:hover {
+    --darkreader-text--tw-text-opacity: 1 !important;
+    color: hsla(var(--p)/var(--darkreader-text--tw-text-opacity)) !important;
+}
+.hover\:text-white:hover {
+    --darkreader-text--tw-text-opacity: 1 !important;
+    color: rgb(255 255 255/var(--darkreader-text--tw-text-opacity)) !important;
+}
+.text-primary {
+    --darkreader-text--tw-text-opacity: 1 !important;
+    color: hsla(var(--p)/var(--darkreader-text--tw-text-opacity)) !important;
+}
+.text-white {
+    --darkreader-text--tw-text-opacity: 1 !important;
+    color: rgb(255 255 255/var(--darkreader-text--tw-text-opacity)) !important;
+}
+
+================================
+
 manjaro.org
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11796,47 +11796,33 @@ manifold.markets
 
 CSS
 .bg-primary {
-    --darkreader-bg--tw-bg-opacity: 1 !important;
-    background-color: hsla(var(--p)/var(--darkreader-bg--tw-bg-opacity)) !important;
+    background-color: hsla(160 83.2% 39.6%) !important;
 }
 .bg-green-600 {
-    --darkreader-bg--tw-bg-opacity: 1 !important;
-    background-color: rgb(22 163 74/var(--darkreader-bg--tw-bg-opacity)) !important;
-}
-.bg-opacity-10 {
-    --darkreader-bg--tw-bg-opacity: 0.4 !important;
+    background-color: rgb(22 163 74/0.1) !important;
 }
 .border-primary {
-    --darkreader-border--tw-border-opacity: 1 !important;
-    border-color: hsla(var(--p)/var(--darkreader-border--tw-border-opacity)) !important;
+    border-color: hsla(160 83.2% 39.6%) !important;
 }
 .btn-outline:hover {
-    --darkreader-bg--tw-bg-opacity: 1 !important;
-    background-color: rgb(255 255 255/var(--darkreader-bg--tw-bg-opacity,1)) !important;
-    --darkreader-border--tw-border-opacity: 1 !important;
-    border-color: rgb(255 255 255/var(--darkreader-border--tw-border-opacity,1)) !important;
-    --darkreader-text--tw-text-opacity: 1 !important;
-    color: rgb(0 0 0/var(--darkreader-text--tw-text-opacity,1)) !important;
+    background-color: rgb(255 255 255) !important;
+    border-color: rgb(255 255 255) !important;
+    color: rgb(0 0 0) !important;
 }
 .hover\:bg-primary-focus:hover {
-    --darkreader-bg--tw-bg-opacity: 1 !important;
-    background-color: hsla(var(--pf)/var(--darkreader-bg--tw-bg-opacity)) !important;
+    background-color: hsla(161 92.3% 30.6%) !important;
 }
 .hover\:text-primary:hover {
-    --darkreader-text--tw-text-opacity: 1 !important;
-    color: hsla(var(--p)/var(--darkreader-text--tw-text-opacity)) !important;
+    color: hsla(160 83.2% 39.6%) !important;
 }
 .hover\:text-white:hover {
-    --darkreader-text--tw-text-opacity: 1 !important;
-    color: rgb(255 255 255/var(--darkreader-text--tw-text-opacity)) !important;
+    color: rgb(255 255 255) !important;
 }
 .text-primary {
-    --darkreader-text--tw-text-opacity: 1 !important;
-    color: hsla(var(--p)/var(--darkreader-text--tw-text-opacity)) !important;
+    color: hsla(160 83.2% 39.6%) !important;
 }
 .text-white {
-    --darkreader-text--tw-text-opacity: 1 !important;
-    color: rgb(255 255 255/var(--darkreader-text--tw-text-opacity)) !important;
+    color: rgb(255 255 255) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11799,6 +11799,13 @@ CSS
     --darkreader-bg--tw-bg-opacity: 1 !important;
     background-color: hsla(var(--p)/var(--darkreader-bg--tw-bg-opacity)) !important;
 }
+.bg-green-600 {
+    --darkreader-bg--tw-bg-opacity: 1 !important;
+    background-color: rgb(22 163 74/var(--darkreader-bg--tw-bg-opacity)) !important;
+}
+.bg-opacity-10 {
+    --darkreader-bg--tw-bg-opacity: 0.4 !important;
+}
 .border-primary {
     --darkreader-border--tw-border-opacity: 1 !important;
     border-color: hsla(var(--p)/var(--darkreader-border--tw-border-opacity)) !important;


### PR DESCRIPTION
Many of the colors necessary for interpreting information on Manifold are missing when using Dark Reader's "Dynamic" mode. Most importantly, Manifold's green buttons fail to function properly, especially when :hover selectors are involved. This PR restores the functionality of those buttons, as well as those involved with canceling limit orders.