### PR TITLE
Fix for drive and mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6031,6 +6031,7 @@ div[data-label="nd"] > div > div > svg > path[fill="#000000"]
 div[role="document"] > div[role="button"] .a-b-c
 div > svg > circle[fill="white"]
 img[src*="empty_state_trash"]
+div[role="dialog"] div[role="document"]
 
 CSS
 span[data-type="spelling"] {
@@ -12118,6 +12119,7 @@ div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
 form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id])
 img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"]
 div[style$="gm_add_black_24dp.png)"]
+div[role="dialog"] div[role="document"]
 
 CSS
 @media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {


### PR DESCRIPTION
- Invert PDFs and docs.

-----

I checked, this rule only works for `.pdf`, `.docx`, `.doc`. It doesn't work for images because they have `div[role="img"]`, and it doesn't work for tables, presentations, `.txt` and unknown files.