### PR TITLE
Fix for practicum.yandex.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15601,7 +15601,9 @@ IGNORE IMAGE ANALYSIS
 practicum.yandex.*
 
 INVERT
-.logo__img
+img[src$="?color=000"]
+.burger
+.lesson-progress__progress-bar
 
 ================================
 


### PR DESCRIPTION
- Fix logo inversion (so it only inverts when it's dark).
- Invert burger menu icons.
- Invert progress bar when completing lessons.