### PR TITLE
dns|konsoleh|robot.hetzner.com - Added fix for other services.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -496,9 +496,15 @@ CSS
 ================================
 
 accounts.hetzner.com
+dns.hetzner.com
+konsoleh.hetzner.com
+robot.hetzner.com
 
 INVERT
 .top-bar-link > img
+.d-flex > img
+#panel_dropdown_btn > img
+#user_dropdown_btn > img
 
 ================================
 


### PR DESCRIPTION
Adding fix to others subdomains for Hetzner.

Before:
![image](https://user-images.githubusercontent.com/14059407/194757540-da7625e8-a05b-4487-b2e1-cc8fb1602e7e.png)

After:
![image](https://user-images.githubusercontent.com/14059407/194757547-3fac2431-5077-4944-aa74-1c4d29f6f4e3.png)

One problem if someone got the fix:
===
The "Hetzner" logo switched from red to pink on DNS subdomain, I don't know how to fix it, sorry.