### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19759,6 +19759,7 @@ INVERT
 .inline-the-guardian-logo__svg
 a[data-link-name$="logo"] > svg
 .crossword__grid .crossword__cell-text
+.most-popular__number
 
 ================================
 


### PR DESCRIPTION
Fixes "Most viewed" section on home page.

Before:
![1](https://user-images.githubusercontent.com/6563728/202851695-fe710974-c00c-47d9-8b91-5127b6576705.png)

After:
![2](https://user-images.githubusercontent.com/6563728/202851704-d3228f18-ebff-4f33-a059-51723644cf70.png)