### PR TITLE
Refactor: move document visibility logic into a separate utility

### DIFF
--- a/src/inject/color-scheme-watcher.ts
+++ b/src/inject/color-scheme-watcher.ts
@@ -1,12 +1,11 @@
 import {isSystemDarkModeEnabled, runColorSchemeChangeDetector, stopColorSchemeChangeDetector} from '../utils/media-query';
 import type {Message} from '../definitions';
 import {MessageType} from '../utils/message';
-
+import {addDocumentVisibilityListener, documentIsVisible, removeDocumentVisibilityListener} from '../utils/visibility';
 
 function cleanup() {
     stopColorSchemeChangeDetector();
-    removeEventListener('visibilitychange', updateEventListeners);
-    removeEventListener('pageshow', updateEventListeners);
+    removeDocumentVisibilityListener(updateEventListeners);
 }
 
 function sendMessage(message: Message) {
@@ -46,13 +45,12 @@ function notifyOfColorScheme(isDark: boolean) {
 
 function updateEventListeners() {
     notifyOfColorScheme(isSystemDarkModeEnabled());
-    if (document.visibilityState === 'visible') {
+    if (documentIsVisible()) {
         runColorSchemeChangeDetector(notifyOfColorScheme);
     } else {
         stopColorSchemeChangeDetector();
     }
 }
 
-addEventListener('visibilitychange', updateEventListeners);
-addEventListener('pageshow', updateEventListeners);
+addDocumentVisibilityListener(updateEventListeners);
 updateEventListeners();

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -329,7 +329,7 @@ function runDynamicStyle() {
 function createThemeAndWatchForUpdates() {
     createStaticStyleOverrides();
 
-    if (document.hidden && !filter.immediateModify) {
+    if (!documentIsVisible() && !filter.immediateModify) {
         addDocumentVisibilityListener(runDynamicStyle);
     } else {
         runDynamicStyle();

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -136,7 +136,7 @@ runColorSchemeChangeDetector((isDark) =>
 );
 
 chrome.runtime.onMessage.addListener(onMessage);
-sendMessage({type: MessageType.CS_FRAME_CONNECT, data: {isDark: isSystemDarkModeEnabled(), isPDF: false}});
+sendMessage({type: MessageType.CS_FRAME_CONNECT, data: {isDark: isSystemDarkModeEnabled()}});
 
 function onPageHide(e: PageTransitionEvent) {
     if (e.persisted === false) {
@@ -149,7 +149,7 @@ function onFreeze() {
 }
 
 function onResume() {
-    sendMessage({type: MessageType.CS_FRAME_RESUME, data: {isDark: isSystemDarkModeEnabled(), isPDF: false}});
+    sendMessage({type: MessageType.CS_FRAME_RESUME, data: {isDark: isSystemDarkModeEnabled()}});
 }
 
 function onDarkThemeDetected() {

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -136,7 +136,7 @@ runColorSchemeChangeDetector((isDark) =>
 );
 
 chrome.runtime.onMessage.addListener(onMessage);
-sendMessage({type: MessageType.CS_FRAME_CONNECT, data: {isDark: isSystemDarkModeEnabled()}});
+sendMessage({type: MessageType.CS_FRAME_CONNECT, data: {isDark: isSystemDarkModeEnabled(), isPDF: false}});
 
 function onPageHide(e: PageTransitionEvent) {
     if (e.persisted === false) {
@@ -149,7 +149,7 @@ function onFreeze() {
 }
 
 function onResume() {
-    sendMessage({type: MessageType.CS_FRAME_RESUME, data: {isDark: isSystemDarkModeEnabled()}});
+    sendMessage({type: MessageType.CS_FRAME_RESUME, data: {isDark: isSystemDarkModeEnabled(), isPDF: false}});
 }
 
 function onDarkThemeDetected() {

--- a/src/utils/visibility.ts
+++ b/src/utils/visibility.ts
@@ -1,6 +1,4 @@
 /**
- * Begining of Page Lifecycle API workarounds
- *
  * The following code contains a workaround for extensions designed to prevent page from knowing when it is hidden
  * GitHub issue: https://github.com/darkreader/darkreader/issues/10004
  * GitHub PR: https://github.com/darkreader/darkreader/pull/10047

--- a/src/utils/visibility.ts
+++ b/src/utils/visibility.ts
@@ -1,0 +1,69 @@
+/**
+ * Begining of Page Lifecycle API workarounds
+ *
+ * The following code contains a workaround for extensions designed to prevent page from knowing when it is hidden
+ * GitHub issue: https://github.com/darkreader/darkreader/issues/10004
+ * GitHub PR: https://github.com/darkreader/darkreader/pull/10047
+ *
+ * Doue to the intntional breakage introduced by these extensions, this utility might incorrecly report that document
+ * is visible while it is not, but it will never report document as hidden while it is visible.
+ *
+ * This code exploits the fact that most such extensions block only a subset of Page Lifecycle API,
+ * which notifies page of being hidden but not of being shown, while Dark Reader really cares only about
+ * page being shown.
+ * Specifically:
+ *  - extensions block visibilitychange and blur event
+ *  - extensions do not block focus event; browsers deliver focus event when user switches to
+ *    a previously hidden tab or previously hidden window (assuming DevTools are closed so window gets the focus)
+ *    if document has focus, then we can assume that it is visible
+ *  - some extensions overwrite document.hidden but not document.visibilityState
+ *  - Firefox has a bug: if extension overwrites document.hidden and document.visibilityState via Object.defineProperty,
+ *    then Firefox will reset them to true and 'hidden' when tab is activated, but document.hasFocus() will be true
+ *  - Safari supports document.visibilityState === 'prerender' which makes document.hidden === true even when document
+ *    is visible to the user
+ */
+let documentVisibilityCallbacks: Set<() => void> = new Set();
+let documentIsVisible_ = !document.hidden;
+function documentVisibilityListener() {
+    if (!document.hidden || document.visibilityState !== 'hidden' || document.hasFocus()) {
+        stopWatchingForDocumentVisibility();
+        documentIsVisible_ = true;
+        const callbacks = documentVisibilityCallbacks;
+        documentVisibilityCallbacks = new Set();
+        callbacks.forEach((callback) => callback());
+    }
+}
+
+// TODO: use EventListenerOptions class once it is updated
+const listenerOptions: any = {
+    capture: true,
+    passive: true,
+};
+function watchForDocumentVisibility() {
+    document.addEventListener('visibilitychange', documentVisibilityListener, listenerOptions);
+    window.addEventListener('pageshow', documentVisibilityListener, listenerOptions);
+    window.addEventListener('focus', documentVisibilityListener, listenerOptions);
+}
+
+function stopWatchingForDocumentVisibility() {
+    document.removeEventListener('visibilitychange', documentVisibilityListener, listenerOptions);
+    window.removeEventListener('pageshow', documentVisibilityListener, listenerOptions);
+    window.removeEventListener('focus', documentVisibilityListener, listenerOptions);
+}
+
+export function addDocumentVisibilityListener(callback: () => void) {
+    if (documentVisibilityCallbacks.size === 0) {
+        watchForDocumentVisibility();
+    }
+    documentVisibilityCallbacks.add(callback);
+}
+
+export function removeDocumentVisibilityListener(callback: () => void) {
+    if (documentVisibilityCallbacks.delete(callback) && documentVisibilityCallbacks.size === 0) {
+        stopWatchingForDocumentVisibility();
+    }
+}
+
+export function documentIsVisible() {
+    return documentIsVisible_;
+}


### PR DESCRIPTION
Follow-up to #10047: I should have placed this logic into a separate utility to begin with, but I didn't so I'm moving it now. This also makes `src/inject/color-scheme-watcher.ts` reuse the same utility.

Note that on MV3 build in theory we might observe excessive BG invocations/messaging due to this since we currently do not debounce color scheme registry messaging. (Only if user has Page Lifecycle API breakers installed, has lots of tabs, etc.) Still looking out for that.