### PR TITLE
Fixes for GitHub.com: remove some unused fixes after redesign

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8519,7 +8519,6 @@ github.com
 github.*.*
 
 INVERT
-[src^="https://github.githubassets.com/images/modules/site/home/logos/platform-"]
 [src="https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg"]
 [src^="https://github.githubassets.com/images/modules/site/home/community-sponsor-"]
 [src^="https://github.githubassets.com/images/modules/site/home/community-readme-"]
@@ -8549,14 +8548,8 @@ INVERT
 .overflow-hidden.position-relative.box-shadow-active-border-mktg.rounded-2-fluid.color-bg-primary.build-in-scale-fade.js-build-in-item
 .build-in-animate.overflow-hidden.box-shadow-active-border-mktg.rounded-2-fluid.position-relative.home-workflow-comp.js-build-in-item
 .mx-lg-auto.col-lg-7.col-12
-svg.home-git-icon > circle
-div.home-branch-container > svg > path
-div.home-git-log-terminal > svg > g
 
 CSS
-div.home-git-log-terminal > svg > path, ul.home-git-log-dark > li > svg > path, ul.home-git-log-light > li > svg > path {
-    display: none;
-}
 .markdown-body code,
 .markdown-body pre,
 .markdown-title code {


### PR DESCRIPTION
GitHub recently shipped a redesign of their frontage making some fixes unnecessary. This removes a few fixes I added and I know for sure are not needed any more. I didn't remove other fixes because I was not entirely sure if they are still used.