### PR TITLE
Fix for steamdeck.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18450,7 +18450,7 @@ i.ml-1
 steamdeck.com
 
 INVERT
-div.col_4.copy
+section#available-now div.col_4.copy
 section#available-now h1
 section#experience div.col_8
 section#experience h2

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18452,6 +18452,8 @@ steamdeck.com
 INVERT
 div.col_4.copy
 section#available-now h1
+section#experience div.col_8
+section#experience h2
 
 IGNORE INLINE STYLE
 #header-logo-arc


### PR DESCRIPTION
Fixes "Steam, without compromises" section on home page.

Before:
![1](https://user-images.githubusercontent.com/6563728/195996121-64508382-967c-4b59-8f62-0ce0005b2764.png)

After:
![2](https://user-images.githubusercontent.com/6563728/195996128-32c6dc28-583e-453f-840d-d1be48d658ff.png)