### PR TITLE
MV3: build for ES2022 syntax

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,7 +5,6 @@
         "module": "ES2015",
         "moduleResolution": "node",
         "lib": [
-            "ES2015",
             "ES2017",
             "Dom",
             "DOM.Iterable"

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -99,7 +99,7 @@ function freeRollupPluginInstance(name, key) {
 
 async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log, test) {
     const {src, dest} = entry;
-    const rollupPluginTypesctiptInstanceKey = `${debug}`;
+    const rollupPluginTypesctiptInstanceKey = `${platform}-${debug}`;
     const rollupPluginReplaceInstanceKey = `${platform}-${debug}-${watch}-${entry.src === 'src/ui/popup/index.tsx'}`;
 
     const destination = typeof dest === 'string' ? dest : dest(platform);
@@ -134,6 +134,9 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
                     rootDir,
                     typescript,
                     tsconfig: rootPath('src/tsconfig.json'),
+                    compilerOptions: platform === PLATFORM.CHROME_MV3 ? {
+                        target: 'ES2021',
+                    }: undefined,
                     noImplicitAny: debug ? false : true,
                     strictNullChecks: debug ? false : true,
                     removeComments: debug ? false : true,

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -136,7 +136,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
                     tsconfig: rootPath('src/tsconfig.json'),
                     compilerOptions: platform === PLATFORM.CHROME_MV3 ? {
                         target: 'ES2022',
-                    }: undefined,
+                    } : undefined,
                     noImplicitAny: debug ? false : true,
                     strictNullChecks: debug ? false : true,
                     removeComments: debug ? false : true,

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -135,7 +135,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
                     typescript,
                     tsconfig: rootPath('src/tsconfig.json'),
                     compilerOptions: platform === PLATFORM.CHROME_MV3 ? {
-                        target: 'ES2021',
+                        target: 'ES2022',
                     }: undefined,
                     noImplicitAny: debug ? false : true,
                     strictNullChecks: debug ? false : true,

--- a/tests/inject/tsconfig.json
+++ b/tests/inject/tsconfig.json
@@ -4,7 +4,6 @@
         "target": "ES2019",
         "module": "ES2015",
         "lib": [
-            "ES2015",
             "ES2017",
             "DOM",
             "DOM.Iterable"


### PR DESCRIPTION
Chromium MV3 is currently limited to Chromium 102+, which supports ES 2022 syntax
https://github.com/darkreader/darkreader/blob/dd55d9393bf726463fd88c1dfaccb0ccf278632e/src/manifest-chrome-mv3.json#L3

I plan to further bump MV3 requirement to Chromium 106+ to be able to use `documentId` for message passing.