### PR TITLE
CI: use NodeJS 16 everywhere

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Set up npm cache
         uses: actions/cache@v2
@@ -31,10 +31,10 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.OS }}
-      
+
       - name: Install npm dependencies
         run: npm ci
-      
+
       - name: Build the extension
         run: npm run release
 

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Node.js setup
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 16.x
           cache: npm
       - name: Track Node and NPM version
         run: node --version && npm --version

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 15.x
+          node-version: 16.x
 
       - name: Verify NPM version
         run: npm --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 15.x
+          node-version: 16.x
 
       - name: Verify NPM version
         run: npm --version
@@ -36,7 +36,7 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-${{ hashFiles('package-lock.json') }}
             ${{ runner.OS }}
-      
+
       - name: Install npm dependencies
         run: npm ci
 


### PR DESCRIPTION
NodeJS 15 reached EOL on 2021-06-01, NodeJS 14 is in maintenance mode, Node 16 is the current LTS. We should move NodeJS 15 tasks to either 14 or 16. Let's go with 16, since it is the most common version in other tasks.