### PR TITLE
Fix: in Chromium detect PDF viewer via script instead of URL

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -277,6 +277,7 @@ export class Extension {
                         const {nodeName, type} = document.body.childNodes[0] as HTMLEmbedElement;
                         return nodeName === 'EMBED' && type === 'application/pdf';
                     }
+
                     if (__CHROMIUM_MV3__) {
                         return (await chrome.scripting.executeScript({
                             target: {tabId, frameIds: [frameId]},
@@ -289,7 +290,8 @@ export class Extension {
                         }, ([r]) => resolve(r)));
                     }
                     return false;
-                }
+                };
+
                 const pdf = async () => isPDF(frameURL || await TabManager.getActiveTabURL());
                 if (((__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && await scriptPDF()) || await pdf()) {
                     this.changeSettings({enableForPDF: !UserStorage.settings.enableForPDF});


### PR DESCRIPTION
Dark Reader relies on `isPDF(url: string)` function to distinguish PDF files. This function fails if files have an incorrect file extension or lack it entirely or if we did not include a particular URL pattern in `isPDF()`. This PR introduces `detectPDF()` which is run within page context and finds the actual `<embed type="application/pdf">` node. The old code is kept in place as a backup in case Chromium changes the way it wraps PDF files into a viewer.