### PR TITLE
Fix: use correct key codes in command update flow

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -7,7 +7,7 @@ import Newsmaker from './newsmaker';
 import TabManager from './tab-manager';
 import UserStorage from './user-storage';
 import {setWindowTheme, resetWindowTheme} from './window-theme';
-import {getCommands, setShortcut, canInjectScript} from './utils/extension-api';
+import {getCommands, canInjectScript} from './utils/extension-api';
 import {isInTimeIntervalLocal, nextTimeInterval, isNightAtLocation, nextTimeChangeAtLocation} from '../utils/time';
 import {isURLInList, getURLHostOrProtocol, isURLEnabled, isPDF} from '../utils/url';
 import {ThemeEngine} from '../generators/theme-engines';
@@ -245,7 +245,6 @@ export class Extension {
             },
             changeSettings: async (settings) => this.changeSettings(settings),
             setTheme: (theme) => this.setTheme(theme),
-            setShortcut: ({command, shortcut}) => this.setShortcut(command, shortcut),
             toggleActiveTab: async () => this.toggleActiveTab(),
             markNewsAsRead: async (ids) => await Newsmaker.markAsRead(...ids),
             markNewsAsDisplayed: async (ids) => await Newsmaker.markAsDisplayed(...ids),
@@ -363,10 +362,6 @@ export class Extension {
     private static async getShortcuts() {
         const commands = await getCommands();
         return commands.reduce((map, cmd) => Object.assign(map, {[cmd.name]: cmd.shortcut}), {} as Shortcuts);
-    }
-
-    private static setShortcut(command: string, shortcut: string) {
-        setShortcut(command, shortcut);
     }
 
     static async collectData(): Promise<ExtensionData> {

--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -7,7 +7,6 @@ export interface ExtensionAdapter {
     collect: () => Promise<ExtensionData>;
     changeSettings: (settings: Partial<UserSettings>) => void;
     setTheme: (theme: Partial<FilterConfig>) => void;
-    setShortcut: ({command, shortcut}: {command: string; shortcut: string}) => void;
     markNewsAsRead: (ids: string[]) => Promise<void>;
     markNewsAsDisplayed: (ids: string[]) => Promise<void>;
     toggleActiveTab: () => void;
@@ -111,9 +110,6 @@ export default class Messenger {
                 break;
             case MessageType.UI_SET_THEME:
                 this.adapter.setTheme(data);
-                break;
-            case MessageType.UI_SET_SHORTCUT:
-                this.adapter.setShortcut(data);
                 break;
             case MessageType.UI_TOGGLE_ACTIVE_TAB:
                 this.adapter.toggleActiveTab();

--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -1,12 +1,6 @@
 import {isPDF} from '../../utils/url';
 import {isFirefox, isEdge} from '../../utils/platform';
 
-declare const browser: {
-    commands: {
-        update({name, shortcut}: chrome.commands.Command): void;
-    };
-};
-
 export function canInjectScript(url: string) {
     if (isFirefox) {
         return (url
@@ -155,10 +149,4 @@ export async function getCommands() {
             }
         });
     });
-}
-
-export function setShortcut(command: string, shortcut: string) {
-    if (typeof browser !== 'undefined' && browser.commands && browser.commands.update) {
-        browser.commands.update({name: command, shortcut});
-    }
 }

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -29,7 +29,7 @@ export interface TabData {
 export interface ExtensionActions {
     changeSettings(settings: Partial<UserSettings>): void;
     setTheme(theme: Partial<FilterConfig>): void;
-    setShortcut(command: string, shortcut: string): void;
+    setShortcut(command: string, shortcut: string): Promise<string>;
     toggleActiveTab(): void;
     markNewsAsRead(ids: string[]): void;
     markNewsAsDisplayed(ids: string[]): void;

--- a/src/ui/connect/connector.ts
+++ b/src/ui/connect/connector.ts
@@ -1,7 +1,6 @@
 import {isFirefox} from '../../utils/platform';
 import type {ExtensionData, ExtensionActions, FilterConfig, Message, UserSettings} from '../../definitions';
 import {MessageType} from '../../utils/message';
-import {logWarn} from '../../inject/utils/log';
 
 declare const browser: {
     commands: {
@@ -75,18 +74,16 @@ export default class Connector implements ExtensionActions {
         if (isFirefox && typeof browser !== 'undefined' && browser.commands && browser.commands.update && browser.commands.getAll) {
             try {
                 await browser.commands.update({name: command, shortcut});
-            } catch (e) {
-                logWarn('Failed to update the shortcut', e);
+            } catch {
+                // Ignore this error
             }
             // Query the real shortcut to get the exact value displayed by Firefox on about:addons
             // or in case user has non-standard keyboard layout
             const commands = await browser.commands.getAll();
             const cmd = commands.find((cmd) => cmd.name === command);
             return cmd && cmd.shortcut || null;
-        } else {
-            logWarn ('setShortcut: this function is implemented only for Firefox and Thunderbird');
-            return null;
         }
+        return null;
     }
 
     changeSettings(settings: Partial<UserSettings>) {

--- a/src/ui/connect/connector.ts
+++ b/src/ui/connect/connector.ts
@@ -1,7 +1,7 @@
 import {isFirefox} from '../../utils/platform';
 import type {ExtensionData, ExtensionActions, FilterConfig, Message, UserSettings} from '../../definitions';
 import {MessageType} from '../../utils/message';
-import {logWarn} from 'inject/utils/log';
+import {logWarn} from '../../inject/utils/log';
 
 declare const browser: {
     commands: {
@@ -75,7 +75,7 @@ export default class Connector implements ExtensionActions {
         if (isFirefox && typeof browser !== 'undefined' && browser.commands && browser.commands.update && browser.commands.getAll) {
             try {
                 await browser.commands.update({name: command, shortcut});
-            } catch(e) {
+            } catch (e) {
                 logWarn('Failed to update the shortcut', e);
             }
             // Query the real shortcut to get the exact value displayed by Firefox on about:addons
@@ -84,7 +84,7 @@ export default class Connector implements ExtensionActions {
             const cmd = commands.find((cmd) => cmd.name === command);
             return cmd && cmd.shortcut || null;
         } else {
-            logWarn('setShortcut: this function is implemented only for Firefox and Thunderbird');
+            logWarn ('setShortcut: this function is implemented only for Firefox and Thunderbird');
             return null;
         }
     }

--- a/src/ui/controls/shortcut/index.tsx
+++ b/src/ui/controls/shortcut/index.tsx
@@ -36,7 +36,10 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
         let ctrl = false, alt = false, command = false, shift = false, key: string = null;
 
         function updateShortcut() {
-            const shortcut = `${ctrl ? 'Ctrl+' : alt ? 'Alt+' : command ? 'Command+' : ''}${shift ? 'Shift+' : ''}${key ? key : ''}`;
+            if (!enteringShortcutInProgress) {
+                return;
+            }
+            const shortcut = `${ctrl ? 'Ctrl+' : ''}${alt ? 'Alt+' : command ? 'Command+' : ''}${shift ? 'Shift+' : ''}${key ? key : ''}`;
             node.textContent = shortcut;
         }
 
@@ -83,6 +86,7 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
             if ((ctrl || alt || command || shift) && key) {
                 removeListeners();
                 node.blur();
+                const shortcut = `${ctrl ? 'Ctrl+' : ''}${alt ? 'Alt+' : command ? 'Command+' : ''}${shift ? 'Shift+' : ''}${key ? key : ''}`;
                 props.onSetShortcut(shortcut).then((shortcut) => {
                     enteringShortcutInProgress = false;
                     node.classList.remove('shortcut--edit');
@@ -99,7 +103,7 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
             } else if (e.key === 'Alt') {
                 alt = false;
             } else if (e.key === 'Command') {
-                alt = false;
+                command = false;
             } else if (e.key === 'Shift') {
                 shift = false;
             } else {

--- a/src/ui/controls/shortcut/index.tsx
+++ b/src/ui/controls/shortcut/index.tsx
@@ -2,7 +2,6 @@ import {m} from 'malevic';
 import {mergeClass} from '../utils';
 import type {Shortcuts} from '../../../definitions';
 import {isFirefox, isEdge} from '../../../utils/platform';
-import {logWarn} from '../../../inject/utils/log';
 
 interface ShortcutLinkProps {
     class?: string | {[cls: string]: any};
@@ -74,11 +73,9 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
                     // implementation-dependent value. The actual key comes from non-deprecated e.code
                     // For details see https://developer.mozilla.org/docs/Web/API/KeyboardEvent/keyCode
                     key = e.code.substring(3);
-                } else {
-                    // This letter is not well-represented by Firefox, probably because it is a Latin-like
-                    // key with accent. This key will not work, even if set via about:addons
-                    logWarn('Could not use this key for a shortcut, please enter a different one', e);
                 }
+                // This letter is not well-represented by Firefox, probably because it is a Latin-like
+                // key with accent. This key will not work, even if set via about:addons
             }
 
             updateShortcut();

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -4,7 +4,6 @@ export enum MessageType {
     UI_UNSUBSCRIBE_FROM_CHANGES = 'ui-unsubscribe-from-changes',
     UI_CHANGE_SETTINGS = 'ui-change-settings',
     UI_SET_THEME = 'ui-set-theme',
-    UI_SET_SHORTCUT = 'ui-set-shortcut',
     UI_TOGGLE_ACTIVE_TAB = 'ui-toggle-active-tab',
     UI_MARK_NEWS_AS_READ = 'ui-mark-news-as-read',
     UI_MARK_NEWS_AS_DISPLAYED = 'ui-mark-news-as-displayed',


### PR DESCRIPTION
This fixes shortcut update logic (exclusive to Firefox) to handle unusual keyboard layouts like accented languages or non-default key mappings like Dvorak instead of QUERTY.