### PR TITLE
Fix jira status style

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1894,6 +1894,9 @@ div.zgsxji-0.jMIyWM > div > div > div > div {
 .ProseMirror hr.ak-editor-selected-node {
     background-color: rgb(0, 101, 255) !important;
 }
+.jira-issue-status-lozenge {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 IGNORE INLINE STYLE
 .ak-editor-content-area *


### PR DESCRIPTION
found while using widgets on jira cloud dashboard

before
![image](https://user-images.githubusercontent.com/26678747/196292279-87e07406-b38a-4e86-bcd7-aa760ca07caf.png)

after
![image](https://user-images.githubusercontent.com/26678747/196292352-de55ab46-c7ac-4840-bdc5-9d12c7e0801b.png)
