### PR TITLE
Fix for brightspace.rug.nl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2893,6 +2893,27 @@ CSS
 
 ================================
 
+brightspace.rug.nl
+
+CSS
+:root {
+    --d2l-menu-background-color: var(--darkreader-neutral-background) !important;
+    --d2l-dropdown-background-color: var(--darkreader-neutral-background) !important;
+    --darkreader-bg--d2l-dropdown-background-color: var(--darkreader-neutral-background) !important;
+    --darkreader-bg--d2l-menu-background-color-hover: var(--darkreader-selection-background) !important;
+    --darkreader-border--d2l-menu-border-color: var(--d2l-color-tungsten) !important;
+}
+d2l-card {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+    border-color: var(--d2l-color-tungsten) !important;
+}
+.d2l-msg-container {
+    border: none !important;
+}
+
+================================
+
 brilliant.org
 
 INVERT


### PR DESCRIPTION
Fixes:
- dropdown menus being fully transparent when in dark mode
- borders of the dropdown entries and course cards being too light
- absence of selection colours
- border that's not supposed to be visible