### PR TITLE
vnexpress.net - fix dark image on dark background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20832,7 +20832,7 @@ div.banner
 vnexpress.net
 
 INVERT
-.item span
+#vibeji-ham
 .logo
 .logo_ft img
 .sub-cate img

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20829,6 +20829,16 @@ div.banner
 
 ================================
 
+vnexpress.net
+
+INVERT
+.item span
+.logo
+.logo_ft img
+.sub-cate img
+
+================================
+
 vod.tvp.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20832,10 +20832,11 @@ div.banner
 vnexpress.net
 
 INVERT
-#vibeji-ham
+#vibeji-ham span
 .logo
 .logo_ft img
 .sub-cate img
+.swiper-pagination-bullet
 
 ================================
 


### PR DESCRIPTION
For https://vnexpress.net:
- Image link `.sub-cate img`
- Top logo `.logo`
- Footer logo `.logo_ft img`.

For https://vnexpress.net/doi-song/cooking:
- Top left menu button `#vibeji-ham span`
- Top and bottom logo `.logo`
- Pagination button `.swiper-pagination-bullet`.