### PR TITLE
Fix for ifixit.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9869,6 +9869,9 @@ ifixit.com
 INVERT
 a[aria-label="home page"]
 
+IGNORE IMAGE ANALYSIS
+*
+
 ================================
 
 iflscience.com


### PR DESCRIPTION
- Certain product images are getting detected as light, they don't have a common selector. Prevent analyzing from happening.