### PR TITLE
Fix for hooktail.sub.jp,hooktail.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9777,6 +9777,20 @@ span[role="presentation"] > .cm-variable-2 {
 
 ================================
 
+hooktail.sub.jp
+hooktail.org
+
+INVERT
+#box img
+.box img
+
+CSS
+#box,.box {                                                                                                                                                                                                                                                                                                                       
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 hootsuite.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9789,7 +9789,10 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 h2 {
-    background-image: none
+    background-image: none;
+}
+a {
+    color: rgb(157, 149, 237);
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9788,6 +9788,9 @@ CSS
 #box,.box {                                                                                                                                                                                                                                                                                                                       
     background-color: var(--darkreader-neutral-background) !important;
 }
+h2 {
+    background-image: none
+}
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -986,6 +986,15 @@ body:not(.scratch):not(.sweet) .o_site-footer
 
 ================================
 
+hooktail.sub.jp
+hooktail.org
+
+NO INVERT
+#box img
+.box img
+
+================================
+
 html5rocks.com
 
 INVERT


### PR DESCRIPTION
This PR fixes a problem in hooktail.sub.jp, hooktail.org where formula images are displayed inverted.

Original:
![image](https://user-images.githubusercontent.com/55338215/212464555-440a4147-9d7b-4947-8bbe-9bc8068870bd.png)
Before (Dark, Filter):
![image](https://user-images.githubusercontent.com/55338215/212464633-d98d0193-0647-46ff-a60e-6d63d850ffe5.png)
Before (Dark, Dynamic):
![image](https://user-images.githubusercontent.com/55338215/212464560-3e5b6c42-3fa1-46ec-b253-4607638c7fb3.png)
After (Dark, Dynamic):
![image](https://user-images.githubusercontent.com/55338215/212464569-a0ab3956-65ea-4aa3-88c0-aed9b65f7025.png)
After (Light, Dynamic):
![image](https://user-images.githubusercontent.com/55338215/212464582-89f39492-2253-4916-8ae3-68e111b23f55.png)
After (Dark, Filter):
![image](https://user-images.githubusercontent.com/55338215/212464609-dcbcd556-ed54-4ce3-a80e-86639928a681.png)
