### PR TITLE
Refactor: create RuntimeMesseageListener

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,6 +7,7 @@ import {makeChromiumHappy} from './make-chromium-happy';
 import DevTools from './devtools';
 import {logInfo} from './utils/log';
 import {sendLog} from './utils/sendLog';
+import Messaging from './utils/messaging';
 
 type TestMessage = {
     type: 'getManifest';
@@ -100,10 +101,10 @@ if (__WATCH__) {
             }
             switch (message.type) {
                 case 'reload:css':
-                    chrome.runtime.sendMessage<Message>({type: MessageType.BG_CSS_UPDATE});
+                    Messaging.sendMessage({type: MessageType.BG_CSS_UPDATE});
                     break;
                 case 'reload:ui':
-                    chrome.runtime.sendMessage<Message>({type: MessageType.BG_UI_UPDATE});
+                    Messaging.sendMessage({type: MessageType.BG_UI_UPDATE});
                     break;
                 case 'reload:full':
                     chrome.tabs.query({}, (tabs) => {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,7 +7,7 @@ import {makeChromiumHappy} from './make-chromium-happy';
 import DevTools from './devtools';
 import {logInfo} from './utils/log';
 import {sendLog} from './utils/sendLog';
-import Messaging from './utils/messaging';
+import Tabs from './utils/messaging';
 
 type TestMessage = {
     type: 'getManifest';
@@ -101,10 +101,10 @@ if (__WATCH__) {
             }
             switch (message.type) {
                 case 'reload:css':
-                    Messaging.sendMessage({type: MessageType.BG_CSS_UPDATE});
+                    Tabs.sendMessage({type: MessageType.BG_CSS_UPDATE});
                     break;
                 case 'reload:ui':
-                    Messaging.sendMessage({type: MessageType.BG_UI_UPDATE});
+                    Tabs.sendMessage({type: MessageType.BG_UI_UPDATE});
                     break;
                 case 'reload:full':
                     chrome.tabs.query({}, (tabs) => {

--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -2,7 +2,7 @@ import {isFirefox} from '../utils/platform';
 import type {ExtensionData, FilterConfig, TabInfo, Message, UserSettings, DevToolsData} from '../definitions';
 import {MessageType} from '../utils/message';
 import {makeFirefoxHappy} from './make-firefox-happy';
-import Messaging from './utils/messaging';
+import Tabs from './utils/messaging';
 
 export interface ExtensionAdapter {
     collect: () => Promise<ExtensionData>;
@@ -163,7 +163,7 @@ export default class Messenger {
 
     static reportChanges(data: ExtensionData) {
         if (this.changeListenerCount > 0) {
-            Messaging.sendMessage({
+            Tabs.sendMessage({
                 type: MessageType.BG_CHANGES,
                 data
             });

--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -2,6 +2,7 @@ import {isFirefox} from '../utils/platform';
 import type {ExtensionData, FilterConfig, TabInfo, Message, UserSettings, DevToolsData} from '../definitions';
 import {MessageType} from '../utils/message';
 import {makeFirefoxHappy} from './make-firefox-happy';
+import Messaging from './utils/messaging';
 
 export interface ExtensionAdapter {
     collect: () => Promise<ExtensionData>;
@@ -162,7 +163,7 @@ export default class Messenger {
 
     static reportChanges(data: ExtensionData) {
         if (this.changeListenerCount > 0) {
-            chrome.runtime.sendMessage<Message>({
+            Messaging.sendMessage({
                 type: MessageType.BG_CHANGES,
                 data
             });

--- a/src/background/utils/messaging.ts
+++ b/src/background/utils/messaging.ts
@@ -1,0 +1,14 @@
+import {DocumentInfo, ExtensionData, Message, TabInfo} from '../../definitions';
+
+type messageListenerResponse = {data?: ExtensionData | TabInfo; error?: string} | {type: '¯\\_(ツ)_/¯'} | 'unsupportedSender';
+
+// Note: return value true indicates that sendResponse() will be called asynchroneously
+type messageListenerCallback = (message: Message, sender: DocumentInfo, sendResponse: (response: messageListenerResponse) => void) => true | void | Promise<void>;
+
+export default class Messaging {
+    private static listeners: messageListenerCallback[];
+
+    static async sendMessage<R>(message: Message): Promise<R> {
+        return chrome.runtime.sendMessage<Message, R>(message);
+    }
+}

--- a/src/background/utils/messaging.ts
+++ b/src/background/utils/messaging.ts
@@ -5,10 +5,14 @@ type messageListenerResponse = {data?: ExtensionData | TabInfo; error?: string} 
 // Note: return value true indicates that sendResponse() will be called asynchroneously
 type messageListenerCallback = (message: Message, sender: DocumentInfo, sendResponse: (response: messageListenerResponse) => void) => true | void | Promise<void>;
 
-export default class Messaging {
+export default class Tabs {
     private static listeners: messageListenerCallback[];
 
     static async sendMessage<R>(message: Message): Promise<R> {
         return chrome.runtime.sendMessage<Message, R>(message);
+    }
+
+    static async sendDocumentMessage<R>(documentId: string, message: Message): Promise<R> {
+        return chrome.tabs.sendMessage<Message, R>(0, message, {documentId} as chrome.tabs.MessageSendOptions);
     }
 }

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -4,6 +4,16 @@ import type {MessageType} from './utils/message';
 import type {AutomationMode} from './utils/automation';
 import type {ThemeEngine} from './generators/theme-engines';
 
+export interface DocumentInfo {
+    tabId: number | null;
+    frameId: number | null;
+    documentId: DocumentId;
+    url: string | null;
+    state: DocumentState;
+    timestamp: number;
+    darkThemeDetected: boolean | null;
+}
+
 export interface ExtensionData {
     isEnabled: boolean;
     isReady: boolean;

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -1,0 +1,15 @@
+/*
+ * These states correspond to possible document states in Page Lifecycle API:
+ * https://developers.google.com/web/updates/2018/07/page-lifecycle-api#developer-recommendations-for-each-state
+ * Some states are not currently used (they are declared for future-proofing).
+ */
+export enum DocumentState {
+    ACTIVE = 0,
+    PASSIVE = 1,
+    HIDDEN = 2,
+    FROZEN = 3,
+    TERMINATED = 4,
+    DISCARDED = 5,
+}
+
+export type DocumentId = number | string;


### PR DESCRIPTION
Previously, we used a dedicated port for sending messages which require response. This was not pretty, it was just a workaround for Firefox and Chromium incompatibility when there are multiple message listeners. This PR registers a single "wrapper" event listener which internally calls all real event listeners.

The difference is:
 - when listener completes prior to calling `sendResponse`, Chromium checks whether listener returns truthy or falsy value, and if value is falsy closes messaging port, the actual value is ignored, so `undefined` is considered falsy
 - Firefox considers a Promise to be truthy and if a listener returns a Promise, Firefox awaits that and returns the value Promise resolves to. If listener returns `Promise<undefined>` (which Dark Reader did), Firefox treats it as a message `undefined`.

Having a single listener alleviates Firefox problem. Also, it will probably improve Safari compatibility helping us eventually release slightly more modern/advanced Dark Reader for Safari, if we decide to do that.