### PR TITLE
Fixed abiturma.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -337,7 +337,7 @@ abiturma.de
 
 INVERT
 div.formula
-amp-img.latex-inline
+amp-img
 
 ================================
 


### PR DESCRIPTION
All latex images need to be inverted.

Here's a link if you need a quick example: https://abiturma.de/mathe-lernen/analysis/umfangreiche-aufgaben/umfangreiche-analysis-aufgaben-zur-abiturvorbereitung