### PR TITLE
Update fix for wikipedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22441,6 +22441,10 @@ body.mediawiki,
 .template-facttext {
     background-color: #eaecf0 !important;
 }
+#mw-page-base {
+  background-color: var(--darkreader-neutral-background);
+  background-image: linear-gradient(rgb(24, 26, 27) 50%, var(--darkreader-neutral-background) 100%);
+}
 
 IGNORE INLINE STYLE
 .legend-color:not(table.wikitable .legend-color)


### PR DESCRIPTION
This improves header gradient in wikipedia

BEFORE
<img width="707" alt="image" src="https://user-images.githubusercontent.com/3027728/212386986-fd6a7bcc-6f16-4072-a98c-cc37b00617c8.png">


AFTER
<img width="706" alt="image" src="https://user-images.githubusercontent.com/3027728/212386775-e905ccb7-f545-446d-b640-aa62e291459c.png">
