### PR TITLE
neowin.net comments section fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13569,6 +13569,8 @@ INVERT
 .select-wrap::after
 #report-article::before
 #comment-help::before
+.comment-button-report::before
+.comment-interact ::before
 
 CSS
 .select option {


### PR DESCRIPTION
https://www.neowin.net/news/windows-11-2022-update-gets-two-years-of-support-no-eol-date-for-windows-11-in-general/

![20220921-1663786215](https://user-images.githubusercontent.com/9846948/191586949-9ab1a409-1d78-4653-987d-73c67fcbdac1.png)
