### PR TITLE
Update dynamic theme for Duolingo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6370,19 +6370,16 @@ INVERT
 
 duolingo.com
 
-INVERT
-.Z392z
-._24NNT
-[data-test="skill-icon"] + div img
-
 CSS
 button[aria-disabled="true"] {
     opacity: 0.3 !important;
 }
+[data-test^="skill-path"] {
+    --darkreader-bg--path-level-color: var(--path-level-color) !important;
+}
 
 IGNORE INLINE STYLE
-div[data-test="challenge-translate-prompt"] svg *
-div[data-test="challenge challenge-translate"] svg *
+svg *
 
 ================================
 


### PR DESCRIPTION
* Remove old rules that no longer apply to new site
I couldn't find the existing class names on the new site, so I removed them.

* Correct the background color for skill path icons
I'm not sure the approach I used is the best, but it seems to work. 

* Do not apply inline styles to SVGs
The `svg *` selector might be too liberal, but it doesn't seem to cause any problems.

* Resolves issue #7946

There are some other outstanding minor cosmetic and readability issues, but they are difficult to develop a long-term fix for because the class names are auto-generated on each new build of the website.

I only tested this with Firefox 107.0.1 on Windows 10 with Dark Reader version 4.9.60. I also checked these changes didn't break anything in the Light Mode.

I'm new to this, so any feedback is welcome!

Before: 
![Screenshot 2022-12-07 153858](https://user-images.githubusercontent.com/5616307/206321050-83bba8b7-128b-42d3-a77e-ef5472ad64be.png)
![Screenshot 2022-12-07 150326](https://user-images.githubusercontent.com/5616307/206318275-20062721-80df-42c6-b825-8474cee8a2fc.png)

After:
![Screenshot 2022-12-07 153925](https://user-images.githubusercontent.com/5616307/206321063-ea62c0b4-dfe1-4490-9fee-99fa99d56f4e.png)
![Screenshot 2022-12-07 150409](https://user-images.githubusercontent.com/5616307/206318638-7381d5b2-594f-4cba-95a6-56230aa49946.png)