### PR TITLE
Fix for palemoon.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15257,6 +15257,14 @@ body {
 
 ================================
 
+palemoon.org
+
+INVERT
+img[src="images/goanna200x66.png"]
+img[src="images/vpsserver.png"]
+
+================================
+
 palshovon.wixsite.com
 
 INVERT


### PR DESCRIPTION
Fixes images on home page.

Before:
![1](https://user-images.githubusercontent.com/6563728/204092271-7de8bd42-1b8e-4c08-affe-a138687fdb98.png)

After:
![2](https://user-images.githubusercontent.com/6563728/204092274-8f2a612e-98da-46ec-8766-a1da79c77901.png)