### PR TITLE
Update blog feed URL

### DIFF
--- a/src/background/newsmaker.ts
+++ b/src/background/newsmaker.ts
@@ -1,4 +1,4 @@
-import {getBlogPostURL} from '../utils/links';
+import {getBlogPostURL, NEWS_URL} from '../utils/links';
 import {getDurationInMinutes} from '../utils/time';
 import type {News} from '../definitions';
 import {readSyncStorage, readLocalStorage, writeSyncStorage, writeLocalStorage} from './utils/extension-api';
@@ -106,7 +106,7 @@ export default class Newsmaker {
 
     private static async getNews() {
         try {
-            const response = await fetch(`https://darkreader.github.io/blog/posts.json`, {cache: 'no-cache'});
+            const response = await fetch(NEWS_URL, {cache: 'no-cache'});
             const $news: Array<Omit<News, 'read' | 'url'> & {date: string}> = await response.json();
             const readNews = await Newsmaker.getReadNews();
             const displayedNews = await Newsmaker.getDisplayedNews();

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,6 +1,7 @@
 import {getUILanguage} from './locales';
 
 export const BLOG_URL = 'https://darkreader.org/blog/';
+export const NEWS_URL = 'https://darkreader.org/blog/posts.json';
 export const DEVTOOLS_DOCS_URL = 'https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md';
 export const DONATE_URL = 'https://opencollective.com/darkreader/donate';
 export const GITHUB_URL = 'https://github.com/darkreader/darkreader';


### PR DESCRIPTION
 - https://darkreader.github.io/blog/posts.json redirects with 301 to https://darkreader.org/blog/posts.json
 - move this string literal into `src/utils/links.ts`
 - I'm writing a CSP for extension (so far MV3-only) and this change will let me exclude GitHub from some directives