### PR TITLE
Improve IPv6 check

### DIFF
--- a/src/utils/ipv6.ts
+++ b/src/utils/ipv6.ts
@@ -1,4 +1,4 @@
-const simpleIPV6Regex = /\[[0-9:a-zA-Z]*?\]/;
+const simpleIPV6Regex = /\[[0-9:a-zA-Z]+?\]/;
 
 export function isIPV6(url: string) {
     const openingBracketIndex = simpleIPV6Regex.exec(url);

--- a/tests/inject/utils/url.tests.ts
+++ b/tests/inject/utils/url.tests.ts
@@ -272,6 +272,7 @@ it('URL is enabled', () => {
     expect(isIPV6('file:///C:/[/test.html')).toEqual(false);
     expect(isIPV6('file:///C:/[/test.html]')).toEqual(false);
     expect(isIPV6('[2001:4860:4860::8844]')).toEqual(true);
+    expect(isIPV6('cplusplus.com/reference/vector/vector/operator[]/')).toEqual(false);
 
     // Temporary Dark Sites list fix
     expect(isURLEnabled(


### PR DESCRIPTION
- Don't consider empty square brackets to be IPv6.
- Resolves #10514