### PR TITLE
Add create.roblox.com/docs to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -153,6 +153,7 @@ coriolis.io
 countermail.com
 cracked.to
 crazygames.com
+create.roblox.com/docs
 crontab.guru
 cryptowat.ch
 cs.rin.ru


### PR DESCRIPTION
Site is dark regardless of system theme.

![image](https://user-images.githubusercontent.com/70541819/192165386-6abf9709-58f2-4793-b75e-29e833aed90f.png)
