### PR TITLE
Fix for fivethirtyeight.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7438,6 +7438,13 @@ INVERT
 #searchform
 .header-espn-link
 
+CSS
+.domain,
+.win-prob,
+.winSentText {
+    stroke: none !important;
+}
+
 ================================
 
 flashscore.com.tr


### PR DESCRIPTION
Fix text and outline on charts in homepage sidebar and chart forecast pages.