### PR TITLE
Add www.damnvulnerabledefi.xyz to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -177,7 +177,7 @@ daddyanity.com
 daily-fire.com
 daksh.eu.org
 danidev.net
-https://www.damnvulnerabledefi.xyz/
+damnvulnerabledefi.xyz
 darckrepacks.com
 daringfireball.net
 dark.diatr.us

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -177,6 +177,7 @@ daddyanity.com
 daily-fire.com
 daksh.eu.org
 danidev.net
+https://www.damnvulnerabledefi.xyz/
 darckrepacks.com
 daringfireball.net
 dark.diatr.us


### PR DESCRIPTION
This site: https://www.damnvulnerabledefi.xyz/ is naturally dark.