### PR TITLE
Fixes for various Document Foundation websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2697,6 +2697,13 @@ nav.pagination {
 
 ================================
 
+blog.documentfoundation.org
+
+INVERT
+img[alt*="The Document Foundation Blog"]
+
+================================
+
 blog.doist.com
 
 INVERT
@@ -6007,6 +6014,22 @@ CSS
 .wy-body-for-nav {
     background-color: unset;
 }
+
+================================
+
+documentfoundation.org
+
+INVERT
+.logo
+img[alt*="LibreOffice Initial Artwork Logo ColorLogoBasic"]
+
+================================
+
+documentliberation.org
+
+INVERT
+img[src="assets/Uploads/dlp/images/logo-calligra.png"]
+img[src="assets/Uploads/dlp/images/logo-libreoffice.png"]
 
 ================================
 
@@ -22664,13 +22687,6 @@ body,
 #container {
     background-image: none !important;
 }
-
-================================
-
-www.documentfoundation.org
-
-INVERT
-a img[alt*="Logo"]
 
 ================================
 


### PR DESCRIPTION
Update fixes for documentfoundation.org.
Fix logo for blog.documentfoundation.org.
Fix logos for documentliberation.org.