### PR TITLE
Fix searchbar background on OpenStax textbooks

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14931,6 +14931,15 @@ CSS
 
 ================================
 
+openstax.org
+
+CSS
+input[data-testid="desktop-search-input"] {
+  background-color: transparent !important;
+}
+
+================================
+
 openvpn.net
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14934,7 +14934,7 @@ CSS
 openstax.org
 
 CSS
-input[data-testid="desktop-search-input"] {
+input[data-testid$="-search-input"] {
   background-color: transparent !important;
 }
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/42941056/197350594-8fb3f2c4-2747-4d1b-8ff8-00476f5d5c55.png)

After:

![image](https://user-images.githubusercontent.com/42941056/197350611-7c91e062-972e-4c2b-84fc-bd6d917b6219.png)

Example URL: https://openstax.org/books/calculus-volume-1/pages/3-7-derivatives-of-inverse-functions