### PR TITLE
Move google PDF inversion behind user setting toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Only invert PDFs on mail.google.com and drive.google.com, if the setting for PDF inversion has been enabled. (#10310)
+
 ## 4.9.60 (Oct 27, 2022)
 
 - Fixed broken hotkeys.

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6117,7 +6117,6 @@ div[data-label="nd"] > div > div > svg > path[fill="#000000"]
 div[role="document"] > div[role="button"] .a-b-c
 div > svg > circle[fill="white"]
 img[src*="empty_state_trash"]
-div[role="dialog"] div[role="document"]
 
 CSS
 span[data-type="spelling"] {
@@ -12251,7 +12250,6 @@ div[aria-label="Hangouts"] > div[role="tablist"] > div[tabid="chat"] > div
 form[method="POST"] ~ table div[style] > div > :first-child button:not([string]):not([id])
 img[src^="//ssl.gstatic.com/ui/v1/icons/common/x"]
 div[style$="gm_add_black_24dp.png)"]
-div[role="dialog"] div[role="document"]
 
 CSS
 @media (min-resolution: 144dpi), (-webkit-min-device-pixel-ratio: 1.5) {

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -1,5 +1,5 @@
 import {formatSitesFixesConfig} from './utils/format';
-import {parseSitesFixesConfig, getSitesFixesFor} from './utils/parse';
+import {parseSitesFixesConfig, getSitesFixesFor, getDomain} from './utils/parse';
 import type {SitePropsIndex} from './utils/parse';
 import {parseArray, formatArray} from '../utils/text';
 import {compareURLPatterns, isURLInList} from '../utils/url';
@@ -78,6 +78,9 @@ export function getDynamicThemeFixesFor(url: string, isTopFrame: boolean, text: 
             common.css += '\nembed[type="application/pdf"][src="about:blank"] { filter: invert(100%) contrast(90%); }';
         } else {
             common.css += '\nembed[type="application/pdf"] { filter: invert(100%) contrast(90%); }';
+        }
+        if (['drive.google.com', 'mail.google.com'].includes(getDomain(url))) {
+            common.invert.push('div[role="dialog"] div[role="document"]');
         }
     }
     const sortedBySpecificity = fixes

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -57,7 +57,7 @@ export function parseSitesFixesConfig<T extends SiteProps>(text: string, options
 }
 
 // URL patterns are guaranteed to not have protocol and leading '/'
-function getDomain(url: string) {
+export function getDomain(url: string) {
     try {
         return (new URL(url)).hostname.toLowerCase();
     } catch (error) {


### PR DESCRIPTION
- Move the inversion added in #10061 to the source code and move them behind the enabledPDF setting.
- Resolves #10286