### PR TITLE
Fix: disable Dark Reader in Firefox sidebar

### DIFF
--- a/src/background/make-firefox-happy.ts
+++ b/src/background/make-firefox-happy.ts
@@ -1,0 +1,12 @@
+import {MessageType} from '../utils/message';
+import type {Message} from '../definitions';
+import {isFirefox} from '../utils/platform';
+
+// This function exists to prevent Firefox Sidebars from appearing broken
+// If the message does not have a proper sender, it aborts Dark Reader instance in that context
+export function makeFirefoxHappy(message: Message, sender: chrome.runtime.MessageSender, sendResponse: (response: 'unsupportedSender') => void) {
+    if (isFirefox && (sender as any).envType === 'content_child' && sender.tab === undefined && message.type === MessageType.CS_FRAME_CONNECT) {
+        sendResponse('unsupportedSender');
+        return true;
+    }
+}

--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -1,6 +1,7 @@
 import {isFirefox} from '../utils/platform';
 import type {ExtensionData, FilterConfig, TabInfo, Message, UserSettings} from '../definitions';
 import {MessageType} from '../utils/message';
+import {makeFirefoxHappy} from './make-firefox-happy';
 
 export interface ExtensionAdapter {
     collect: () => Promise<ExtensionData>;
@@ -35,7 +36,10 @@ export default class Messenger {
         }
     }
 
-    private static messageListener(message: Message, sender: chrome.runtime.MessageSender, sendResponse: (response: {data?: ExtensionData | TabInfo; error?: string}) => void) {
+    private static messageListener(message: Message, sender: chrome.runtime.MessageSender, sendResponse: (response: {data?: ExtensionData | TabInfo; error?: string} | 'unsupportedSender') => void) {
+        if (isFirefox && makeFirefoxHappy(message, sender, sendResponse)) {
+            return;
+        }
         const allowedSenderURL = [
             chrome.runtime.getURL('/ui/popup/index.html'),
             chrome.runtime.getURL('/ui/devtools/index.html'),

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -8,6 +8,7 @@ import {logInfo, logWarn} from './utils/log';
 import {StateManager} from '../utils/state-manager';
 import {getURLHostOrProtocol} from '../utils/url';
 import {isPanel} from './utils/tab';
+import {makeFirefoxHappy} from './make-firefox-happy';
 
 declare const __CHROMIUM_MV3__: boolean;
 declare const __THUNDERBIRD__: boolean;
@@ -58,6 +59,9 @@ export default class TabManager {
         this.getTabMessage = getTabMessage;
 
         chrome.runtime.onMessage.addListener(async (message: Message, sender, sendResponse) => {
+            if (isFirefox && makeFirefoxHappy(message, sender, sendResponse)) {
+                return;
+            }
             switch (message.type) {
                 case MessageType.CS_FRAME_CONNECT: {
                     onColorSchemeChange(message.data.isDark);


### PR DESCRIPTION
This is a temporary fix for Firefox Sidebars, which simply disables Dark Reader in Firefox Sidebar to prevent Dark Reader "fallback" style from breaking tabs. I would like to include this fix in Dark Reader 4.9.59, so it is intentionally designed to be as trivial as possible to avoid regressions. Relevant issues: #7130 and #10105.

This PR does not cause any changes in diff for any built output except for Firefox and Thunderbird.

I would like to include proper support for Firefox and Opera Sidebars in Dark Reader 4.9.50. Possibly, I will also support Vivaldi sidebars. That effort is tracked as #10114.