### PR TITLE
fix for last.fm

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10878,6 +10878,9 @@ CSS
 .user-dashboard-scalable-content span {
     color: ${#666666} !important;
 }
+.linkfire-button {
+    --darkreader-border--play-arrow-color: var(--gray-50) !important;
+}
 
 IGNORE IMAGE ANALYSIS
 .masthead-logo-loading


### PR DESCRIPTION
fix for very dark play button on artist/album page
color set to original used without dark reader