### PR TITLE
Update to logo of petco.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15642,7 +15642,7 @@ img[src*="logo"]
 petco.com/shop/en/petcostore
 
 INVERT
-a[class^="LogoAnchor__Container"]
+a[class^="LogoAnchor__Container-sc-7693ee16-2.etEBxV"]
 button[class^="HamburgerButton"]
 img.center-block.margin-top-sm
 h1.pals-header


### PR DESCRIPTION
For some reason the previous fix for [petco.com](https://www.petco.com/shop/en/petcostore) no longer works. This works, but similar to my previous pull request, someone else might be able to work out something cleaner.