### PR TITLE
Remove raycast.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -627,7 +627,6 @@ raunaksitoula.com
 rawg.io
 rawgiving.com
 ray.so
-raycast.com
 razorsecure.com
 rbt.asia
 rdck.dev


### PR DESCRIPTION
- Due to https://manual.raycast.com.