### PR TITLE
Fix for lrt.lt

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1263,6 +1263,14 @@ CSS
 
 ================================
 
+apie.lrt.lt
+
+INVERT
+img[alt="LRT"]
+button[class^="Burger_burger"]
+
+================================
+
 apkpure.com
 
 INVERT
@@ -12308,6 +12316,13 @@ CSS
 img {
     mix-blend-mode: normal !important;
 }
+
+================================
+
+lrt.lt
+
+INVERT
+img[src*="/images/logo/logo-"]
 
 ================================
 


### PR DESCRIPTION
Fixed logos and hamburger menu button in lrt.lt, apie.lrt.lt.

![image](https://user-images.githubusercontent.com/16837066/211693738-f51fad1e-9257-4703-8ec7-27ac40ec6fc7.png) ![image](https://user-images.githubusercontent.com/16837066/211693852-55048e90-f7a9-4398-823a-7dfb6e09625b.png)

![image](https://user-images.githubusercontent.com/16837066/211693658-fcacab31-8d6c-49a8-acdb-b1f28accb828.png)
![image](https://user-images.githubusercontent.com/16837066/211694202-4eefcd6f-cc31-407e-aa36-05a637c1362a.png)
