### PR TITLE
Show protected site message on new UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Only invert PDFs on mail.google.com and drive.google.com, if the setting for PDF inversion has been enabled. (#10310)
+- Show in the new UI design when a page is disabled, because it's protected by the browser. (#10338)
 
 ## 4.9.60 (Oct 27, 2022)
 

--- a/src/ui/popup/main-page/site-toggle.tsx
+++ b/src/ui/popup/main-page/site-toggle.tsx
@@ -10,13 +10,14 @@ export default function SiteToggleGroup(props: ViewProps) {
     const tab = props.data.activeTab;
     const isPageEnabled = isURLEnabled(tab.url, props.data.settings, tab, props.data.isAllowedFileSchemeAccess);
     const isFile = isChromium && isLocalFile(tab.url);
-    const {isDarkThemeDetected} = tab;
+    const {isDarkThemeDetected, isProtected} = tab;
     const descriptionText = (isFile && !props.data.isAllowedFileSchemeAccess) ? (
         getLocalMessage('local_files_forbidden')
     ) : isPDF(tab.url) ? (
         isPageEnabled ? 'Enabled for PDF files' : 'Disabled for PDF files'
     ) : isDarkThemeDetected ? 'Dark theme detected on page' : (
-        isPageEnabled ? 'Enabled for current website' : 'Disabled for current website'
+        isPageEnabled ? 'Enabled for current website' :
+            isProtected ? getLocalMessage('page_protected') : 'Disabled for current website'
     );
     const description = (
         <span


### PR DESCRIPTION
- Show in the new UI when a site is not enabled, because it's protected by the browser.
- Resolves #10321