### PR TITLE
Remove newlines within CSS URL value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Remove newlines from CSS URL values, before handling them.
+
 ## 4.9.57 (Aug 23, 2022)
 
 - Fix iframes not getting modified when settings were changed.

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -91,10 +91,12 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
 export const cssURLRegex = /url\((('.*?')|(".*?")|([^\)]*?))\)/g;
 export const cssImportRegex = /@import\s*(url\()?(('.+?')|(".+?")|([^\)]*?))\)? ?(screen)?;?/gi;
 
-// First try to extract the CSS URL value.
-// Then do some post fixes, like unescaping backslashes in the URL. (Chromium don't handle this natively).
+// First try to extract the CSS URL value. Then do some post fixes, like unescaping
+// backslashes in the URL. (Chromium don't handle this natively). Remove all newlines
+// beforehand, otherwise `.` will fail matching the content within the url, as it
+// doesn't match any linebreaks.
 export function getCSSURLValue(cssURL: string) {
-    return cssURL.trim().replace(/^url\((.*)\)$/, '$1').trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1').replace(/(?:\\(.))/g, '$1');
+    return cssURL.trim().replace(/[\n\r\\]+/g, '').replace(/^url\((.*)\)$/, '$1').trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1').replace(/(?:\\(.))/g, '$1');
 }
 
 export function getCSSBaseBath(url: string) {
@@ -109,7 +111,7 @@ export function replaceCSSRelativeURLsWithAbsolute($css: string, cssBasePath: st
         // To prevent the whole operation from failing, let's just skip those
         // invalid URL's and let them be invalid.
         try {
-            return `url("${getAbsoluteURL(cssBasePath, pathValue)}")`;
+            return `url('${getAbsoluteURL(cssBasePath, pathValue)}')`;
         } catch (err) {
             logWarn('Not able to replace relative URL with Absolute URL, skipping');
             return match;


### PR DESCRIPTION
- Before we try to match the contents of CSS URL, remove all newlines/multines before parsing it via regex, otherwise the `.` regex character will fail to match the contents, as it doesn't match any linebreaks by default.
- Resolves #9862