### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -35,6 +35,7 @@ anitrack.co
 anon.sx
 antalbiztonsag.com
 aonprd.com
+aplcart.info
 app.destinyitemmanager.com
 app.keeweb.info
 app.plex.tv


### PR DESCRIPTION
adds aplcart.info. without dark reader enabled:
![image](https://user-images.githubusercontent.com/40673815/207442427-330dcff8-f491-4990-ac63-0a2a9967ca63.png)
with:
![image](https://user-images.githubusercontent.com/40673815/207442478-dd523172-a9ba-4165-9c2e-45af1b99f4d7.png)
