### PR TITLE
MV3: add options_ui key

### DIFF
--- a/src/manifest-chrome-mv3.json
+++ b/src/manifest-chrome-mv3.json
@@ -9,6 +9,9 @@
         },
         "default_popup": "ui/popup/index.html"
     },
+    "options_ui": {
+        "page": "ui/popup/index.html"
+    },
     "background": {
         "service_worker": "background.js"
     },

--- a/src/ui/popup/components/header/style.less
+++ b/src/ui/popup/components/header/style.less
@@ -15,10 +15,11 @@
         background-image: url('../assets/images/darkreader-type.svg');
         background-size: 100%;
         grid-area: logo;
-        height: @popup-content-width / 10;
+        min-height: @popup-content-width / 10;
         outline: none;
         text-indent: -999rem;
-        width: @popup-content-width;
+        min-width: @popup-content-width;
+        aspect-ratio: 10;
 
         &:hover {
             filter: brightness(1.05);

--- a/src/ui/popup/style.less
+++ b/src/ui/popup/style.less
@@ -21,11 +21,11 @@ body {
     box-sizing: content-box;
     display: flex;
     flex-direction: column;
-    height: @popup-content-height;
+    min-height: @popup-content-height;
     margin: 0 auto;
     padding: @popup-content-padding;
     position: relative;
-    width: @popup-content-width;
+    min-width: @popup-content-width;
 }
 
 .header {
@@ -157,6 +157,7 @@ footer {
 
 body {
     border: 2px solid white;
+    overflow: hidden;
 }
 
 .overlay {


### PR DESCRIPTION
This PR adds a way to open popup within the browse-provided interface. For now, I made it Chromium MV3 exclusive to avoid store review delays, but this is supported by MV2 and Firefox as well. This aims to fix problem with the lack of [feedback messages during settings import](https://github.com/darkreader/darkreader/pull/9990#issuecomment-1265715287).