### PR TITLE
Fix for steamdeck.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18845,6 +18845,7 @@ section#available-now div.col_4.copy
 section#available-now h1
 section#experience div.col_8
 section#experience h2
+section#topfeature div.col_5
 
 IGNORE INLINE STYLE
 #header-logo-arc


### PR DESCRIPTION
Fixes text on "Software" page.

Before:
![1](https://user-images.githubusercontent.com/6563728/208251722-cb1eaeb5-5c20-4412-9f02-5d33eec9262c.png)

After:
![2](https://user-images.githubusercontent.com/6563728/208251732-a9e96030-1901-4f74-847e-4f960b5e0763.png)