### PR TITLE
Update dynamic-theme-fixes-config for bol.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2908,6 +2908,15 @@ CSS
 
 ================================
 
+bol.de
+
+CSS
+.tm-artikelbild-wrapper {
+    z-index: 0 !important;
+}
+
+================================
+
 bonfire.com
 
 INVERT


### PR DESCRIPTION
On bol.de pictures aren't shown for search results. Example: https://www.bol.de/kategorie/brettspiele-4810/

I changed the z-index of the shadow-box-wrapper so the picture is in foreground. This disables the option to click the picture, but at least it shows. Unfortunately i'm not well-versed in CSS, so this is the best i can do.
If anyone has a better solution please chime in.