### PR TITLE
final-fantasy.ch - Fix white-on-white text

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7336,6 +7336,17 @@ header.ant-layout-header img
 
 ================================
 
+final-fantasy.ch
+
+CSS
+nav ul li:first-child span {
+color:#000;
+}
+h1 {
+color:#000;
+}
+================================
+
 finn.no
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7339,11 +7339,9 @@ header.ant-layout-header img
 final-fantasy.ch
 
 CSS
-nav ul li:first-child span {
-color:#000;
-}
+nav ul li:first-child span,
 h1 {
-color:#000;
+    color: #000 !important;
 }
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7343,6 +7343,7 @@ nav ul li:first-child span,
 h1 {
     color: #000 !important;
 }
+
 ================================
 
 finn.no


### PR DESCRIPTION
Fix for white text on white background on fansite https://www.final-fantasy.ch, simply making it readable again.

Source page: https://www.final-fantasy.ch/Ff8/ff8objets.php?objetid=126
Screenshot before: https://i.gyazo.com/cfdeb60ab48df1ccd5e2479080743c08.png
Screenshot after: https://i.gyazo.com/d07a2402463871a93dc493ed4377769f.png