### PR TITLE
Fix for accounts.hetzner.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -495,6 +495,13 @@ CSS
 
 ================================
 
+accounts.hetzner.com
+
+INVERT
+.top-bar-link > img
+
+================================
+
 accounts.spotify.com
 
 INVERT


### PR DESCRIPTION
- Invert dropdown menu icons

Before:
<img width="111" alt="image" src="https://user-images.githubusercontent.com/1006477/194546553-bed59994-e286-43a7-9007-803bb7743df2.png">
After:
<img width="152" alt="image" src="https://user-images.githubusercontent.com/1006477/194546526-d8905d84-e7e0-4990-bc40-68ff78e68c30.png">
