### PR TITLE
Servicenow code editor

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -57,6 +57,22 @@ IGNORE INLINE STYLE
 
 ================================
 
+*.service-now.com
+
+CSS
+.cm-s-snc span.cm-string {
+  color: #cf947b !important;
+}
+.cm-s-snc span.cm-def {
+  color: #60a4d8 !important;
+}
+.cm-s-snc span.cm-property {
+  color: #ffffff !important;
+}
+
+
+================================
+
 01net.com
 
 CSS


### PR DESCRIPTION
Changed the colors for code editor in servicenow instances

================================

*.service-now.com

CSS
.cm-s-snc span.cm-string {
  color: #cf947b !important;
}
.cm-s-snc span.cm-def {
  color: #60a4d8 !important;
}
.cm-s-snc span.cm-property {
  color: #ffffff !important;
}
