### PR TITLE
Fix nytimes.com Wirecutter (Dynamic)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14711,6 +14711,7 @@ CSS
 nytimes.com
 
 INVERT
+#site_header_wrapper a[aria-label="Wirecutter"]
 div#live-country-map.live-country-map-embed
 div#live-us-map.live-us-map-embed
 g > text


### PR DESCRIPTION
Fix header
example page: https://www.nytimes.com/wirecutter/