### PR TITLE
Fix for brightspace.rug.nl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2893,6 +2893,33 @@ CSS
 
 ================================
 
+brightspace.rug.nl
+
+CSS
+d2l-menu-item,
+d2l-menu-item-link,
+d2l-card {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+d2l-menu-item,
+d2l-menu-item-link {
+  border-top-color: var(--d2l-color-tungsten) !important;
+  border-bottom-color: var(--d2l-color-tungsten) !important;
+}
+d2l-menu-item:hover,
+d2l-menu-item-link:hover {
+    background-color: var(--darkreader-selection-background) !important;
+}
+d2l-card {
+    border-color: var(--d2l-color-tungsten) !important;
+}
+#d2l-dropdown-wrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 brilliant.org
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2896,23 +2896,24 @@ CSS
 brightspace.rug.nl
 
 CSS
-d2l-menu-item,
-d2l-menu-item-link,
 d2l-card {
     background-color: var(--darkreader-neutral-background) !important;
     color: var(--darkreader-neutral-text) !important;
+    border-color: var(--d2l-color-tungsten) !important;
 }
 d2l-menu-item,
 d2l-menu-item-link {
-  border-top-color: var(--d2l-color-tungsten) !important;
-  border-bottom-color: var(--d2l-color-tungsten) !important;
+    border-top-color: var(--d2l-color-tungsten) !important;
+    border-bottom-color: var(--d2l-color-tungsten) !important;
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
 }
 d2l-menu-item:hover,
 d2l-menu-item-link:hover {
     background-color: var(--darkreader-selection-background) !important;
 }
-d2l-card {
-    border-color: var(--d2l-color-tungsten) !important;
+.d2l-msg-container {
+    border: none !important;
 }
 #d2l-dropdown-wrapper {
     background-color: var(--darkreader-neutral-background) !important;


### PR DESCRIPTION
Fixes:
- dropdown menus being fully transparent when in dark mode
- lightens borders of the dropdown entries and course cards
- fixes absence of selection colours
- removes border that's not supposed to be visible 