### PR TITLE
Fixes pill tags and other icons on ShipStation.com (https://github.com/darkreader/darkreader/issues/10225)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17666,6 +17666,22 @@ INVERT
 
 ================================
 
+shipstation.com
+
+INVERT
+.note-icon-3F9ryyv
+.sub-item-icon-1L2L6PE
+
+CSS
+.status-text-1NbkYoX {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.pill-18Ymbb9
+
+================================
+
 shop.dr-rath.com
 
 CSS


### PR DESCRIPTION
Fixes this issue with shipstation.com
https://github.com/darkreader/darkreader/issues/10225

This helps preserve the meaning behind each tag and note (The pill and note icons) in ShipStation, especially when working in a team with users who do not use dark mode.

Also added CSS to help readability on Awaiting Shipment status.