### PR TITLE
Partial fix for beta.icloud.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2359,6 +2359,24 @@ body {
 
 ================================
 
+beta.icloud.com
+
+INVERT
+.sc-iujRgT.jxLrRl
+.icloud-text.image
+.img.app-icon-icloud
+#cloudos-loading-spinner
+.editor-container
+.light > svg
+
+CSS
+.cw-pane-container,
+.reminders {
+    background-image: none !important;
+}
+
+================================
+
 betanews.com
 
 CSS


### PR DESCRIPTION
I fixed beta.icloud.com
white background on dark fixed
images inverted fixed
text not showing correctly(white) fixed
logo fixed.
I did not know how to not invert images colors in note/text field.