### PR TITLE
Fix for mobile.bg

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12906,6 +12906,15 @@ IGNORE INLINE STYLE
 
 ================================
 
+mobile.bg
+
+CSS
+table .tablereset {
+  background-image: none !important;
+}
+
+================================
+
 moegirl.org.cn
 
 CSS


### PR DESCRIPTION
Promoted listings have a light image as background which interferes with the inverted colors. This removes the image so all works correctly.

Before:
![image](https://user-images.githubusercontent.com/13023509/192657764-22b80106-9e3a-40a9-acf1-66f4a52feb56.png)

After:
![image](https://user-images.githubusercontent.com/13023509/192657796-88fbbaad-fc03-4b8d-838c-834720bab3ed.png)
