### PR TITLE
Fix for eman-physics.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6795,6 +6795,13 @@ body {
 
 ================================
 
+eman-physics.net
+
+INVERT
+.middle_area img
+
+================================
+
 endeavouros.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6808,9 +6808,9 @@ CSS
 .maintxt,
 .display  {
     background: none !important;
-}                                                                                                                                                back
+}
 body {
-    background-color: var(--darkreader-neutral-background) !important;                        
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6804,7 +6804,9 @@ CSS
 .middle_area {
     border-left-color: transparent !important;
 }
-.middle_area,.maintxt,.display  {
+.middle_area,
+.maintxt,
+.display  {
     background: none !important;
 }                                                                                                                                                back
 body {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6800,6 +6800,17 @@ eman-physics.net
 INVERT
 .middle_area img
 
+CSS
+.middle_area {
+    border-left-color: transparent !important;
+}
+.middle_area,.maintxt,.display  {
+    background: none !important;
+}                                                                                                                                                back
+body {
+    background-color: var(--darkreader-neutral-background) !important;                        
+}
+
 ================================
 
 endeavouros.com

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -577,6 +577,13 @@ header
 
 ================================
 
+eman-physics.net
+
+NO INVERT
+.middle_area img
+
+================================
+
 exhentai.org
 e-hentai.org
 


### PR DESCRIPTION
This PR fixes a problem in eman-physics.net where formula images are displayed inverted.
Before: 
![image](https://user-images.githubusercontent.com/55338215/212466370-06243c2e-b309-43d7-82d2-b11394e6b1a7.png)
After: 
![image](https://user-images.githubusercontent.com/55338215/212466375-9aa2afe5-48a3-475b-b30b-27f75a16022f.png)
