### PR TITLE
kapitanbomba.pl logo header fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10607,6 +10607,13 @@ INVERT
 
 ================================
 
+kapitanbomba.pl
+
+INVERT
+.custom-logo
+
+================================
+
 katahiromz.web.fc2.com
 
 CSS


### PR DESCRIPTION
https://kapitanbomba.pl

![20220926-1664207244](https://user-images.githubusercontent.com/9846948/192322347-46aecfd2-0044-4b58-b62c-42a76726f0b0.png)
