### PR TITLE
Fix: avoid flash of unstyled content when changing tabs on Firefox

### DIFF
--- a/src/inject/color-scheme-watcher.ts
+++ b/src/inject/color-scheme-watcher.ts
@@ -1,11 +1,11 @@
 import {isSystemDarkModeEnabled, runColorSchemeChangeDetector, stopColorSchemeChangeDetector} from '../utils/media-query';
 import type {Message} from '../definitions';
 import {MessageType} from '../utils/message';
-import {addDocumentVisibilityListener, documentIsVisible, removeDocumentVisibilityListener} from '../utils/visibility';
+import {setDocumentVisibilityListener, documentIsVisible, removeDocumentVisibilityListener} from '../utils/visibility';
 
 function cleanup() {
     stopColorSchemeChangeDetector();
-    removeDocumentVisibilityListener(updateEventListeners);
+    removeDocumentVisibilityListener();
 }
 
 function sendMessage(message: Message) {
@@ -52,5 +52,5 @@ function updateEventListeners() {
     }
 }
 
-addDocumentVisibilityListener(updateEventListeners);
+setDocumentVisibilityListener(updateEventListeners);
 updateEventListeners();

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -21,7 +21,7 @@ import {injectProxy} from './stylesheet-proxy';
 import {clearColorCache, parseColorWithCache} from '../../utils/color';
 import {parsedURLCache} from '../../utils/url';
 import {variablesStore} from './variables';
-import {addDocumentVisibilityListener, documentIsVisible, removeDocumentVisibilityListener} from '../../utils/visibility';
+import {setDocumentVisibilityListener, documentIsVisible, removeDocumentVisibilityListener} from '../../utils/visibility';
 
 declare const __TEST__: boolean;
 declare const __CHROMIUM_MV3__: boolean;
@@ -330,7 +330,7 @@ function createThemeAndWatchForUpdates() {
     createStaticStyleOverrides();
 
     if (!documentIsVisible() && !filter.immediateModify) {
-        addDocumentVisibilityListener(runDynamicStyle);
+        setDocumentVisibilityListener(runDynamicStyle);
     } else {
         runDynamicStyle();
     }
@@ -540,7 +540,7 @@ export function removeDynamicTheme() {
 export function cleanDynamicThemeCache() {
     variablesStore.clear();
     parsedURLCache.clear();
-    removeDocumentVisibilityListener(runDynamicStyle);
+    removeDocumentVisibilityListener();
     cancelRendering();
     stopWatchingForUpdates();
     cleanModificationCache();


### PR DESCRIPTION
PR #10047 introduced logic for adding multiple page visibility listeners (callbacks) at once. Unfortunately, using a `Set` or even just an `Array` for storing callbacks prevents Firefox from performing some code optimizations for some reason, which may cause flashes of white content when switching tabs. This PR simplifies code to ever permit adding only a single listener which is stored in a variable.

Fixes #10221.