### PR TITLE
dark-sites.config: add splatoon3.ink

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -720,6 +720,7 @@ spacex.com
 spark.lucko.me
 speedrun.com
 speedtest.net
+splatoon3.ink
 splatoon.nintendo.com
 sponsorshipshq.com
 spyware.neocities.org

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -720,8 +720,8 @@ spacex.com
 spark.lucko.me
 speedrun.com
 speedtest.net
-splatoon3.ink
 splatoon.nintendo.com
+splatoon3.ink
 sponsorshipshq.com
 spyware.neocities.org
 srrdb.com


### PR DESCRIPTION
Site is dark by default, and its background also breaks if Dark Reader is on.