### PR TITLE
Invert font color of presented answers

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8378,6 +8378,7 @@ INVERT
 .menuImg
 .buttonContent.stylebarButton
 .EuclidianPanel > canvas
+.stepTreeElem
 
 ================================
 


### PR DESCRIPTION
I only tested with the [solver tool](https://www.geogebra.org/solver).

I am not sure if it might break any of the other tools.

By default, the font's color of answers is dark when using dark mode. This should set it to invert into white.