### PR TITLE
Fix for market.yandex.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12623,8 +12623,13 @@ INVERT
 market.yandex.*
 
 INVERT
-ymaps[class$="ground-pane"]
-ymaps[class$="svg-icon-content"] > ymaps
+ymaps[class$="main-engine-container"] > canvas
+ymaps[class$="marker"] > div > div > div
+
+CSS
+a[data-zone-name="offerLink"]:has(img) {
+    background-color: #fff !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Update rules for map inverting.
- Add background for store images.

Site page example: https://market.yandex.ru/product--naushniki-apple-earpods-3-5-mm/8478688/offers

<details><summary>Before</summary>

![screenshot-market-yandex-ru-product-naushniki-apple-earpods-3-5-mm-8478688--1671208158592](https://user-images.githubusercontent.com/19418601/208144715-f265b452-79cc-4c8b-a584-765a2dbcba7a.png)

</details>

<details><summary>After</summary>

![screenshot-market-yandex-ru-product-naushniki-apple-earpods-3-5-mm-8478688--1671208168822](https://user-images.githubusercontent.com/19418601/208144774-aa16b032-aa01-4652-a293-51eb3847b941.png)

</details>
