### PR TITLE
Fixes for rewards.microsoft.com and rewards.bing.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17053,6 +17053,26 @@ path[d^="M121.865 50.29c0"]
 
 ================================
 
+rewards.bing.com
+
+IGNORE INLINE STYLE
+path
+INVERT
+#promo-item > section > div > div > h1
+#promo-item > section > div > div > p
+
+================================
+
+rewards.microsoft.com
+
+IGNORE INLINE STYLE
+path
+INVERT
+#promo-item > section > div > div > h1
+#promo-item > section > div > div > p
+
+================================
+
 rfi.fr
 
 INVERT


### PR DESCRIPTION
Added support for rewards.microsoft.com and rewards.bing.com. Right now rewards.microsoft.com redirects to rewards.bing.com, but they are the same site, Microsoft just changed the URL to bing in the last day or so. The IGNORE INLINE STYLE is there to make sure the various svg icons and animations they have on the page stay their original color, since they can look weird when modified (see the example images below).
Before:
![before path change](https://user-images.githubusercontent.com/1144106/204878684-ad1cd44a-bd96-4948-9002-10344f4c61f1.png)
After:
![after path change](https://user-images.githubusercontent.com/1144106/204878774-ed874f3a-9ade-4c76-a21a-4219250f6f86.png)


 The INVERT is to make some text remain dark in so that it can be read in front of a bright image behind it (see the example images below).
Before:
![before text change](https://user-images.githubusercontent.com/1144106/204878843-0a1a3286-643d-42b9-9c8d-3430adb454a5.png)
After:
![after text change](https://user-images.githubusercontent.com/1144106/204878877-419a7b46-26a3-4008-bf0c-16fb82edee29.png)