### PR TITLE
Fix for pphosted.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15951,6 +15951,15 @@ INVERT
 
 ================================
 
+pphosted.com
+
+CSS
+#menu_items {
+   background-image: none !important;
+}
+
+================================
+
 praca.pl
 
 INVERT


### PR DESCRIPTION
The admin console left navigation for proofpoint hosted SaaS.

Current default dynamic theme has white text on a white background that
looks similar to these: https://www.google.com/search?q=white+grid.