### PR TITLE
Make node restorer robust against complete DOM removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Only invert PDFs on mail.google.com and drive.google.com, if the setting for PDF inversion has been enabled. (#10310)
 - Show in the new UI design when a page is disabled, because it's protected by the browser. (#10338)
+- Better restore for darkreader elements, when the whole DOM is being overwritten.
 
 ## 4.9.60 (Oct 27, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Only invert PDFs on mail.google.com and drive.google.com, if the setting for PDF inversion has been enabled. (#10310)
 - Show in the new UI design when a page is disabled, because it's protected by the browser. (#10338)
-- Better restore for darkreader elements, when the whole DOM is being overwritten.
+- Better restore for darkreader elements, when the whole DOM is being overwritten. (#10372)
 
 ## 4.9.60 (Oct 27, 2022)
 

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -75,7 +75,7 @@ const nodePositionWatchers = new Map<string, ReturnType<typeof watchForNodePosit
 
 function setupNodePositionWatcher(node: Node, alias: string) {
     nodePositionWatchers.has(alias) && nodePositionWatchers.get(alias).stop();
-    nodePositionWatchers.set(alias, watchForNodePosition(node, 'parent'));
+    nodePositionWatchers.set(alias, watchForNodePosition(node, 'head'));
 }
 
 function stopStylePositionWatchers() {


### PR DESCRIPTION
- Currently if the whole DOM was removed and created from scratch, Dark Reader wouldn't be able to restore the elements that were in `<head>`. The new code now takes into account this specific scenario(by detecting `.isConnected`) as well fixing the `parent` value if it happens. Given this now ties to parent being `<head>` the mode name changed accordingly.
- Resolves #10349