### PR TITLE
Add background handling for lectricebikes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11489,6 +11489,18 @@ CSS
 
 ================================
 
+lectricebikes.com
+
+CSS
+:root{
+        --gradient-base-background-1: var(--darkreader-neutral-background) !important;
+        --gradient-base-background-2: var(--darkreader-neutral-background) !important;
+        --gradient-base-accent-1: var(--darkreader-neutral-text) !important;
+        --gradient-base-accent-2: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 leetcode.com
 leetcode-cn.com
 


### PR DESCRIPTION
I'm not very familiar with HTML, but it appears there are some variables in the page source e.g. `--gradient-base-background-1: #FFFFFF;` and changing it to darkreader backgrounds fixes the background. It's within `<head> <style data-shopify="">` I can't figure out how to make the text other than the multiple shades of blue, which is only potentially problematic on the light theme, but my attempt is in here also (original values for --gradient-base-accent match the darkreader values for --blue and --ltblue).

My first ever commit, so please bear with me.