### PR TITLE
Ignore google font when checking for imports

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -143,7 +143,9 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
                 rule = cssRules[i];
                 if ((rule as CSSImportRule).href) {
                     if (checkCrossOrigin) {
-                        if ((rule as CSSImportRule).href.startsWith('http') && !(rule as CSSImportRule).href.startsWith(location.origin)) {
+                        if (!(rule as CSSImportRule).href.startsWith('https://fonts.googleapis.com/') &&
+                            (rule as CSSImportRule).href.startsWith('http') &&
+                            !(rule as CSSImportRule).href.startsWith(location.origin)) {
                             result = true;
                             break cssRulesLoop;
                         }


### PR DESCRIPTION
- The usage of this function doesn't care if there's a cross-origin google font CSS import rule, as we already ignore them in the code somewhere else.
- Resolves #10477