### PR TITLE
MV3: remove tabs permission

### DIFF
--- a/src/manifest-chrome-mv3.json
+++ b/src/manifest-chrome-mv3.json
@@ -41,7 +41,6 @@
         "alarms",
         "fontSettings",
         "scripting",
-        "tabs",
         "storage",
         "unlimitedStorage"
     ],


### PR DESCRIPTION
tabs permission generates the following permission message during installation:
"Read your browsing history"