### PR TITLE
Update fix for theverge.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20112,6 +20112,11 @@ INVERT
 .c-tab-bar__logo
 .c-footer__logo-link
 
+CSS
+.\[\&_a\]\:shadow-underline-black a {
+  --darkreader-bg--tw-shadow: inset 0 -1px 0 0 #fff !important; /* Makes links' underlines visible in dark mode */
+}
+
 ================================
 
 thewindowsclub.com


### PR DESCRIPTION
Changes the underline color for links in the body to be white instead of black on a black background while using dark mode. Unfortunately it also changes the underline color for light mode but I don't know how to separate dark and light mode.