### PR TITLE
Build system: fix code style task

### DIFF
--- a/tasks/code-style.js
+++ b/tasks/code-style.js
@@ -19,12 +19,8 @@ const options = {
 
 const extensions = ['html', 'css', 'js'];
 
-async function codeStyle({platforms, debug}) {
-    if (debug) {
-        throw new Error('code-style task does not support debug builds');
-    }
-    const platform = Object.values(PLATFORM).find((platform) => platforms[platform]);
-    const dir = getDestDir({debug, platform});
+async function processPlatform(platform) {
+    const dir = getDestDir({debug: false, platform});
     const files = await getPaths(extensions.map((ext) => `${dir}/**/*.${ext}`));
     for (const file of files) {
         const code = await readFile(file);
@@ -34,9 +30,19 @@ async function codeStyle({platforms, debug}) {
         });
         if (code !== formatted) {
             await writeFile(file, formatted);
-            debug && log.ok(file);
         }
     }
+}
+
+async function codeStyle({platforms, debug}) {
+    if (debug) {
+        throw new Error('code-style task does not support debug builds');
+    }
+    const promisses = [];
+    Object.values(PLATFORM)
+      .filter((platform) => platforms[platform])
+      .forEach((platform) => promisses.push(processPlatform(platform)));
+    await Promise.all(promisses);
 }
 
 const codeStyleTask = createTask(

--- a/tasks/code-style.js
+++ b/tasks/code-style.js
@@ -2,7 +2,7 @@
 import prettier from 'prettier';
 import paths from './paths.js';
 import {createTask} from './task.js';
-import {log, readFile, writeFile, getPaths} from './utils.js';
+import {readFile, writeFile, getPaths} from './utils.js';
 const {getDestDir, PLATFORM} = paths;
 
 /** @type {import('prettier').Options} */
@@ -40,8 +40,8 @@ async function codeStyle({platforms, debug}) {
     }
     const promisses = [];
     Object.values(PLATFORM)
-      .filter((platform) => platforms[platform])
-      .forEach((platform) => promisses.push(processPlatform(platform)));
+        .filter((platform) => platforms[platform])
+        .forEach((platform) => promisses.push(processPlatform(platform)));
     await Promise.all(promisses);
 }
 


### PR DESCRIPTION
Previously, code formatting would be done only for the first enabled build platform in the list. After this patch, we actually format all files in all enabled platforms.

Tested that this patch does not produce any changes in the built output by running `npm run build -- --${platform}` for every platform individually.

This bug might have caused this confusion: https://discord.com/channels/700258399702482945/700258399702482948/1006603458394210415