### PR TITLE
Fix for storytellphys.wordpress.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19126,6 +19126,13 @@ CSS
 
 ================================
 
+storytellphys.wordpress.com
+
+INVERT
+img
+
+================================
+
 strava.com
 
 INVERT

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2134,6 +2134,13 @@ INVERT
 
 ================================
 
+storytellphys.wordpress.com
+
+NO INVERT
+img
+
+================================
+
 studio.restlet.com
 cloud.rest-let.com
 


### PR DESCRIPTION
This PR fixes a problem in storytellphys.wordpress.com where formula images are displayed inverted.
Before (Dark, Filter):
![image](https://user-images.githubusercontent.com/55338215/212467054-c1c0236b-70de-475c-9d82-584a586e8511.png)
Before (Dark, Dynamic):
![image](https://user-images.githubusercontent.com/55338215/212467022-a7229569-3998-4a93-b113-f8250219f818.png)
After (Dark, Filter):
![image](https://user-images.githubusercontent.com/55338215/212467063-0e32eddc-8e61-42a0-ba67-c3eae7d5a066.png)
After (Dark, Dynamic):
![image](https://user-images.githubusercontent.com/55338215/212467036-69544937-0c1e-42d1-9836-c04ab33ec930.png)
