### PR TITLE
Fix: ensure style exists before calling putRootVars()

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -224,9 +224,11 @@ function createDynamicStyleOverrides() {
 
     variablesStore.matchVariablesAndDependants();
     variablesStore.setOnRootVariableChange(() => {
-        variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
+        const rootVarsStyle = createOrUpdateStyle('darkreader--root-vars');
+        variablesStore.putRootVars(rootVarsStyle, filter);
     });
-    variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
+    const rootVarsStyle = createOrUpdateStyle('darkreader--root-vars');
+    variablesStore.putRootVars(rootVarsStyle, filter);
 
     styleManagers.forEach((manager) => manager.render(filter, ignoredImageAnalysisSelectors));
     if (loadingStyles.size === 0) {
@@ -437,7 +439,8 @@ function watchForUpdates() {
             const styleAttr = element.getAttribute('style') || '';
             if (styleAttr.includes('--')) {
                 variablesStore.matchVariablesAndDependants();
-                variablesStore.putRootVars(document.head.querySelector('.darkreader--root-vars'), filter);
+                const rootVarsStyle = createOrUpdateStyle('darkreader--root-vars');
+                variablesStore.putRootVars(rootVarsStyle, filter);
             }
         }
     }, (root) => {


### PR DESCRIPTION
Prior to this commit, it was possible to trigger `putRootVars()` with `null` when `<style>` with id `darkreader--root-vars` was removed and not re-created. It did not cause any visual issues, so I was not sure how to fix it best (nothing to test against). [With this extension](https://chrome.google.com/webstore/detail/disable-page-visibility-a/eecfoibnnhheckhfokpihgefmlnenofb) it is possible to break some APIs, then put page into background (cover with other pages) wait for page to go inactive, then reactivate it and observe a visual glitch very similar to #10004. After this PR, DR works well even with that extension.

Tangentially related to #10047.