### PR TITLE
Fix: two race conditions during background startup

### DIFF
--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -8,6 +8,7 @@ import type {ParsedColorSchemeConfig} from '../utils/colorscheme-parser';
 import {ParseColorSchemeConfig} from '../utils/colorscheme-parser';
 import {logWarn} from './utils/log';
 import {DEFAULT_COLORSCHEME} from '../defaults';
+import UserStorage from './user-storage';
 
 const CONFIG_URLs = {
     darkSites: {
@@ -144,7 +145,14 @@ export default class ConfigManager {
         this.handleStaticThemes();
     }
 
-    static async load(config: Config) {
+    static async load(config?: Config) {
+        if (!config) {
+            await UserStorage.loadSettings();
+            config = {
+                local: !UserStorage.settings.syncSitesFixes
+            };
+        }
+
         await Promise.all([
             this.loadColorSchemes(config),
             this.loadDarkSites(config),

--- a/src/background/devtools.ts
+++ b/src/background/devtools.ts
@@ -260,8 +260,12 @@ export default class DevTools {
     }
 
     static async getDynamicThemeFixesText() {
-        const $fixes = await this.getSavedDynamicThemeFixes();
-        const fixes = $fixes ? parseDynamicThemeFixes($fixes) : parseDynamicThemeFixes(ConfigManager.DYNAMIC_THEME_FIXES_RAW);
+        let rawFixes = await this.getSavedDynamicThemeFixes();
+        if (!rawFixes) {
+            await ConfigManager.load();
+            rawFixes = ConfigManager.DYNAMIC_THEME_FIXES_RAW;
+        }
+        const fixes = parseDynamicThemeFixes(rawFixes);
         return formatDynamicThemeFixes(fixes);
     }
 
@@ -294,8 +298,12 @@ export default class DevTools {
     }
 
     static async getInversionFixesText() {
-        const $fixes = await this.getSavedInversionFixes();
-        const fixes = $fixes ? parseInversionFixes($fixes) : parseInversionFixes(ConfigManager.INVERSION_FIXES_RAW);
+        let rawFixes = await this.getSavedInversionFixes();
+        if (!rawFixes) {
+            await ConfigManager.load();
+            rawFixes = ConfigManager.INVERSION_FIXES_RAW;
+        }
+        const fixes = parseInversionFixes(rawFixes);
         return formatInversionFixes(fixes);
     }
 
@@ -328,8 +336,12 @@ export default class DevTools {
     }
 
     static async getStaticThemesText() {
-        const $themes = await this.getSavedStaticThemes();
-        const themes = $themes ? parseStaticThemes($themes) : parseStaticThemes(ConfigManager.STATIC_THEMES_RAW);
+        let rawThemes = await this.getSavedStaticThemes();
+        if (!rawThemes) {
+            await ConfigManager.load();
+            rawThemes = ConfigManager.STATIC_THEMES_RAW;
+        }
+        const themes = parseStaticThemes(rawThemes);
         return formatStaticThemes(themes);
     }
 

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -61,9 +61,10 @@ export class Extension {
     private static SYSTEM_COLOR_LOCAL_STORAGE_KEY = 'system-color-state';
     private static systemColorStateManager: StateManager<SystemColorState>;
 
-    // Record whether extension had initialized itself
+    // Record whether Extension.init() already ran since the last GB start
     private static initialized = false;
 
+    // This sync initializer needs to run on every BG restart before anything else can happen
     static init() {
         if (this.initialized) {
             return;

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -61,7 +61,15 @@ export class Extension {
     private static SYSTEM_COLOR_LOCAL_STORAGE_KEY = 'system-color-state';
     private static systemColorStateManager: StateManager<SystemColorState>;
 
+    // Record whether extension had initialized itself
+    private static initialized = false;
+
     static init() {
+        if (this.initialized) {
+            return;
+        }
+        this.initialized = true;
+
         new Newsmaker();
         DevTools.init(async () => this.onSettingsChanged());
         Messenger.init(this.getMessengerAdapter());
@@ -190,6 +198,7 @@ export class Extension {
     }
 
     static async start() {
+        this.init();
         await Promise.all([
             ConfigManager.load({local: true}),
             this.MV3syncSystemColorStateManager(null),
@@ -377,6 +386,7 @@ export class Extension {
     }
 
     private static async loadData() {
+        this.init();
         const promises = [this.stateManager.loadState()];
         if (!UserStorage.settings) {
             promises.push(UserStorage.loadSettings());

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -42,8 +42,7 @@ type TestMessage = {
     id: number;
 };
 
-// Initialize extension
-Extension.init();
+// Start extension
 Extension.start();
 
 const welcome = `  /''''\\


### PR DESCRIPTION
This fixes two bugs in early BG startup:
 - extension attempted to do some work before loading DevTools and other components
 - DevTools attempted to access ConfigManager data before it was loaded

Possibly related to recent bug when Dark Reader automation did not work right after Firefox update and sometimes on Chrome. (I do not have any means to test this hypothesis.)

Repro steps:
 - install out MV3 build on Chromium (easiest to reproduce), enable DR (just set to ON, no automation)
 - close browser to shut down BG
 - repeat until bug occurs (up to 5 times): open browser and before opening anything else, open Popup (will fail to load) or open example.com (will be white)