### PR TITLE
Partial fix non-inverted menu images at inet.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9722,6 +9722,19 @@ IGNORE INLINE STYLE
 
 ================================
 
+inet.se
+
+INVERT
+.h1yh8nho
+.i1gv55ha
+
+CSS
+:root {
+--svg-icon-default-color: #e8e6e3
+}
+
+================================
+
 infinitysearch.co
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9730,7 +9730,7 @@ INVERT
 
 CSS
 :root {
---svg-icon-default-color: #e8e6e3
+    --svg-icon-default-color: #e8e6e3 !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9726,7 +9726,7 @@ inet.se
 
 INVERT
 .h1yh8nho
-.i1gv55ha
+a.item-button span[class*="icon"]
 
 CSS
 :root {


### PR DESCRIPTION
Fixed non-inverted menu images in sidemenu and submenues. Could not track down why some images unloads (problem existed before this fix).