### PR TITLE
Fix for steamdeck.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18296,8 +18296,16 @@ i.ml-1
 
 steamdeck.com
 
+INVERT
+div.col_4.copy
+section#available-now h1
+
 IGNORE INLINE STYLE
 #header-logo-arc ~ *
+
+IGNORE IMAGE ANALYSIS
+section#available-now .content
+section#available-now .deck-video-frame
 
 ================================
 


### PR DESCRIPTION
Fixes "Available now" section on home page.

Before:
![1](https://user-images.githubusercontent.com/6563728/194709912-023f492d-b8d3-4c81-8891-c0d2b148c02f.png)

After:
![2](https://user-images.githubusercontent.com/6563728/194709922-cca8fa74-30ad-47e8-b274-d8b972c4aa90.png)