### PR TITLE
Fix: hide "System" Automation option in Chromium on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixes a issue where `darkreader-fallback` wasn't removed from the DOM, when Dark Reader finds a `<meta name="darkreader-lock">` element.
 - Be stricter when the user specifies a last slash for a URL in the sitelist.
+- Hide "System" Automation on Chromium on Linux because Chromium on Linux does not support Media Queries.
 
 ## 4.9.58 (Sep 22, 2022)
 

--- a/src/ui/controls/message-box/index.tsx
+++ b/src/ui/controls/message-box/index.tsx
@@ -21,9 +21,11 @@ export default function MessageBox(props: MessageBoxProps) {
                     <Button class="message-box__button message-box__button-ok" onclick={props.onOK}>
                         OK
                     </Button>
-                    <Button class="message-box__button message-box__button-cancel" onclick={props.onCancel} style={props.hideCancel ? 'display: none' : ''}>
-                        Cancel
-                    </Button>
+                    {props.hideCancel ? null :
+                        <Button class="message-box__button message-box__button-cancel" onclick={props.onCancel}>
+                            Cancel
+                        </Button>
+                    }
                 </div>
             </div>
         </Overlay.Portal>

--- a/src/ui/popup/automation-page/index.tsx
+++ b/src/ui/popup/automation-page/index.tsx
@@ -7,6 +7,7 @@ import type {Message} from '../../../definitions';
 import type {ViewProps} from '../types';
 import type {Automation} from 'definitions';
 import {AutomationMode} from '../../../utils/automation';
+import {isChromium, isLinux} from '../../../utils/platform';
 
 declare const __CHROMIUM_MV3__: boolean;
 
@@ -127,36 +128,39 @@ export default function AutomationPage(props: ViewProps) {
             <p class="automation-page__location-description">
                 {getLocalMessage('set_location')}
             </p>
-            <div class={[
-                'automation-page__line',
-                'automation-page__system-dark-mode',
-            ]}
-            >
-                <CheckBox
-                    class="automation-page__system-dark-mode__checkbox"
-                    checked={isSystemAutomation}
-                    onchange={(e: {target: {checked: boolean}}) => changeAutomationMode(e.target.checked ? AutomationMode.SYSTEM : AutomationMode.NONE)}
-                />
-                <Button
-                    class={{
-                        'automation-page__system-dark-mode__button': true,
-                        'automation-page__system-dark-mode__button--active': isSystemAutomation,
-                    }}
-                    onclick={() => {
-                        if (__CHROMIUM_MV3__) {
-                            chrome.runtime.sendMessage<Message>({
-                                type: MessageType.UI_COLOR_SCHEME_CHANGE,
-                                data: {isDark: matchMedia('(prefers-color-scheme: dark)').matches}
-                            });
-                        }
-                        changeAutomationMode(isSystemAutomation ? AutomationMode.NONE : AutomationMode.SYSTEM);
-                    }}
-                >{getLocalMessage('system_dark_mode')}
-                </Button>
-            </div>
-            <p class="automation-page__description">
-                {getLocalMessage('system_dark_mode_description')}
-            </p>
+            {isLinux && isChromium ? null :
+                <div>
+                    <div class={[
+                        'automation-page__line',
+                        'automation-page__system-dark-mode',
+                    ]}
+                    >
+                        <CheckBox
+                            class="automation-page__system-dark-mode__checkbox"
+                            checked={isSystemAutomation}
+                            onchange={(e: {target: {checked: boolean}}) => changeAutomationMode(e.target.checked ? AutomationMode.SYSTEM : AutomationMode.NONE)}/>
+                        <Button
+                            class={{
+                                'automation-page__system-dark-mode__button': true,
+                                'automation-page__system-dark-mode__button--active': isSystemAutomation,
+                            }}
+                            onclick={() => {
+                                if (__CHROMIUM_MV3__) {
+                                    chrome.runtime.sendMessage<Message>({
+                                        type: MessageType.UI_COLOR_SCHEME_CHANGE,
+                                        data: {isDark: matchMedia('(prefers-color-scheme: dark)').matches}
+                                    });
+                                }
+                                changeAutomationMode(isSystemAutomation ? AutomationMode.NONE : AutomationMode.SYSTEM);
+                            } }
+                        >{getLocalMessage('system_dark_mode')}
+                        </Button>
+                    </div>
+                    <p class="automation-page__description">
+                        {getLocalMessage('system_dark_mode_description')}
+                    </p>
+                </div>
+            }
             <DropDown
                 onChange={(selected: any) => changeAutomationBehavior(selected)}
                 selected={props.data.settings.automation.behavior}

--- a/src/ui/popup/components/header/more-toggle-settings.tsx
+++ b/src/ui/popup/components/header/more-toggle-settings.tsx
@@ -3,6 +3,7 @@ import {Button, CheckBox, TextBox, TimeRangePicker} from '../../../controls';
 import {getLocalMessage} from '../../../../utils/locales';
 import type {Automation, ExtWrapper} from '../../../../definitions';
 import {AutomationMode} from '../../../../utils/automation';
+import {isChromium, isLinux} from '../../../../utils/platform';
 
 type MoreToggleSettingsProps = ExtWrapper & {
     isExpanded: boolean;
@@ -130,27 +131,31 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
                 <p class="header__app-toggle__more-settings__location-description">
                     {getLocalMessage('set_location')}
                 </p>
-                <div class={[
-                    'header__app-toggle__more-settings__line',
-                    'header__app-toggle__more-settings__system-dark-mode',
-                ]}
-                >
-                    <CheckBox
-                        class="header__app-toggle__more-settings__system-dark-mode__checkbox"
-                        checked={isSystemAutomation}
-                        onchange={(e: {target: HTMLInputElement}) => changeAutomationMode(e.target.checked ? AutomationMode.SYSTEM : AutomationMode.NONE)}
-                    />
-                    <Button
-                        class={{
-                            'header__app-toggle__more-settings__system-dark-mode__button': true,
-                            'header__app-toggle__more-settings__system-dark-mode__button--active': isSystemAutomation,
-                        }}
-                        onclick={() =>changeAutomationMode(isSystemAutomation ? AutomationMode.NONE : AutomationMode.SYSTEM)}
-                    >{getLocalMessage('system_dark_mode')}</Button>
-                </div>
-                <p class="header__app-toggle__more-settings__description">
-                    {getLocalMessage('system_dark_mode_description')}
-                </p>
+                {isLinux && isChromium ? null :
+                    <div>
+                        <div class={[
+                            'header__app-toggle__more-settings__line',
+                            'header__app-toggle__more-settings__system-dark-mode',
+                        ]}
+                        >
+                            <CheckBox
+                                class="header__app-toggle__more-settings__system-dark-mode__checkbox"
+                                checked={isSystemAutomation}
+                                onchange={(e: {target: HTMLInputElement}) => changeAutomationMode(e.target.checked ? AutomationMode.SYSTEM : AutomationMode.NONE)}
+                            />
+                            <Button
+                                class={{
+                                    'header__app-toggle__more-settings__system-dark-mode__button': true,
+                                    'header__app-toggle__more-settings__system-dark-mode__button--active': isSystemAutomation,
+                                }}
+                                onclick={() =>changeAutomationMode(isSystemAutomation ? AutomationMode.NONE : AutomationMode.SYSTEM)}
+                            >{getLocalMessage('system_dark_mode')}</Button>
+                        </div>
+                        <p class="header__app-toggle__more-settings__description">
+                            {getLocalMessage('system_dark_mode_description')}
+                        </p>
+                    </div>
+                }
             </div>
         </div>
     );

--- a/src/ui/popup/components/header/style.less
+++ b/src/ui/popup/components/header/style.less
@@ -114,15 +114,6 @@
             border-top: @size-border solid @color-border;
             display: flex;
             flex-direction: column;
-            height:
-                @size-control-inner
-                + @indent-large
-                + @more-settings-line-height
-                + @indent-small
-                + @more-settings-line-height
-                + @indent-small
-                + @more-settings-line-height
-                + @indent-large;
             left: 0;
             position: absolute;
             top: @popup-content-padding + @size-control-inner * 2 + @size-border + @indent-small;

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -39,6 +39,7 @@ export const isEdge = (__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && (!__FIREFOX__ &&
 export const isSafari = !__CHROMIUM_MV2__ && !__CHROMIUM_MV3__ && !__FIREFOX__ && !__THUNDERBIRD__ && userAgent.includes('safari') && !isChromium;
 export const isWindows = platform.startsWith('win');
 export const isMacOS = platform.startsWith('mac');
+export const isLinux = isNavigatorDefined ? ((navigator.userAgentData && navigator.userAgentData.platform === 'Linux') || (navigator.userAgent && navigator.userAgent.includes('Linux'))) : false;
 export const isMobile = (isNavigatorDefined && navigator.userAgentData) ? navigator.userAgentData.mobile : userAgent.includes('mobile');
 export const isShadowDomSupported = typeof ShadowRoot === 'function';
 export const isMatchMediaChangeEventListenerSupported = __CHROMIUM_MV3__ || (


### PR DESCRIPTION
Chromium currently fetches color preferences from GTK environments like Gnome, but does not relay them to the page content. Chromium is not even aware of preferences in KDE environments like KDE at all.