### PR TITLE
muratordom.pl logo header fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13144,6 +13144,13 @@ INVERT
 
 ================================
 
+muratordom.pl
+
+INVERT
+.logo
+
+================================
+
 murena.com
 
 INVERT


### PR DESCRIPTION
https://muratordom.pl/

![20220921-1663742026](https://user-images.githubusercontent.com/9846948/191431414-4b6096e4-477b-4f06-94c5-78c6bc914086.png)
