### PR TITLE
MV2: backport CSS Stylesheet proxy injection

### DIFF
--- a/src/inject/dynamic-theme/mv2-proxy.ts
+++ b/src/inject/dynamic-theme/mv2-proxy.ts
@@ -1,0 +1,8 @@
+import {injectProxy} from './stylesheet-proxy';
+
+document && document.currentScript && document.currentScript.remove();
+const argString = document && document.currentScript && document.currentScript.dataset.arg;
+if (argString !== undefined) {
+    const arg: boolean = JSON.parse(argString);
+    injectProxy(arg);
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,6 +36,9 @@
             "match_about_blank": true
         }
     ],
+    "web_accessible_resources": [
+        "inject/proxy.js"
+    ],
     "permissions": [
         "alarms",
         "fontSettings",

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -28,7 +28,8 @@ const {getDestDir, PLATFORM, rootDir, rootPath} = paths;
 const jsEntries = [
     {
         src: 'src/background/index.ts',
-        // Prior to Chrome 93, background service worker had to be in top-level directory
+        // Prior to Chrome 93, background service worker had to be in top-level directory.
+        // We keep it there for nicety of folder layout.
         dest: (platform) => platform === PLATFORM.CHROME_MV3 ? 'background.js' : 'background/index.js',
         reloadType: reload.FULL,
     },
@@ -36,6 +37,12 @@ const jsEntries = [
         src: 'src/inject/index.ts',
         dest: 'inject/index.js',
         reloadType: reload.FULL,
+    },
+    {
+        src: 'src/inject/dynamic-theme/mv2-proxy.ts',
+        dest: 'inject/proxy.js',
+        reloadType: reload.FULL,
+        platform: PLATFORM.CHROME_MV2,
     },
     {
         src: 'src/inject/dynamic-theme/mv3-proxy.ts',


### PR DESCRIPTION
This backports to MV2 builds CSS Stylesheet proxy injection via `<script src="">` instead of inline script. I believe that the inline injection breaks on Safari causing some sites to have bad theme, but I can not verify that this actually fixes the problem. This is a draft until:
 - we decide if we want to launch this on Chromium, Firefox, and Safari all at once or stretch it out
 - I add a test in a separate PR
 - test for a bit to make sure no regressions appear
 - we discuss this PR since it changes `manifest.json` (the original reason to delay this change to MV3)