### PR TITLE
Fix "Back" button in settings on mobile

### DIFF
--- a/src/ui/popup/body/index.tsx
+++ b/src/ui/popup/body/index.tsx
@@ -36,6 +36,9 @@ type PageId = (
     | 'manage-settings'
 );
 
+let popstate: () => void = null;
+isMobile && window.addEventListener('popstate', () => popstate && popstate());
+
 function Pages(props: ViewProps) {
     const context = getContext();
     const store = context.store as {
@@ -46,31 +49,36 @@ function Pages(props: ViewProps) {
     }
 
     function onThemeNavClick() {
+        isMobile && history.pushState(undefined, undefined);
         store.activePage = 'theme';
         context.refresh();
     }
 
     function onSettingsNavClick() {
+        isMobile && history.pushState(undefined, undefined);
         store.activePage = 'settings';
         context.refresh();
     }
 
     function onAutomationNavClick() {
+        isMobile && history.pushState(undefined, undefined);
         store.activePage = 'automation';
         context.refresh();
     }
 
     function onManageSettingsClick() {
+        isMobile && history.pushState(undefined, undefined);
         store.activePage = 'manage-settings';
         context.refresh();
     }
 
     function onSiteListNavClick() {
+        isMobile && history.pushState(undefined, undefined);
         store.activePage = 'site-list';
         context.refresh();
     }
 
-    function onBackClick() {
+    function goBack() {
         const activePage = store.activePage;
         const settingsPageSubpages = ['automation', 'manage-settings', 'site-list'] as PageId[];
         if (settingsPageSubpages.includes(activePage)) {
@@ -79,6 +87,16 @@ function Pages(props: ViewProps) {
             store.activePage = 'main';
         }
         context.refresh();
+    }
+
+    popstate = goBack;
+
+    function onBackClick() {
+        if (isMobile) {
+            history.back();
+        } else {
+            goBack();
+        }
     }
 
     return (


### PR DESCRIPTION
Previously, if user opened settings, clicked "Settings" and then "Automation" and then clicked Android-provided back button, the page would be closed. After this commit, if user goes to "Automation" page and then clicks Android-provided back button, user will get back to "Settings" page, as if they clicked Dark Reader's own "Back" button.

This is mobile-specific because desktop browsers also have "forward" button and users could get confused if they opened Dark Reader options in a tab and saw "forward" button get activated when they press "back".