### PR TITLE
Fix regression introduced in 8cb71f4

### DIFF
--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -157,7 +157,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
                     __THUNDERBIRD__: platform === PLATFORM.THUNDERBIRD,
                     __PORT__: watch ? String(PORT) : '-1',
                     __TEST__: test,
-                    __WATCH_: watch,
+                    __WATCH__: watch,
                     __LOG__: log ? `"${log}"` : false,
                 })
             ),


### PR DESCRIPTION
Commit 8cb71f4 introduced a regression which threw error during install but somehow miraculously did not fail the tests.