### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1910,6 +1910,10 @@ div.zgsxji-0.jMIyWM > div > div > div > div {
 .jira-issue-status-lozenge {
     background-color: var(--darkreader-neutral-background) !important;
 }
+.fabric-text-color-mark {
+ --darkreader-text--custom-text-color: var(--custom-text-color);
+}
+
 
 IGNORE INLINE STYLE
 .ak-editor-content-area *

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1911,7 +1911,7 @@ div.zgsxji-0.jMIyWM > div > div > div > div {
     background-color: var(--darkreader-neutral-background) !important;
 }
 .fabric-text-color-mark {
- --darkreader-text--custom-text-color: var(--custom-text-color);
+    --darkreader-text--custom-text-color: var(--custom-text-color);
 }
 
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1914,7 +1914,6 @@ div.zgsxji-0.jMIyWM > div > div > div > div {
     --darkreader-text--custom-text-color: var(--custom-text-color);
 }
 
-
 IGNORE INLINE STYLE
 .ak-editor-content-area *
 


### PR DESCRIPTION
When editing a page on Confluence, assigning custom text color is overwritten because--for some reason--DarkReader creates a `--darkreader-text` override of `--custom-text-color`, but it's not defined. 

This is just defining the override back to the original custom text color, which allows manual text color changes to work again.