### PR TITLE
Add dark site

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -324,6 +324,7 @@ getwacup.com
 gfl.matsuda.tips
 gflcorner.com
 ggapp.io
+ghasemi.dev
 ghidra-sre.org
 gianmarco.ga
 giantbomb.com


### PR DESCRIPTION
Respectfully requesting my portfolio site (https://ghasemi.dev) be added to the whitelist. The only color scheme is dark, and google sites Iframes break with DR active.

Thank you!