### PR TITLE
Fix for howstuffworks.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9804,6 +9804,13 @@ INVERT
 
 ================================
 
+howstuffworks.com
+
+INVERT
+a[data-track-gtm="Logo"]
+
+================================
+
 hp.com
 *.hp.com
 


### PR DESCRIPTION
Fix primary header link
Example page: https://entertainment.howstuffworks.com/john-cage.htm