### PR TITLE
Fix `sharedrop.io` undetectable QR code

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17620,6 +17620,15 @@ CSS
 
 ================================
 
+sharedrop.io
+
+CSS
+.qr-code img {
+    border: 10px solid #FFF !important;
+}
+
+================================
+
 sharepoint.com
 
 INVERT


### PR DESCRIPTION
This PR fixes the unscannable room QR code on [sharedrop.io](https://www.sharedrop.io/).