### PR TITLE
Remove inactive site from dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -44,7 +44,6 @@ app.sqldbm.com
 applesilicongames.com
 application.security
 aqtiongame.com
-ara-ara-ufufu.herokuapp.com
 archive.ragtag.moe
 ardov.me
 ari-web.xyz


### PR DESCRIPTION
ara-ara-ufufu.herokuapp.com - Invalid URL