### PR TITLE
Invert for mathematical formulas on WikiData

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21929,6 +21929,7 @@ wikidata.org
 INVERT
 .wd-mp-headerimage
 .mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
 img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21928,6 +21928,7 @@ wikidata.org
 
 INVERT
 .wd-mp-headerimage
+.mwe-math-fallback-image-inline
 img[alt="audio speaker icon"]
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
Formulas written certain places (see the examples on https://www.wikidata.org/wiki/Property:P2534 ), are black on a dark background. This fix should invert it correctly.