### PR TITLE
Fix: settings export in Kiwi browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixes a issue where `darkreader-fallback` wasn't removed from the DOM, when Dark Reader finds a `<meta name="darkreader-lock">` element.
 - Be stricter when the user specifies a last slash for a URL in the sitelist.
 - Hide "System" Automation on Chromium on Linux because Chromium on Linux does not support Media Queries.
+- Improve Kiwi browser support: work around for Kiwi bug in file download during settings import, fix opening open Dark Reader DevTools
 
 ## 4.9.58 (Sep 22, 2022)
 

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -179,6 +179,9 @@ export default class TabManager {
                     break;
 
                 case MessageType.UI_SAVE_FILE: {
+                    if (__CHROMIUM_MV3__) {
+                        break;
+                    }
                     const {content, name} = message.data;
                     const a = document.createElement('a');
                     a.href = URL.createObjectURL(new Blob([content]));

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -40,7 +40,7 @@ export function openFile(options: {extensions: string[]}, callback: (content: st
 }
 
 export function saveFile(name: string, content: string) {
-    if (isFirefox) {
+    if (__CHROMIUM_MV3__ || isFirefox || isMobile) {
         const a = document.createElement('a');
         a.href = URL.createObjectURL(new Blob([content]));
         a.download = name;


### PR DESCRIPTION
Kiwi browser has a bug which prevents files from being downloaded from background page: Kiwi initiates file download and requests unique file name from the system, but never actually completes the download.