### PR TITLE
Refactor: extract DevTools data from ExtensionData

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -15,7 +15,7 @@ import createCSSFilterStylesheet from '../generators/css-filter';
 import {getDynamicThemeFixesFor} from '../generators/dynamic-theme';
 import createStaticStylesheet from '../generators/static-theme';
 import {createSVGFilterStylesheet, getSVGFilterMatrixValue, getSVGReverseFilterMatrixValue} from '../generators/svg-filter';
-import type {ExtensionData, FilterConfig, Shortcuts, UserSettings, TabInfo, TabData, Command} from '../definitions';
+import type {ExtensionData, FilterConfig, Shortcuts, UserSettings, TabInfo, TabData, Command, DevToolsData} from '../definitions';
 import {isSystemDarkModeEnabled, runColorSchemeChangeDetector} from '../utils/media-query';
 import {isFirefox} from '../utils/platform';
 import {MessageType} from '../utils/message';
@@ -243,6 +243,9 @@ export class Extension {
             collect: async () => {
                 return await this.collectData();
             },
+            collectDevToolsData: async () => {
+                return await this.collectDevToolsData();
+            },
             changeSettings: async (settings) => this.changeSettings(settings),
             setTheme: (theme) => this.setTheme(theme),
             toggleActiveTab: async () => this.toggleActiveTab(),
@@ -369,17 +372,11 @@ export class Extension {
         const [
             news,
             shortcuts,
-            dynamicFixesText,
-            filterFixesText,
-            staticThemesText,
             activeTab,
             isAllowedFileSchemeAccess,
         ] = await Promise.all([
             Newsmaker.getLatest(),
             this.getShortcuts(),
-            DevTools.getDynamicThemeFixesText(),
-            DevTools.getInversionFixesText(),
-            DevTools.getStaticThemesText(),
             this.getActiveTabInfo(),
             new Promise<boolean>((r) => chrome.extension.isAllowedFileSchemeAccess(r)),
         ]);
@@ -392,12 +389,24 @@ export class Extension {
             shortcuts,
             colorScheme: ConfigManager.COLOR_SCHEMES_RAW!,
             forcedScheme: this.autoState === 'scheme-dark' ? 'dark' : this.autoState === 'scheme-light' ? 'light' : null,
-            devtools: {
-                dynamicFixesText,
-                filterFixesText,
-                staticThemesText,
-            },
             activeTab,
+        };
+    }
+
+    static async collectDevToolsData(): Promise<DevToolsData> {
+        const [
+            dynamicFixesText,
+            filterFixesText,
+            staticThemesText
+        ] = await Promise.all([
+            DevTools.getDynamicThemeFixesText(),
+            DevTools.getInversionFixesText(),
+            DevTools.getStaticThemesText(),
+        ]);
+        return {
+            dynamicFixesText,
+            filterFixesText,
+            staticThemesText
         };
     }
 

--- a/src/background/make-chromium-happy.ts
+++ b/src/background/make-chromium-happy.ts
@@ -15,6 +15,7 @@ export function makeChromiumHappy() {
         if (![
             // Messenger
             MessageType.UI_GET_DATA,
+            MessageType.UI_GET_DEVTOOLS_DATA,
             MessageType.UI_APPLY_DEV_DYNAMIC_THEME_FIXES,
             MessageType.UI_APPLY_DEV_INVERSION_FIXES,
             MessageType.UI_APPLY_DEV_STATIC_THEMES,

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -13,12 +13,13 @@ export interface ExtensionData {
     shortcuts: Shortcuts;
     colorScheme: ParsedColorSchemeConfig;
     forcedScheme: 'dark' | 'light' | null;
-    devtools: {
-        dynamicFixesText: string;
-        filterFixesText: string;
-        staticThemesText: string;
-    };
     activeTab: TabInfo;
+}
+
+export interface DevToolsData {
+    dynamicFixesText: string;
+    filterFixesText: string;
+    staticThemesText: string;
 }
 
 export interface TabData {

--- a/src/ui/connect/connector.ts
+++ b/src/ui/connect/connector.ts
@@ -1,5 +1,5 @@
 import {isFirefox} from '../../utils/platform';
-import type {ExtensionData, ExtensionActions, FilterConfig, Message, UserSettings} from '../../definitions';
+import type {ExtensionData, ExtensionActions, FilterConfig, Message, UserSettings, DevToolsData} from '../../definitions';
 import {MessageType} from '../../utils/message';
 
 declare const browser: {
@@ -49,6 +49,13 @@ export default class Connector implements ExtensionActions {
             return await this.firefoxSendRequestWithResponse<ExtensionData>(MessageType.UI_GET_DATA);
         }
         return await this.sendRequest<ExtensionData>(MessageType.UI_GET_DATA);
+    }
+
+    async getDevToolsData() {
+        if (isFirefox) {
+            return await this.firefoxSendRequestWithResponse<DevToolsData>(MessageType.UI_GET_DEVTOOLS_DATA);
+        }
+        return await this.sendRequest<DevToolsData>(MessageType.UI_GET_DEVTOOLS_DATA);
     }
 
     private onChangesReceived = ({type, data}: Message) => {

--- a/src/ui/devtools/components/body.tsx
+++ b/src/ui/devtools/components/body.tsx
@@ -4,13 +4,13 @@ import {withState, useState} from 'malevic/state';
 import {Button, MessageBox, Overlay} from '../../controls';
 import {ThemeEngine} from '../../../generators/theme-engines';
 import {DEVTOOLS_DOCS_URL} from '../../../utils/links';
-import type {ExtWrapper} from '../../../definitions';
+import type {DevToolsData, ExtWrapper} from '../../../definitions';
 import {getCurrentThemePreset} from '../../popup/theme/utils';
 import {isFirefox} from '../../../utils/platform';
 
-type BodyProps = ExtWrapper;
+type BodyProps = ExtWrapper & {devtools: DevToolsData};
 
-function Body({data, actions}: BodyProps) {
+function Body({data, actions, devtools}: BodyProps) {
     const context = getContext();
     const {state, setState} = useState({errorText: null as string | null});
     let textNode: HTMLTextAreaElement;
@@ -20,17 +20,17 @@ function Body({data, actions}: BodyProps) {
     const wrapper = (theme.engine === ThemeEngine.staticTheme
         ? {
             header: 'Static Theme Editor',
-            fixesText: data.devtools.staticThemesText,
+            fixesText: devtools.staticThemesText,
             apply: (text: string) => actions.applyDevStaticThemes(text),
             reset: () => actions.resetDevStaticThemes(),
         } : theme.engine === ThemeEngine.cssFilter || theme.engine === ThemeEngine.svgFilter ? {
             header: 'Inversion Fix Editor',
-            fixesText: data.devtools.filterFixesText,
+            fixesText: devtools.filterFixesText,
             apply: (text: string) => actions.applyDevInversionFixes(text),
             reset: () => actions.resetDevInversionFixes(),
         } : {
             header: 'Dynamic Theme Editor',
-            fixesText: data.devtools.dynamicFixesText,
+            fixesText: devtools.dynamicFixesText,
             apply: (text: string) => actions.applyDevDynamicThemeFixes(text),
             reset: () => actions.resetDevDynamicThemeFixes(),
         });

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,5 +1,6 @@
 export enum MessageType {
     UI_GET_DATA = 'ui-get-data',
+    UI_GET_DEVTOOLS_DATA = 'ui-get-devtools-data',
     UI_SUBSCRIBE_TO_CHANGES = 'ui-subscribe-to-changes',
     UI_UNSUBSCRIBE_FROM_CHANGES = 'ui-unsubscribe-from-changes',
     UI_CHANGE_SETTINGS = 'ui-change-settings',


### PR DESCRIPTION
Users reported lag when extension popup is opened. It is likely caused by Dark Reader parsing DevTools fixes on every invocation to populate `ExtensinData`. This PR splits these configs out of `ExtensionData` into `DevToolsData` thus making extension do less work when popup is opened, which hopefully will improve performance (reduce latency of popup load).

![image](https://user-images.githubusercontent.com/45960703/211175261-01d738c6-46a1-423f-9258-c2e019168e83.png)
