### PR TITLE
Updated dynamic theme for overreacted.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14382,7 +14382,7 @@ INVERT
 overreacted.io
 
 CSS
-div[style*="background: var(--bg)"] {
+:root {
     --bg: var(--darkreader-neutral-background) !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14379,6 +14379,15 @@ INVERT
 
 ================================
 
+overreacted.io
+
+CSS
+div[style*="background: var(--bg)"] {
+    --bg: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 overwatchleague.com
 
 CSS


### PR DESCRIPTION
The background of the `div` was set using an inline style with a CSS variable. I have overridden the CSS variable with the value of the one used by Dark Reader

Test Link: https://overreacted.io/optimized-for-change/
