### PR TITLE
Improve IPV6 check for URLs

### DIFF
--- a/src/utils/ipv6.ts
+++ b/src/utils/ipv6.ts
@@ -1,10 +1,12 @@
+const simpleIPV6Regex = /\[[0-9:a-zA-Z]*?\]/;
+
 export function isIPV6(url: string) {
-    const openingBracketIndex = url.indexOf('[');
-    if (openingBracketIndex < 0) {
+    const openingBracketIndex = simpleIPV6Regex.exec(url);
+    if (!openingBracketIndex) {
         return false;
     }
     const queryIndex = url.indexOf('?');
-    if (queryIndex >= 0 && openingBracketIndex > queryIndex) {
+    if (queryIndex >= 0 && openingBracketIndex.index > queryIndex) {
         return false;
     }
     return true;

--- a/tests/inject/utils/url.tests.ts
+++ b/tests/inject/utils/url.tests.ts
@@ -1,5 +1,6 @@
 import {isURLEnabled, isURLMatched, isPDF, isFullyQualifiedDomain, getURLHostOrProtocol, getAbsoluteURL} from '../../../src/utils/url';
 import type {UserSettings} from '../../../src/definitions';
+import {isIPV6} from '../../../src/utils/ipv6';
 
 it('URL is enabled', () => {
     // Not invert listed
@@ -250,6 +251,9 @@ it('URL is enabled', () => {
         'google.co.uk/order.php?bar=[foo]',
         '[2001:4860:4860::8844]',
     )).toEqual(false);
+    expect(isIPV6('file:///C:/[/test.html')).toEqual(false);
+    expect(isIPV6('file:///C:/[/test.html]')).toEqual(false);
+    expect(isIPV6('[2001:4860:4860::8844]')).toEqual(true);
 
     // Temporary Dark Sites list fix
     expect(isURLEnabled(


### PR DESCRIPTION
- While it's not rock solid, it's better than the current function. Ultimately should be fixed by #2517
- Resolves #10160