### PR TITLE
Refactor: enable strictNullChecks in TypeScript compiler configuration

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,7 +17,7 @@ const isIFrame = (() => {
     }
 })();
 
-export function enable(themeOptions: Partial<Theme> = {}, fixes: DynamicThemeFix = null) {
+export function enable(themeOptions: Partial<Theme> | null = {}, fixes: DynamicThemeFix | null = null) {
     const theme = {...DEFAULT_THEME, ...themeOptions};
 
     if (theme.engine !== ThemeEngine.dynamicTheme) {
@@ -40,8 +40,8 @@ export function disable() {
 
 const darkScheme = matchMedia('(prefers-color-scheme: dark)');
 let store = {
-    themeOptions: null as Partial<Theme>,
-    fixes: null as DynamicThemeFix,
+    themeOptions: null as Partial<Theme> | null,
+    fixes: null as DynamicThemeFix | null,
 };
 
 function handleColorScheme() {
@@ -52,7 +52,7 @@ function handleColorScheme() {
     }
 }
 
-export function auto(themeOptions: Partial<Theme> | false = {}, fixes: DynamicThemeFix = null) {
+export function auto(themeOptions: Partial<Theme> | false = {}, fixes: DynamicThemeFix | null = null) {
     if (themeOptions) {
         store = {themeOptions, fixes};
         handleColorScheme();

--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -35,36 +35,40 @@ const CONFIG_URLs = {
 };
 const REMOTE_TIMEOUT_MS = getDuration({seconds: 10});
 
-interface Config {
+interface LocalConfig {
+    local: boolean;
+}
+
+interface Config extends LocalConfig {
     name?: string;
     local: boolean;
-    localURL?: string;
+    localURL: string;
     remoteURL?: string;
 }
 
 export default class ConfigManager {
-    static DARK_SITES?: string[];
-    static DYNAMIC_THEME_FIXES_INDEX?: SitePropsIndex<DynamicThemeFix>;
-    static DYNAMIC_THEME_FIXES_RAW?: string;
-    static INVERSION_FIXES_INDEX?: SitePropsIndex<InversionFix>;
-    static INVERSION_FIXES_RAW?: string;
-    static STATIC_THEMES_INDEX?: SitePropsIndex<StaticTheme>;
-    static STATIC_THEMES_RAW?: string;
-    static COLOR_SCHEMES_RAW?: ParsedColorSchemeConfig;
+    static DARK_SITES: string[];
+    static DYNAMIC_THEME_FIXES_INDEX: SitePropsIndex<DynamicThemeFix> | null;
+    static DYNAMIC_THEME_FIXES_RAW: string | null;
+    static INVERSION_FIXES_INDEX: SitePropsIndex<InversionFix> | null;
+    static INVERSION_FIXES_RAW: string | null;
+    static STATIC_THEMES_INDEX: SitePropsIndex<StaticTheme> | null;
+    static STATIC_THEMES_RAW: string | null;
+    static COLOR_SCHEMES_RAW: ParsedColorSchemeConfig | null;
 
     static raw = {
-        darkSites: null as string,
-        dynamicThemeFixes: null as string,
-        inversionFixes: null as string,
-        staticThemes: null as string,
-        colorSchemes: null as string,
+        darkSites: null as string | null,
+        dynamicThemeFixes: null as string | null,
+        inversionFixes: null as string | null,
+        staticThemes: null as string | null,
+        colorSchemes: null as string | null,
     };
 
     static overrides = {
-        darkSites: null as string,
-        dynamicThemeFixes: null as string,
-        inversionFixes: null as string,
-        staticThemes: null as string,
+        darkSites: null as string | null,
+        dynamicThemeFixes: null as string | null,
+        inversionFixes: null as string | null,
+        staticThemes: null as string | null,
     };
 
     private static async loadConfig({
@@ -91,7 +95,7 @@ export default class ConfigManager {
         return $config;
     }
 
-    private static async loadColorSchemes({local}: Config) {
+    private static async loadColorSchemes({local}: LocalConfig) {
         const $config = await this.loadConfig({
             name: 'Color Schemes',
             local,
@@ -102,7 +106,7 @@ export default class ConfigManager {
         this.handleColorSchemes();
     }
 
-    private static async loadDarkSites({local}: Config) {
+    private static async loadDarkSites({local}: LocalConfig) {
         const sites = await this.loadConfig({
             name: 'Dark Sites',
             local,
@@ -113,7 +117,7 @@ export default class ConfigManager {
         this.handleDarkSites();
     }
 
-    private static async loadDynamicThemeFixes({local}: Config) {
+    private static async loadDynamicThemeFixes({local}: LocalConfig) {
         const fixes = await this.loadConfig({
             name: 'Dynamic Theme Fixes',
             local,
@@ -124,7 +128,7 @@ export default class ConfigManager {
         this.handleDynamicThemeFixes();
     }
 
-    private static async loadInversionFixes({local}: Config) {
+    private static async loadInversionFixes({local}: LocalConfig) {
         const fixes = await this.loadConfig({
             name: 'Inversion Fixes',
             local,
@@ -135,7 +139,7 @@ export default class ConfigManager {
         this.handleInversionFixes();
     }
 
-    private static async loadStaticThemes({local}: Config) {
+    private static async loadStaticThemes({local}: LocalConfig) {
         const themes = await this.loadConfig({
             name: 'Static Themes',
             local,
@@ -146,7 +150,7 @@ export default class ConfigManager {
         this.handleStaticThemes();
     }
 
-    static async load(config?: Config) {
+    static async load(config?: LocalConfig) {
         if (!config) {
             await UserStorage.loadSettings();
             config = {
@@ -165,7 +169,7 @@ export default class ConfigManager {
 
     private static handleColorSchemes() {
         const $config = this.raw.colorSchemes;
-        const {result, error} = ParseColorSchemeConfig($config);
+        const {result, error} = ParseColorSchemeConfig($config || '');
         if (error) {
             logWarn(`Color Schemes parse error, defaulting to fallback. ${error}.`);
             this.COLOR_SCHEMES_RAW = DEFAULT_COLORSCHEME;
@@ -176,23 +180,23 @@ export default class ConfigManager {
 
     private static handleDarkSites() {
         const $sites = this.overrides.darkSites || this.raw.darkSites;
-        this.DARK_SITES = parseArray($sites);
+        this.DARK_SITES = parseArray($sites || '');
     }
 
     static handleDynamicThemeFixes() {
-        const $fixes = this.overrides.dynamicThemeFixes || this.raw.dynamicThemeFixes;
+        const $fixes = this.overrides.dynamicThemeFixes || this.raw.dynamicThemeFixes || '';
         this.DYNAMIC_THEME_FIXES_INDEX = indexSitesFixesConfig<DynamicThemeFix>($fixes);
         this.DYNAMIC_THEME_FIXES_RAW = $fixes;
     }
 
     static handleInversionFixes() {
-        const $fixes = this.overrides.inversionFixes || this.raw.inversionFixes;
+        const $fixes = this.overrides.inversionFixes || this.raw.inversionFixes || '';
         this.INVERSION_FIXES_INDEX = indexSitesFixesConfig<InversionFix>($fixes);
         this.INVERSION_FIXES_RAW = $fixes;
     }
 
     static handleStaticThemes() {
-        const $themes = this.overrides.staticThemes || this.raw.staticThemes;
+        const $themes = this.overrides.staticThemes || this.raw.staticThemes || '';
         this.STATIC_THEMES_INDEX = indexSitesFixesConfig<StaticTheme>($themes);
         this.STATIC_THEMES_RAW = $themes;
     }

--- a/src/background/content-script-manager.ts
+++ b/src/background/content-script-manager.ts
@@ -9,7 +9,7 @@ enum ContentScriptManagerState {
     NOTREGISTERED,
 }
 
-// TODO: remove once @types/chrome is updated
+// TODO: remove type after dependency update
 // eslint-disable-next-line @typescript-eslint/no-namespace
 declare namespace chrome.scripting {
     export function getRegisteredContentScripts(filter: { ids: string[] }, callback: (scripts: null[]) => void): void;

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -120,7 +120,7 @@ if (__WATCH__) {
                     chrome.tabs.query({}, (tabs) => {
                         for (const tab of tabs) {
                             if (canInjectScript(tab.url)) {
-                                chrome.tabs.sendMessage<Message>(tab.id, {type: MessageType.BG_RELOAD});
+                                chrome.tabs.sendMessage<Message>(tab.id!, {type: MessageType.BG_RELOAD});
                             }
                         }
                         chrome.runtime.reload();
@@ -160,7 +160,7 @@ if (__TEST__) {
     socket.onmessage = (e) => {
         try {
             const message: TestMessage = JSON.parse(e.data);
-            const respond = (data?: ExtensionData | string | boolean | {[key: string]: string}) => socket.send(JSON.stringify({
+            const respond = (data?: ExtensionData | string | boolean | {[key: string]: string} | null) => socket.send(JSON.stringify({
                 data,
                 id: message.id,
             }));

--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -44,7 +44,7 @@ export default class Messenger {
             chrome.runtime.getURL('/ui/devtools/index.html'),
             chrome.runtime.getURL('/ui/stylesheet-editor/index.html')
         ];
-        if (allowedSenderURL.includes(sender.url)) {
+        if (allowedSenderURL.includes(sender.url!)) {
             this.onUIMessage(message, sendResponse);
             return ([
                 MessageType.UI_GET_DATA,
@@ -53,7 +53,7 @@ export default class Messenger {
     }
 
     private static firefoxPortListener(port: chrome.runtime.Port) {
-        let promise: Promise<ExtensionData | TabInfo>;
+        let promise: Promise<ExtensionData | TabInfo | null>;
         switch (port.name) {
             case MessageType.UI_GET_DATA:
                 promise = this.adapter.collect();
@@ -125,7 +125,7 @@ export default class Messenger {
                 break;
             case MessageType.UI_APPLY_DEV_DYNAMIC_THEME_FIXES: {
                 const error = this.adapter.applyDevDynamicThemeFixes(data);
-                sendResponse({error: (error ? error.message : null)});
+                sendResponse({error: (error ? error.message : undefined)});
                 break;
             }
             case MessageType.UI_RESET_DEV_DYNAMIC_THEME_FIXES:
@@ -133,7 +133,7 @@ export default class Messenger {
                 break;
             case MessageType.UI_APPLY_DEV_INVERSION_FIXES: {
                 const error = this.adapter.applyDevInversionFixes(data);
-                sendResponse({error: (error ? error.message : null)});
+                sendResponse({error: (error ? error.message : undefined)});
                 break;
             }
             case MessageType.UI_RESET_DEV_INVERSION_FIXES:
@@ -141,7 +141,7 @@ export default class Messenger {
                 break;
             case MessageType.UI_APPLY_DEV_STATIC_THEMES: {
                 const error = this.adapter.applyDevStaticThemes(data);
-                sendResponse({error: error ? error.message : null});
+                sendResponse({error: error ? error.message : undefined});
                 break;
             }
             case MessageType.UI_RESET_DEV_STATIC_THEMES:

--- a/src/background/newsmaker.ts
+++ b/src/background/newsmaker.ts
@@ -6,9 +6,9 @@ import {StateManager} from '../utils/state-manager';
 import {logWarn} from './utils/log';
 import IconManager from './icon-manager';
 
-interface NewsmakerState {
+interface NewsmakerState extends Record<string, unknown> {
     latest: News[];
-    latestTimestamp: number;
+    latestTimestamp: number | null;
 }
 
 export default class Newsmaker {
@@ -19,7 +19,7 @@ export default class Newsmaker {
     private static initialized: boolean;
     private static stateManager: StateManager<NewsmakerState>;
     private static latest: News[];
-    private static latestTimestamp: number;
+    private static latestTimestamp: number | null;
 
     constructor() {
         if (Newsmaker.initialized) {

--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -11,7 +11,7 @@ const SAVE_TIMEOUT = 1000;
 
 export default class UserStorage {
     private static loadBarrier: PromiseBarrier<UserSettings, void>;
-    private static saveStorageBarrier: PromiseBarrier<void, void>;
+    private static saveStorageBarrier: PromiseBarrier<void, void> | null;
     static settings: Readonly<UserSettings>;
 
     static async loadSettings() {
@@ -86,8 +86,6 @@ export default class UserStorage {
             UserStorage.set({syncSettings: false});
             UserStorage.saveSyncSetting(false);
             UserStorage.loadBarrier.resolve(local);
-            UserStorage.migrateAutomationSettings($sync);
-            UserStorage.fillDefaults($sync);
             return local;
         }
 

--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -1,7 +1,7 @@
 import {isPDF} from '../../utils/url';
 import {isFirefox, isEdge} from '../../utils/platform';
 
-export function canInjectScript(url: string) {
+export function canInjectScript(url: string | null | undefined) {
     if (isFirefox) {
         return (url
             && !url.startsWith('about:')
@@ -34,8 +34,8 @@ export function canInjectScript(url: string) {
     );
 }
 
-export async function readSyncStorage<T extends {[key: string]: any}>(defaults: T): Promise<T> {
-    return new Promise<T>((resolve) => {
+export async function readSyncStorage<T extends {[key: string]: any}>(defaults: T): Promise<T | null> {
+    return new Promise<T | null>((resolve) => {
         chrome.storage.sync.get(null, (sync: any) => {
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError.message);

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -34,7 +34,7 @@ export async function readText(params: RequestParams): Promise<string> {
             // XMLHttpRequest is not available in Service Worker contexts like
             // Manifest V3 background context
             let abortController: AbortController;
-            let signal: AbortSignal;
+            let signal: AbortSignal | undefined;
             let timedOut = false;
             if (params.timeout) {
                 abortController = new AbortController();
@@ -73,7 +73,7 @@ interface CacheRecord {
 }
 
 class LimitedCacheStorage {
-    // TODO: remove any cast once declarations are updated
+    // TODO: remove type cast after dependency update
     private static QUOTA_BYTES = ((!__TEST__ && (navigator as any).deviceMemory) || 4) * 16 * 1024 * 1024;
     private static TTL = getDuration({minutes: 10});
     private static ALARM_NAME = 'network';
@@ -106,7 +106,7 @@ class LimitedCacheStorage {
 
     get(url: string) {
         if (this.records.has(url)) {
-            const record = this.records.get(url);
+            const record = this.records.get(url)!;
             record.expires = Date.now() + LimitedCacheStorage.TTL;
             this.records.delete(url);
             this.records.set(url, record);

--- a/src/background/utils/sendLog.ts
+++ b/src/background/utils/sendLog.ts
@@ -1,16 +1,16 @@
 declare const __DEBUG__: boolean;
 declare const __LOG__: 'info' | 'warn';
 
-let socket: WebSocket = null;
-let messageQueue: string[] | null = [];
+let socket: WebSocket | null = null;
+let messageQueue: string[] = [];
 function createSocket() {
     if (socket) {
         return;
     }
     socket = new WebSocket(`ws://localhost:${9000}`);
     socket.addEventListener('open', () => {
-        messageQueue.forEach((message) => socket.send(message));
-        messageQueue = null;
+        messageQueue.forEach((message) => this.send(message));
+        messageQueue = [];
     });
 }
 

--- a/src/background/window-theme.ts
+++ b/src/background/window-theme.ts
@@ -3,7 +3,7 @@ import {parseColorWithCache} from '../utils/color';
 import {modifyBackgroundColor, modifyForegroundColor, modifyBorderColor} from '../generators/modify-colors';
 import type {FilterConfig} from '../definitions';
 
-// TODO: remove this after TypeScript declarations are updated
+// TODO: remove type after dependency update
 declare const browser: {
     theme: {
         update: ((theme: any) => Promise<void>);
@@ -11,7 +11,7 @@ declare const browser: {
     };
 };
 
-const themeColorTypes: { [key: string]: string } = {
+const themeColorTypes: { [key: string]: 'bg' | 'text' | 'border' } = {
     accentcolor: 'bg',
     button_background_active: 'text',
     button_background_hover: 'text',
@@ -71,13 +71,13 @@ const $colors: { [key: string]: string } = {
 
 export function setWindowTheme(filter: FilterConfig) {
     const colors = Object.entries($colors).reduce((obj: { [key: string]: string }, [key, value]) => {
-        const type: string = themeColorTypes[key];
+        const type: 'bg' | 'text' | 'border' = themeColorTypes[key];
         const modify: ((rgb: RGBA, filter: FilterConfig) => string) = {
             'bg': modifyBackgroundColor,
             'text': modifyForegroundColor,
             'border': modifyBorderColor,
         }[type];
-        const rgb = parseColorWithCache(value);
+        const rgb = parseColorWithCache(value)!;
         const modified = modify(rgb, filter);
         obj[key] = modified;
         return obj;

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -12,7 +12,7 @@ export interface ExtensionData {
     news: News[];
     shortcuts: Shortcuts;
     colorScheme: ParsedColorSchemeConfig;
-    forcedScheme: 'dark' | 'light';
+    forcedScheme: 'dark' | 'light' | null;
     devtools: {
         dynamicFixesText: string;
         filterFixesText: string;
@@ -29,7 +29,7 @@ export interface TabData {
 export interface ExtensionActions {
     changeSettings(settings: Partial<UserSettings>): void;
     setTheme(theme: Partial<FilterConfig>): void;
-    setShortcut(command: string, shortcut: string): Promise<string>;
+    setShortcut(command: string, shortcut: string): Promise<string | null>;
     toggleActiveTab(): void;
     markNewsAsRead(ids: string[]): void;
     markNewsAsDisplayed(ids: string[]): void;
@@ -118,16 +118,16 @@ export interface TimeSettings {
 }
 
 export interface LocationSettings {
-    latitude: number;
-    longitude: number;
+    latitude: number | null;
+    longitude: number | null;
 }
 
 export interface TabInfo {
     url: string;
     isProtected: boolean;
-    isInjected: boolean;
+    isInjected: boolean | null;
     isInDarkList: boolean;
-    isDarkThemeDetected: boolean;
+    isDarkThemeDetected: boolean | null;
 }
 
 export interface Message {

--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -43,7 +43,7 @@ export function hasFirefoxNewRootBehavior() {
 }
 
 export default function createCSSFilterStyleSheet(config: FilterConfig, url: string, isTopFrame: boolean, fixes: string, index: SitePropsIndex<InversionFix>) {
-    const filterValue = getCSSFilterValue(config);
+    const filterValue = getCSSFilterValue(config)!;
     const reverseFilterValue = 'invert(100%) hue-rotate(180deg)';
     return cssFilterStyleSheetTemplate(filterValue, reverseFilterValue, config, url, isTopFrame, fixes, index);
 }
@@ -255,7 +255,7 @@ export function formatInversionFixes(inversionFixes: InversionFix[]) {
 
     return formatSitesFixesConfig(fixes, {
         props: Object.values(inversionFixesCommands),
-        getPropCommandName: (prop) => Object.entries(inversionFixesCommands).find(([, p]) => p === prop)[0],
+        getPropCommandName: (prop) => Object.entries(inversionFixesCommands).find(([, p]) => p === prop)![0],
         formatPropValue: (prop, value) => {
             if (prop === 'css') {
                 return (value as string).trim().replace(/\n+/g, '\n');

--- a/src/generators/dynamic-theme.ts
+++ b/src/generators/dynamic-theme.ts
@@ -33,7 +33,7 @@ export function formatDynamicThemeFixes(dynamicThemeFixes: DynamicThemeFix[]) {
 
     return formatSitesFixesConfig(fixes, {
         props: Object.values(dynamicThemeFixesCommands),
-        getPropCommandName: (prop) => Object.entries(dynamicThemeFixesCommands).find(([, p]) => p === prop)[0],
+        getPropCommandName: (prop) => Object.entries(dynamicThemeFixesCommands).find(([, p]) => p === prop)![0],
         formatPropValue: (prop, value) => {
             if (prop === 'css') {
                 return (value as string).trim().replace(/\n+/g, '\n');
@@ -49,7 +49,7 @@ export function formatDynamicThemeFixes(dynamicThemeFixes: DynamicThemeFix[]) {
     });
 }
 
-export function getDynamicThemeFixesFor(url: string, isTopFrame: boolean, text: string, index: SitePropsIndex<DynamicThemeFix>, enabledForPDF: boolean): DynamicThemeFix[] {
+export function getDynamicThemeFixesFor(url: string, isTopFrame: boolean, text: string, index: SitePropsIndex<DynamicThemeFix>, enabledForPDF: boolean): DynamicThemeFix[] | null {
     const fixes = getSitesFixesFor(url, text, index, {
         commands: Object.keys(dynamicThemeFixesCommands),
         getCommandPropName: (command) => dynamicThemeFixesCommands[command],

--- a/src/generators/modify-colors.ts
+++ b/src/generators/modify-colors.ts
@@ -40,17 +40,17 @@ function getCacheId(rgb: RGBA, theme: Theme) {
     return resultId;
 }
 
-function modifyColorWithCache(rgb: RGBA, theme: Theme, modifyHSL: (hsl: HSLA, pole?: HSLA, anotherPole?: HSLA) => HSLA, poleColor?: string, anotherPoleColor?: string) {
+function modifyColorWithCache(rgb: RGBA, theme: Theme, modifyHSL: (hsl: HSLA, pole?: HSLA | null, anotherPole?: HSLA | null) => HSLA, poleColor?: string, anotherPoleColor?: string) {
     let fnCache: Map<string, string>;
     if (colorModificationCache.has(modifyHSL)) {
-        fnCache = colorModificationCache.get(modifyHSL);
+        fnCache = colorModificationCache.get(modifyHSL)!;
     } else {
         fnCache = new Map();
         colorModificationCache.set(modifyHSL, fnCache);
     }
     const id = getCacheId(rgb, theme);
     if (fnCache.has(id)) {
-        return fnCache.get(id);
+        return fnCache.get(id)!;
     }
 
     const hsl = rgbToHSL(rgb);

--- a/src/generators/static-theme.ts
+++ b/src/generators/static-theme.ts
@@ -76,12 +76,12 @@ export default function createStaticStylesheet(config: FilterConfig, url: string
 
     if (!siteTheme || !siteTheme.noCommon) {
         lines.push('/* Common theme */');
-        lines.push(...ruleGenerators.map((gen) => gen(commonTheme, theme)));
+        lines.push(...ruleGenerators.map((gen) => gen(commonTheme, theme)!));
     }
 
     if (siteTheme) {
         lines.push(`/* Theme for ${siteTheme.url.join(' ')} */`);
-        lines.push(...ruleGenerators.map((gen) => gen(siteTheme, theme)));
+        lines.push(...ruleGenerators.map((gen) => gen(siteTheme, theme)!));
     }
 
     if (config.useFont || config.textStroke > 0) {
@@ -94,7 +94,7 @@ export default function createStaticStylesheet(config: FilterConfig, url: string
         .join('\n');
 }
 
-function createRuleGen(getSelectors: (siteTheme: StaticTheme) => string[], generateDeclarations: (theme: ThemeColors) => string[], modifySelector: ((s: string) => string) = (s) => s) {
+function createRuleGen(getSelectors: (siteTheme: StaticTheme) => string[] | undefined, generateDeclarations: (theme: ThemeColors) => string[], modifySelector: ((s: string) => string) = (s) => s) {
     return (siteTheme: StaticTheme, themeColors: ThemeColors) => {
         const selectors = getSelectors(siteTheme);
         if (selectors == null || selectors.length === 0) {

--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -144,11 +144,11 @@ export function indexSitesFixesConfig<T extends SiteProps>(text: string): SitePr
     let recordStart = 0;
     // Delimiter between two blocks
     const delimiterRegex = /^\s*={2,}\s*$/gm;
-    let delimiter: RegExpMatchArray;
+    let delimiter: RegExpMatchArray | null;
     let count = 0;
     while ((delimiter = delimiterRegex.exec(text))) {
-        const nextDelimiterStart = delimiter.index;
-        const nextDelimiterEnd = delimiter.index + delimiter[0].length;
+        const nextDelimiterStart = delimiter.index!;
+        const nextDelimiterEnd = delimiter.index! + delimiter[0].length;
 
         processBlock(recordStart, nextDelimiterStart, count);
 

--- a/src/inject/color-scheme-watcher.ts
+++ b/src/inject/color-scheme-watcher.ts
@@ -9,7 +9,7 @@ function cleanup() {
 }
 
 function sendMessage(message: Message) {
-    const responseHandler = (response: 'unsupportedSender' | undefined) => {
+    const responseHandler = (response: Message | 'unsupportedSender' | undefined) => {
         // Vivaldi bug workaround. See TabManager for details.
         if (response === 'unsupportedSender') {
             cleanup();

--- a/src/inject/detector.ts
+++ b/src/inject/detector.ts
@@ -4,10 +4,10 @@ function hasBuiltInDarkTheme() {
     const drStyles = document.querySelectorAll('.darkreader') as NodeListOf<HTMLStyleElement & {disabled: boolean}>;
     drStyles.forEach((style) => style.disabled = true);
 
-    const rootColor = parseColorWithCache(getComputedStyle(document.documentElement).backgroundColor);
-    const bodyColor = document.body ? parseColorWithCache(getComputedStyle(document.body).backgroundColor) : {r: 0, g: 0, b: 0, a: 0};
-    const rootLightness = (1 - rootColor.a) + rootColor.a * getSRGBLightness(rootColor.r, rootColor.g, rootColor.b);
-    const finalLightness = (1 - bodyColor.a) * rootLightness + bodyColor.a * getSRGBLightness(bodyColor.r, bodyColor.g, bodyColor.b);
+    const rootColor = parseColorWithCache(getComputedStyle(document.documentElement).backgroundColor)!;
+    const bodyColor = document.body ? parseColorWithCache(getComputedStyle(document.body).backgroundColor)! : {r: 0, g: 0, b: 0, a: 0};
+    const rootLightness = (1 - rootColor.a!) + rootColor.a! * getSRGBLightness(rootColor.r, rootColor.g, rootColor.b);
+    const finalLightness = (1 - bodyColor.a!) * rootLightness + bodyColor.a! * getSRGBLightness(bodyColor.r, bodyColor.g, bodyColor.b);
     const darkThemeDetected = finalLightness < 0.5;
 
     drStyles.forEach((style) => style.disabled = false);
@@ -31,8 +31,8 @@ function hasSomeStyle() {
     return false;
 }
 
-let observer: MutationObserver;
-let readyStateListener: () => void;
+let observer: MutationObserver | null;
+let readyStateListener: (() => void) | null;
 
 export function runDarkThemeDetector(callback: (hasDarkTheme: boolean) => void) {
     stopDarkThemeDetector();

--- a/src/inject/dynamic-theme/css-collection.ts
+++ b/src/inject/dynamic-theme/css-collection.ts
@@ -58,7 +58,7 @@ export async function collectCSS() {
 
     const modifiedCSS: string[] = [];
     document.querySelectorAll('.darkreader--sync').forEach((element: HTMLStyleElement) => {
-        forEach(element.sheet.cssRules, (rule) => {
+        forEach(element.sheet!.cssRules, (rule) => {
             rule && rule.cssText && modifiedCSS.push(rule.cssText);
         });
     });

--- a/src/inject/dynamic-theme/css-rules.ts
+++ b/src/inject/dynamic-theme/css-rules.ts
@@ -70,7 +70,7 @@ export function iterateCSSDeclarations(style: CSSStyleDeclaration, iterate: (pro
     if (cssText.includes('var(')) {
         if (isSafari) {
             // Safari doesn't show shorthand properties' values
-            shorthandVarDepPropRegexps.forEach(([prop, regexp]) => {
+            shorthandVarDepPropRegexps!.forEach(([prop, regexp]) => {
                 const match = cssText.match(regexp);
                 if (match && match[1]) {
                     const val = match[1].trim();

--- a/src/inject/dynamic-theme/fixes.ts
+++ b/src/inject/dynamic-theme/fixes.ts
@@ -11,14 +11,14 @@ import {isURLInList} from '../../utils/url';
  *        and fixes matching the document origin
  * @returns A single fix constructed from the generic fix and a single most relevant other fix
  */
-export function findRelevantFix(documentURL: string, fixes: DynamicThemeFix[]): number {
+export function findRelevantFix(documentURL: string, fixes: DynamicThemeFix[]): number | null {
     if (!Array.isArray(fixes) || fixes.length === 0 || fixes[0].url[0] !== '*') {
         logWarn('selectRelevantFix() failed to construct a single fix', documentURL, fixes);
         return null;
     }
 
     let maxSpecificity = 0;
-    let maxSpecificityIndex: number = null;
+    let maxSpecificityIndex: number | null = null;
     for (let i = 1; i < fixes.length; i++) {
         if (isURLInList(documentURL, fixes[i].url)) {
             // Note: this is legacy logic, a bit odd
@@ -38,7 +38,7 @@ export function findRelevantFix(documentURL: string, fixes: DynamicThemeFix[]): 
  * @param fixes The original fixes
  * @returns The combined fix
  */
-export function combineFixes(fixes: DynamicThemeFix[]): DynamicThemeFix {
+export function combineFixes(fixes: DynamicThemeFix[]): DynamicThemeFix | null {
     if (fixes.length === 0 || fixes[0].url[0] !== '*') {
         logWarn('combineFixes() failed to construct a single fix', fixes);
         return null;
@@ -49,7 +49,7 @@ export function combineFixes(fixes: DynamicThemeFix[]): DynamicThemeFix {
     }
 
     return {
-        url: null,
+        url: [],
         invert: combineArrays(fixes.map((fix) => fix.invert)),
         css: fixes.map((fix) => fix.css).filter(Boolean).join('\n'),
         ignoreInlineStyle: combineArrays(fixes.map((fix) => fix.ignoreInlineStyle)),

--- a/src/inject/dynamic-theme/image.ts
+++ b/src/inject/dynamic-theme/image.ts
@@ -69,8 +69,8 @@ async function urlToImage(url: string) {
 }
 
 const MAX_ANALIZE_PIXELS_COUNT = 32 * 32;
-let canvas: HTMLCanvasElement | OffscreenCanvas;
-let context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+let canvas: HTMLCanvasElement | OffscreenCanvas | null;
+let context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
 
 function createCanvas() {
     const maxWidth = MAX_ANALIZE_PIXELS_COUNT;
@@ -78,7 +78,7 @@ function createCanvas() {
     canvas = document.createElement('canvas');
     canvas.width = maxWidth;
     canvas.height = maxHeight;
-    context = canvas.getContext('2d', {willReadFrequently: true});
+    context = canvas.getContext('2d', {willReadFrequently: true})!;
     context.imageSmoothingEnabled = false;
 }
 
@@ -97,7 +97,13 @@ function analyzeImage(image: HTMLImageElement) {
     const {naturalWidth, naturalHeight} = image;
     if (naturalHeight === 0 || naturalWidth === 0) {
         logWarn(`logWarn(Image is empty ${image.currentSrc})`);
-        return null;
+        return {
+            isDark: false,
+            isLight: false,
+            isTransparent: false,
+            isLarge: false,
+            isTooLarge: false,
+        };
     }
 
     // Get good appromized image size in memory terms.
@@ -121,10 +127,10 @@ function analyzeImage(image: HTMLImageElement) {
     const k = Math.min(1, Math.sqrt(MAX_ANALIZE_PIXELS_COUNT / naturalPixelsCount));
     const width = Math.ceil(naturalWidth * k);
     const height = Math.ceil(naturalHeight * k);
-    context.clearRect(0, 0, width, height);
+    context!.clearRect(0, 0, width, height);
 
-    context.drawImage(image, 0, 0, naturalWidth, naturalHeight, 0, 0, width, height);
-    const imageData = context.getImageData(0, 0, width, height);
+    context!.drawImage(image, 0, 0, naturalWidth, naturalHeight, 0, 0, width, height);
+    const imageData = context!.getImageData(0, 0, width, height);
     const d = imageData.data;
 
     const TRANSPARENT_ALPHA_THRESHOLD = 0.05;

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -122,7 +122,7 @@ export function watchForInlineStyles(
 ) {
     deepWatchForInlineStyles(document, elementStyleDidChange, shadowRootDiscovered);
     iterateShadowHosts(document.documentElement, (host) => {
-        deepWatchForInlineStyles(host.shadowRoot, elementStyleDidChange, shadowRootDiscovered);
+        deepWatchForInlineStyles(host.shadowRoot!, elementStyleDidChange, shadowRootDiscovered);
     });
 }
 
@@ -132,8 +132,8 @@ function deepWatchForInlineStyles(
     shadowRootDiscovered: (root: ShadowRoot) => void,
 ) {
     if (treeObservers.has(root)) {
-        treeObservers.get(root).disconnect();
-        attrObservers.get(root).disconnect();
+        treeObservers.get(root)!.disconnect();
+        attrObservers.get(root)!.disconnect();
     }
 
     const discoveredNodes = new WeakSet<Node>();
@@ -151,8 +151,8 @@ function deepWatchForInlineStyles(
                 return;
             }
             discoveredNodes.add(node);
-            shadowRootDiscovered(n.shadowRoot);
-            deepWatchForInlineStyles(n.shadowRoot, elementStyleDidChange, shadowRootDiscovered);
+            shadowRootDiscovered(n.shadowRoot!);
+            deepWatchForInlineStyles(n.shadowRoot!, elementStyleDidChange, shadowRootDiscovered);
         });
     }
 
@@ -167,16 +167,16 @@ function deepWatchForInlineStyles(
     treeObservers.set(root, treeObserver);
 
     let attemptCount = 0;
-    let start: number = null;
+    let start: number | null = null;
     const ATTEMPTS_INTERVAL = getDuration({seconds: 10});
     const RETRY_TIMEOUT = getDuration({seconds: 2});
     const MAX_ATTEMPTS_COUNT = 50;
     let cache: MutationRecord[] = [];
-    let timeoutId: ReturnType<typeof setTimeout> = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const handleAttributeMutations = throttle((mutations: MutationRecord[]) => {
         mutations.forEach((m) => {
-            if (INLINE_STYLE_ATTRS.includes(m.attributeName)) {
+            if (INLINE_STYLE_ATTRS.includes(m.attributeName!)) {
                 elementStyleDidChange(m.target as HTMLElement);
             }
         });
@@ -301,7 +301,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
     }
 
     if (element.hasAttribute('bgcolor')) {
-        let value = element.getAttribute('bgcolor');
+        let value = element.getAttribute('bgcolor')!;
         if (value.match(/^[0-9a-f]{3}$/i) || value.match(/^[0-9a-f]{6}$/i)) {
             value = `#${value}`;
         }
@@ -312,7 +312,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
     // It's valid HTML code according to the specs, https://html.spec.whatwg.org/#attr-link-color
     // We don't want to touch such link as it cause weird behavior of the browser(Silent DOMException).
     if (element.hasAttribute('color') && (element as HTMLLinkElement).rel !== 'mask-icon') {
-        let value = element.getAttribute('color');
+        let value = element.getAttribute('color')!;
         if (value.match(/^[0-9a-f]{3}$/i) || value.match(/^[0-9a-f]{6}$/i)) {
             value = `#${value}`;
         }
@@ -321,7 +321,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
     if (element instanceof SVGElement) {
         if (element.hasAttribute('fill')) {
             const SMALL_SVG_LIMIT = 32;
-            const value = element.getAttribute('fill');
+            const value = element.getAttribute('fill')!;
             if (value !== 'none') {
                 if (!(element instanceof SVGTextElement)) {
                     // getBoundingClientRect forces a layout change. And when it so happens that.
@@ -345,11 +345,11 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
             }
         }
         if (element.hasAttribute('stop-color')) {
-            setCustomProp('stop-color', 'background-color', element.getAttribute('stop-color'));
+            setCustomProp('stop-color', 'background-color', element.getAttribute('stop-color')!);
         }
     }
     if (element.hasAttribute('stroke')) {
-        const value = element.getAttribute('stroke');
+        const value = element.getAttribute('stroke')!;
         setCustomProp('stroke', element instanceof SVGLineElement || element instanceof SVGTextElement ? 'border-color' : 'color', value);
     }
     element.style && iterateCSSDeclarations(element.style, (property, value) => {

--- a/src/inject/dynamic-theme/meta-theme-color.ts
+++ b/src/inject/dynamic-theme/meta-theme-color.ts
@@ -5,8 +5,8 @@ import type {FilterConfig} from '../../definitions';
 
 const metaThemeColorName = 'theme-color';
 const metaThemeColorSelector = `meta[name="${metaThemeColorName}"]`;
-let srcMetaThemeColor: string = null;
-let observer: MutationObserver = null;
+let srcMetaThemeColor: string | null = null;
+let observer: MutationObserver | null = null;
 
 function changeMetaThemeColor(meta: HTMLMetaElement, theme: FilterConfig) {
     srcMetaThemeColor = srcMetaThemeColor || meta.content;
@@ -32,7 +32,7 @@ export function changeMetaThemeColorWhenAvailable(theme: FilterConfig) {
                 for (let j = 0; j < addedNodes.length; j++) {
                     const node = addedNodes[j];
                     if (node instanceof HTMLMetaElement && node.name === metaThemeColorName) {
-                        observer.disconnect();
+                        observer!.disconnect();
                         observer = null;
                         changeMetaThemeColor(node, theme);
                         break loop;

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -13,7 +13,7 @@ import {isFirefox, isCSSColorSchemePropSupported} from '../../utils/platform';
 import type {parsedGradient} from '../../utils/parsing';
 import {parseGradient} from '../../utils/parsing';
 
-export type CSSValueModifier = (theme: Theme) => string | Promise<string>;
+export type CSSValueModifier = (theme: Theme) => string | Promise<string | null>;
 
 export interface CSSValueModifierResult {
     result: string;
@@ -46,10 +46,10 @@ export function getModifiableCSSDeclaration(
     rule: CSSStyleRule,
     variablesStore: VariablesStore,
     ignoreImageSelectors: string[],
-    isCancelled: () => boolean,
-): ModifiableCSSDeclaration {
+    isCancelled: (() => boolean) | null,
+): ModifiableCSSDeclaration | null {
     if (property.startsWith('--')) {
-        const modifier = getVariableModifier(variablesStore, property, value, rule, ignoreImageSelectors, isCancelled);
+        const modifier = getVariableModifier(variablesStore, property, value, rule, ignoreImageSelectors, isCancelled!);
         if (modifier) {
             return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
@@ -73,7 +73,7 @@ export function getModifiableCSSDeclaration(
             return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
     } else if (property === 'background-image' || property === 'list-style-image') {
-        const modifier = getBgImageModifier(value, rule, ignoreImageSelectors, isCancelled);
+        const modifier = getBgImageModifier(value, rule, ignoreImageSelectors, isCancelled!);
         if (modifier) {
             return {property, value: modifier, important: getPriority(rule.style, property), sourceValue: value};
         }
@@ -143,7 +143,7 @@ export function getSelectionColor(theme: Theme) {
         backgroundColorSelection = modifyBackgroundColor({r: 0, g: 96, b: 212}, {...theme, grayscale: 0});
         foregroundColorSelection = modifyForegroundColor({r: 255, g: 255, b: 255}, {...theme, grayscale: 0});
     } else {
-        const rgb = parseColorWithCache(theme.selectionColor);
+        const rgb = parseColorWithCache(theme.selectionColor)!;
         const hsl = rgbToHSL(rgb);
         backgroundColorSelection = theme.selectionColor;
         if (hsl.l < 0.5) {
@@ -185,7 +185,7 @@ function getModifiedScrollbarStyle(theme: Theme) {
         colorThumbActive = modifyBackgroundColor({r: 96, g: 96, b: 96}, theme);
         colorCorner = modifyBackgroundColor({r: 255, g: 255, b: 255}, theme);
     } else {
-        const rgb = parseColorWithCache(theme.scrollbarColor);
+        const rgb = parseColorWithCache(theme.scrollbarColor)!;
         const hsl = rgbToHSL(rgb);
         const isLight = hsl.l > 0.5;
         const lighten = (lighter: number) => ({...hsl, l: clamp(hsl.l + lighter, 0, 1)});
@@ -210,6 +210,9 @@ function getModifiedScrollbarStyle(theme: Theme) {
     lines.push(`    background-color: ${colorThumbActive};`);
     lines.push('}');
     lines.push('::-webkit-scrollbar-corner {');
+    // TODO: assign colorCorner a value in else branch above (when theme.scrollbarColor !== 'auto')
+    // eslint-disable-next-line
+    // @ts-ignore
     lines.push(`    background-color: ${colorCorner};`);
     lines.push('}');
     if (isFirefox) {
@@ -241,7 +244,7 @@ const unparsableColors = new Set([
     'unset',
 ]);
 
-function getColorModifier(prop: string, value: string, rule: CSSStyleRule): string | CSSValueModifier {
+function getColorModifier(prop: string, value: string, rule: CSSStyleRule): string | CSSValueModifier | null {
     if (unparsableColors.has(value.toLowerCase())) {
         return value;
     }
@@ -269,7 +272,7 @@ function getColorModifier(prop: string, value: string, rule: CSSStyleRule): stri
 }
 
 const imageDetailsCache = new Map<string, ImageDetails>();
-const awaitingForImageLoading = new Map<string, Array<(imageDetails: ImageDetails) => void>>();
+const awaitingForImageLoading = new Map<string, Array<(imageDetails: ImageDetails | null) => void>>();
 
 function shouldIgnoreImage(selectorText: string, selectors: string[]) {
     if (!selectorText || selectors.length === 0) {
@@ -302,7 +305,7 @@ export function getBgImageModifier(
     rule: CSSStyleRule,
     ignoreImageSelectors: string[],
     isCancelled: () => boolean,
-): string | CSSValueModifier {
+): string | CSSValueModifier | null {
     try {
         const gradients = parseGradient(value);
         const urls = getMatches(cssURLRegex, value);
@@ -336,20 +339,20 @@ export function getBgImageModifier(
 
                 let rgb = parseColorWithCache(part);
                 if (rgb) {
-                    return (filter: FilterConfig) => modifyGradientColor(rgb, filter);
+                    return (filter: FilterConfig) => modifyGradientColor(rgb!, filter);
                 }
 
                 const space = part.lastIndexOf(' ');
                 rgb = parseColorWithCache(part.substring(0, space));
                 if (rgb) {
-                    return (filter: FilterConfig) => `${modifyGradientColor(rgb, filter)} ${part.substring(space + 1)}`;
+                    return (filter: FilterConfig) => `${modifyGradientColor(rgb!, filter)} ${part.substring(space + 1)}`;
                 }
 
                 const colorStopMatch = part.match(colorStopRegex);
                 if (colorStopMatch) {
                     rgb = parseColorWithCache(colorStopMatch[3]);
                     if (rgb) {
-                        return (filter: FilterConfig) => `${colorStopMatch[1]}(${colorStopMatch[2] ? `${colorStopMatch[2]}, ` : ''}${modifyGradientColor(rgb, filter)})`;
+                        return (filter: FilterConfig) => `${colorStopMatch[1]}(${colorStopMatch[2] ? `${colorStopMatch[2]}, ` : ''}${modifyGradientColor(rgb!, filter)})`;
                     }
                 }
 
@@ -370,23 +373,23 @@ export function getBgImageModifier(
             const {parentStyleSheet} = rule;
             const baseURL = (parentStyleSheet && parentStyleSheet.href) ?
                 getCSSBaseBath(parentStyleSheet.href) :
-                parentStyleSheet.ownerNode?.baseURI || location.origin;
+                parentStyleSheet!.ownerNode?.baseURI || location.origin;
             url = getAbsoluteURL(baseURL, url);
 
             const absoluteValue = `url("${url}")`;
 
-            return async (filter: FilterConfig) => {
+            return async (filter: FilterConfig): Promise<string | null> => {
                 if (isURLEmpty) {
                     return "url('')";
                 }
-                let imageDetails: ImageDetails;
+                let imageDetails: ImageDetails | null;
                 if (imageDetailsCache.has(url)) {
-                    imageDetails = imageDetailsCache.get(url);
+                    imageDetails = imageDetailsCache.get(url)!;
                 } else {
                     try {
                         if (awaitingForImageLoading.has(url)) {
-                            const awaiters = awaitingForImageLoading.get(url);
-                            imageDetails = await new Promise<ImageDetails>((resolve) => awaiters.push(resolve));
+                            const awaiters = awaitingForImageLoading.get(url)!;
+                            imageDetails = await new Promise<ImageDetails | null>((resolve) => awaiters.push(resolve));
                             if (!imageDetails) {
                                 return null;
                             }
@@ -394,7 +397,7 @@ export function getBgImageModifier(
                             awaitingForImageLoading.set(url, []);
                             imageDetails = await getImageDetails(url);
                             imageDetailsCache.set(url, imageDetails);
-                            awaitingForImageLoading.get(url).forEach((resolve) => resolve(imageDetails));
+                            awaitingForImageLoading.get(url)!.forEach((resolve) => resolve(imageDetails));
                             awaitingForImageLoading.delete(url);
                         }
                         if (isCancelled()) {
@@ -403,7 +406,7 @@ export function getBgImageModifier(
                     } catch (err) {
                         logWarn(err);
                         if (awaitingForImageLoading.has(url)) {
-                            awaitingForImageLoading.get(url).forEach((resolve) => resolve(null));
+                            awaitingForImageLoading.get(url)!.forEach((resolve) => resolve(null));
                             awaitingForImageLoading.delete(url);
                         }
                         return absoluteValue;
@@ -416,7 +419,7 @@ export function getBgImageModifier(
 
         const getBgImageValue = (imageDetails: ImageDetails, filter: FilterConfig) => {
             const {isDark, isLight, isTransparent, isLarge, isTooLarge, width} = imageDetails;
-            let result: string;
+            let result: string | null;
             if (isTooLarge) {
                 logInfo(`Not modifying too large image ${imageDetails.src}`);
                 result = `url("${imageDetails.src}")`;
@@ -444,7 +447,7 @@ export function getBgImageModifier(
             return result;
         };
 
-        const modifiers: CSSValueModifier[] = [];
+        const modifiers: Array<CSSValueModifier | null> = [];
 
         let matchIndex = 0;
         let prevHasComma = false;
@@ -473,7 +476,7 @@ export function getBgImageModifier(
             if (type === 'url') {
                 modifiers.push(getURLModifier(match));
             } else if (type === 'gradient') {
-                modifiers.push(getGradientModifier({match, index, typeGradient, hasComma, offset}));
+                modifiers.push(getGradientModifier({match, index, typeGradient: typeGradient as string, hasComma: hasComma || false, offset}));
             }
 
             if (i === matches.length - 1) {
@@ -482,7 +485,7 @@ export function getBgImageModifier(
         });
 
         return (filter: FilterConfig) => {
-            const results = modifiers.filter(Boolean).map((modify) => modify(filter));
+            const results = modifiers.filter(Boolean).map((modify) => modify!(filter));
             if (results.some((r) => r instanceof Promise)) {
                 return Promise.all(results).then((asyncResults) => {
                     return asyncResults.filter(Boolean).join('');
@@ -501,7 +504,7 @@ export function getBgImageModifier(
     }
 }
 
-export function getShadowModifierWithInfo(value: string): CSSValueModifierWithInfo {
+export function getShadowModifierWithInfo(value: string): CSSValueModifierWithInfo | null {
     try {
         let index = 0;
         const colorMatches = getMatches(/(^|\s)(?!calc)([a-z]+\(.+?\)|#[0-9a-f]+|[a-z]+)(.*?(inset|outset)?($|,))/ig, value, 2);
@@ -533,7 +536,7 @@ export function getShadowModifierWithInfo(value: string): CSSValueModifierWithIn
     }
 }
 
-export function getShadowModifier(value: string): CSSValueModifier {
+export function getShadowModifier(value: string): CSSValueModifier | null {
     const shadowModifier = getShadowModifierWithInfo(value);
     if (!shadowModifier) {
         return null;

--- a/src/inject/dynamic-theme/mv3-proxy.ts
+++ b/src/inject/dynamic-theme/mv3-proxy.ts
@@ -16,7 +16,7 @@ function injectProxyAndCleanup(arg: boolean) {
 }
 
 function regularPath() {
-    const argString = document.currentScript.dataset.arg;
+    const argString = document.currentScript!.dataset.arg;
     if (argString !== undefined) {
         document.documentElement.dataset[key] = 'true';
         const arg: boolean = JSON.parse(argString);

--- a/src/inject/dynamic-theme/network.ts
+++ b/src/inject/dynamic-theme/network.ts
@@ -23,10 +23,10 @@ export async function bgFetch(request: FetchRequest) {
 
 chrome.runtime.onMessage.addListener(({type, data, error, id}: Message) => {
     if (type === MessageType.BG_FETCH_RESPONSE) {
-        const resolve = resolvers.get(id);
-        const reject = rejectors.get(id);
-        resolvers.delete(id);
-        rejectors.delete(id);
+        const resolve = resolvers.get(id!);
+        const reject = rejectors.get(id!);
+        resolvers.delete(id!);
+        rejectors.delete(id!);
         if (error) {
             reject && reject(error);
         } else {

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -27,7 +27,7 @@ export type StyleElement = HTMLLinkElement | HTMLStyleElement;
 
 export type detailsArgument = {secondRound: boolean};
 export interface StyleManager {
-    details(options: detailsArgument): {rules: CSSRuleList};
+    details(options: detailsArgument): {rules: CSSRuleList} | null;
     render(theme: Theme, ignoreImageAnalysis: string[]): void;
     pause(): void;
     destroy(): void;
@@ -53,16 +53,16 @@ function isFontsGoogleApiStyle(element: HTMLLinkElement): boolean {
     }
 }
 
-export function shouldManageStyle(element: Node) {
+export function shouldManageStyle(element: Node | null): boolean {
     return (
         (
             (element instanceof HTMLStyleElement) ||
             (element instanceof SVGStyleElement) ||
             (
                 element instanceof HTMLLinkElement &&
-                element.rel &&
+                Boolean(element.rel) &&
                 element.rel.toLowerCase().includes('stylesheet') &&
-                element.href &&
+                Boolean(element.href) &&
                 !element.disabled &&
                 (isFirefox ? !element.href.startsWith('moz-extension://') : true) &&
                 !isFontsGoogleApiStyle(element)
@@ -74,7 +74,7 @@ export function shouldManageStyle(element: Node) {
     );
 }
 
-export function getManageableStyles(node: Node, results = [] as StyleElement[], deep = true) {
+export function getManageableStyles(node: Node | null, results = [] as StyleElement[], deep = true) {
     if (shouldManageStyle(node)) {
         results.push(node as StyleElement);
     } else if (node instanceof Element || (isShadowDomSupported && node instanceof ShadowRoot) || node === document) {
@@ -106,15 +106,15 @@ export function cleanLoadingLinks() {
 
 export function manageStyle(element: StyleElement, {update, loadingStart, loadingEnd}: {update: () => void; loadingStart: () => void; loadingEnd: () => void}): StyleManager {
     const prevStyles: HTMLStyleElement[] = [];
-    let next: Element = element;
+    let next: Element | null = element;
     while ((next = next.nextElementSibling) && next.matches('.darkreader')) {
         prevStyles.push(next as HTMLStyleElement);
     }
-    let corsCopy: HTMLStyleElement = prevStyles.find((el) => el.matches('.darkreader--cors') && !corsStyleSet.has(el)) || null;
-    let syncStyle: HTMLStyleElement | SVGStyleElement = prevStyles.find((el) => el.matches('.darkreader--sync') && !syncStyleSet.has(el)) || null;
+    let corsCopy: HTMLStyleElement | null = prevStyles.find((el) => el.matches('.darkreader--cors') && !corsStyleSet.has(el)) || null;
+    let syncStyle: HTMLStyleElement | SVGStyleElement | null = prevStyles.find((el) => el.matches('.darkreader--sync') && !syncStyleSet.has(el)) || null;
 
-    let corsCopyPositionWatcher: ReturnType<typeof watchForNodePosition> = null;
-    let syncStylePositionWatcher: ReturnType<typeof watchForNodePosition> = null;
+    let corsCopyPositionWatcher: ReturnType<typeof watchForNodePosition> | null = null;
+    let syncStylePositionWatcher: ReturnType<typeof watchForNodePosition> | null = null;
 
     let cancelAsyncOperations = false;
     let isOverrideEmpty = true;
@@ -127,14 +127,14 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
     const observerOptions: MutationObserverInit = {attributes: true, childList: true, subtree: true, characterData: true};
 
     function containsCSSImport() {
-        return element instanceof HTMLStyleElement && element.textContent.trim().match(cssImportRegex);
+        return element instanceof HTMLStyleElement && element.textContent!.trim().match(cssImportRegex);
     }
 
     // It loops trough the cssRules and check for CSSImportRule and their `href`.
     // If the `href` isn't local and doesn't start with the same-origin.
     // We can be ensure that's a cross-origin import
     // And should add a cors-sheet to this element.
-    function hasImports(cssRules: CSSRuleList, checkCrossOrigin: boolean) {
+    function hasImports(cssRules: CSSRuleList | null, checkCrossOrigin: boolean) {
         let result = false;
         if (cssRules) {
             let rule: CSSRule;
@@ -157,10 +157,10 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
         return result;
     }
 
-    function getRulesSync(): CSSRuleList {
+    function getRulesSync(): CSSRuleList | null {
         if (corsCopy) {
             logInfo('[getRulesSync] Using cors-copy.');
-            return corsCopy.sheet.cssRules;
+            return corsCopy.sheet!.cssRules;
         }
         if (containsCSSImport()) {
             logInfo('[getRulesSync] CSSImport detected.');
@@ -190,13 +190,13 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
     function insertStyle() {
         if (corsCopy) {
             if (element.nextSibling !== corsCopy) {
-                element.parentNode.insertBefore(corsCopy, element.nextSibling);
+                element.parentNode!.insertBefore(corsCopy, element.nextSibling);
             }
             if (corsCopy.nextSibling !== syncStyle) {
-                element.parentNode.insertBefore(syncStyle, corsCopy.nextSibling);
+                element.parentNode!.insertBefore(syncStyle!, corsCopy.nextSibling);
             }
         } else if (element.nextSibling !== syncStyle) {
-            element.parentNode.insertBefore(syncStyle, element.nextSibling);
+            element.parentNode!.insertBefore(syncStyle!, element.nextSibling);
         }
     }
 
@@ -217,7 +217,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
     let wasLoadingError = false;
     const loadingLinkId = ++loadingLinkCounter;
 
-    async function getRulesAsync(): Promise<CSSRuleList> {
+    async function getRulesAsync(): Promise<CSSRuleList | null> {
         let cssText: string;
         let cssBasePath: string;
 
@@ -230,7 +230,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             if (
                 (!cssRules && !accessError && !isSafari) ||
                 (isSafari && !element.sheet) ||
-                isStillLoadingError(accessError)
+                isStillLoadingError(accessError!)
             ) {
                 try {
                     logInfo(`Linkelement ${loadingLinkId} is not loaded yet and thus will be await for`, element);
@@ -266,7 +266,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
                 return null;
             }
         } else if (containsCSSImport()) {
-            cssText = element.textContent.trim();
+            cssText = element.textContent!.trim();
             cssBasePath = getCSSBaseBath(location.href);
         } else {
             return null;
@@ -283,7 +283,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             }
             if (corsCopy) {
                 corsCopyPositionWatcher = watchForNodePosition(corsCopy, 'prev-sibling');
-                return corsCopy.sheet.cssRules;
+                return corsCopy.sheet!.cssRules;
             }
         }
 
@@ -342,7 +342,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             }
         }
 
-        function prepareOverridesSheet() {
+        function prepareOverridesSheet(): CSSStyleSheet {
             if (!syncStyle) {
                 createSyncStyle();
             }
@@ -355,24 +355,24 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             // But for other websites (e.g. facebook.com)
             // some images disappear when `textContent`
             // is initially set to an empty string.
-            if (syncStyle.sheet == null) {
-                syncStyle.textContent = '';
+            if (syncStyle!.sheet == null) {
+                syncStyle!.textContent = '';
             }
 
-            const sheet = syncStyle.sheet;
+            const sheet = syncStyle!.sheet;
 
-            removeCSSRulesFromSheet(sheet);
+            removeCSSRulesFromSheet(sheet!);
 
             if (syncStylePositionWatcher) {
                 syncStylePositionWatcher.run();
             } else {
-                syncStylePositionWatcher = watchForNodePosition(syncStyle, 'prev-sibling', () => {
+                syncStylePositionWatcher = watchForNodePosition(syncStyle!, 'prev-sibling', () => {
                     forceRenderStyle = true;
                     buildOverrides();
                 });
             }
 
-            return syncStyle.sheet;
+            return syncStyle!.sheet!;
         }
 
         function buildOverrides() {
@@ -380,13 +380,13 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             forceRenderStyle = false;
             sheetModifier.modifySheet({
                 prepareSheet: prepareOverridesSheet,
-                sourceCSSRules: rules,
+                sourceCSSRules: rules!,
                 theme,
                 ignoreImageAnalysis,
                 force,
                 isAsyncCancelled: () => cancelAsyncOperations,
             });
-            isOverrideEmpty = syncStyle.sheet.cssRules.length === 0;
+            isOverrideEmpty = syncStyle!.sheet!.cssRules.length === 0;
             if (sheetModifier.shouldRebuildStyle()) {
                 // "update" function schedules rebuilding the style
                 // ideally to wait for link loading, because some sites put links any time,
@@ -398,7 +398,7 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
         buildOverrides();
     }
 
-    function getRulesOrError(): [CSSRuleList, Error] {
+    function getRulesOrError(): [CSSRuleList | null, Error | null] {
         try {
             if (element.sheet == null) {
                 return [null, null];
@@ -436,8 +436,8 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
         }
     }
 
-    let rulesChangeKey: number = null;
-    let rulesCheckFrameId: number = null;
+    let rulesChangeKey: number | null = null;
+    let rulesCheckFrameId: number | null = null;
 
     function getRulesChangeKey() {
         const rules = safeGetSheetRules();
@@ -467,7 +467,8 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
     }
 
     function stopWatchingForSheetChangesUsingRAF() {
-        cancelAnimationFrame(rulesCheckFrameId);
+        // TODO: reove cast once types are updated
+        cancelAnimationFrame(rulesCheckFrameId as number);
     }
 
     let areSheetChangesPending = false;
@@ -624,7 +625,7 @@ async function replaceCSSImports(cssText: string, basePath: string, cache = new 
         const absoluteURL = getAbsoluteURL(basePath, importURL);
         let importedCSS: string;
         if (cache.has(absoluteURL)) {
-            importedCSS = cache.get(absoluteURL);
+            importedCSS = cache.get(absoluteURL)!;
         } else {
             try {
                 importedCSS = await loadText(absoluteURL);
@@ -653,8 +654,8 @@ function createCORSCopy(srcElement: StyleElement, cssText: string) {
     cors.classList.add('darkreader--cors');
     cors.media = 'screen';
     cors.textContent = cssText;
-    srcElement.parentNode.insertBefore(cors, srcElement.nextSibling);
-    cors.sheet.disabled = true;
+    srcElement.parentNode!.insertBefore(cors, srcElement.nextSibling);
+    cors.sheet!.disabled = true;
     corsStyleSet.add(cors);
     return cors;
 }

--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -42,7 +42,7 @@ export function createStyleSheetModifier() {
     const rulesTextCache = new Set<string>();
     const rulesModCache = new Map<string, ModifiableCSSRule>();
     const varTypeChangeCleaners = new Set<() => void>();
-    let prevFilterKey: string = null;
+    let prevFilterKey: string | null = null;
     let hasNonLoadedLink = false;
     let wasRebuilt = false;
     function shouldRebuildStyle() {
@@ -79,7 +79,7 @@ export function createStyleSheetModifier() {
             if (textDiffersFromPrev) {
                 rulesChanged = true;
             } else {
-                modRules.push(rulesModCache.get(cssText));
+                modRules.push(rulesModCache.get(cssText)!);
                 return;
             }
 
@@ -91,13 +91,13 @@ export function createStyleSheetModifier() {
                 }
             });
 
-            let modRule: ModifiableCSSRule = null;
+            let modRule: ModifiableCSSRule | null = null;
             if (modDecs.length > 0) {
-                const parentRule = rule.parentRule;
+                const parentRule = rule.parentRule!;
                 modRule = {selector: rule.selectorText, declarations: modDecs, parentRule};
                 modRules.push(modRule);
             }
-            rulesModCache.set(cssText, modRule);
+            rulesModCache.set(cssText, modRule!);
         }, () => {
             hasNonLoadedLink = true;
         });
@@ -116,7 +116,7 @@ export function createStyleSheetModifier() {
 
         interface ReadyGroup {
             isGroup: true;
-            rule: CSSRule;
+            rule: CSSRule | null;
             rules: Array<ReadyGroup | ReadyStyleRule>;
         }
 
@@ -128,7 +128,7 @@ export function createStyleSheetModifier() {
 
         interface ReadyDeclaration {
             property: string;
-            value: string | Array<{property: string; value: string}>;
+            value: string | Array<{property: string; value: string}> | null;
             important: boolean;
             sourceValue: string;
             asyncKey?: number;
@@ -170,13 +170,13 @@ export function createStyleSheetModifier() {
             }
 
             if (groupRefs.has(rule)) {
-                return groupRefs.get(rule);
+                return groupRefs.get(rule)!;
             }
 
             const group: ReadyGroup = {rule, rules: [], isGroup: true};
             groupRefs.set(rule, group);
 
-            const parentGroup = getGroup(rule.parentRule);
+            const parentGroup = getGroup(rule.parentRule!);
             parentGroup.rules.push(group);
 
             return group;
@@ -191,7 +191,7 @@ export function createStyleSheetModifier() {
             const readyDeclarations = readyStyleRule.declarations;
             group.rules.push(readyStyleRule);
 
-            function handleAsyncDeclaration(property: string, modified: Promise<string>, important: boolean, sourceValue: string) {
+            function handleAsyncDeclaration(property: string, modified: Promise<string | null>, important: boolean, sourceValue: string) {
                 const asyncKey = ++asyncDeclarationCounter;
                 const asyncDeclaration: ReadyDeclaration = {property, value: null, important, asyncKey, sourceValue};
                 readyDeclarations.push(asyncDeclaration);
@@ -306,14 +306,14 @@ export function createStyleSheetModifier() {
         }
 
         function rebuildAsyncRule(key: number) {
-            const {rule, target, index} = asyncDeclarations.get(key);
+            const {rule, target, index} = asyncDeclarations.get(key)!;
             target.deleteRule(index);
             setRule(target, index, rule);
             asyncDeclarations.delete(key);
         }
 
         function rebuildVarRule(key: number) {
-            const {rule, target, index} = varDeclarations.get(key);
+            const {rule, target, index} = varDeclarations.get(key)!;
             target.deleteRule(index);
             setRule(target, index, rule);
         }

--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -35,20 +35,20 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
 
 
     const cleanUp = () => {
-        Object.defineProperty(CSSStyleSheet.prototype, 'addRule', addRuleDescriptor);
-        Object.defineProperty(CSSStyleSheet.prototype, 'insertRule', insertRuleDescriptor);
-        Object.defineProperty(CSSStyleSheet.prototype, 'deleteRule', deleteRuleDescriptor);
-        Object.defineProperty(CSSStyleSheet.prototype, 'removeRule', removeRuleDescriptor);
+        Object.defineProperty(CSSStyleSheet.prototype, 'addRule', addRuleDescriptor!);
+        Object.defineProperty(CSSStyleSheet.prototype, 'insertRule', insertRuleDescriptor!);
+        Object.defineProperty(CSSStyleSheet.prototype, 'deleteRule', deleteRuleDescriptor!);
+        Object.defineProperty(CSSStyleSheet.prototype, 'removeRule', removeRuleDescriptor!);
         document.removeEventListener('__darkreader__cleanUp', cleanUp);
         document.removeEventListener('__darkreader__addUndefinedResolver', addUndefinedResolver);
         if (enableStyleSheetsProxy) {
-            Object.defineProperty(Document.prototype, 'styleSheets', documentStyleSheetsDescriptor);
+            Object.defineProperty(Document.prototype, 'styleSheets', documentStyleSheetsDescriptor!);
         }
         if (shouldWrapHTMLElement) {
-            Object.defineProperty(Element.prototype, 'getElementsByTagName', getElementsByTagNameDescriptor);
+            Object.defineProperty(Element.prototype, 'getElementsByTagName', getElementsByTagNameDescriptor!);
         }
         if (shouldProxyChildNodes) {
-            Object.defineProperty(Node.prototype, 'childNodes', childNodesDescriptor);
+            Object.defineProperty(Node.prototype, 'childNodes', childNodesDescriptor!);
         }
     };
 
@@ -64,7 +64,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
     const updateSheetEvent = new Event('__darkreader__updateSheet');
 
     function proxyAddRule(selector?: string, style?: string, index?: number): number {
-        addRuleDescriptor.value.call(this, selector, style, index);
+        addRuleDescriptor!.value.call(this, selector, style, index);
         if (this.ownerNode && !this.ownerNode.classList.contains('darkreader')) {
             this.ownerNode.dispatchEvent(updateSheetEvent);
         }
@@ -73,7 +73,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
     }
 
     function proxyInsertRule(rule: string, index?: number): number {
-        const returnValue = insertRuleDescriptor.value.call(this, rule, index);
+        const returnValue = insertRuleDescriptor!.value.call(this, rule, index);
         if (this.ownerNode && !this.ownerNode.classList.contains('darkreader')) {
             this.ownerNode.dispatchEvent(updateSheetEvent);
         }
@@ -81,14 +81,14 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
     }
 
     function proxyDeleteRule(index: number): void {
-        deleteRuleDescriptor.value.call(this, index);
+        deleteRuleDescriptor!.value.call(this, index);
         if (this.ownerNode && !this.ownerNode.classList.contains('darkreader')) {
             this.ownerNode.dispatchEvent(updateSheetEvent);
         }
     }
 
     function proxyRemoveRule(index?: number): void {
-        removeRuleDescriptor.value.call(this, index);
+        removeRuleDescriptor!.value.call(this, index);
         if (this.ownerNode && !this.ownerNode.classList.contains('darkreader')) {
             this.ownerNode.dispatchEvent(updateSheetEvent);
         }
@@ -96,7 +96,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
 
     function proxyDocumentStyleSheets() {
         const getCurrentValue = () => {
-            const docSheets: StyleSheetList = documentStyleSheetsDescriptor.get.call(this);
+            const docSheets: StyleSheetList = documentStyleSheetsDescriptor!.get!.call(this);
 
             const filteredSheets = [...docSheets].filter((styleSheet) => {
                 return !(styleSheet.ownerNode as Element).classList.contains('darkreader');
@@ -125,11 +125,11 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
 
     function proxyGetElementsByTagName(tagName: string): NodeListOf<HTMLElement> {
         if (tagName !== 'style') {
-            return getElementsByTagNameDescriptor.value.call(this, tagName);
+            return getElementsByTagNameDescriptor!.value.call(this, tagName);
         }
 
         const getCurrentElementValue = () => {
-            const elements: NodeListOf<HTMLElement> = getElementsByTagNameDescriptor.value.call(this, tagName);
+            const elements: NodeListOf<HTMLElement> = getElementsByTagNameDescriptor!.value.call(this, tagName);
 
             return Object.setPrototypeOf([...elements].filter((element: HTMLElement) => {
                 return !element.classList.contains('darkreader');
@@ -151,7 +151,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
     }
 
     function proxyChildNodes(): NodeListOf<ChildNode> {
-        const childNodes: NodeListOf<ChildNode> = childNodesDescriptor.get.call(this);
+        const childNodes: NodeListOf<ChildNode> = childNodesDescriptor!.get!.call(this);
 
         return Object.setPrototypeOf([...childNodes].filter((element: ChildNode) => {
             return !(element as HTMLElement).classList || !(element as HTMLElement).classList.contains('darkreader');

--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -9,7 +9,7 @@ import {parseColorWithCache} from '../../utils/color';
 
 export interface ModifiedVarDeclaration {
     property: string;
-    value: string | Promise<string>;
+    value: string | Promise<string | null>;
 }
 
 export type CSSVariableModifier = (theme: Theme) => {
@@ -56,7 +56,7 @@ export class VariablesStore {
     private isVarType(varName: string, typeNum: number) {
         return (
             this.varTypes.has(varName) &&
-            (this.varTypes.get(varName) & typeNum) > 0
+            (this.varTypes.get(varName)! & typeNum) > 0
         );
     }
 
@@ -75,7 +75,7 @@ export class VariablesStore {
         this.varRefs.forEach((refs, v) => {
             refs.forEach((r) => {
                 if (this.varTypes.has(v)) {
-                    this.resolveVariableType(r, this.varTypes.get(v));
+                    this.resolveVariableType(r, this.varTypes.get(v)!);
                 }
             });
         });
@@ -113,7 +113,7 @@ export class VariablesStore {
         this.changedTypeVars.forEach((varName) => {
             if (this.typeChangeSubscriptions.has(varName)) {
                 this.typeChangeSubscriptions
-                    .get(varName)
+                    .get(varName)!
                     .forEach((callback) => {
                         callback();
                     });
@@ -173,7 +173,7 @@ export class VariablesStore {
                 addModifiedValue(VAR_TYPE_BORDERCOLOR, wrapBorderColorVariableName, tryModifyBorderColor);
                 if (this.isVarType(varName, VAR_TYPE_BGIMG)) {
                     const property = wrapBgImgVariableName(varName);
-                    let modifiedValue: string | Promise<string> = sourceValue;
+                    let modifiedValue: string | Promise<string | null> = sourceValue;
                     if (isVarDependant(sourceValue)) {
                         modifiedValue = replaceCSSVariablesNames(
                             sourceValue,
@@ -182,7 +182,7 @@ export class VariablesStore {
                         );
                     }
                     const bgModifier = getBgImageModifier(modifiedValue, rule, ignoredImgSelectors, isCancelled);
-                    modifiedValue = typeof bgModifier === 'function' ? bgModifier(theme) : bgModifier;
+                    modifiedValue = typeof bgModifier === 'function' ? bgModifier(theme) : bgModifier!;
                     declarations.push({
                         property,
                         value: modifiedValue,
@@ -217,7 +217,7 @@ export class VariablesStore {
         };
     }
 
-    getModifierForVarDependant(property: string, sourceValue: string): CSSValueModifier {
+    getModifierForVarDependant(property: string, sourceValue: string): CSSValueModifier | null {
         // TODO(gusted): This condition is incorrect, as the sourceValue still contains a variable.
         // Simply replacing it with some definition is incorrect as variables are element-independent.
         // Fully handling this requires having a function that gives the variable's value given an
@@ -274,7 +274,7 @@ export class VariablesStore {
                     );
                     // Check if the property is box-shadow and if so, do a pass-through to modify the shadow.
                     if (property === 'box-shadow') {
-                        const shadowModifier = getShadowModifierWithInfo(variableReplaced);
+                        const shadowModifier = getShadowModifierWithInfo(variableReplaced)!;
                         const modifiedShadow = shadowModifier(theme);
                         if (modifiedShadow.unparseableMatchesLength !== modifiedShadow.matchesLength) {
                             return modifiedShadow.result;
@@ -316,7 +316,7 @@ export class VariablesStore {
         if (!this.typeChangeSubscriptions.has(varName)) {
             this.typeChangeSubscriptions.set(varName, new Set());
         }
-        const rootStore = this.typeChangeSubscriptions.get(varName);
+        const rootStore = this.typeChangeSubscriptions.get(varName)!;
         if (!rootStore.has(callback)) {
             rootStore.add(callback);
         }
@@ -324,7 +324,7 @@ export class VariablesStore {
 
     private unsubscribeFromVariableTypeChanges(varName: string, callback: () => void) {
         if (this.typeChangeSubscriptions.has(varName)) {
-            this.typeChangeSubscriptions.get(varName).delete(callback);
+            this.typeChangeSubscriptions.get(varName)!.delete(callback);
         }
     }
 
@@ -407,7 +407,7 @@ export class VariablesStore {
                 if (!this.varRefs.has(property)) {
                     this.varRefs.set(property, new Set());
                 }
-                this.varRefs.get(property).add(ref);
+                this.varRefs.get(property)!.add(ref);
             });
         } else if (property === 'background-color' || property === 'box-shadow') {
             this.iterateVarDeps(value, (v) => this.resolveVariableType(v, VAR_TYPE_BGCOLOR));
@@ -446,7 +446,7 @@ export class VariablesStore {
         varDeps.forEach((v) => iterator(v));
     }
 
-    private findVarRef(varName: string, iterator: (v: string) => boolean, stack = new Set<string>()): string {
+    private findVarRef(varName: string, iterator: (v: string) => boolean, stack = new Set<string>()): string | null {
         if (stack.has(varName)) {
             return null;
         }
@@ -480,7 +480,7 @@ export class VariablesStore {
     }
 
     putRootVars(styleElement: HTMLStyleElement, theme: Theme) {
-        const sheet = styleElement.sheet;
+        const sheet = styleElement.sheet!;
         if (sheet.cssRules.length > 0) {
             sheet.deleteRule(0);
         }
@@ -521,21 +521,21 @@ interface VariableMatch extends Range {
     value: string;
 }
 
-function getVariableRange(input: string, searchStart = 0): Range {
+function getVariableRange(input: string, searchStart = 0): Range | null {
     const start = input.indexOf('var(', searchStart);
     if (start >= 0) {
         const range = getParenthesesRange(input, start + 3);
         if (range) {
             return {start, end: range.end};
         }
-        return null;
     }
+    return null;
 }
 
 function getVariablesMatches(input: string): VariableMatch[] {
     const ranges: VariableMatch[] = [];
     let i = 0;
-    let range: Range;
+    let range: Range | null;
     while ((range = getVariableRange(input, i))) {
         const {start, end} = range;
         ranges.push({start, end, value: input.substring(start, end)});
@@ -544,7 +544,7 @@ function getVariablesMatches(input: string): VariableMatch[] {
     return ranges;
 }
 
-function replaceVariablesMatches(input: string, replacer: (match: string) => string) {
+function replaceVariablesMatches(input: string, replacer: (match: string) => string | null) {
     const matches = getVariablesMatches(input);
     const matchesCount = matches.length;
     if (matchesCount === 0) {
@@ -553,7 +553,7 @@ function replaceVariablesMatches(input: string, replacer: (match: string) => str
 
     const inputLength = input.length;
     const replacements = matches.map((m) => replacer(m.value));
-    const parts: string[] = [];
+    const parts: Array<string | null> = [];
     parts.push(input.substring(0, matches[0].start));
     for (let i = 0; i < matchesCount; i++) {
         parts.push(replacements[i]);
@@ -703,7 +703,7 @@ function insertVarValues(source: string, varValues: Map<string, string>, stack =
         }
         stack.add(name);
         const varValue = varValues.get(name) || fallback;
-        let inserted: string = null;
+        let inserted: string | null = null;
         if (varValue) {
             if (isVarDependant(varValue)) {
                 inserted = insertVarValues(varValue, varValues, stack);

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -16,7 +16,7 @@ interface ChangedStyles {
 }
 
 const undefinedGroups = new Map<string, Set<Element>>();
-let elementsDefinitionCallback: (elements: Element[]) => void;
+let elementsDefinitionCallback: ((elements: Element[]) => void) | null;
 
 function collectUndefinedElements(root: ParentNode) {
     if (!isDefinedSelectorSupported) {
@@ -40,11 +40,11 @@ function collectUndefinedElements(root: ParentNode) {
                     if (elementsDefinitionCallback) {
                         const elements = undefinedGroups.get(tag);
                         undefinedGroups.delete(tag);
-                        elementsDefinitionCallback(Array.from(elements));
+                        elementsDefinitionCallback(Array.from(elements!));
                     }
                 });
             }
-            undefinedGroups.get(tag).add(el);
+            undefinedGroups.get(tag)!.add(el);
         });
 }
 
@@ -58,7 +58,7 @@ const resolvers = new Map<string, () => void>();
 function handleIsDefined(e: CustomEvent<{tag: string}>) {
     canOptimizeUsingProxy = true;
     if (resolvers.has(e.detail.tag)) {
-        const resolve = resolvers.get(e.detail.tag);
+        const resolve = resolvers.get(e.detail.tag)!;
         resolve();
     }
 }
@@ -107,8 +107,8 @@ export function watchForStyleChanges(currentStyles: StyleElement[], update: (sty
     const nextStyleSiblings = new WeakMap<Element, Element>();
 
     function saveStylePosition(style: StyleElement) {
-        prevStyleSiblings.set(style, style.previousElementSibling);
-        nextStyleSiblings.set(style, style.nextElementSibling);
+        prevStyleSiblings.set(style, style.previousElementSibling!);
+        nextStyleSiblings.set(style, style.nextElementSibling!);
     }
 
     function forgetStylePosition(style: StyleElement) {

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -27,7 +27,7 @@ function sendMessage(message: Message) {
     if (unloaded) {
         return;
     }
-    const responseHandler = (response: 'unsupportedSender' | undefined) => {
+    const responseHandler = (response: Message | 'unsupportedSender' | undefined) => {
         // Vivaldi bug workaround. See TabManager for details.
         if (response === 'unsupportedSender') {
             removeStyle();
@@ -39,7 +39,7 @@ function sendMessage(message: Message) {
 
     try {
         if (__CHROMIUM_MV3__) {
-            const promise: Promise<Message | 'unsupportedSender'> = chrome.runtime.sendMessage<Message>(message);
+            const promise = chrome.runtime.sendMessage<Message, Message | 'unsupportedSender'>(message);
             promise.then(responseHandler).catch(cleanup);
         } else {
             chrome.runtime.sendMessage<Message, 'unsupportedSender' | undefined>(message, responseHandler);

--- a/src/inject/style.ts
+++ b/src/inject/style.ts
@@ -2,7 +2,7 @@ import {createNodeAsap, removeNode} from './utils/dom';
 
 export function createOrUpdateStyle(css: string, type: string) {
     createNodeAsap({
-        selectNode: () => document.getElementById('dark-reader-style'),
+        selectNode: () => document.getElementById('dark-reader-style')!,
         createNode: (target) => {
             document.documentElement.setAttribute('data-darkreader-mode', type);
             const style = document.createElement('style');
@@ -13,7 +13,7 @@ export function createOrUpdateStyle(css: string, type: string) {
             target.appendChild(style);
         },
         updateNode: (existing) => {
-            if (css.replace(/^\s+/gm, '') !== existing.textContent.replace(/^\s+/gm, '')) {
+            if (css.replace(/^\s+/gm, '') !== existing.textContent!.replace(/^\s+/gm, '')) {
                 existing.textContent = css;
             }
         },

--- a/src/inject/svg-filter.ts
+++ b/src/inject/svg-filter.ts
@@ -2,7 +2,7 @@ import {createNodeAsap, removeNode} from './utils/dom';
 
 export function createOrUpdateSVGFilter(svgMatrix: string, svgReverseMatrix: string) {
     createNodeAsap({
-        selectNode: () => document.getElementById('dark-reader-svg'),
+        selectNode: () => document.getElementById('dark-reader-svg')!,
         createNode: (target) => {
             const SVG_NS = 'http://www.w3.org/2000/svg';
             const createMatrixFilter = (id: string, matrix: string) => {
@@ -36,12 +36,12 @@ export function createOrUpdateSVGFilter(svgMatrix: string, svgReverseMatrix: str
             target.appendChild(svg);
         },
         updateNode: (existing) => {
-            const existingMatrix = existing.firstChild.firstChild as SVGFEColorMatrixElement;
+            const existingMatrix = existing.firstChild!.firstChild as SVGFEColorMatrixElement;
             if (existingMatrix.getAttribute('values') !== svgMatrix) {
                 existingMatrix.setAttribute('values', svgMatrix);
 
                 // Fix not triggering repaint
-                const style = document.getElementById('dark-reader-style');
+                const style = document.getElementById('dark-reader-style')!;
                 const css = style.textContent;
                 style.textContent = '';
                 style.textContent = css;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -18,6 +18,7 @@
         "downlevelIteration": true,
         "noImplicitAny": true,
         "resolveJsonModule": true,
+        "strictNullChecks": true,
         "jsx": "react",
         "jsxFactory": "m",
         "noEmit": true

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -27,6 +27,8 @@ export function getMockData(override = {} as Partial<ExtensionData>): ExtensionD
             customThemes: [],
             siteList: [],
             siteListEnabled: [],
+            syncSitesFixes: false,
+            enableContextMenus: false,
             applyToListedOnly: false,
             changeBrowserTheme: false,
             enableForPDF: true,

--- a/src/ui/controls/color-dropdown/index.tsx
+++ b/src/ui/controls/color-dropdown/index.tsx
@@ -32,7 +32,7 @@ export default function ColorDropDown(props: ColorDropDownProps) {
         props.hasDefaultOption ? {id: 'default', content: labels.DEFAULT} : null,
         props.hasAutoOption ? {id: 'auto', content: labels.AUTO} : null,
         {id: 'custom', content: labels.CUSTOM},
-    ].filter((v) => v);
+    ].filter((v) => v) as Array<{id: string; content: string}>;
 
     const selectedDropDownValue = (
         props.value === '' ? 'default' :
@@ -40,7 +40,7 @@ export default function ColorDropDown(props: ColorDropDownProps) {
                 'custom'
     );
 
-    function onDropDownChange(value: string) {
+    function onDropDownChange(value: 'default' | 'auto' | 'custom') {
         const result = {
             default: '',
             auto: 'auto',
@@ -60,7 +60,7 @@ export default function ColorDropDown(props: ColorDropDownProps) {
 
     function onRootRender(root: Element) {
         if (shouldFocusOnPicker) {
-            const pickerNode = root.querySelector('.color-dropdown__picker');
+            const pickerNode = root.querySelector('.color-dropdown__picker')!;
             ColorPicker.focus(pickerNode);
         }
     }
@@ -70,7 +70,7 @@ export default function ColorDropDown(props: ColorDropDownProps) {
             class={{
                 'color-dropdown': true,
                 'color-dropdown--open': store.isOpen,
-                [props.class]: Boolean(props.class),
+                [props.class!]: Boolean(props.class),
             }}
             onrender={onRootRender}
         >

--- a/src/ui/controls/color-picker/hsb-picker.tsx
+++ b/src/ui/controls/color-picker/hsb-picker.tsx
@@ -21,10 +21,10 @@ interface HSBPickerProps {
 interface HSBPickerState {
     wasPrevHidden: boolean;
     hueCanvasRendered: boolean;
-    activeHSB: HSB;
-    activeChangeHandler: (color: string) => void;
-    hueTouchStartHandler: (e: TouchEvent) => void;
-    sbTouchStartHandler: (e: TouchEvent) => void;
+    activeHSB: HSB | null;
+    activeChangeHandler: ((color: string) => void) | null;
+    hueTouchStartHandler: ((e: TouchEvent) => void) | null;
+    sbTouchStartHandler: ((e: TouchEvent) => void) | null;
 }
 
 const hsbPickerDefaults: HSBPickerState = {
@@ -78,7 +78,7 @@ function hsbToString(hsb: HSB) {
 
 function render(canvas: HTMLCanvasElement, getPixel: (x: number, y: number) => Uint8ClampedArray) {
     const {width, height} = canvas;
-    const context = canvas.getContext('2d');
+    const context = canvas.getContext('2d')!;
     const imageData = context.getImageData(0, 0, width, height);
     const d = imageData.data;
     for (let y = 0; y < height; y++) {
@@ -122,19 +122,19 @@ export default function HSBPicker(props: HSBPickerProps) {
     const didColorChange = props.color !== prevColor && props.color !== prevActiveColor;
     let activeHSB: HSB;
     if (didColorChange) {
-        const rgb = parseColorWithCache(props.color);
+        const rgb = parseColorWithCache(props.color)!;
         activeHSB = rgbToHSB(rgb);
         store.activeHSB = activeHSB;
     } else {
-        activeHSB = store.activeHSB;
+        activeHSB = store.activeHSB!;
     }
 
     function onSBCanvasRender(canvas: HTMLCanvasElement) {
         if (isElementHidden(canvas)) {
             return;
         }
-        const hue = activeHSB.h;
-        const prevHue = prevColor && rgbToHSB(parseColorWithCache(prevColor)).h;
+        const hue = activeHSB!.h;
+        const prevHue = prevColor && rgbToHSB(parseColorWithCache(prevColor)!).h;
         if (store.wasPrevHidden || hue !== prevHue) {
             renderSB(hue, canvas);
         }

--- a/src/ui/controls/color-picker/index.tsx
+++ b/src/ui/controls/color-picker/index.tsx
@@ -19,7 +19,7 @@ function isValidColor(color: string) {
 const colorPickerFocuses = new WeakMap<Node, () => void>();
 
 function focusColorPicker(node: Node) {
-    const focus = colorPickerFocuses.get(node);
+    const focus = colorPickerFocuses.get(node)!;
     focus();
 }
 

--- a/src/ui/controls/dropdown/index.tsx
+++ b/src/ui/controls/dropdown/index.tsx
@@ -1,7 +1,7 @@
 import {m} from 'malevic';
 import {getContext} from 'malevic/dom';
 
-type DropDownOption<T> = {id: T; content: Malevic.Child};
+export type DropDownOption<T> = {id: T; content: Malevic.Child};
 
 interface DropDownProps<T> {
     class?: string;
@@ -66,7 +66,7 @@ export default function DropDown<T>(props: DropDownProps<T>) {
                 class={{
                     'dropdown__list__item': true,
                     'dropdown__list__item--selected': value.id === props.selected,
-                    [props.class]: props.class != null,
+                    [props.class!]: Boolean(props.class),
                 }}
                 onclick={() => {
                     store.isOpen = false;
@@ -79,14 +79,14 @@ export default function DropDown<T>(props: DropDownProps<T>) {
         );
     }
 
-    const selectedContent = props.options.find((value) => value.id === props.selected).content;
+    const selectedContent = props.options.find((value) => value.id === props.selected)!.content;
 
     return (
         <span
             class={{
                 'dropdown': true,
                 'dropdown--open': store.isOpen,
-                [props.class]: Boolean(props.class),
+                [props.class!]: Boolean(props.class),
             }}
         >
             <span

--- a/src/ui/controls/overlay/index.ts
+++ b/src/ui/controls/overlay/index.ts
@@ -15,7 +15,7 @@ function getOverlayDOMNode(key: any) {
         node.classList.add('overlay');
         node.addEventListener('click', (e) => {
             if (clickListeners.has(node) && e.currentTarget === node) {
-                const listener = clickListeners.get(node);
+                const listener = clickListeners.get(node)!;
                 listener();
             }
         });
@@ -44,7 +44,7 @@ function Portal(props: OverlayPortalProps, ...content: Malevic.Child[]) {
     const context = getContext();
 
     context.onRender(() => {
-        const node = getOverlayDOMNode(props.key);
+        const node = getOverlayDOMNode(props.key)!;
         if (props.onOuterClick) {
             clickListeners.set(node, props.onOuterClick);
         } else {
@@ -54,7 +54,7 @@ function Portal(props: OverlayPortalProps, ...content: Malevic.Child[]) {
     });
 
     context.onRemove(() => {
-        const container = getOverlayDOMNode(props.key);
+        const container = getOverlayDOMNode(props.key)!;
         render(container, null);
     });
 

--- a/src/ui/controls/select/index.tsx
+++ b/src/ui/controls/select/index.tsx
@@ -16,7 +16,7 @@ interface SelectProps {
 
 interface SelectState {
     isExpanded: boolean;
-    focusedIndex: number;
+    focusedIndex: number | null;
 }
 
 function Select(props: SelectProps) {
@@ -90,11 +90,11 @@ function Select(props: SelectProps) {
     function onSelectOption(e: MouseEvent) {
         let current = e.target as HTMLElement;
         while (current && !nodesValues.has(current)) {
-            current = current.parentElement;
+            current = current.parentElement!;
         }
 
         if (current) {
-            const value = nodesValues.get(current);
+            const value = nodesValues.get(current)!;
             props.onChange(value);
         }
 
@@ -109,7 +109,7 @@ function Select(props: SelectProps) {
     function removeValueNode(value: string) {
         const el = valueNodes.get(value);
         valueNodes.delete(value);
-        nodesValues.delete(el);
+        nodesValues.delete(el!);
     }
 
     return (

--- a/src/ui/controls/shortcut/index.tsx
+++ b/src/ui/controls/shortcut/index.tsx
@@ -7,8 +7,8 @@ interface ShortcutLinkProps {
     class?: string | {[cls: string]: any};
     commandName: string;
     shortcuts: Shortcuts;
-    textTemplate: (shortcut: string) => string;
-    onSetShortcut: (shortcut: string) => Promise<string>;
+    textTemplate: (shortcut: string | null) => string;
+    onSetShortcut: (shortcut: string) => Promise<string | null>;
 }
 
 /**
@@ -33,7 +33,7 @@ export default function ShortcutLink(props: ShortcutLinkProps) {
 
         // Note: these variables are function-global to be able to update shortcut display,
         // but they are overwritten right before shortcut is set.
-        let ctrl = false, alt = false, command = false, shift = false, key: string = null;
+        let ctrl = false, alt = false, command = false, shift = false, key: string | null = null;
 
         function updateShortcut() {
             if (!enteringShortcutInProgress) {

--- a/src/ui/controls/slider/index.tsx
+++ b/src/ui/controls/slider/index.tsx
@@ -9,7 +9,7 @@ interface SliderProps {
     max: number;
     step: number;
     formatValue: (value: number) => string;
-    onChange: (value: number) => void;
+    onChange: (value: number | null) => void;
 }
 
 function stickToStep(x: number, step: number) {
@@ -27,12 +27,12 @@ export default function Slider(props: SliderProps) {
     const context = getContext();
     const store = context.store as {
         isActive: boolean;
-        activeValue: number;
+        activeValue: number | null;
         activeProps: SliderProps;
         trackNode: HTMLElement;
         thumbNode: HTMLElement;
         wheelTimeoutId: number;
-        wheelValue: number;
+        wheelValue: number | null;
     };
 
     store.activeProps = props;
@@ -75,7 +75,7 @@ export default function Slider(props: SliderProps) {
                 : null;
 
             function getTouch(e: TouchEvent) {
-                const find = (touches: TouchList) => Array.from(touches).find((t) => t.identifier === touchId);
+                const find = (touches: TouchList) => Array.from(touches).find((t) => t.identifier === touchId)!;
                 return find(e.changedTouches) || find(e.touches);
             }
 
@@ -168,7 +168,7 @@ export default function Slider(props: SliderProps) {
     }
 
     const refreshOnWheel = throttle(() => {
-        store.activeValue = stickToStep(store.wheelValue, props.step);
+        store.activeValue = stickToStep(store.wheelValue!, props.step);
         store.wheelTimeoutId = setTimeout(() => {
             const {onChange} = store.activeProps;
             onChange(store.activeValue);

--- a/src/ui/controls/toggle/index.tsx
+++ b/src/ui/controls/toggle/index.tsx
@@ -34,13 +34,13 @@ export default function Toggle(props: ToggleProps) {
         <span class={cls}>
             <span
                 class={clsOn}
-                onclick={onChange ? () => !checked && onChange(true) : null}
+                onclick={onChange ? () => !checked && onChange(true) : undefined}
             >
                 {props.labelOn}
             </span>
             <span
                 class={clsOff}
-                onclick={onChange ? () => checked && onChange(false) : null}
+                onclick={onChange ? () => checked && onChange(false) : undefined}
             >
                 {props.labelOff}
             </span>

--- a/src/ui/controls/updown/track.tsx
+++ b/src/ui/controls/updown/track.tsx
@@ -8,7 +8,7 @@ interface TrackProps {
 
 export default function Track(props: TrackProps) {
     const valueStyle = {'width': `${props.value * 100}%`};
-    const isClickable = props.onChange != null;
+    const isClickable = Boolean(props.onChange);
 
     function onMouseDown(e: MouseEvent) {
         const targetNode = e.currentTarget as HTMLElement;
@@ -31,7 +31,7 @@ export default function Track(props: TrackProps) {
 
         function onMouseUp(e: MouseEvent) {
             const value = getValue(e.clientX);
-            props.onChange(value);
+            props.onChange!(value);
             cleanup();
         }
 
@@ -63,7 +63,7 @@ export default function Track(props: TrackProps) {
                 'track': true,
                 'track--clickable': Boolean(props.onChange),
             }}
-            onmousedown={isClickable ? onMouseDown : null}
+            onmousedown={isClickable ? onMouseDown : undefined}
         >
             <span class="track__value" style={valueStyle}></span>
             <label class="track__label">

--- a/src/ui/controls/utils.ts
+++ b/src/ui/controls/utils.ts
@@ -6,7 +6,7 @@ function toArray<T>(x: T | T[]) {
 
 export function mergeClass(
     cls: string | {[cls: string]: any} | Array<string | {[cls: string]: any}>,
-    propsCls: string | {[cls: string]: any} | Array<string | {[cls: string]: any}>
+    propsCls: string | {[cls: string]: any} | Array<string | {[cls: string]: any}> | undefined
 ) {
     const normalized = toArray(cls).concat(toArray(propsCls));
     return classes(...normalized);

--- a/src/ui/controls/virtual-scroll/index.tsx
+++ b/src/ui/controls/virtual-scroll/index.tsx
@@ -4,7 +4,7 @@ import {render, getContext} from 'malevic/dom';
 interface VirtualScrollProps {
     root: Malevic.Spec;
     items: Malevic.Spec[];
-    scrollToIndex?: number;
+    scrollToIndex?: number | null | undefined;
 }
 
 export default function VirtualScroll(props: VirtualScrollProps) {
@@ -29,7 +29,7 @@ export default function VirtualScroll(props: VirtualScrollProps) {
                     onrender: null,
                 },
             };
-            const tempNode = render(root, tempItem).firstElementChild;
+            const tempNode = render(root, tempItem).firstElementChild!;
             store.itemHeight = tempNode.getBoundingClientRect().height;
         }
         const {itemHeight} = store;
@@ -55,7 +55,7 @@ export default function VirtualScroll(props: VirtualScrollProps) {
         if (document.activeElement) {
             let current = document.activeElement;
             while (current && current.parentElement !== wrapper) {
-                current = current.parentElement;
+                current = current.parentElement!;
             }
             if (current) {
                 focusedIndex = store.nodesIndices.get(current);
@@ -93,7 +93,7 @@ export default function VirtualScroll(props: VirtualScrollProps) {
                 </div>
             ));
 
-        render(wrapper, items);
+        render(wrapper!, items);
     }
 
     let rootNode: Element;
@@ -111,7 +111,8 @@ export default function VirtualScroll(props: VirtualScrollProps) {
             onrender: (node) => {
                 rootNode = node;
                 rootDidRender && rootDidRender(rootNode);
-                renderContent(rootNode, isNaN(props.scrollToIndex) ? -1 : props.scrollToIndex);
+                // TODO: remove type cast after dependency update
+                renderContent(rootNode, isNaN(props.scrollToIndex!) ? -1 : props.scrollToIndex!);
             },
             onscroll: () => {
                 if (rootNode.scrollTop === prevScrollTop) {

--- a/src/ui/devtools/components/body.tsx
+++ b/src/ui/devtools/components/body.tsx
@@ -12,7 +12,7 @@ type BodyProps = ExtWrapper;
 
 function Body({data, actions}: BodyProps) {
     const context = getContext();
-    const {state, setState} = useState({errorText: null as string});
+    const {state, setState} = useState({errorText: null as string | null});
     let textNode: HTMLTextAreaElement;
     const previewButtonText = data.settings.previewNewDesign ? 'Switch to old design' : 'Preview new design';
     const {theme} = getCurrentThemePreset({data, actions});

--- a/src/ui/devtools/index.tsx
+++ b/src/ui/devtools/index.tsx
@@ -28,7 +28,7 @@ if (__TEST__) {
         const respond = (message: {type: string; id: number; data?: string}) => socket.send(JSON.stringify(message));
         const message: {type: string; id: number; data: string} = JSON.parse(e.data);
         try {
-            const textarea: HTMLTextAreaElement = document.querySelector('textarea#editor');
+            const textarea: HTMLTextAreaElement = document.querySelector('textarea#editor')!;
             const [buttonReset, buttonApply] = document.querySelectorAll('button');
             switch (message.type) {
                 case 'debug-devtools-paste':

--- a/src/ui/popup/automation-page/index.tsx
+++ b/src/ui/popup/automation-page/index.tsx
@@ -106,7 +106,7 @@ export default function AutomationPage(props: ViewProps) {
                     class="automation-page__location__latitude"
                     placeholder={getLocalMessage('latitude')}
                     onchange={(e: {target: HTMLInputElement}) => locationChanged(e.target, e.target.value, 'latitude')}
-                    oncreate={(node: HTMLInputElement) => node.value = getLocationString(locationSettings.latitude)}
+                    oncreate={(node: HTMLInputElement) => node.value = getLocationString(locationSettings.latitude!)}
                     onkeypress={(e) => {
                         if (e.key === 'Enter') {
                             (e.target as HTMLInputElement).blur();
@@ -117,7 +117,7 @@ export default function AutomationPage(props: ViewProps) {
                     class="automation-page__location__longitude"
                     placeholder={getLocalMessage('longitude')}
                     onchange={(e: {target: HTMLInputElement}) => locationChanged(e.target, e.target.value, 'longitude')}
-                    oncreate={(node: HTMLInputElement) => node.value = getLocationString(locationSettings.longitude)}
+                    oncreate={(node: HTMLInputElement) => node.value = getLocationString(locationSettings.longitude!)}
                     onkeypress={(e) => {
                         if (e.key === 'Enter') {
                             (e.target as HTMLInputElement).blur();

--- a/src/ui/popup/body/index.tsx
+++ b/src/ui/popup/body/index.tsx
@@ -36,7 +36,7 @@ type PageId = (
     | 'manage-settings'
 );
 
-let popstate: () => void = null;
+let popstate: (() => void) | null = null;
 isMobile && window.addEventListener('popstate', () => popstate && popstate());
 
 function Pages(props: ViewProps) {
@@ -49,31 +49,31 @@ function Pages(props: ViewProps) {
     }
 
     function onThemeNavClick() {
-        isMobile && history.pushState(undefined, undefined);
+        isMobile && history.pushState(undefined, '');
         store.activePage = 'theme';
         context.refresh();
     }
 
     function onSettingsNavClick() {
-        isMobile && history.pushState(undefined, undefined);
+        isMobile && history.pushState(undefined, '');
         store.activePage = 'settings';
         context.refresh();
     }
 
     function onAutomationNavClick() {
-        isMobile && history.pushState(undefined, undefined);
+        isMobile && history.pushState(undefined, '');
         store.activePage = 'automation';
         context.refresh();
     }
 
     function onManageSettingsClick() {
-        isMobile && history.pushState(undefined, undefined);
+        isMobile && history.pushState(undefined, '');
         store.activePage = 'manage-settings';
         context.refresh();
     }
 
     function onSiteListNavClick() {
-        isMobile && history.pushState(undefined, undefined);
+        isMobile && history.pushState(undefined, '');
         store.activePage = 'site-list';
         context.refresh();
     }

--- a/src/ui/popup/components/custom-settings-toggle/index.tsx
+++ b/src/ui/popup/components/custom-settings-toggle/index.tsx
@@ -14,7 +14,7 @@ export default function CustomSettingsToggle({data, actions}: ExtWrapper) {
 
     const urlText = host
         .split('.')
-        .reduce((elements, part, i) => elements.concat(
+        .reduce<string[]>((elements, part, i) => elements.concat(
             <wbr />,
             `${i > 0 ? '.' : ''}${part}`
         ), []);

--- a/src/ui/popup/components/engine-switch/index.tsx
+++ b/src/ui/popup/components/engine-switch/index.tsx
@@ -24,9 +24,9 @@ export default function EngineSwitch({engine, onChange}: EngineSwitchProps) {
     return (
         <div class="engine-switch">
             <MultiSwitch
-                value={engineNames.find(([code]) => code === engine)[1]}
+                value={engineNames.find(([code]) => code === engine)![1]}
                 options={engineNames.map(([, name]) => name)}
-                onChange={(value) => onChange(engineNames.find(([, name]) => name === value)[0])}
+                onChange={(value) => onChange(engineNames.find(([, name]) => name === value)![0])}
             />
             <span
                 class={{

--- a/src/ui/popup/components/header/index.tsx
+++ b/src/ui/popup/components/header/index.tsx
@@ -95,7 +95,7 @@ function Header({data, actions, onMoreToggleSettingsClick}: HeaderProps) {
                     {(isTimeAutomation
                         ? <WatchIcon hours={now.getHours()} minutes={now.getMinutes()} />
                         : (isLocationAutomation
-                            ? (<SunMoonIcon date={now} latitude={data.settings.location.latitude} longitude={data.settings.location.longitude} />)
+                            ? (<SunMoonIcon date={now} latitude={data.settings.location.latitude!} longitude={data.settings.location.longitude!} />)
                             : <SystemIcon />))}
                 </span>
             </div>

--- a/src/ui/popup/components/header/more-toggle-settings.tsx
+++ b/src/ui/popup/components/header/more-toggle-settings.tsx
@@ -24,7 +24,7 @@ export default function MoreToggleSettings({data, actions, isExpanded, onClose}:
         },
     };
 
-    function getLocationString(location: number) {
+    function getLocationString(location: number | null) {
         if (location == null) {
             return '';
         }

--- a/src/ui/popup/components/site-toggle/index.tsx
+++ b/src/ui/popup/components/site-toggle/index.tsx
@@ -23,12 +23,12 @@ export default function SiteToggleButton({data, actions}: ExtWrapper) {
         (!tab.isProtected && !pdf) ||
         tab.isInjected
     );
-    const isSiteEnabled = isURLEnabled(tab.url, data.settings, tab, data.isAllowedFileSchemeAccess) && tab.isInjected;
+    const isSiteEnabled: boolean = isURLEnabled(tab.url, data.settings, tab, data.isAllowedFileSchemeAccess) && Boolean(tab.isInjected);
     const host = getURLHostOrProtocol(tab.url);
 
     const urlText = host
         .split('.')
-        .reduce((elements, part, i) => elements.concat(
+        .reduce<string[]>((elements, part, i) => elements.concat(
             <wbr />,
             `${i > 0 ? '.' : ''}${part}`
         ), []);

--- a/src/ui/popup/index.tsx
+++ b/src/ui/popup/index.tsx
@@ -62,7 +62,7 @@ if (__TEST__) {
                 const newLink = document.createElement('link');
                 newLink.rel = 'stylesheet';
                 newLink.href = url.replace(/\?.*$/, `?nocache=${Date.now()}`);
-                link.parentElement.insertBefore(newLink, link);
+                link.parentElement!.insertBefore(newLink, link);
                 link.remove();
             });
         }
@@ -79,7 +79,7 @@ if (__TEST__) {
             const message: {type: string; id: number; data: string} = JSON.parse(e.data);
             if (message.type === 'click') {
                 const selector = message.data;
-                const element: HTMLElement = document.querySelector(selector);
+                const element: HTMLElement = document.querySelector(selector)!;
                 element.click();
                 respond({type: 'click-response', id: message.id});
             } else if (message.type === 'exists') {
@@ -88,7 +88,7 @@ if (__TEST__) {
                 respond({type: 'exists-response', id: message.id, data: element != null});
             } else if (message.type === 'rect') {
                 const selector = message.data;
-                const element: HTMLElement = document.querySelector(selector);
+                const element: HTMLElement = document.querySelector(selector)!;
                 const rect = element.getBoundingClientRect();
                 respond({type: 'rect-response', id: message.id, data: {left: rect.left, top: rect.top, width: rect.width, height: rect.height}});
             }

--- a/src/ui/popup/main-page/app-switch.tsx
+++ b/src/ui/popup/main-page/app-switch.tsx
@@ -82,7 +82,7 @@ export default function AppSwitch(props: ViewProps) {
                         {(isTimeAutomation
                             ? <WatchIcon hours={now.getHours()} minutes={now.getMinutes()} />
                             : (isLocationAutomation
-                                ? (<SunMoonIcon date={now} latitude={props.data.settings.location.latitude} longitude={props.data.settings.location.longitude} />)
+                                ? (<SunMoonIcon date={now} latitude={props.data.settings.location.latitude!} longitude={props.data.settings.location.longitude!} />)
                                 : <SystemIcon />))}
                     </span>
                 </MultiSwitch>

--- a/src/ui/popup/manage-settings-page/export-theme.tsx
+++ b/src/ui/popup/manage-settings-page/export-theme.tsx
@@ -9,7 +9,7 @@ import {MessageType} from '../../../utils/message';
 export default function ExportTheme() {
     const listener = ({type, data}: Message, sender: chrome.runtime.MessageSender) => {
         if (type === MessageType.CS_EXPORT_CSS_RESPONSE) {
-            const url = getURLHostOrProtocol(sender.tab.url).replace(/[^a-z0-1\-]/g, '-');
+            const url = getURLHostOrProtocol(sender.tab!.url!).replace(/[^a-z0-1\-]/g, '-');
             saveFile(`DarkReader-${url}.css`, data);
             chrome.runtime.onMessage.removeListener(listener);
         }

--- a/src/ui/popup/site-list-page/site-list.tsx
+++ b/src/ui/popup/site-list-page/site-list.tsx
@@ -34,7 +34,7 @@ export default function SiteList(props: SiteListProps) {
     });
 
     function onTextChange(e: Event & {target: HTMLInputElement}) {
-        const index = store.indices.get(e.target);
+        const index = store.indices.get(e.target)!;
         const values = props.siteList.slice();
         const value = e.target.value.trim();
         if (values.includes(value)) {
@@ -57,7 +57,7 @@ export default function SiteList(props: SiteListProps) {
 
     function removeValue(event: MouseEvent) {
         const previousSibling = ((event.target as HTMLInputElement).previousSibling as HTMLInputElement);
-        const index = store.indices.get(previousSibling);
+        const index = store.indices.get(previousSibling)!;
         const filtered = props.siteList.slice();
         filtered.splice(index, 1);
         store.shouldFocusAtIndex = index;

--- a/src/ui/popup/theme/controls/mode.tsx
+++ b/src/ui/popup/theme/controls/mode.tsx
@@ -20,7 +20,7 @@ export default function Mode(props: {mode: ThemeEngine; onChange: (mode: ThemeEn
         <ThemeControl label="Mode">
             <div class="mode-control-container">
                 <DropDown
-                    selected={modes.find((m) => m.id === props.mode).id}
+                    selected={modes.find((m) => m.id === props.mode)!.id}
                     options={modes}
                     onChange={props.onChange}
                 />

--- a/src/ui/popup/theme/page/index.tsx
+++ b/src/ui/popup/theme/page/index.tsx
@@ -148,7 +148,7 @@ export default function ThemePage(props: ViewProps) {
                     <ColorsGroup theme={theme} change={change} colorSchemes={props.data.colorScheme} />
                 </Collapsible.Group>
                 <Collapsible.Group id="font" label="Font & more">
-                    <FontGroup theme={theme} fonts={props.fonts} change={change} />
+                    <FontGroup theme={theme} fonts={props.fonts!} change={change} />
                 </Collapsible.Group>
             </Collapsible>
             <ResetButton {...props} />

--- a/src/ui/popup/theme/preset-picker/index.tsx
+++ b/src/ui/popup/theme/preset-picker/index.tsx
@@ -5,6 +5,7 @@ import {isURLInList, isURLMatched, getURLHostOrProtocol} from '../../../../utils
 import {DropDown, MessageBox} from '../../../controls';
 import type {ViewProps} from '../../types';
 import {generateUID} from '../../../../utils/uid';
+import type {DropDownOption} from '../../../controls/dropdown';
 
 function PresetItem(props: ViewProps & {preset: ThemePreset}) {
     const context = getContext();
@@ -80,7 +81,7 @@ export default function PresetPicker(props: ViewProps) {
         ...userPresetsOptions,
         addNewPresetOption,
         customSitePresetOption,
-    ].filter(Boolean);
+    ].filter(Boolean) as Array<DropDownOption<string>>;
 
     function onPresetChange(id: string) {
         const filteredCustomThemes = props.data.settings.customThemes.filter(({url}) => !isURLInList(tab.url, url));
@@ -115,7 +116,7 @@ export default function PresetPicker(props: ViewProps) {
 
             const extended = filteredPresets.concat({
                 id: `preset-${generateUID()}`,
-                name: newPresetName,
+                name: newPresetName!,
                 urls: [host],
                 theme: {...props.data.settings.theme},
             });

--- a/src/ui/popup/utils/issues.ts
+++ b/src/ui/popup/utils/issues.ts
@@ -34,10 +34,10 @@ export function fixNotClosingPopupOnNavigation() {
         }
         let target = e.target as HTMLElement;
         while (target && !(target instanceof HTMLAnchorElement)) {
-            target = target.parentElement;
+            target = target.parentElement!;
         }
         if (target && target.hasAttribute('href')) {
-            chrome.tabs.create({url: target.getAttribute('href')});
+            chrome.tabs.create({url: target.getAttribute('href')!});
             e.preventDefault();
             if (!__THUNDERBIRD__) {
                 window.close();

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -30,8 +30,8 @@ export function openFile(options: {extensions: string[]}, callback: (content: st
     const reader = new FileReader();
     reader.onloadend = () => callback(reader.result as string);
     input.onchange = () => {
-        if (input.files[0]) {
-            reader.readAsText(input.files[0]);
+        if (input.files![0]) {
+            reader.readAsText(input.files![0]);
             document.body.removeChild(input);
         }
     };
@@ -53,7 +53,7 @@ export function saveFile(name: string, content: string) {
 type AnyVoidFunction = (...args: any[]) => void;
 
 export function throttle<F extends AnyVoidFunction>(callback: F): F {
-    let frameId: number = null;
+    let frameId: number | null = null;
     return ((...args: any[]) => {
         if (!frameId) {
             callback(...args);
@@ -100,7 +100,7 @@ function onSwipeStart(
     function getTouch(e: TouchEvent) {
         return Array.from(e.changedTouches).find(
             ({identifier: id}) => id === touchId,
-        );
+        )!;
     }
 
     const onPointerMove = throttle((e) => {
@@ -154,8 +154,8 @@ type page = 'devtools' | 'stylesheet-editor';
 // This function ping-pongs a message to possible DevTools popups.
 // This function should have reasonable performance since it sends
 // messages only to popups and not regular windows.
-async function getExtensionPageTabMV3(): Promise<chrome.tabs.Tab> {
-    return new Promise<chrome.tabs.Tab>((resolve) => {
+async function getExtensionPageTabMV3(): Promise<chrome.tabs.Tab | null> {
+    return new Promise((resolve) => {
         chrome.windows.getAll({
             populate: true,
             windowTypes: ['popup'],
@@ -163,11 +163,11 @@ async function getExtensionPageTabMV3(): Promise<chrome.tabs.Tab> {
             const responses: Array<Promise<string>> = [];
             let found = false;
             for (const window of w) {
-                const response = chrome.tabs.sendMessage<string, 'getExtensionPageTabMV3_pong'>(window.tabs[0].id, 'getExtensionPageTabMV3_ping', {frameId: 0});
+                const response = chrome.tabs.sendMessage<string, 'getExtensionPageTabMV3_pong'>(window.tabs![0]!.id!, 'getExtensionPageTabMV3_ping', {frameId: 0});
                 response.then((response) => {
                     if (response === 'getExtensionPageTabMV3_pong') {
                         found = true;
-                        resolve(window.tabs[0]);
+                        resolve(window.tabs![0]);
                     }
                 });
                 responses.push(response);
@@ -177,7 +177,7 @@ async function getExtensionPageTabMV3(): Promise<chrome.tabs.Tab> {
     });
 }
 
-async function getExtensionPageTab(url: string): Promise<chrome.tabs.Tab> {
+async function getExtensionPageTab(url: string): Promise<chrome.tabs.Tab | null> {
     if (__CHROMIUM_MV3__) {
         return getExtensionPageTabMV3();
     }
@@ -193,7 +193,7 @@ export async function openExtensionPage(page: page) {
     if (isMobile) {
         const extensionPageTab = await getExtensionPageTab(url);
         if (extensionPageTab !== null) {
-            chrome.tabs.update(extensionPageTab.id, {active: true});
+            chrome.tabs.update(extensionPageTab.id!, {active: true});
             window.close();
         } else {
             chrome.tabs.create({url});

--- a/src/utils/async-queue.ts
+++ b/src/utils/async-queue.ts
@@ -5,7 +5,7 @@ export type QueueEntry = () => void;
 // It's fully asyncronous and uses promises and tries to get 60FPS.
 export default class AsyncQueue {
     private queue: QueueEntry[] = [];
-    private timerId: number = null;
+    private timerId: number | null = null;
     private frameDuration = 1000 / 60;
 
     addToQueue(entry: QueueEntry) {
@@ -29,7 +29,7 @@ export default class AsyncQueue {
         this.timerId = requestAnimationFrame(() => {
             this.timerId = null;
             const start = Date.now();
-            let cb: () => void;
+            let cb: (() => void) | undefined;
             while ((cb = this.queue.shift())) {
                 cb();
                 if (Date.now() - start >= this.frameDuration) {

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -18,10 +18,10 @@ export interface HSLA {
 const hslaParseCache = new Map<string, HSLA>();
 const rgbaParseCache = new Map<string, RGBA>();
 
-export function parseColorWithCache($color: string) {
+export function parseColorWithCache($color: string): RGBA | null {
     $color = $color.trim();
     if (rgbaParseCache.has($color)) {
-        return rgbaParseCache.get($color);
+        return rgbaParseCache.get($color)!;
     }
     // We cannot _really_ parse any color which has the calc() expression,
     // so we try our best to remove those and then parse the value.
@@ -147,7 +147,7 @@ const rgbMatch = /^rgba?\([^\(\)]+\)$/;
 const hslMatch = /^hsla?\([^\(\)]+\)$/;
 const hexMatch = /^#[0-9a-f]+$/i;
 
-export function parse($color: string): RGBA {
+export function parse($color: string): RGBA | null {
     const c = $color.trim().toLowerCase();
 
     if (c.match(rgbMatch)) {
@@ -178,7 +178,7 @@ export function parse($color: string): RGBA {
 }
 
 function getNumbers($color: string) {
-    const numbers = [];
+    const numbers: string[] = [];
     let prevPos = 0;
     let isMining = false;
     // Get the first `(`.
@@ -266,7 +266,7 @@ function parseHex($hex: string) {
 }
 
 function getColorByName($color: string) {
-    const n = knownColors.get($color);
+    const n = knownColors.get($color)!;
     return {
         r: (n >> 16) & 255,
         g: (n >> 8) & 255,
@@ -276,7 +276,7 @@ function getColorByName($color: string) {
 }
 
 function getSystemColor($color: string) {
-    const n = systemColors.get($color);
+    const n = systemColors.get($color)!;
     return {
         r: (n >> 16) & 255,
         g: (n >> 8) & 255,

--- a/src/utils/colorscheme-parser.ts
+++ b/src/utils/colorscheme-parser.ts
@@ -47,7 +47,7 @@ export interface ParsedColorSchemeConfig {
     dark: { [name: string]: ColorSchemeVariant };
 }
 
-export function ParseColorSchemeConfig(config: string): { result: ParsedColorSchemeConfig; error: string } {
+export function ParseColorSchemeConfig(config: string): { result: ParsedColorSchemeConfig; error: string | null } {
     // Let's first get all "possible" sections of the text.
     // We're adding `\n` so the sections "first" word is the
     // name of the color scheme. We could remove this and
@@ -72,7 +72,7 @@ export function ParseColorSchemeConfig(config: string): { result: ParsedColorSch
     // And also the reason why the parsing failed.
     // It will be the first error that is found.
     let interrupt = false;
-    let error = null;
+    let error: string | null = null;
 
     const throwError = (message: string) => {
         if (!interrupt) {
@@ -122,7 +122,7 @@ export function ParseColorSchemeConfig(config: string): { result: ParsedColorSch
             return;
         }
 
-        const checkVariant = (lineIndex: number, isSecondVariant: boolean): ColorSchemeVariant & { variant: string } => {
+        const checkVariant = (lineIndex: number, isSecondVariant: boolean): (ColorSchemeVariant & { variant?: string }) | undefined => {
             // Get the possible variant name.
             const variant = lines[lineIndex];
             if (!variant) {
@@ -182,18 +182,18 @@ export function ParseColorSchemeConfig(config: string): { result: ParsedColorSch
             };
         };
 
-        const firstVariant = checkVariant(2, false);
+        const firstVariant = checkVariant(2, false)!;
         const isFirstVariantLight = firstVariant.variant === 'LIGHT';
         delete firstVariant.variant;
         // If the interrupt variable is set, we should stop parsing.
         if (interrupt) {
             return;
         }
-        let secondVariant = null;
+        let secondVariant: typeof firstVariant | null = null;
         let isSecondVariantLight = false;
         // Check if the 7th line is defined otherwise we should stop parsing.
         if (lines[6]) {
-            secondVariant = checkVariant(6, true);
+            secondVariant = checkVariant(6, true)!;
             isSecondVariantLight = secondVariant.variant === 'LIGHT';
             delete secondVariant.variant;
             // If the interrupt variable is set, we should stop parsing.

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,7 +1,7 @@
 type AnyFn = (...args: any[]) => void;
 
 export function debounce<F extends AnyFn>(delay: number, fn: F): F {
-    let timeoutId: ReturnType<typeof setTimeout> = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     return ((...args: any[]) => {
         if (timeoutId) {
             clearTimeout(timeoutId);

--- a/src/utils/ipv6.ts
+++ b/src/utils/ipv6.ts
@@ -14,8 +14,8 @@ export function isIPV6(url: string) {
 
 const ipV6HostRegex = /\[.*?\](\:\d+)?/;
 
-export function compareIPV6(firstURL: string, secondURL: string) {
-    const firstHost = firstURL.match(ipV6HostRegex)[0];
-    const secondHost = secondURL.match(ipV6HostRegex)[0];
+export function compareIPV6(firstURL: string, secondURL: string): boolean {
+    const firstHost = firstURL.match(ipV6HostRegex)![0];
+    const secondHost = secondURL.match(ipV6HostRegex)![0];
     return firstHost === secondHost;
 }

--- a/src/utils/math-eval.ts
+++ b/src/utils/math-eval.ts
@@ -10,7 +10,7 @@ export function evalMath(expression: string): number {
     // The working stack where new tokens are pushed.
     const workingStack: string[] = [];
 
-    let lastToken: string;
+    let lastToken: string | undefined;
     // Iterate over the expression.
     for (let i = 0, len = expression.length; i < len; i++) {
         const token = expression[i];
@@ -33,8 +33,8 @@ export function evalMath(expression: string): number {
 
                 // Is the current operation equal or less than the current operation?
                 // Then move that operation to the rpnStack.
-                if (op.lessOrEqualThan(currentOp)) {
-                    rpnStack.push(workingStack.shift());
+                if (op!.lessOrEqualThan(currentOp)) {
+                    rpnStack.push(workingStack.shift()!);
                 } else {
                     break;
                 }

--- a/src/utils/media-query.ts
+++ b/src/utils/media-query.ts
@@ -1,6 +1,6 @@
 import {isMatchMediaChangeEventListenerSupported} from './platform';
 
-let query: MediaQueryList = null;
+let query: MediaQueryList | null = null;
 const onChange: ({matches}: {matches: boolean}) => void = ({matches}) => listeners.forEach((listener) => listener(matches));
 const listeners = new Set<(isDark: boolean) => void>();
 

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -15,7 +15,7 @@ async function getOKResponse(url: string, mimeType?: string, origin?: string) {
         return response;
     }
 
-    if (mimeType && !response.headers.get('Content-Type').startsWith(mimeType)) {
+    if (mimeType && !response.headers.get('Content-Type')!.startsWith(mimeType)) {
         throw new Error(`Mime type mismatch when loading ${url}`);
     }
 

--- a/src/utils/parsing.ts
+++ b/src/utils/parsing.ts
@@ -27,7 +27,7 @@ export function parseGradient(value: string): parsedGradient[] {
     let index = 0;
     let startIndex = conicGradient.length;
     while ((index = value.indexOf('gradient', startIndex)) !== -1) {
-        let typeGradient: string;
+        let typeGradient: string | undefined;
         // Now we check the type of gradient.
         // the current index starts at `g` of gradient.
         // So we have to do a reverse lookup to find the type of gradient.
@@ -59,7 +59,7 @@ export function parseGradient(value: string): parsedGradient[] {
 
         // Now we know the type of gradient.
         // We can go parse the rest of the value as a gradient.
-        const {start, end} = getParenthesesRange(value, index + gradientLength);
+        const {start, end} = getParenthesesRange(value, index + gradientLength)!;
 
         const match = value.substring(start + 1, end - 1);
         startIndex = end + 1 + conicGradientLength;

--- a/src/utils/promise-barrier.ts
+++ b/src/utils/promise-barrier.ts
@@ -1,6 +1,6 @@
 export class PromiseBarrier<RESOLVUTION, REJECTION> {
-    private resolves: Array<(value?: RESOLVUTION) => void> = [];
-    private rejects: Array<(reason?: REJECTION) => void> = [];
+    private resolves: Array<(value: RESOLVUTION) => void> = [];
+    private rejects: Array<(reason: REJECTION) => void> = [];
     private wasResolved = false;
     private wasRejected = false;
     private resolution: RESOLVUTION;
@@ -19,27 +19,27 @@ export class PromiseBarrier<RESOLVUTION, REJECTION> {
         });
     }
 
-    async resolve(value?: RESOLVUTION){
+    async resolve(value: RESOLVUTION){
         if (this.wasRejected || this.wasResolved) {
             return;
         }
         this.wasResolved = true;
         this.resolution = value;
         this.resolves.forEach((resolve) => resolve(value));
-        this.resolves = null;
-        this.rejects = null;
+        this.resolves = [];
+        this.rejects = [];
         return new Promise<void>((resolve) => setTimeout(() => resolve()));
     }
 
-    async reject(reason?: REJECTION){
+    async reject(reason: REJECTION){
         if (this.wasRejected || this.wasResolved) {
             return;
         }
         this.wasRejected = true;
         this.reason = reason;
         this.rejects.forEach((reject) => reject(reason));
-        this.resolves = null;
-        this.rejects = null;
+        this.resolves = [];
+        this.rejects = [];
         return new Promise<void>((resolve) => setTimeout(() => resolve()));
     }
 

--- a/src/utils/state-manager.ts
+++ b/src/utils/state-manager.ts
@@ -7,7 +7,7 @@ import {StateManagerImpl} from './state-manager-impl';
 
 import {isNonPersistent} from './platform';
 
-export class StateManager<T> {
+export class StateManager<T extends Record<string, unknown>> {
     private stateManager: StateManagerImpl<T> | null;
 
     constructor(localStorageKey: string, parent: any, defaults: T, logWarn: (log: string) => void){

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -50,7 +50,7 @@ export function formatArray(arr: string[]) {
 
 export function getMatches(regex: RegExp, input: string, group = 0) {
     const matches: string[] = [];
-    let m: RegExpMatchArray;
+    let m: RegExpMatchArray | null;
     while ((m = regex.exec(input))) {
         matches.push(m[group]);
     }
@@ -91,7 +91,7 @@ export function formatCSS(text: string) {
         .split('\n'));
 
     let depth = 0;
-    const formatted = [];
+    const formatted: string[] = [];
 
     for (let x = 0, len = css.length; x < len; x++) {
         const line = `${css[x] }\n`;

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,6 +1,6 @@
 export function throttle<T extends(...args: any[]) => any>(callback: T) {
     let pending = false;
-    let frameId: number = null;
+    let frameId: number | null = null;
     let lastArgs: any[];
 
     const throttled: T = ((...args: any[]) => {
@@ -20,7 +20,8 @@ export function throttle<T extends(...args: any[]) => any>(callback: T) {
     }) as any;
 
     const cancel = () => {
-        cancelAnimationFrame(frameId);
+        // TODO: reove cast once types are updated
+        cancelAnimationFrame(frameId as number);
         pending = false;
         frameId = null;
     };
@@ -34,10 +35,10 @@ declare const __TEST__: boolean;
 
 export function createAsyncTasksQueue() {
     const tasks: Task[] = [];
-    let frameId: number = null;
+    let frameId: number | null = null;
 
     function runTasks() {
-        let task: Task;
+        let task: Task | undefined;
         while ((task = tasks.shift())) {
             task();
         }
@@ -56,7 +57,8 @@ export function createAsyncTasksQueue() {
 
     function cancel() {
         tasks.splice(0);
-        cancelAnimationFrame(frameId);
+        // TODO: reove cast once types are updated
+        cancelAnimationFrame(frameId as number);
         frameId = null;
     }
 

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -37,7 +37,7 @@ function compareTime(time1: number[], time2: number[]) {
     return 1;
 }
 
-export function nextTimeInterval(time0: string, time1: string, date: Date = new Date()): number {
+export function nextTimeInterval(time0: string, time1: string, date: Date = new Date()): number | null {
     const a = parse24HTime(time0);
     const b = parse24HTime(time1);
     const t = [date.getHours(), date.getMinutes()];
@@ -125,7 +125,14 @@ function getSunsetSunriseUTCTime(
     latitude: number,
     longitude: number,
     date: Date,
-) {
+): {
+    alwaysDay: true;
+} | {
+    alwaysNight: true;
+} | {
+    sunriseTime: number;
+    sunsetTime: number;
+} {
     const dec31 = Date.UTC(date.getUTCFullYear(), 0, 0, 0, 0, 0, 0);
     const oneDay = getDuration({days: 1});
     const dayOfYear = Math.floor((date.getTime() - dec31) / oneDay);
@@ -236,13 +243,21 @@ export function isNightAtLocation(
 ): boolean {
     const time = getSunsetSunriseUTCTime(latitude, longitude, date);
 
+    // eslint-disable-next-line
+    // @ts-ignore
     if (time.alwaysDay) {
         return false;
+    // eslint-disable-next-line
+    // @ts-ignore
     } else if (time.alwaysNight) {
         return true;
     }
 
+    // eslint-disable-next-line
+    // @ts-ignore
     const sunriseTime = time.sunriseTime;
+    // eslint-disable-next-line
+    // @ts-ignore
     const sunsetTime = time.sunsetTime;
     const currentTime = (
         date.getUTCHours() * getDuration({hours: 1}) +
@@ -261,12 +276,18 @@ export function nextTimeChangeAtLocation(
 ): number {
     const time = getSunsetSunriseUTCTime(latitude, longitude, date);
 
+    // eslint-disable-next-line
+    // @ts-ignore
     if (time.alwaysDay) {
         return date.getTime() + getDuration({days: 1});
+    // eslint-disable-next-line
+    // @ts-ignore
     } else if (time.alwaysNight) {
         return date.getTime() + getDuration({days: 1});
     }
 
+    // eslint-disable-next-line
+    // @ts-ignore
     const [firstTimeOnDay, lastTimeOnDay] = time.sunriseTime < time.sunsetTime ? [time.sunriseTime, time.sunsetTime] : [time.sunsetTime, time.sunriseTime];
     const currentTime = (
         date.getUTCHours() * getDuration({hours: 1}) +
@@ -275,14 +296,14 @@ export function nextTimeChangeAtLocation(
         date.getUTCMilliseconds()
     );
 
-    if (currentTime <= firstTimeOnDay) {
+    if (currentTime <= firstTimeOnDay!) {
         // Timeline:
         // --- firstTimeOnDay <---> lastTimeOnDay ---
         //  ^
         // Current time
         return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0, 0, 0, firstTimeOnDay);
     }
-    if (currentTime <= lastTimeOnDay) {
+    if (currentTime <= lastTimeOnDay!) {
         // Timeline:
         // --- firstTimeOnDay <---> lastTimeOnDay ---
         //                      ^

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,10 +15,10 @@ function fixBaseURL($url: string) {
     return anchor.href;
 }
 
-export function parseURL($url: string, $base: string = null) {
+export function parseURL($url: string, $base: string | null = null): URL {
     const key = `${$url}${$base ? `;${$base}` : ''}`;
     if (parsedURLCache.has(key)) {
-        return parsedURLCache.get(key);
+        return parsedURLCache.get(key)!;
     }
     if ($base) {
         const parsedURL = new URL($url, fixBaseURL($base));
@@ -130,7 +130,7 @@ function createUrlRegex(urlTemplate: string): RegExp {
 
     let slashIndex: number;
     let beforeSlash: string;
-    let afterSlash: string;
+    let afterSlash: string | undefined;
     if ((slashIndex = urlTemplate.indexOf('/')) >= 0) {
         beforeSlash = urlTemplate.substring(0, slashIndex); // google.*
         afterSlash = urlTemplate.replace(/\$/g, '').substring(slashIndex); // /login/abc

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -47,14 +47,14 @@ function isOneOf(...values: any[]) {
     return (x: any) => values.includes(x);
 }
 
-function hasRequiredProperties<T>(obj: T, keys: Array<keyof T>) {
+function hasRequiredProperties<T extends Record<string, unknown>>(obj: T, keys: Array<keyof T>) {
     return keys.every((key) => obj.hasOwnProperty(key));
 }
 
 function createValidator() {
     const errors: string[] = [];
 
-    function validateProperty<T>(obj: T, key: keyof T, validator: (x: any) => boolean, fallback: T) {
+    function validateProperty<T extends Record<string, unknown>>(obj: T, key: keyof T, validator: (x: any) => boolean, fallback: T) {
         if (!obj.hasOwnProperty(key) || validator(obj[key])) {
             return;
         }
@@ -62,7 +62,7 @@ function createValidator() {
         obj[key] = fallback[key];
     }
 
-    function validateArray<T, V>(obj: T, key: keyof T, validator: (x: V) => boolean) {
+    function validateArray<T extends Record<string, unknown>, V>(obj: T, key: keyof T, validator: (x: V) => boolean) {
         if (!obj.hasOwnProperty(key)) {
             return;
         }
@@ -179,7 +179,7 @@ export function validateSettings(settings: Partial<UserSettings>) {
     return {errors, settings};
 }
 
-export function validateTheme(theme: Partial<Theme>) {
+export function validateTheme(theme: Partial<Theme> | null | undefined) {
     if (!isPlainObject(theme)) {
         return {errors: ['Theme is not a plain object'], theme: DEFAULT_THEME};
     }

--- a/src/utils/visibility.ts
+++ b/src/utils/visibility.ts
@@ -24,7 +24,7 @@
  * has issues optimizing code with multiple callbacks stored in array or in a set.
  */
 
-let documentVisibilityListener: () => void = null;
+let documentVisibilityListener: (() => void) | null = null;
 
 let documentIsVisible_ = !document.hidden;
 
@@ -35,15 +35,15 @@ const listenerOptions: any = {
 };
 
 function watchForDocumentVisibility() {
-    document.addEventListener('visibilitychange', documentVisibilityListener, listenerOptions);
-    window.addEventListener('pageshow', documentVisibilityListener, listenerOptions);
-    window.addEventListener('focus', documentVisibilityListener, listenerOptions);
+    document.addEventListener('visibilitychange', documentVisibilityListener!, listenerOptions);
+    window.addEventListener('pageshow', documentVisibilityListener!, listenerOptions);
+    window.addEventListener('focus', documentVisibilityListener!, listenerOptions);
 }
 
 function stopWatchingForDocumentVisibility() {
-    document.removeEventListener('visibilitychange', documentVisibilityListener, listenerOptions);
-    window.removeEventListener('pageshow', documentVisibilityListener, listenerOptions);
-    window.removeEventListener('focus', documentVisibilityListener, listenerOptions);
+    document.removeEventListener('visibilitychange', documentVisibilityListener!, listenerOptions);
+    window.removeEventListener('pageshow', documentVisibilityListener!, listenerOptions);
+    window.removeEventListener('focus', documentVisibilityListener!, listenerOptions);
 }
 
 export function setDocumentVisibilityListener(callback: () => void) {

--- a/tasks/bundle-api.js
+++ b/tasks/bundle-api.js
@@ -32,6 +32,7 @@ async function bundleAPI({debug, watch}) {
                 typescript,
                 tsconfig: rootPath('src/api/tsconfig.json'),
                 noImplicitAny: debug ? false : true,
+                strictNullChecks: debug ? false : true,
                 removeComments: debug ? false : true,
                 sourceMap: debug ? true : false,
                 inlineSources: debug ? true : false,

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -135,6 +135,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
                     typescript,
                     tsconfig: rootPath('src/tsconfig.json'),
                     noImplicitAny: debug ? false : true,
+                    strictNullChecks: debug ? false : true,
                     removeComments: debug ? false : true,
                     sourceMap: debug ? true : false,
                     inlineSources: debug ? true : false,

--- a/tasks/translate.js
+++ b/tasks/translate.js
@@ -24,6 +24,9 @@ async function translateEnLine(lineNumber) {
     const enLocale = locales.find((l) => l.locale === 'en');
     const otherLocales = locales.filter((l) => l.locale !== 'en');
 
+    if (!enLocale) {
+        throw new Error('Could not find English (en) locale.');
+    }
     const enLines = enLocale.content.split('\n');
     const index = lineNumber - 1;
     const line = enLines[index];

--- a/tests/inject/karma.conf.js
+++ b/tests/inject/karma.conf.js
@@ -14,7 +14,7 @@ import paths from '../../tasks/paths.js';
 const {rootPath} = paths;
 
 /**
- * @param {LocalConfig} config
+ * @param {Partial<LocalConfig>} config
  * @param {Record<string, string>} env
  * @returns {ConfigOptions}
  */

--- a/tests/unit/inject/fixes.tests.ts
+++ b/tests/unit/inject/fixes.tests.ts
@@ -4,7 +4,7 @@ import {multiline} from '../../support/test-utils';
 
 describe('Select fixes via findRelevantFix()', () => {
     const emptyFix: DynamicThemeFix = {
-        url: null,
+        url: [],
         css: '',
         invert: [],
         ignoreImageAnalysis: [],
@@ -14,8 +14,6 @@ describe('Select fixes via findRelevantFix()', () => {
 
     it('If fix list is empty or invalid, findRelevantFix() returns null', () => {
         expect(findRelevantFix('https://example.com', [])).toBe(null);
-        expect(findRelevantFix('https://example.com', null)).toBe(null);
-        expect(findRelevantFix('https://example.com', undefined)).toBe(null);
         expect(findRelevantFix('https://example.com', 1 as any)).toBe(null);
         expect(findRelevantFix('https://example.com', 'a' as any)).toBe(null);
         expect(findRelevantFix('https://example.com', {} as any)).toBe(null);
@@ -169,7 +167,7 @@ describe('Select fixes via findRelevantFix()', () => {
 
 describe('Construct single fix via combineFixes()', () => {
     const emptyFix: DynamicThemeFix = {
-        url: null,
+        url: [],
         css: '',
         invert: [],
         ignoreImageAnalysis: [],
@@ -189,7 +187,7 @@ describe('Construct single fix via combineFixes()', () => {
                 url: ['example.com'],
                 css: 'h1 { color: yellow; }',
             }
-        ]).css).toBe(multiline(
+        ])!.css).toBe(multiline(
             'body { background: blue; }',
             'h1 { color: yellow; }',
         ));
@@ -206,7 +204,7 @@ describe('Construct single fix via combineFixes()', () => {
                 ...emptyFix,
                 invert: ['svg'],
             }
-        ]).invert).toStrictEqual(['img', 'svg']);
+        ])!.invert).toStrictEqual(['img', 'svg']);
     });
 
     it('Merges ignoreImageAnalysis', () => {
@@ -220,7 +218,7 @@ describe('Construct single fix via combineFixes()', () => {
                 ...emptyFix,
                 ignoreImageAnalysis: ['svg'],
             }
-        ]).ignoreImageAnalysis).toStrictEqual(['img', 'svg']);
+        ])!.ignoreImageAnalysis).toStrictEqual(['img', 'svg']);
     });
 
     it('Merges ignoreInlineStyle', () => {
@@ -234,7 +232,7 @@ describe('Construct single fix via combineFixes()', () => {
                 ...emptyFix,
                 ignoreInlineStyle: ['svg'],
             }
-        ]).ignoreInlineStyle).toStrictEqual(['img', 'svg']);
+        ])!.ignoreInlineStyle).toStrictEqual(['img', 'svg']);
     });
 
     it('disableStyleSheetsProxy is true if it is true in at least one fix', () => {
@@ -246,9 +244,8 @@ describe('Construct single fix via combineFixes()', () => {
             },
             {
                 ...emptyFix,
-                disableStyleSheetsProxy: null,
             }
-        ]).disableStyleSheetsProxy).toBe(false);
+        ])!.disableStyleSheetsProxy).toBe(false);
 
         expect(combineFixes([
             {
@@ -264,6 +261,6 @@ describe('Construct single fix via combineFixes()', () => {
                 ...emptyFix,
                 disableStyleSheetsProxy: false,
             }
-        ]).disableStyleSheetsProxy).toBe(true);
+        ])!.disableStyleSheetsProxy).toBe(true);
     });
 });

--- a/tests/unit/tsconfig.json
+++ b/tests/unit/tsconfig.json
@@ -17,6 +17,7 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "noImplicitAny": true,
+        "strictNullChecks": true,
         "inlineSourceMap": true
     }
 }

--- a/tests/unit/utils/state-manager.tests.ts
+++ b/tests/unit/utils/state-manager.tests.ts
@@ -143,7 +143,7 @@ describe('State manager utility', () => {
 
         expect(getCount).toEqual(1);
 
-        getCallback({});
+        getCallback!({});
 
         promises.all('pending');
 
@@ -499,9 +499,9 @@ describe('State manager utility', () => {
         const storage: any = {};
 
         let getCount = 0;
-        let getCallback: () => void;
+        let getCallback: (() => void) | undefined;
         const resolveGet = () => {
-            getCallback();
+            getCallback!();
             getCallback = undefined;
         };
 
@@ -514,9 +514,9 @@ describe('State manager utility', () => {
         };
 
         let setCount = 0;
-        let setCallback: () => void;
+        let setCallback: (() => void) | undefined;
         const resolveSet = () => {
-            setCallback();
+            setCallback!();
             setCallback = undefined;
         };
 
@@ -528,12 +528,12 @@ describe('State manager utility', () => {
             };
         };
 
-        let onChangedListener: (data: any) => void = null;
+        let onChangedListener: ((data: any) => void) | undefined;
         const modifyInternalState = (data: any) => {
             expect(onChangedListener).toBeTruthy();
             const oldValue = storage[key];
             storage[key] = data;
-            onChangedListener({
+            onChangedListener!({
                 [key]: {
                     oldValue,
                     newValue: data

--- a/tests/unit/utils/uid.tests.ts
+++ b/tests/unit/utils/uid.tests.ts
@@ -32,6 +32,8 @@ test('Unique identifier generation (popyfilled)', () => {
     expect(generateUID()).toEqual('a19cc926bf7f4d5fbf9c202bc7a4c7c6');
     expect(shim2).toHaveBeenCalled();
 
+    // eslint-disable-next-line
+    // @ts-ignore
     delete globalThis.crypto;
 });
 

--- a/tests/unit/utils/validation.tests.ts
+++ b/tests/unit/utils/validation.tests.ts
@@ -38,7 +38,7 @@ test('Settings Validation', () => {
         lightSchemeTextColor: '#ffffff00',
         scrollbarColor: false,
         selectionColor: 'green',
-        styleSystemControls: null as boolean,
+        styleSystemControls: null as boolean | null,
         lightColorScheme: '',
         darkColorScheme: false,
         immediateModify: 1,
@@ -54,7 +54,7 @@ test('Settings Validation', () => {
 
     const wonkySet = {
         enabled: '',
-        fetchNews: null as boolean,
+        fetchNews: null as boolean | null,
         theme: {
             mode: 'dark',
             brightness: 250,
@@ -72,7 +72,7 @@ test('Settings Validation', () => {
             lightSchemeTextColor: '#ffffff00',
             scrollbarColor: false,
             selectionColor: 'green',
-            styleSystemControls: null as boolean,
+            styleSystemControls: null as boolean | null,
             lightColorScheme: '',
             darkColorScheme: false,
             immediateModify: 1,
@@ -98,9 +98,9 @@ test('Settings Validation', () => {
         ],
         siteList: ['a.com', '', 'b.com'],
         siteListEnabled: {0: 'a.com', 1: 'b.com'},
-        applyToListedOnly: null as boolean,
+        applyToListedOnly: null as boolean | null,
         changeBrowserTheme: 1,
-        syncSettings: null as boolean,
+        syncSettings: null as boolean | null,
         syncSitesFixes: 0,
         automation: {
             enabled: false,
@@ -116,7 +116,7 @@ test('Settings Validation', () => {
             longitude: '5.3',
         },
         previewNewDesign: '',
-        enableForPDF: null as boolean,
+        enableForPDF: null as boolean | null,
         enableForProtectedPages: 'ok',
         enableContextMenus: 'yes',
         detectDarkTheme: 'no',


### PR DESCRIPTION
By default, TypeScript conflates `null` and `undefined` types with each other sometimes even the types containing actual data. For example, in `src/inject/dynamic-theme/modify-css.ts` the variable `colorCorner` is a `string` but in some cases it can be used before it is assigned (so it is `undefined`) and is stringed as `"undefined"` apparently leading to a minor bug.
This PR sets `strictNullChecks` to `true` for builds and some tests (notably, skipping browser tests). Also, it updates type declarations with `null` and `undefined` types as appropriate, and adds non-null assertions as appropriate. The goal of this PR is to simply enumerate all potentially problematic type casts (by logging ESLint warnings) without modifying code behavior at all and with minimal changes to built output. Follow-up PR(s) will resolve the problematic assertions and fix the bug described above.