### PR TITLE
Fix for celio.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3616,6 +3616,16 @@ body {
 
 ================================
 
+celio.com
+
+INVERT
+.ec_account__user
+.ec_header__logo
+.ec_minicart__user
+.ec_store__locator
+
+================================
+
 ceneo.pl
 
 INVERT


### PR DESCRIPTION
- Fix missing inversion for menu button and main logo.

> Before: ![image](https://user-images.githubusercontent.com/63471198/195980086-a6502c5d-162f-42b4-aefa-223e5ad09f57.png)

> After: ![image](https://user-images.githubusercontent.com/63471198/195980081-14289131-37a1-437a-96db-1cb88b44cfff.png)