### PR TITLE
Update Catppuccin to latest version

### DIFF
--- a/src/config/color-schemes.drconf
+++ b/src/config/color-schemes.drconf
@@ -13,8 +13,12 @@ text: #e8e6e3
 Catppuccin
 
 DARK
-background: #161320
-text: #d9e0ee
+background: #1e1e2e
+text: #cdd6f4
+
+LIGHT
+background: #eff1f5
+text: #4c4f69
 
 ================================
 


### PR DESCRIPTION
The latest version of Catppuccin includes an official dark theme, "Catppuccin Mocha," as well as an official light theme, "Catppuccin Latte."
The latest version of Catppuccin for Dark Reader is available here: https://github.com/catppuccin/dark-reader