### PR TITLE
Fix for mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11731,9 +11731,6 @@ CSS
 mail.google.com
 
 INVERT
-img.Hl
-img.Hk
-img.Ha
 .asor_t0
 .asor_i4
 .d-Na-Jo.d-Na-N-ax3
@@ -11754,6 +11751,7 @@ img[src$="profile_mask2.png"]
 div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
 form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id])
 img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"]
+div[style$="gm_add_black_24dp.png)"]
 
 CSS
 @media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {


### PR DESCRIPTION
- Remove inversion for composition buttons (see #1065)
- Add invert for "Get Add-ons" in right-sidebar
- Resolves https://github.com/darkreader/darkreader/issues/9419#issuecomment-1240155435