### PR TITLE
neowin.net icon revert fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13557,6 +13557,12 @@ neowin.net
 INVERT
 .comment-link
 .news-view-switcher span
+.author a.twitter-link
+.meta-comments
+.comment-link::before
+.select-wrap::after
+#report-article::before
+#comment-help::before
 
 CSS
 .select option {


### PR DESCRIPTION
https://www.neowin.net/news/windows-11-beta-build-22621601-includes-fix-for-dual-sim-calling-and-more/

![20220921-1663783592](https://user-images.githubusercontent.com/9846948/191578998-13853fe5-0487-45ca-8ad7-792ddfe264c2.png)
![20220921-1663783576](https://user-images.githubusercontent.com/9846948/191579002-fb645436-ee78-4d56-9a2a-ba0998f0d924.png)
![20220921-1663783561](https://user-images.githubusercontent.com/9846948/191579006-1284fbe6-6717-4bfe-8bbf-4653abc94271.png)

- twitter icon near author
- exclamation mark (report)
- question mark
- comment counter icon
- expand sort comment icon menu
