### PR TITLE
Remove dynamic theme when darkreader-lock is detected early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixes a issue where `darkreader-fallback` wasn't removed from the DOM, when Dark Reader finds a `<meta name="darkreader-lock">` element.
+
 ## 4.9.58 (Sep 22, 2022)
 
 - Remove newlines from CSS URL values, before handling them.

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -488,6 +488,7 @@ export function createOrUpdateDynamicTheme(filterConfig: FilterConfig, dynamicTh
     isIFrame = iframe;
     if (document.head) {
         if (isAnotherDarkReaderInstanceActive()) {
+            removeDynamicTheme();
             return;
         }
         document.documentElement.setAttribute('data-darkreader-mode', 'dynamic');


### PR DESCRIPTION
- Currently if `document.head` is already available to Dark Reader(and thus doesn't need to run a mutationobserver), it wouldn't remove the `darkreader-fallback` element when a `<meta name="darkreader-lock">` was found.
- Resolves https://github.com/darkreader/darkreader/discussions/9802#discussioncomment-3713482