### PR TITLE
Polska Press domains merge and fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13439,12 +13439,57 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+dziennikbaltycki.pl
+dzienniklodzki.pl
+dziennikpolski24.pl
+echodnia.eu
+expressbydgoski.pl
+expressilustrowany.pl
+gazetakrakowska.pl
+gazetalubuska.pl
+gazetawroclawska.pl
+gk24.pl
+gloswielkopolski.pl
+gol24.pl
+gp24.pl
+gra.pl
+gs24.pl
+i.pl
+kurierlubelski.pl
+motofakty.pl
 naszemiasto.pl
+nowiny24.pl
+nowosci.com.pl
+nto.pl
+pomorska.pl
+poranny.pl
+sportowy24.pl
+strefaagro.pl
 strefabiznesu.pl
+strefaedukacji.pl
+stronakobiet.pl
+stronazdrowia.pl
+telemagazyn.pl
+to.com.pl
+wspolczesna.pl
 
 INVERT
-.componentsNavigationNavbar__logo
 .atomsNavigationFooterLinks__logo
+.atomsSocialmediaExposition__content svg
+.componentsGalleryNavbar__btn_close
+.componentsGalleryNavbar__logo
+.componentsNavigationNavbar__logo
+.componentsNavigationTopnavbar__icons div span svg
+a[href="https://i.pl/firmy"] svg
+a[href="https://i.pl/szukaj"] svg
+
+CSS
+svg path[d^="M154.992 47.9999H128L13"] {
+    fill: ${black} !important;
+}
+svg path[d^="M64 28L68 24V15.9999H82"] {
+    fill: ${black} !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6182,6 +6182,60 @@ img[alt="Dziennik"]
 
 ================================
 
+dziennikbaltycki.pl
+dzienniklodzki.pl
+dziennikpolski24.pl
+echodnia.eu
+expressbydgoski.pl
+expressilustrowany.pl
+gazetakrakowska.pl
+gazetalubuska.pl
+gazetawroclawska.pl
+gk24.pl
+gloswielkopolski.pl
+gol24.pl
+gp24.pl
+gra.pl
+gs24.pl
+i.pl
+kurierlubelski.pl
+motofakty.pl
+naszemiasto.pl
+nowiny24.pl
+nowosci.com.pl
+nto.pl
+pomorska.pl
+poranny.pl
+sportowy24.pl
+strefaagro.pl
+strefabiznesu.pl
+strefaedukacji.pl
+stronakobiet.pl
+stronazdrowia.pl
+telemagazyn.pl
+to.com.pl
+wspolczesna.pl
+
+INVERT
+.atomsNavigationFooterLinks__logo
+.atomsSocialmediaExposition__content svg
+.componentsGalleryNavbar__btn_close
+.componentsGalleryNavbar__logo
+.componentsNavigationNavbar__logo
+.componentsNavigationTopnavbar__icons div span svg
+a[href="https://i.pl/firmy"] svg
+a[href="https://i.pl/szukaj"] svg
+
+CSS
+svg path[d^="M154.992 47.9999H128L13"] {
+    fill: ${black} !important;
+}
+svg path[d^="M64 28L68 24V15.9999H82"] {
+    fill: ${black} !important;
+}
+
+================================
+
 dzienniknaukowy.pl
 
 INVERT
@@ -13436,60 +13490,6 @@ nasa.gov
 
 IGNORE IMAGE ANALYSIS
 .vjs-has-started .vjs-control-bar .vjs-control.vjs-logo-image
-
-================================
-
-dziennikbaltycki.pl
-dzienniklodzki.pl
-dziennikpolski24.pl
-echodnia.eu
-expressbydgoski.pl
-expressilustrowany.pl
-gazetakrakowska.pl
-gazetalubuska.pl
-gazetawroclawska.pl
-gk24.pl
-gloswielkopolski.pl
-gol24.pl
-gp24.pl
-gra.pl
-gs24.pl
-i.pl
-kurierlubelski.pl
-motofakty.pl
-naszemiasto.pl
-nowiny24.pl
-nowosci.com.pl
-nto.pl
-pomorska.pl
-poranny.pl
-sportowy24.pl
-strefaagro.pl
-strefabiznesu.pl
-strefaedukacji.pl
-stronakobiet.pl
-stronazdrowia.pl
-telemagazyn.pl
-to.com.pl
-wspolczesna.pl
-
-INVERT
-.atomsNavigationFooterLinks__logo
-.atomsSocialmediaExposition__content svg
-.componentsGalleryNavbar__btn_close
-.componentsGalleryNavbar__logo
-.componentsNavigationNavbar__logo
-.componentsNavigationTopnavbar__icons div span svg
-a[href="https://i.pl/firmy"] svg
-a[href="https://i.pl/szukaj"] svg
-
-CSS
-svg path[d^="M154.992 47.9999H128L13"] {
-    fill: ${black} !important;
-}
-svg path[d^="M64 28L68 24V15.9999H82"] {
-    fill: ${black} !important;
-}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6227,9 +6227,7 @@ a[href="https://i.pl/firmy"] svg
 a[href="https://i.pl/szukaj"] svg
 
 CSS
-svg path[d^="M154.992 47.9999H128L13"] {
-    fill: ${black} !important;
-}
+svg path[d^="M154.992 47.9999H128L13"],
 svg path[d^="M64 28L68 24V15.9999H82"] {
     fill: ${black} !important;
 }


### PR DESCRIPTION
Samples.  Same CMS and owner - Polska Press. 
Owner site
- https://polskapress.pl/o-nas
Portals domains samples:
- https://katowice.naszemiasto.pl/
- https://katowice.naszemiasto.pl/sercu-na-ratunek-xxvi-miedzynarodowy-kongres-polskiego/ga/c1-9008455/zd/75550035
- https://i.pl

Sort order selectors, CSS fix intented for i.pl icons header. 

![20220923-1663912784](https://user-images.githubusercontent.com/9846948/191901932-be16aee9-5133-4479-9b13-b044ea5ddab0.png)

![20220923-1663913924](https://user-images.githubusercontent.com/9846948/191902494-dc54169b-9c40-4595-b7e9-2b09e0151a60.png)

![20220923-1663913848](https://user-images.githubusercontent.com/9846948/191902051-b5fc5afb-2a24-4a1e-ade9-71da85e93aa4.png)

