### PR TITLE
Fix for nagatabi-p.jimdofree.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14079,6 +14079,13 @@ span[class*="nk-icon_id_business-feedback-task"] > svg > g > path
 
 ================================
 
+nagatabi-p.jimdofree.com
+
+INVERT
+.cc-imagewrapper > img
+
+================================
+
 nalog.ru
 
 INVERT

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1579,6 +1579,13 @@ INVERT
 
 ================================
 
+nagatabi-p.jimdofree.com
+
+NO INVERT
+.cc-imagewrapper > img
+
+================================
+
 neopets.com
 
 INVERT


### PR DESCRIPTION
This PR fixes a problem in nagatabi-p.jimdofree.com where formula images are displayed inverted.

Before (Dark): 
![image](https://user-images.githubusercontent.com/55338215/212463719-ee195348-278e-4b0c-bbe7-2d592e9d8888.png)
After (Dark):
![image](https://user-images.githubusercontent.com/55338215/212463739-12fad9fb-c4a0-4ace-a507-230b0592d594.png)
After (Light):
![image](https://user-images.githubusercontent.com/55338215/212463748-2d00821a-780a-475a-83bd-79a2764e0514.png)

