### PR TITLE
Fixes for Google Photos

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14653,6 +14653,15 @@ INVERT
 
 ================================
 
+photos.google.com
+
+CSS
+textarea {
+    background-color: #00000000 !important;
+}
+
+================================
+
 phys.nagoya-u.ac.jp
 
 INVERT


### PR DESCRIPTION
On the page to create/edit an album, the text input area for the title of the album is a different shade of grey than the rest of the background. This addresses that issue by making its background transparent.
Before:
![2022-09-04-121643_1366x768_scrot](https://user-images.githubusercontent.com/69745509/188301106-3d0bd33f-d0cb-4d66-998e-c1ba1a0c19af.png)
After:
![2022-09-04-121620_1366x768_scrot](https://user-images.githubusercontent.com/69745509/188301119-659ae910-878a-4c6a-a73d-b0a335ecf091.png)

AFAIK, most other text input fields are `<input>` elements; the only other `<textarea>` that I can find doesn not behave badly with this change (this is the input box for commenting on an album).