### PR TITLE
Update fix for steamdeck.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19001,18 +19001,18 @@ i.ml-1
 steamdeck.com
 
 INVERT
-section#available-now div.col_4.copy
-section#available-now h1
+section#available-now div.col_9
 section#experience div.col_8
 section#experience h2
 section#topfeature div.col_5
 
+CSS
+section#available-now {
+    background-color: #f0f0f0 !important;
+}
+
 IGNORE INLINE STYLE
 #header-logo-arc
-
-IGNORE IMAGE ANALYSIS
-section#available-now .content
-section#available-now .deck-video-frame
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19008,7 +19008,7 @@ section#topfeature div.col_5
 
 CSS
 section#available-now {
-    background-color: #f0f0f0 !important;
+    background-color: ${#0f0f0f} !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
* Fixes "Available now" section on home page.
* Deletes outdated fixes introduced in #10033.

Before:
![1](https://user-images.githubusercontent.com/6563728/211155312-f7521c9c-7ca8-40db-b90a-efc449288b50.png)

After:
![2](https://user-images.githubusercontent.com/6563728/211155325-b49d4ab8-2f5c-4b1b-8040-c0895e75422b.png)