### PR TITLE
Add dark sites: www.eveonline.com + subdomains

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -150,6 +150,7 @@ codestackr.com
 codewars.com
 colean.cc
 comicextra.com
+community.eveonline.com
 connect-4.xyz
 coolmathgames.com
 coriolis.io
@@ -300,6 +301,7 @@ forum.lastos.org
 forum.tribler.org
 forum.xda-developers.com
 forumplayer.dev
+forums.eveonline.com
 forums.launchbox-app.com
 fox.com
 fpn.firefox.com
@@ -676,6 +678,7 @@ seaofthieves.fandom.com
 search.biboumail.fr
 search.nebulacentre.net
 secrethitler.io
+secure.eveonline.com
 serebii.net
 settings.gg
 seximal.net
@@ -791,6 +794,7 @@ ukui.org
 undergroundcellar.com
 underlords.com
 undertale.com
+universe.eveonline.com
 unlimiter.github.io/pika
 userdiag.com
 ussr.obys.agency
@@ -840,6 +844,7 @@ www.benjidanecki.eu
 www.canalplus.com
 www.cc.com
 www.digikam.org
+www.eveonline.com
 www.mechapower.eu
 www.mrdemoapple.uk
 www.mtv.com


### PR DESCRIPTION
As discussed in #10470 , this list should be more site-specific while leaving out not-dark-by-default subdomains such as support.eveonline.com

Added subdomains for eveonline.com:
- www.
- community.
- forums.
- secure.
- universe.