### PR TITLE
Fix for appstoreconnect.apple.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1548,6 +1548,13 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+appstoreconnect.apple.com
+
+IGNORE IMAGE ANALYSIS
+.hIEXIe
+
+================================
+
 aprs.fi
 
 INVERT


### PR DESCRIPTION
Don't invert app icons in analytics