### PR TITLE
Fix for ica.coop

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9779,6 +9779,13 @@ CSS
 
 ================================
 
+ica.coop
+
+INVERT
+.main-header__logo
+
+================================
+
 icloud.com
 
 INVERT


### PR DESCRIPTION
Fixes logo on most pages.

Before:
![1](https://user-images.githubusercontent.com/6563728/200122222-342d343b-d367-4ce5-bc95-ef4957acbbb5.png)

After:
![2](https://user-images.githubusercontent.com/6563728/200122227-23b62bb5-7ab1-45ba-b11e-5e6c5f1f4b54.png)