### PR TITLE
Fix browser compatibility images on developer.mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5351,7 +5351,7 @@ a.external::after
 .breadcrumbs-container li .breadcrumb::after
 ul.main-menu .top-level-entry::before
 span.icon
-#browser_compatibility + a + figure .bc-head-icon-symbol
+#browser_compatibility + a + figure .icon
 
 CSS
 .logo-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5352,6 +5352,8 @@ a.external::after
 ul.main-menu .top-level-entry::before
 span.icon
 #browser_compatibility + a + figure .icon
+.bc-level
+.legend-icons
 
 CSS
 .logo-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5351,6 +5351,7 @@ a.external::after
 .breadcrumbs-container li .breadcrumb::after
 ul.main-menu .top-level-entry::before
 span.icon
+#browser_compatibility + a + figure .bc-head-icon-symbol
 
 CSS
 .logo-text,


### PR DESCRIPTION
Fixed browser compatibility images (see table on https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API#browser_compatibility for example)