### PR TITLE
Add dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -179,6 +179,7 @@ darkreader.org
 dartpad.dev
 dash.cavebot.xyz
 datomatic.no-intro.org
+dbdicontoolbox.com/web
 dblstatistics.com
 deadbydaylight.com
 deadbydaylight.fandom.com
@@ -451,6 +452,7 @@ liquidplus.com
 listen.moe
 livesplit.org
 loadout.tf
+loldle.net
 lolesports.com
 lollilol.xyz
 lookmovie.ag
@@ -780,6 +782,7 @@ spacex.com
 spark.lucko.me
 speedrun.com
 speedtest.net
+splatoon.nintendo.com
 sponsorshipshq.com
 sportsurge.net
 spyware.neocities.org


### PR DESCRIPTION
- dbdicontoolbox.com/web - Dark Reader hides the background when it's on
- loldle.net - no effect, already dark
- splatoon.nintendo.com - removes some green colors of some buttons