### PR TITLE
Add "dark" site

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -679,6 +679,7 @@ search.biboumail.fr
 search.nebulacentre.net
 secrethitler.io
 secure.eveonline.com
+septatrix.github.io/prefers-color-scheme-test/
 serebii.net
 settings.gg
 seximal.net


### PR DESCRIPTION
This site is used to test the CSS media query feature `prefers-color-scheme` from browsers, so Dark Reader shouldn't interfere.