### PR TITLE
allegro.pl invert images in offer list

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -874,6 +874,7 @@ a[data-analytics-click-label="offerClick"]
 ._292b3_juwzk
 ._6a66d_44ioA
 ._e5e62_MQmce
+.m3h2_8
 
 CSS
 #opbox-listing--base i,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -870,7 +870,7 @@ div[data-analytics-category="allegro.container"]
 div[data-analytics-interaction-value="DELIVERY_FREEBOX"] div
 form[name="payments"]
 a[data-analytics-click-label="offerClick"]
-.role="presentation"
+[role="presentation"]
 ._292b3_juwzk
 ._6a66d_44ioA
 ._e5e62_MQmce

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -870,6 +870,7 @@ div[data-analytics-category="allegro.container"]
 div[data-analytics-interaction-value="DELIVERY_FREEBOX"] div
 form[name="payments"]
 a[data-analytics-click-label="offerClick"]
+.role="presentation"
 ._292b3_juwzk
 ._6a66d_44ioA
 ._e5e62_MQmce

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -865,11 +865,14 @@ div.sob6jg.so1d89.mpof_ki
 a[data-analytics-click-value="SellerAllListing"]
 .mpof_ki.m389_6m > h6
 .indiana-scroll-container > ul[role="radiogroup"]
-._292b3_juwzk
 div[data-analytics-view-label="sellersOffersGroup"]
 div[data-analytics-category="allegro.container"]
 div[data-analytics-interaction-value="DELIVERY_FREEBOX"] div
 form[name="payments"]
+a[data-analytics-click-label="offerClick"]
+._292b3_juwzk
+._6a66d_44ioA
+._e5e62_MQmce
 
 CSS
 #opbox-listing--base i,


### PR DESCRIPTION
Since changes in dev branch Dark Reader all images on site are inverted in default. 
This tricky PR workaround  for a while. 
I sorted _weird_ selectors also. 

![20221015-1665853742](https://user-images.githubusercontent.com/9846948/195999176-806b6d92-dbc3-4649-87d5-32318ba6b277.png)

![20221015-1665853481](https://user-images.githubusercontent.com/9846948/195999144-c77dfab8-eff2-43ad-aefd-7a3efe2405e3.png)

![20221015-1665853851](https://user-images.githubusercontent.com/9846948/195999252-6c1054c3-0769-42d8-8cb4-a617dbf7e013.png)




