### PR TITLE
allegro.pl DEL smart invert

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -819,7 +819,6 @@ div[class="mpof_ki m389_6m"]
 img[alt="Zakup z pakietem Smart"]
 div.sob6jg.so1d89.mpof_ki
 .so15i8
-._1e32a_sudoG
 a[data-analytics-click-value="SellerAllListing"]
 .mpof_ki.m389_6m > h6
 


### PR DESCRIPTION
SITE https://allegro.pl/kategoria/smartfony-i-telefony-komorkowe-165

![20220927-1664297278](https://user-images.githubusercontent.com/9846948/192587131-9f70cee9-3516-49d7-947c-ff4b89c830cd.png)

For some reason rule does no work anymore - so delete it. 