### PR TITLE
Fix for practicum.yandex.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15602,6 +15602,7 @@ practicum.yandex.*
 
 INVERT
 img[src$="?color=000"]
+.progress-circle__shape
 .burger
 .lesson-progress__progress-bar
 


### PR DESCRIPTION
- Invert the round progress icon of the entire course.