### PR TITLE
Add leafly.com w/ TODO list

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11563,6 +11563,18 @@ CSS
 
 ================================
 
+leafly.com
+
+CSS
+.bg-light-grey {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.bg-default {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 leagueoflegends.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11565,6 +11565,9 @@ CSS
 
 leafly.com
 
+INVERT
+div.pl-lg
+
 CSS
 .bg-light-grey {
     background-color: var(--darkreader-neutral-background) !important;


### PR DESCRIPTION
IMPLEMENTED:
- Made the "level bars" on strain pages visible.
- Made cookies notice visible.

TODO:
- [1] On any strain page: There are a handful of w3.org SVGs that I didn't know the solution for however. A couple until you scroll down to the "effects" section, [2] where there are nine grouped up together. 
- [3] Near the bottom of a strains page, there's a bit where lines are drawn that are not visible in dark mode, however on a different strain page there can be varying amounts of lines. 
- [4] The search filters are difficult to read in dark mode. Interestingly, on rare occasions it works fine. I don't know how to reproduce this in either direction, as this is only the second time I've seen it as readable in a few days.
- [5] Social media buttons (found on articles) are difficult to read in dark mode. Interestingly, "copy link" does not follow this explicitly.

I've been looking for a solution to all of these, but my programming skills are not very fleshed out. If someone does have the solution for these, I would be interested in learning about it!

[1]
![image](https://user-images.githubusercontent.com/15604491/204119267-00d03d09-cfd9-4b4d-b786-8ffc16997717.png)
![image](https://user-images.githubusercontent.com/15604491/204119280-b5ea31ff-dfb4-407c-81df-cd46b50c0c63.png)
![image](https://user-images.githubusercontent.com/15604491/204119283-591b0f5c-f8c5-471b-842b-e27c906cf6d7.png)
![image](https://user-images.githubusercontent.com/15604491/204119287-0665506b-f852-461b-92f4-9b0dd3303292.png)
[2]
![image](https://user-images.githubusercontent.com/15604491/204120650-b4286578-c371-4577-b953-155559644fcc.png)
![image](https://user-images.githubusercontent.com/15604491/204120660-5925c40d-abc9-407f-ad48-0fdba3c3bfeb.png)
[3]
![image](https://user-images.githubusercontent.com/15604491/204121332-3831cbff-a0d9-46ec-8e37-ca38254945dd.png)
![image](https://user-images.githubusercontent.com/15604491/204121345-a276d865-e1af-4d48-91b3-802759867d62.png)
![image](https://user-images.githubusercontent.com/15604491/204121486-573dae35-eaf9-462d-b01d-6672e65bfb32.png)
[4]
![image](https://user-images.githubusercontent.com/15604491/204353442-562098d5-5693-4e2f-9df0-2bf62c53ab08.png)
![image](https://user-images.githubusercontent.com/15604491/204353387-3a627048-c1e3-4e77-8443-3d6960140a0e.png)
![image](https://user-images.githubusercontent.com/15604491/204352811-ecf91221-e01f-4693-9038-b534ef3c8c03.png)

[5]
![image](https://user-images.githubusercontent.com/15604491/204121206-5f86cacd-80de-4394-9269-4ae7b487f552.png)
![image](https://user-images.githubusercontent.com/15604491/204121219-727f5588-0c94-4e17-9521-7aedba20b9e6.png)