### PR TITLE
Fix for celio.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3659,6 +3659,7 @@ INVERT
 .ec_account__user
 .ec_header__logo
 .ec_minicart__user
+.ec_search__link
 .ec_store__locator
 
 ================================


### PR DESCRIPTION
- Fix missing inversion for search button.

> Before
>![image](https://user-images.githubusercontent.com/63471198/203409972-7e027b28-c0c8-4d1d-87b3-d3d580095ab1.png)

>  After
> ![image](https://user-images.githubusercontent.com/63471198/203410123-b3f02bd4-8b85-4854-b5f5-6fae946bac78.png)