### PR TITLE
CI: fix browser tests and disallow failing on CI

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run browser tests on Chromium
         if: ${{ matrix.chrome }}
         # TODO: profile flaky tests and remove the next line
-        continue-on-error: true
+        continue-on-error: false
         uses: GabrielBB/xvfb-action@v1.6
         with:
           run: npm run test:chrome && npm run test:chrome-mv3

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -86,8 +86,6 @@ jobs:
 
       - name: Run browser tests on Chromium
         if: ${{ matrix.chrome }}
-        # TODO: profile flaky tests and remove the next line
-        continue-on-error: false
         uses: GabrielBB/xvfb-action@v1.6
         with:
           run: npm run test:chrome && npm run test:chrome-mv3

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -55,8 +55,8 @@ declare const __DEBUG__: boolean;
 declare const __WATCH__: boolean;
 declare const __LOG__: string | false;
 declare const __PORT__: number;
-declare const __TEST__: number;
-declare const __CHROMIUM_MV3__: number;
+declare const __TEST__: boolean;
+declare const __CHROMIUM_MV3__: boolean;
 
 if (__CHROMIUM_MV3__) {
     chrome.runtime.onInstalled.addListener(async () => {

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -3,7 +3,7 @@ import {getStringSize} from '../../utils/text';
 import {getDuration} from '../../utils/time';
 import {isXMLHttpRequestSupported, isFetchSupported} from '../../utils/platform';
 
-declare const __TEST__: number;
+declare const __TEST__: boolean;
 
 interface RequestParams {
     url: string;

--- a/src/ui/devtools/index.tsx
+++ b/src/ui/devtools/index.tsx
@@ -21,7 +21,7 @@ async function start() {
 
 start();
 
-declare const __TEST__: number;
+declare const __TEST__: boolean;
 if (__TEST__) {
     const socket = new WebSocket(`ws://localhost:8894`);
     socket.onmessage = (e) => {

--- a/src/ui/popup/automation-page/index.tsx
+++ b/src/ui/popup/automation-page/index.tsx
@@ -10,6 +10,7 @@ import {AutomationMode} from '../../../utils/automation';
 import {isChromium, isLinux} from '../../../utils/platform';
 
 declare const __CHROMIUM_MV3__: boolean;
+declare const __TEST__: boolean;
 
 export default function AutomationPage(props: ViewProps) {
     const isSystemAutomation = props.data.settings.automation.mode === AutomationMode.SYSTEM;
@@ -128,7 +129,7 @@ export default function AutomationPage(props: ViewProps) {
             <p class="automation-page__location-description">
                 {getLocalMessage('set_location')}
             </p>
-            {isLinux && isChromium ? null :
+            {!__TEST__ && isLinux && isChromium ? null :
                 <div>
                     <div class={[
                         'automation-page__line',

--- a/src/ui/popup/components/header/more-toggle-settings.tsx
+++ b/src/ui/popup/components/header/more-toggle-settings.tsx
@@ -5,6 +5,8 @@ import type {Automation, ExtWrapper} from '../../../../definitions';
 import {AutomationMode} from '../../../../utils/automation';
 import {isChromium, isLinux} from '../../../../utils/platform';
 
+declare const __TEST__: boolean;
+
 type MoreToggleSettingsProps = ExtWrapper & {
     isExpanded: boolean;
     onClose: () => void;
@@ -131,7 +133,7 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
                 <p class="header__app-toggle__more-settings__location-description">
                     {getLocalMessage('set_location')}
                 </p>
-                {isLinux && isChromium ? null :
+                {!__TEST__ && isLinux && isChromium ? null :
                     <div>
                         <div class={[
                             'header__app-toggle__more-settings__line',

--- a/src/ui/popup/utils/issues.ts
+++ b/src/ui/popup/utils/issues.ts
@@ -1,7 +1,7 @@
 import {compareChromeVersions, chromiumVersion, isWindows, isOpera, isYaBrowser, isVivaldi, isEdge, isMacOS} from '../../../utils/platform';
 
 declare const __THUNDERBIRD__: boolean;
-declare const __CHROMIUM_MV3__: number;
+declare const __CHROMIUM_MV3__: boolean;
 
 export function popupHasBuiltInBorders() {
     return !__CHROMIUM_MV3__ && Boolean(

--- a/tests/browser/e2e/toggle.tests.ts
+++ b/tests/browser/e2e/toggle.tests.ts
@@ -25,7 +25,7 @@ async function emulateMedia(name: string, value: string) {
     await backgroundUtils.emulateMedia(name, value);
 }
 
-describe('Toggling The Extension', () => {
+describe('Toggling the extension', () => {
     // TODO: remove flakes and remove this line
     jest.retryTimes(3, {logErrorsBeforeRetry: true});
 
@@ -40,7 +40,7 @@ describe('Toggling The Extension', () => {
         await expect(page.evaluate(() => getComputedStyle(document.querySelector('a')).color)).resolves.toBe('rgb(51, 145, 255)');
 
         await popupUtils.click('.toggle__off');
-        await timeout(250);
+        await timeout(500);
 
         await expect(page.evaluate(() => getComputedStyle(document.documentElement).backgroundColor)).resolves.toBe('rgba(0, 0, 0, 0)');
         await expect(page.evaluate(() => getComputedStyle(document.documentElement).color)).resolves.toBe('rgb(0, 0, 0)');
@@ -50,7 +50,7 @@ describe('Toggling The Extension', () => {
         await expect(page.evaluate(() => getComputedStyle(document.querySelector('a')).color)).resolves.toBe('rgb(0, 0, 238)');
 
         await popupUtils.click('.toggle__on');
-        await timeout(250);
+        await timeout(500);
 
         await expect(page.evaluate(() => getComputedStyle(document.documentElement).backgroundColor)).resolves.toBe('rgb(24, 26, 27)');
         await expect(page.evaluate(() => getComputedStyle(document.documentElement).color)).resolves.toBe('rgb(232, 230, 227)');

--- a/tests/inject/dynamic/image-analysis.tests.ts
+++ b/tests/inject/dynamic/image-analysis.tests.ts
@@ -173,6 +173,7 @@ describe('IMAGE ANALYSIS', () => {
         );
         createOrUpdateDynamicTheme(theme, null, false);
         await waitForEvent('__darkreader__test__asyncQueueComplete');
+        await timeout(500);
         const bgImageValue = getComputedStyle(container.querySelector('i')).backgroundImage;
         const info = await getBgImageInfo(bgImageValue);
         expect(info.darkness).toBe(0);


### PR DESCRIPTION
This is a follow-up to #9926 which makes browser tests on Chromium mandatory for CI to pass.