### PR TITLE
Skip styles that specify `all: revert`

### DIFF
--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -83,6 +83,13 @@ export function createStyleSheetModifier() {
                 return;
             }
 
+            // A very specific case to skip. This causes a lot of calls to `getModifiableCSSDeclaration`
+            // and currently contributes nothing in real-world case.
+            // TODO: Allow `setRule` to throw a exception when we're modifying SVGs namespace styles.
+            if (rule.style.all === 'revert') {
+                return;
+            }
+
             const modDecs: ModifiableCSSDeclaration[] = [];
             rule.style && iterateCSSDeclarations(rule.style, (property, value) => {
                 const mod = getModifiableCSSDeclaration(property, value, rule, variablesStore, ignoreImageAnalysis, isAsyncCancelled);


### PR DESCRIPTION
- The browser will expand specific CSS declaration to all possible properties that can have the `revert` value, this contributes nothing in the real world and therefor skip it. The real reason is to:
- Resolves #10367