### PR TITLE
add nodejs.org to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -539,6 +539,7 @@ nitter.net
 nitter.nixnet.services
 nitter.pussthecat.org
 nitter.snopyta.org
+nodejs.org
 nomanssky.com
 northward.info
 nostv.pt


### PR DESCRIPTION
I tested it in Firefox Private tabs, multiple times, it looks dark by default (I guess?)