### PR TITLE
facebook.com fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7055,7 +7055,6 @@ div[id*="jsc_c_"] {
 }
 
 IGNORE INLINE STYLE
-div[role="button"]
 [role="button"] svg
 [role="button"] svg line
 div svg[viewBox="0 0 36 36"] mask path


### PR DESCRIPTION
revert all fixes for button backgrounds as it breaks when dark reader is enabled for light mode of facebook.