### PR TITLE
Refactor: use openExtensionPage() consistently

### DIFF
--- a/src/ui/popup/components/body.tsx
+++ b/src/ui/popup/components/body.tsx
@@ -13,9 +13,9 @@ import SiteListSettings from './site-list-settings';
 import {getDuration} from '../../../utils/time';
 import {DONATE_URL, GITHUB_URL, PRIVACY_URL, TWITTER_URL, getHelpURL} from '../../../utils/links';
 import {getLocalMessage} from '../../../utils/locales';
-import {compose} from '../../utils';
+import {compose, openExtensionPage} from '../../utils';
 import type {ExtensionData, ExtensionActions, News as NewsObject} from '../../../definitions';
-import {isMobile, isFirefox} from '../../../utils/platform';
+import {isMobile} from '../../../utils/platform';
 
 declare const __THUNDERBIRD__: boolean;
 
@@ -32,12 +32,7 @@ interface BodyState {
 }
 
 function openDevTools() {
-    chrome.windows.create({
-        type: 'panel',
-        url: isFirefox ? '../devtools/index.html' : 'ui/devtools/index.html',
-        width: 600,
-        height: 600,
-    });
+    openExtensionPage('devtools');
 }
 
 function Body(props: BodyProps & {fonts: string[]}) {

--- a/src/ui/popup/components/body.tsx
+++ b/src/ui/popup/components/body.tsx
@@ -31,8 +31,8 @@ interface BodyState {
     moreToggleSettingsOpen: boolean;
 }
 
-function openDevTools() {
-    openExtensionPage('devtools');
+async function openDevTools() {
+    await openExtensionPage('devtools');
 }
 
 function Body(props: BodyProps & {fonts: string[]}) {

--- a/src/ui/popup/components/engine-switch/index.tsx
+++ b/src/ui/popup/components/engine-switch/index.tsx
@@ -2,7 +2,7 @@ import {m} from 'malevic';
 import {MultiSwitch} from '../../../controls';
 import {ThemeEngine} from '../../../../generators/theme-engines';
 import {getLocalMessage} from '../../../../utils/locales';
-import {isFirefox} from '../../../../utils/platform';
+import {openExtensionPage} from '../../../utils';
 
 const engineNames: Array<[ThemeEngine, string]> = [
     [ThemeEngine.cssFilter, getLocalMessage('engine_filter')],
@@ -17,12 +17,7 @@ interface EngineSwitchProps {
 }
 
 function openCSSEditor() {
-    chrome.windows.create({
-        type: 'panel',
-        url: isFirefox ? '../stylesheet-editor/index.html' : 'ui/stylesheet-editor/index.html',
-        width: 600,
-        height: 600,
-    });
+    openExtensionPage('stylesheet-editor');
 }
 
 export default function EngineSwitch({engine, onChange}: EngineSwitchProps) {

--- a/src/ui/popup/settings-page/devtools.tsx
+++ b/src/ui/popup/settings-page/devtools.tsx
@@ -5,7 +5,7 @@ import {NavButton} from '../../controls';
 import ControlGroup from '../control-group';
 
 async function openDevTools() {
-    await openExtensionPage('devtools/index.html');
+    await openExtensionPage('devtools');
 }
 
 export default function DevToolsGroup() {

--- a/src/ui/popup/theme/controls/mode.tsx
+++ b/src/ui/popup/theme/controls/mode.tsx
@@ -7,7 +7,7 @@ import {openExtensionPage} from '../../../utils';
 
 export default function Mode(props: {mode: ThemeEngine; onChange: (mode: ThemeEngine) => void}) {
     async function openCSSEditor() {
-        await openExtensionPage('stylesheet-editor/index.html');
+        await openExtensionPage('stylesheet-editor');
     }
 
     const modes = [

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -176,7 +176,8 @@ export async function getExtensionPageObject(path: string): Promise<chrome.windo
     });
 }
 
-export async function openExtensionPage(path: string) {
+export async function openExtensionPage(page: 'devtools' | 'stylesheet-editor') {
+    const path = `${page}/index.html`;
     const cssEditorObject = await getExtensionPageObject(path);
     if (isMobile) {
         if (cssEditorObject) {
@@ -193,6 +194,9 @@ export async function openExtensionPage(path: string) {
     } else {
         chrome.windows.create({
             type: 'popup',
+            // Note: this is a hack which works on Firefox because all
+            // UI pages have paths like ui/*/index.html
+            // See also: https://github.com/w3c/webextensions/issues/273
             url: isFirefox ? `../${path}` : `ui/${path}`,
             width: 600,
             height: 600,


### PR DESCRIPTION
Localize all Firefox path hacks in one place and add a comment.