### PR TITLE
forum.kaspersky.com add to invision forum list

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7778,6 +7778,7 @@ body {
 
 forum.eset.com
 forum.ithardware.pl
+forum.kaspersky.com
 forums.getpaint.net
 forums.laptopvideo2go.com
 nieidealny.pl/forum


### PR DESCRIPTION
https://forum.kaspersky.com/topic/github-adaway-detected-as-malware-adblock-downloading-hosts-cannot-whitelist-14827/#comment-68284

![20221118-1668798227](https://user-images.githubusercontent.com/9846948/202782876-6c020578-b2e0-4798-bdda-d056e66b271e.png)
