### PR TITLE
Fix: on Firefox, register commands in setTimeout()

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -299,7 +299,7 @@ export class Extension {
                         }, ([r]) => resolve(r)));
                     }
                     return false;
-                };
+                }
 
                 const pdf = async () => isPDF(frameURL || await TabManager.getActiveTabURL());
                 if (((__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && await scriptPDF(tabId, frameId)) || await pdf()) {

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -92,7 +92,12 @@ export class Extension {
 
         if (chrome.commands) {
             // Firefox Android does not support chrome.commands
-            chrome.commands.onCommand.addListener(async (command, {id: tabId}) => this.onCommand(command as Command, tabId, 0, undefined));
+            if (isFirefox) {
+                // Firefox may not register onCommand listener on extension startup so we need to use setTimeout
+                setTimeout(() => chrome.commands.onCommand.addListener(async (command) => this.onCommand(command as Command, null, null, null)));
+            } else {
+                chrome.commands.onCommand.addListener(async (command, tab) => this.onCommand(command as Command, tab && tab.id || null, 0, null));
+            }
         }
 
         if (chrome.permissions.onRemoved) {
@@ -269,7 +274,11 @@ export class Extension {
                 break;
             case 'addSite': {
                 logInfo('Add Site command entered');
-                const scriptPDF = async (): Promise<boolean> => {
+                async function scriptPDF(tabId: number, frameId: number): Promise<boolean> {
+                    // We can not detect PDF if we do not know where we are looking for it
+                    if (!(Number.isInteger(tabId) && Number.isInteger(frameId))) {
+                        return false;
+                    }
                     function detectPDF(): boolean {
                         if (document.body.childElementCount !== 1) {
                             return false;
@@ -293,7 +302,7 @@ export class Extension {
                 };
 
                 const pdf = async () => isPDF(frameURL || await TabManager.getActiveTabURL());
-                if (((__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && await scriptPDF()) || await pdf()) {
+                if (((__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && await scriptPDF(tabId, frameId)) || await pdf()) {
                     this.changeSettings({enableForPDF: !UserStorage.settings.enableForPDF});
                 } else {
                     this.toggleActiveTab();
@@ -316,8 +325,8 @@ export class Extension {
     private static onCommand = debounce(75, this.onCommandInternal);
 
     private static registerContextMenus() {
-        chrome.contextMenus.onClicked.addListener(async ({menuItemId, frameId, frameUrl, pageUrl}, {id: tabId}) =>
-            this.onCommand(menuItemId as Command, tabId, frameId, frameUrl || pageUrl));
+        chrome.contextMenus.onClicked.addListener(async ({menuItemId, frameId, frameUrl, pageUrl}, tab) =>
+            this.onCommand(menuItemId as Command, tab && tab.id || null, frameId || null, frameUrl || pageUrl));
         chrome.contextMenus.removeAll(() => {
             this.registeredContextMenus = false;
             chrome.contextMenus.create({

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,4 +1,4 @@
-type AnyFn = (...args: any[]) => any;
+type AnyFn = (...args: any[]) => void;
 
 export function debounce<F extends AnyFn>(delay: number, fn: F): F {
     let timeoutId: ReturnType<typeof setTimeout> = null;


### PR DESCRIPTION
Fixes #10176.

Firefox for some reason silently failed to register context menus via `chrome.commands.onCommand.addListener` on the first run, so we need to wrap it into `setTimeout()` (with no delay).