### PR TITLE
Be stricter towards last slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Fixes a issue where `darkreader-fallback` wasn't removed from the DOM, when Dark Reader finds a `<meta name="darkreader-lock">` element.
+- Be stricter when the user specifies a last slash for a URL in the sitelist.
 
 ## 4.9.58 (Sep 22, 2022)
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -118,7 +118,7 @@ function createUrlRegex(urlTemplate: string): RegExp {
     urlTemplate = urlTemplate.trim();
     const exactBeginning = (urlTemplate[0] === '^');
     const exactEnding = (urlTemplate[urlTemplate.length - 1] === '$');
-    const hasLastSlash = /\/\$?/.test(urlTemplate);
+    const hasLastSlash = /\/\$?$/.test(urlTemplate);
 
     urlTemplate = (urlTemplate
         .replace(/^\^/, '') // Remove ^ at start

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -118,6 +118,7 @@ function createUrlRegex(urlTemplate: string): RegExp {
     urlTemplate = urlTemplate.trim();
     const exactBeginning = (urlTemplate[0] === '^');
     const exactEnding = (urlTemplate[urlTemplate.length - 1] === '$');
+    const hasLastSlash = /\/\$?/.test(urlTemplate);
 
     urlTemplate = (urlTemplate
         .replace(/^\^/, '') // Remove ^ at start
@@ -169,7 +170,7 @@ function createUrlRegex(urlTemplate: string): RegExp {
 
     result += (exactEnding ?
         '(\\/?(\\?[^\/]*?)?)$' // All following queries
-        : '(\\/?.*?)$' // All following paths and queries
+        : `(\\/${hasLastSlash ? '' : '?'}.*?)$` // All following paths and queries
     );
 
     //

--- a/tests/inject/utils/url.tests.ts
+++ b/tests/inject/utils/url.tests.ts
@@ -132,6 +132,16 @@ it('URL is enabled', () => {
         {enableForPDF: true, siteList: ['https://www.google.com/very/good/hidden/folder/pdf#file.pdf'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
+    expect(isURLEnabled(
+        'https://leetcode.com/problems/two-sum/',
+        {enableForPDF: false, siteList: ['leetcode.com/problems/'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        {isProtected: false, isInDarkList: false},
+    )).toBe(false);
+    expect(isURLEnabled(
+        'https://leetcode.com/problemset/all/',
+        {enableForPDF: false, siteList: ['leetcode.com/problems/'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        {isProtected: false, isInDarkList: false},
+    )).toBe(true);
 
     // Dark theme detection
     expect(isURLEnabled(


### PR DESCRIPTION
- Currently `example.com/help/` would match `example.com/helpme` URL, this is incorrect as the user explicitly specifies the last slash. This patch fixes that by making the last slash mandatory for the URL matching.
- Resolves #9905