### PR TITLE
Fix `webrtc.org`

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21878,6 +21878,29 @@ INVERT
 
 ================================
 
+webrtc.org
+
+INVERT
+.devsite-site-logo
+
+CSS
+:root {
+    --devsite-header-color-upper: initial;
+    --devsite-background-1: var(--darkreader-neutral-background);
+    --devsite-select-color: var(--darkreader-neutral-text) !important;
+}
+section.devsite-landing-row:nth-child(3) {
+    background: var(--darkreader-bg--devsite-primary-color);
+}
+blockquote {
+    background: unset;
+}
+button[type="button"] > span.label {
+    color: var(--darkreader-neutral-text);
+}
+
+================================
+
 webtoons.com
 
 CSS


### PR DESCRIPTION
closes #10456

This PR is not complete yet, @Gusted are there darkreader variables available for different shades? This site uses css variables from `--devsite-background-1` to `devsite-background-5` for different background shades.