### PR TITLE
PolskaPress services selectors update

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6408,11 +6408,15 @@ to.com.pl
 wspolczesna.pl
 
 INVERT
+.atomsArticleFoot__tools svg
+.atomsCommentsExposition__icon svg
+.atomsNavigationBreadcrumbs__content svg
 .atomsNavigationFooterLinks__logo
 .atomsSocialmediaExposition__content svg
 .componentsGalleryNavbar__btn_close
 .componentsGalleryNavbar__logo
 .componentsNavigationNavbar__logo
+.componentsNavigationMenu__logo
 .componentsNavigationTopnavbar__icons div span svg
 a[href="https://i.pl/firmy"] svg
 a[href="https://i.pl/szukaj"] svg

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6410,13 +6410,15 @@ wspolczesna.pl
 INVERT
 .atomsArticleFoot__tools svg
 .atomsCommentsExposition__icon svg
+.atomsGalleryButtonsNavigation__left svg
+.atomsGalleryButtonsNavigation__right svg
 .atomsNavigationBreadcrumbs__content svg
 .atomsNavigationFooterLinks__logo
 .atomsSocialmediaExposition__content svg
 .componentsGalleryNavbar__btn_close
 .componentsGalleryNavbar__logo
-.componentsNavigationNavbar__logo
 .componentsNavigationMenu__logo
+.componentsNavigationNavbar__logo
 .componentsNavigationTopnavbar__icons div span svg
 a[href="https://i.pl/firmy"] svg
 a[href="https://i.pl/szukaj"] svg


### PR DESCRIPTION
sample 
https://gazetawroclawska.pl/ceny-z-jarmarku-bozonarodzeniowego-we-wroclawiu-wata-cukrowa-40-zl-paczki-za-25-zl/ar/c3-17054565
https://gazetawroclawska.pl/strefa-biznesu

![20221121-1669051893](https://user-images.githubusercontent.com/9846948/203123039-94e8c906-6fcc-422e-9ef8-2c2c485d2f68.png)
![20221121-1669052063](https://user-images.githubusercontent.com/9846948/203123053-ff31ba7f-af7c-4e97-927b-03849ba169fd.png)
![20221121-1669052069](https://user-images.githubusercontent.com/9846948/203123055-f225187b-1688-4bda-b642-1a53fbe60de1.png)
