### PR TITLE
Fix: put createUrlRegex() into a try-catch

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -109,74 +109,78 @@ export function isURLMatched(url: string, urlTemplate: string): boolean {
         return compareIPV6(url, urlTemplate);
     } else if (!isFirstIPV6 && !isSecondIPV6) {
         const regex = createUrlRegex(urlTemplate);
-        return Boolean(url.match(regex));
+        return regex !== null && Boolean(url.match(regex));
     }
     return false;
 }
 
-function createUrlRegex(urlTemplate: string): RegExp {
-    urlTemplate = urlTemplate.trim();
-    const exactBeginning = (urlTemplate[0] === '^');
-    const exactEnding = (urlTemplate[urlTemplate.length - 1] === '$');
-    const hasLastSlash = /\/\$?$/.test(urlTemplate);
+function createUrlRegex(urlTemplate: string): RegExp | null {
+    try {
+        urlTemplate = urlTemplate.trim();
+        const exactBeginning = (urlTemplate[0] === '^');
+        const exactEnding = (urlTemplate[urlTemplate.length - 1] === '$');
+        const hasLastSlash = /\/\$?$/.test(urlTemplate);
 
-    urlTemplate = (urlTemplate
-        .replace(/^\^/, '') // Remove ^ at start
-        .replace(/\$$/, '') // Remove $ at end
-        .replace(/^.*?\/{2,3}/, '') // Remove scheme
-        .replace(/\?.*$/, '') // Remove query
-        .replace(/\/$/, '') // Remove last slash
-    );
+        urlTemplate = (urlTemplate
+            .replace(/^\^/, '') // Remove ^ at start
+            .replace(/\$$/, '') // Remove $ at end
+            .replace(/^.*?\/{2,3}/, '') // Remove scheme
+            .replace(/\?.*$/, '') // Remove query
+            .replace(/\/$/, '') // Remove last slash
+        );
 
-    let slashIndex: number;
-    let beforeSlash: string;
-    let afterSlash: string | undefined;
-    if ((slashIndex = urlTemplate.indexOf('/')) >= 0) {
-        beforeSlash = urlTemplate.substring(0, slashIndex); // google.*
-        afterSlash = urlTemplate.replace(/\$/g, '').substring(slashIndex); // /login/abc
-    } else {
-        beforeSlash = urlTemplate.replace(/\$/g, '');
-    }
-
-    //
-    // SCHEME and SUBDOMAINS
-
-    let result = (exactBeginning ?
-        '^(.*?\\:\\/{2,3})?' // Scheme
-        : '^(.*?\\:\\/{2,3})?([^\/]*?\\.)?' // Scheme and subdomains
-    );
-
-    //
-    // HOST and PORT
-
-    const hostParts = beforeSlash.split('.');
-    result += '(';
-    for (let i = 0; i < hostParts.length; i++) {
-        if (hostParts[i] === '*') {
-            hostParts[i] = '[^\\.\\/]+?';
+        let slashIndex: number;
+        let beforeSlash: string;
+        let afterSlash: string | undefined;
+        if ((slashIndex = urlTemplate.indexOf('/')) >= 0) {
+            beforeSlash = urlTemplate.substring(0, slashIndex); // google.*
+            afterSlash = urlTemplate.replace(/\$/g, '').substring(slashIndex); // /login/abc
+        } else {
+            beforeSlash = urlTemplate.replace(/\$/g, '');
         }
-    }
-    result += hostParts.join('\\.');
-    result += ')';
 
-    //
-    // PATH and QUERY
+        //
+        // SCHEME and SUBDOMAINS
 
-    if (afterSlash) {
+        let result = (exactBeginning ?
+            '^(.*?\\:\\/{2,3})?' // Scheme
+            : '^(.*?\\:\\/{2,3})?([^\/]*?\\.)?' // Scheme and subdomains
+        );
+
+        //
+        // HOST and PORT
+
+        const hostParts = beforeSlash.split('.');
         result += '(';
-        result += afterSlash.replace('/', '\\/');
+        for (let i = 0; i < hostParts.length; i++) {
+            if (hostParts[i] === '*') {
+                hostParts[i] = '[^\\.\\/]+?';
+            }
+        }
+        result += hostParts.join('\\.');
         result += ')';
+
+        //
+        // PATH and QUERY
+
+        if (afterSlash) {
+            result += '(';
+            result += afterSlash.replace('/', '\\/');
+            result += ')';
+        }
+
+        result += (exactEnding ?
+            '(\\/?(\\?[^\/]*?)?)$' // All following queries
+            : `(\\/${hasLastSlash ? '' : '?'}.*?)$` // All following paths and queries
+        );
+
+        //
+        // Result
+
+        return new RegExp(result, 'i');
+    } catch (e) {
+        return null;
     }
-
-    result += (exactEnding ?
-        '(\\/?(\\?[^\/]*?)?)$' // All following queries
-        : `(\\/${hasLastSlash ? '' : '?'}.*?)$` // All following paths and queries
-    );
-
-    //
-    // Result
-
-    return new RegExp(result, 'i');
 }
 
 export function isPDF(url: string) {


### PR DESCRIPTION
This function contains a lot of regex magic so it is possible to put a relatively simple pattern into `src/config/dark-sites.config` and accidentally create an invalid regex which will throw in `RegExp()` constructor.