### PR TITLE
Invert Wikipedia location map text

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21819,6 +21819,8 @@ body > .oo-ui-windowManager .vega .marks
 .mw-kartographer-mapDialog-map
 img[alt="audio speaker icon"]
 img[src*="Wiktionary-logo"]
+.locmap .pl
+.locmap .pr
 
 CSS
 .mwe-popups-discreet > img,


### PR DESCRIPTION
Example: https://en.wikipedia.org/wiki/Tokyo_Station

<img width="1392" alt="Screenshot 2022-10-29 at 11 34 13" src="https://user-images.githubusercontent.com/21101839/198808361-916fbe41-7d6c-422d-84c6-90439c6f6408.png">
