### PR TITLE
Add `/` as terminating character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fixed a edge case with extracting numbers, it's now able to extract `rgb(0 0 0/0.04)`. (#10565)
+
 ## 4.9.61 (Jan 2, 2023)
 
 - Only invert PDFs on mail.google.com and drive.google.com, if the setting for PDF inversion has been enabled. (#10310)

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -190,7 +190,7 @@ function getNumbers($color: string) {
         if (c >= '0' && c <= '9' || c === '.' || c === '+' || c === '-') {
             // Enable the mining flag.
             isMining = true;
-        } else if (isMining && (c === ' ' || c === ',')) {
+        } else if (isMining && (c === ' ' || c === ',' || c === '/')) {
             // isMining is true and we got a terminating
             // character. So we can push the current number
             // into the array.

--- a/tests/unit/utils/color.tests.ts
+++ b/tests/unit/utils/color.tests.ts
@@ -13,6 +13,7 @@ test('Color parsing', () => {
     expect(parse('rgb(255 0 153 / 1)')).toEqual({r: 255, g: 0, b: 153, a: 1});
     expect(parse('rgb(255 0 153 / 100%)')).toEqual({r: 255, g: 0, b: 153, a: 1});
     expect(parse('rgb(255, 0, 153.6, 1)')).toEqual({r: 255, g: 0, b: 154, a: 1});
+    expect(parse('rgb(0 0 0/0.04)')).toEqual({r: 0, g: 0, b: 0, a: 0.04});
     expect(parse('rgb(1e2, .5e1, .5e0, +.25e2%)')).toEqual({r: 100, g: 5, b: 1, a: 0.25});
 
     expect(parse('rgba(51, 170, 51, .1)')).toEqual({r: 51, g: 170, b: 51, a: 0.1});


### PR DESCRIPTION
- `/` should be considered as terminating character when extracting numbers.
- Resolves #10531