### PR TITLE
Fix for debian.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4851,12 +4851,18 @@ body
 debian.org
 
 INVERT
+.community img
 #logo
+.os-dl-btn
+.os-img-container img
 
 CSS
 body {
     background-image: none !important;
 }
+
+IGNORE IMAGE ANALYSIS
+#splash h1
 
 ================================
 


### PR DESCRIPTION
Fixes images on home page.

Before:
![1](https://user-images.githubusercontent.com/6563728/189488731-a37393b6-4995-4de7-995d-8decc4dea2fa.png)
![2](https://user-images.githubusercontent.com/6563728/189488743-954caa55-3c6f-4bde-b15f-299b8c6a6ab3.png)

After:
![3](https://user-images.githubusercontent.com/6563728/189488749-4a32e920-57f7-4d11-ba21-9e883fbd61b3.png)
![4](https://user-images.githubusercontent.com/6563728/189488754-030927ad-8f40-466f-bb8c-dfc5e83af4a0.png)