### PR TITLE
Improvements for q.utoronto.ca

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16174,17 +16174,17 @@ a.external > span > img:first-child
 
 CSS
 :root {
-  --ic-brand-global-nav-ic-icon-svg-fill--active: var(--darkreader-text--ic-link-color) !important;
-  --darkreader-bg--ic-brand-global-nav-bgd: var(--ic-brand-global-nav-bgd) !important;
-  --darkreader-bg--ic-brand-global-nav-logo-bgd: var(--ic-brand-global-nav-logo-bgd) !important;
-  --darkreader-border--ic-brand-global-nav-avatar-border: var(--ic-brand-global-nav-avatar-border) !important;
+    --ic-brand-global-nav-ic-icon-svg-fill--active: var(--darkreader-text--ic-link-color) !important;
+    --darkreader-bg--ic-brand-global-nav-bgd: var(--ic-brand-global-nav-bgd) !important;
+    --darkreader-bg--ic-brand-global-nav-logo-bgd: var(--ic-brand-global-nav-logo-bgd) !important;
+    --darkreader-border--ic-brand-global-nav-avatar-border: var(--ic-brand-global-nav-avatar-border) !important;
 }
 .ic-app-header__menu-list-link:hover,
 .ic-app-header__menu-list-link:focus {
-  background-color: ${rgba(0, 0, 0, 0.2)} !important;
+    background-color: ${rgba(0, 0, 0, 0.2)} !important;
 }
 .ic-DashboardCard {
-  box-shadow: ${rgba(0, 0, 0, 0.3)} 0px 1px 5px !important;
+    box-shadow: ${rgba(0, 0, 0, 0.3)} 0px 1px 5px !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16178,7 +16178,8 @@ CSS
   --darkreader-bg--ic-brand-global-nav-bgd: var(--ic-brand-global-nav-bgd) !important;
   --darkreader-bg--ic-brand-global-nav-logo-bgd: var(--ic-brand-global-nav-logo-bgd) !important;
 }
-.ic-app-header__menu-list-link:hover, .ic-app-header__menu-list-link:focus {
+.ic-app-header__menu-list-link:hover,
+.ic-app-header__menu-list-link:focus {
   background-color: ${rgba(0, 0, 0, 0.2)} !important;
 }
 .ic-DashboardCard {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16177,6 +16177,7 @@ CSS
   --ic-brand-global-nav-ic-icon-svg-fill--active: var(--darkreader-text--ic-link-color) !important;
   --darkreader-bg--ic-brand-global-nav-bgd: var(--ic-brand-global-nav-bgd) !important;
   --darkreader-bg--ic-brand-global-nav-logo-bgd: var(--ic-brand-global-nav-logo-bgd) !important;
+  --darkreader-border--ic-brand-global-nav-avatar-border: var(--ic-brand-global-nav-avatar-border) !important;
 }
 .ic-app-header__menu-list-link:hover,
 .ic-app-header__menu-list-link:focus {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16165,6 +16165,28 @@ CSS
 
 ================================
 
+q.utoronto.ca
+
+INVERT
+.ic-sidebar-logo__image
+.instructure_file_link_holder > .file_download_btn
+a.external > span > img:first-child
+
+CSS
+:root {
+  --ic-brand-global-nav-ic-icon-svg-fill--active: var(--darkreader-text--ic-link-color) !important;
+  --darkreader-bg--ic-brand-global-nav-bgd: var(--ic-brand-global-nav-bgd) !important;
+  --darkreader-bg--ic-brand-global-nav-logo-bgd: var(--ic-brand-global-nav-logo-bgd) !important;
+}
+.ic-app-header__menu-list-link:hover, .ic-app-header__menu-list-link:focus {
+  background-color: ${rgba(0, 0, 0, 0.2)} !important;
+}
+.ic-DashboardCard {
+  border: 1px ${#bbb} solid !important;
+}
+
+================================
+
 qcc.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16184,7 +16184,7 @@ CSS
   background-color: ${rgba(0, 0, 0, 0.2)} !important;
 }
 .ic-DashboardCard {
-  border: 1px ${#bbb} solid !important;
+  box-shadow: ${rgba(0, 0, 0, 0.3)} 0px 1px 5px !important;
 }
 
 ================================


### PR DESCRIPTION
List of changes:

- Invert Quercus logo in the top right (the original is a black image)
- Invert file download buttons (the originals are black images)
- Invert another link button, similar to the file download buttons
- Adjust the icon color for the selected item on the sidebar to be consistent with the text
- Prevent inverting the left sidebar color (the original color is fine in both dark and light mode)
- Change the hover color to be light rather than dark in dark mode
- Add a border around homepage cards in dark mode (this isn't visible in light mode)

Unfortunately this site is not visible publicly. I'm happy to provide screenshots of the changes if you would be more comfortable.