### PR TITLE
Add dark site flipperhub.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -292,6 +292,7 @@ filterblade.xyz
 filterlists.com
 fireship.io
 fleepy.tv
+flipperhub.com
 florr.io
 fluxpoint.dev
 fmovies.to


### PR DESCRIPTION
https://flipperhub.com already supports dark themes and the addition of Dark Reader on it will cause UI issues. (some images will be completely blacked out).