### PR TITLE
Refactor: use isTopFrame instead of frameURL

### DIFF
--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -42,21 +42,21 @@ export function hasFirefoxNewRootBehavior() {
     );
 }
 
-export default function createCSSFilterStyleSheet(config: FilterConfig, url: string, frameURL: string, fixes: string, index: SitePropsIndex<InversionFix>) {
+export default function createCSSFilterStyleSheet(config: FilterConfig, url: string, isTopFrame: boolean, fixes: string, index: SitePropsIndex<InversionFix>) {
     const filterValue = getCSSFilterValue(config);
     const reverseFilterValue = 'invert(100%) hue-rotate(180deg)';
-    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, fixes, index);
+    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, isTopFrame, fixes, index);
 }
 
-export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterValue: string, config: FilterConfig, url: string, frameURL: string, fixes: string, index: SitePropsIndex<InversionFix>) {
-    const fix = getInversionFixesFor(frameURL || url, fixes, index);
+export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterValue: string, config: FilterConfig, url: string, isTopFrame: boolean, fixes: string, index: SitePropsIndex<InversionFix>) {
+    const fix = getInversionFixesFor(url, fixes, index);
 
     const lines: string[] = [];
 
     lines.push('@media screen {');
 
     // Add leading rule
-    if (filterValue && !frameURL) {
+    if (filterValue && isTopFrame) {
         lines.push('');
         lines.push('/* Leading rule */');
         lines.push(createLeadingRule(filterValue));
@@ -93,7 +93,7 @@ export function cssFilterStyleSheetTemplate(filterValue: string, reverseFilterVa
         lines.push('}');
     });
 
-    if (!frameURL) {
+    if (isTopFrame) {
         const light = [255, 255, 255];
         // If browser affected by Chromium Issue 501582, set dark background on html
         // Or if browser is Firefox v102+

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -49,8 +49,8 @@ export function formatDynamicThemeFixes(dynamicThemeFixes: DynamicThemeFix[]) {
     });
 }
 
-export function getDynamicThemeFixesFor(url: string, frameURL: string, text: string, index: SitePropsIndex<DynamicThemeFix>, enabledForPDF: boolean) {
-    const fixes = getSitesFixesFor(frameURL || url, text, index, {
+export function getDynamicThemeFixesFor(url: string, isTopFrame: boolean, text: string, index: SitePropsIndex<DynamicThemeFix>, enabledForPDF: boolean) {
+    const fixes = getSitesFixesFor(url, text, index, {
         commands: Object.keys(dynamicThemeFixesCommands),
         getCommandPropName: (command) => dynamicThemeFixesCommands[command],
         parseCommandValue: (command, value) => {
@@ -84,7 +84,7 @@ export function getDynamicThemeFixesFor(url: string, frameURL: string, text: str
         .slice(1)
         .map((theme) => {
             return {
-                specificity: isURLInList(frameURL || url, theme.url) ? theme.url[0].length : 0,
+                specificity: isURLInList(url, theme.url) ? theme.url[0].length : 0,
                 theme
             };
         })

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -58,7 +58,7 @@ function mix(color1: number[], color2: number[], t: number) {
     return color1.map((c, i) => Math.round(c * (1 - t) + color2[i] * t));
 }
 
-export default function createStaticStylesheet(config: FilterConfig, url: string, frameURL: string, staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>) {
+export default function createStaticStylesheet(config: FilterConfig, url: string, isTopFrame: boolean, staticThemes: string, staticThemesIndex: SitePropsIndex<StaticTheme>) {
     const srcTheme = config.mode === 1 ? darkTheme : lightTheme;
     const theme = Object.entries(srcTheme).reduce((t, [prop, color]) => {
         const [r, g, b, a] = color;
@@ -70,7 +70,7 @@ export default function createStaticStylesheet(config: FilterConfig, url: string
     }, {} as ThemeColors);
 
     const commonTheme = getCommonTheme(staticThemes, staticThemesIndex);
-    const siteTheme = getThemeFor(frameURL || url, staticThemes, staticThemesIndex);
+    const siteTheme = getThemeFor(url, staticThemes, staticThemesIndex);
 
     const lines: string[] = [];
 

--- a/src/generators/svg-filter.ts
+++ b/src/generators/svg-filter.ts
@@ -4,7 +4,7 @@ import type {FilterConfig, InversionFix} from '../definitions';
 import {isFirefox} from '../utils/platform';
 import type {SitePropsIndex} from './utils/parse';
 
-export function createSVGFilterStylesheet(config: FilterConfig, url: string, frameURL: string, fixes: string, index: SitePropsIndex<InversionFix>) {
+export function createSVGFilterStylesheet(config: FilterConfig, url: string, isTopFrame: boolean, fixes: string, index: SitePropsIndex<InversionFix>) {
     let filterValue: string;
     let reverseFilterValue: string;
     if (isFirefox) {
@@ -15,7 +15,7 @@ export function createSVGFilterStylesheet(config: FilterConfig, url: string, fra
         filterValue = 'url(#dark-reader-filter)';
         reverseFilterValue = 'url(#dark-reader-reverse-filter)';
     }
-    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, frameURL, fixes, index);
+    return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, isTopFrame, fixes, index);
 }
 
 function getEmbeddedSVGFilterValue(matrixValue: string) {


### PR DESCRIPTION
Previously, `getConnectionMessage()` was accepting a `url` (tab URL which is top frame's URL) and `frameURL` (which is the actual URL of the frame that is requesting the style). Internally, it actually used `url` only to compare it to `frameURL` and assumed that if they matched the frame was the top frame. This had two issues:
 - (nit) the assumption is not strictly valid, since technically I can load the same URL in top frame and the subframe (albeit, this is pointless and would actually require some simple trickery to avoid infinite recursion "hall-of-mirrors" effect)
 - (main reason) I would like to avoid having to implicitly send over tab data or at least top-frame's URL in every message from an iframe because it actually complicates fixing Sidebar bug (see #10105)