### PR TITLE
Fix: revert Popup UI CSS width and height changes after v4.9.58

### DIFF
--- a/src/ui/popup/body/style.less
+++ b/src/ui/popup/body/style.less
@@ -26,13 +26,15 @@
 
     .m-logo {
         background-image: url('../assets/images/darkreader-type.svg');
+        background-position: center;
+        background-size: 100%;
         display: inline-block;
         grid-area: logo;
-        aspect-ratio: 10;
+        height: @popup-content-width / 10;
         margin: 0 auto;
         outline: none;
         text-indent: -999rem;
-        width: 100%;
+        width: @popup-content-width;
     }
 
     .m-help-button {

--- a/src/ui/popup/components/header/style.less
+++ b/src/ui/popup/components/header/style.less
@@ -15,10 +15,10 @@
         background-image: url('../assets/images/darkreader-type.svg');
         background-size: 100%;
         grid-area: logo;
+        height: @popup-content-width / 10;
         outline: none;
         text-indent: -999rem;
         width: @popup-content-width;
-        aspect-ratio: 10;
 
         &:hover {
             filter: brightness(1.05);

--- a/src/ui/popup/style.less
+++ b/src/ui/popup/style.less
@@ -26,10 +26,6 @@ body {
     padding: @popup-content-padding;
     position: relative;
     width: @popup-content-width;
-    // Prevent popup from entering a feedback loop when it displays scrollbars,
-    // adjusts popup size to be larger, then hides scrollbars, adjusts popup size to be smaller,
-    // then displays scrollbars, etc.
-    overflow: hidden;
 }
 
 .header {


### PR DESCRIPTION
This PR reverts Popup CSS changes the following commits:
 - 4c226cfb99b51ffa6172b76b1ca51bdaa502875f
 - 964967d780c031d87bb1d8ce0b28d53c4419e55f
 - 2118ba29fc5f092f1965a7f2785831e90cbe1618