### PR TITLE
Refactor: make dependencies task use npm upgrade

### DIFF
--- a/tasks/dependencies.js
+++ b/tasks/dependencies.js
@@ -1,7 +1,6 @@
 // @ts-check
 import {exec} from 'node:child_process';
 import {fileURLToPath} from 'node:url';
-import {readFile, writeFile} from 'node:fs/promises';
 import {log} from './utils.js';
 
 const cwd = fileURLToPath(new URL('../', import.meta.url));
@@ -29,12 +28,12 @@ async function buildAll() {
 }
 
 async function main() {
-    log.ok('Building with old dependencies')
+    log.ok('Building with old dependencies');
     await buildAll();
     log.ok('Built with old dependencies');
     await command('mv build build-old');
     await command('mv darkreader.js darkreader-old.js');
-    log.ok('Moved built output')
+    log.ok('Moved built output');
 
     log.ok('Installing new dependencies');
     await command('npm upgrade');

--- a/tasks/dependencies.js
+++ b/tasks/dependencies.js
@@ -7,21 +7,6 @@ import {log} from './utils.js';
 const cwd = fileURLToPath(new URL('../', import.meta.url));
 const packagePath = `${cwd}/package.json`;
 
-async function getOutdated() {
-    return /** @type {Promise<object | null>} */(new Promise((resolve, reject) => {
-        exec('npm outdated --json', {cwd}, (error, stdout) => {
-            if (!error) {
-                log.error('Nothing to upgrade');
-                reject();
-                return;
-            }
-
-            const packages = JSON.parse(stdout.toString());
-            resolve(packages);
-        });
-    }));
-}
-
 /**
  *
  * @param {string} script
@@ -43,39 +28,31 @@ async function buildAll() {
     await command('npm run build -- --release --api --chrome --chrome-mv3 --firefox --thunderbird');
 }
 
-async function patchPackage(outdated) {
-    const original = JSON.parse((await readFile(packagePath)).toString());
-    for (const pkg in outdated) {
-        original.devDependencies[pkg] = outdated[pkg].latest;
-    }
-    return original;
-}
-
 async function main() {
-    const outdated = await getOutdated();
-    if (!outdated){
-        return;
-    }
-
+    log.ok('Building with old dependencies')
     await buildAll();
+    log.ok('Built with old dependencies');
     await command('mv build build-old');
     await command('mv darkreader.js darkreader-old.js');
-    log.ok('Built old code');
+    log.ok('Moved built output')
 
-    const patched = await patchPackage(outdated);
-    log.ok('Created package.json');
-    await writeFile(packagePath, `${JSON.stringify(patched, null, 2)}\n`);
-    log.ok('Wrote package.json');
+    log.ok('Installing new dependencies');
+    await command('npm upgrade');
     await command('npm i');
     log.ok('Installed new dependencies');
+
     await buildAll();
-    log.ok('Built new code');
-    await command('diff -r build-old/release build/release');
+    log.ok('Built with new dependencies');
+
+    await command('diff -r build-old/release/chrome build/release/chrome');
+    await command('diff -r build-old/release/chrome-mv3 build/release/chrome-mv3');
+    await command('diff -r build-old/release/firefox build/release/firefox');
+    await command('diff -r build-old/release/thunderbird build/release/thunderbird');
     await command('diff darkreader-old.js darkreader.js');
     log.ok('Dependency upgrade does not result in change to built output');
 
     await command('git add package.json package-lock.json');
-    await command('git commit -m "Bump dependencies"');
+    await command('git commit -m "Upgrade dependencies"');
     log.ok('Created commit');
     // TODO: when moving this to CI, provide branch name in CI config, along with
     // a token


### PR DESCRIPTION
Use standard `npm upgrade` instead of custom logic.