### PR TITLE
MV3: use strict CSP

### DIFF
--- a/src/manifest-chrome-mv3.json
+++ b/src/manifest-chrome-mv3.json
@@ -16,7 +16,7 @@
         "service_worker": "background.js"
     },
     "content_security_policy": {
-        "extension_pages": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-hashes' 'sha256-Xi0E9ZtMHXUaj/gPUMMzBcxFgbc2rwmcSys1oJBVhA4='; img-src * data:; connect-src *; navigate-to 'self' https://darkreader.org/* https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md https://github.com/darkreader/darkreader https://opencollective.com/darkreader/donate https://twitter.com/darkreaderapp; media-src 'none'; child-src 'none'; worker-src 'none'; object-src 'none'"
+        "extension_pages": "default-src 'none'; script-src 'self'; style-src 'self'; img-src * data:; connect-src *; navigate-to 'self' https://darkreader.org/* https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md https://github.com/darkreader/darkreader https://opencollective.com/darkreader/donate https://twitter.com/darkreaderapp; media-src 'none'; child-src 'none'; worker-src 'none'; object-src 'none'"
     },
     "content_scripts": [
         {

--- a/src/utils/csp.ts
+++ b/src/utils/csp.ts
@@ -20,12 +20,7 @@ export function prepareCSPMV3(): chrome.runtime.ManifestV3['content_security_pol
         extension_pages: {
             'default-src': [CSP.NONE],
             'script-src': [CSP.SELF],
-            'style-src': [
-                CSP.SELF,
-                "'unsafe-hashes'",
-                // TODO: This hash comes from Malevic, look into removing it
-                "'sha256-Xi0E9ZtMHXUaj/gPUMMzBcxFgbc2rwmcSys1oJBVhA4='",
-            ],
+            'style-src': [CSP.SELF],
             'img-src': [
                 '*',
                 'data:',

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -98,6 +98,15 @@ export const isCSSColorSchemePropSupported = (() => {
         return false;
     }
     const el = document.createElement('div');
-    el.setAttribute('style', 'color-scheme: dark');
+    if (typeof el.style.colorScheme === 'string') {
+        return true;
+    }
+    // TODO: remove the following code
+    // This feature detection method requires weak or missing CSP in manifest.json
+    try {
+        el.setAttribute('style', 'color-scheme: dark');
+    } catch (e) {
+        return false;
+    }
     return el.style && el.style.colorScheme === 'dark';
 })();


### PR DESCRIPTION
This is a follow-up to #10069 which updates MV3 extension code to remove `'unsafe-hashes' from `style-src`. I probably could have done it in the original PR, but mistakenly thought that the problematic code lived in a separate repo.