### PR TITLE
Fix for mint.intuit.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12604,6 +12604,21 @@ INVERT
 
 ================================
 
+mint.intuit.com
+
+INVERT
+.recharts-cartesian-axis-ticks
+
+CSS
+[class*="ExpandableCard-wrapper"] {
+    background: none !important;
+}
+
+IGNORE INLINE STYLE
+.recharts-sector
+
+================================
+
 miro.com
 
 INVERT


### PR DESCRIPTION
- Invert dark y axis ticks on bar graphs in trends
- Remove bright backgrounds behind dashboard card sections
- Ignore inline style for pie chart colors in trends