### PR TITLE
Added modrinth.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -480,6 +480,7 @@ minlor.net
 misode.github.io
 mixxx.org
 mmorpg.com
+modrinth.com
 monitoror.com
 monkeytype.com
 moonwiz.io


### PR DESCRIPTION
[modrinth.com](https://modrinth.com) is dark by default