### PR TITLE
Fix for beta.icloud.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2352,6 +2352,25 @@ body {
 
 ================================
 
+beta.icloud.com
+
+INVERT
+.apple-icloud-logo > g > path:first-child
+
+CSS
+.homepage-gradient-background::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0 0 0 / 0.7);
+    z-index: -1;
+}
+
+================================
+
 betanews.com
 
 CSS


### PR DESCRIPTION
- Invert logo.
- Make background dark.

I added a semi-transparent dark background to keep the image in the background. Or will such a decision greatly affect performance and is it easier to just remove the image in the background?