### PR TITLE
Add dark site: eveonline.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -266,6 +266,7 @@ esportal.com
 essentialsp.tk
 etke.cc
 etlegacy.com
+eveonline.com
 evewho.com
 evokemusic.ai
 evowars.io


### PR DESCRIPTION
As per the checklist:

- The site is dark-by-default, regardless of system's preferred color scheme
- There are no redirects
- The website is complete and finished.

Not 100% sure if subdomains need adding as well, but we use the following subdomains, each of which also uses the same dark-by-default design:

- www.eveonline.com
- secure.eveonline.com
- universe.eveonline.com
- community.eveonline.com
- forums.eveonline.com

Looking at dark-sites.config I am assuming that matching is done on a partial domain basis. If not, please let me know and I'll add the other subdomains as well.