### PR TITLE
Handle raw values in `inspectVariable`

### DIFF
--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -368,8 +368,10 @@ export class VariablesStore {
         }
         this.definedVars.add(varName);
 
-        const color = parseColorWithCache(value);
-        if (color) {
+        // Check if the value is either a raw value or a value that can be parsed
+        // e.g. rgb, hsl.
+        const isColor = rawValueRegex.test(value) || parseColorWithCache(value);
+        if (isColor) {
             this.unknownColorVars.add(varName);
         } else if (
             value.includes('url(') ||


### PR DESCRIPTION
- If the value is a raw value, it may be considered a unknown color vars. The code to parse and modify raw values is actually already in the codebase for a while, but not all placed handled raw values gracefully.
- Resolves #10486