### PR TITLE
Add website in global dark list description

### DIFF
--- a/src/ui/popup/main-page/site-toggle.tsx
+++ b/src/ui/popup/main-page/site-toggle.tsx
@@ -10,15 +10,25 @@ export default function SiteToggleGroup(props: ViewProps) {
     const tab = props.data.activeTab;
     const isPageEnabled = isURLEnabled(tab.url, props.data.settings, tab, props.data.isAllowedFileSchemeAccess);
     const isFile = isChromium && isLocalFile(tab.url);
-    const {isDarkThemeDetected, isProtected} = tab;
-    const descriptionText = (isFile && !props.data.isAllowedFileSchemeAccess) ? (
-        getLocalMessage('local_files_forbidden')
-    ) : isPDF(tab.url) ? (
-        isPageEnabled ? 'Enabled for PDF files' : 'Disabled for PDF files'
-    ) : isDarkThemeDetected ? 'Dark theme detected on page' : (
-        isPageEnabled ? 'Enabled for current website' :
-            isProtected ? getLocalMessage('page_protected') : 'Disabled for current website'
-    );
+    const {isDarkThemeDetected, isProtected, isInDarkList} = tab;
+    let descriptionText = '';
+
+    if (isFile && !props.data.isAllowedFileSchemeAccess) {
+        descriptionText = getLocalMessage('local_files_forbidden');
+    } else if (isPDF(tab.url)) {
+        descriptionText = isPageEnabled ? 'Enabled for PDF files' : 'Disabled for PDF files';
+    } else if (isDarkThemeDetected) {
+        descriptionText = 'Dark theme detected on page';
+    } else if (isPageEnabled) {
+        descriptionText = 'Enabled for current website';
+    } else if (isProtected) {
+        descriptionText = getLocalMessage('page_protected');
+    } else if (isInDarkList) {
+        descriptionText = getLocalMessage('page_in_dark_list');
+    } else {
+        descriptionText = 'Disabled for current website';
+    }
+
     const description = (
         <span
             class={{


### PR DESCRIPTION
- When visiting a website that's in the global dark list, show this in the popup.
- Resolves #10366