### PR TITLE
Add a TODO note to handle incorrect condition

### DIFF
--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -218,6 +218,12 @@ export class VariablesStore {
     }
 
     getModifierForVarDependant(property: string, sourceValue: string): CSSValueModifier {
+        // TODO(gusted): This condition is incorrect, as the sourceValue still might contain a
+        // variable. And simply replacing it with some definition is incorrect as variable's
+        // are element-independent. Fully handling this, requires to have an function that gives the
+        // variable's value given an element's position in the DOM. That's expensive and "stupid", so
+        // likely handle the edge-cases like: rgb(22 163 74/var(--tb-bg-opacity)) and hope that just
+        // reducing the opacity is good enough.
         if (sourceValue.match(/^\s*(rgb|hsl)a?\(/)) {
             const isBg = property.startsWith('background');
             const isText = isTextColorProperty(property);


### PR DESCRIPTION
- Just a small patch to add a public TODO, that explains about that the current condition is breaking real-world examples(see source code) of incorrectly handling how to modify colors that partially has variables.
- Found while looking at https://github.com/darkreader/darkreader/pull/9722