### PR TITLE
Fix for 9game.cn

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -253,6 +253,13 @@ CSS
 
 ================================
 
+9game.cn
+
+INVERT
+.logo9game
+
+================================
+
 a11ywithlindsey.com
 
 INVERT


### PR DESCRIPTION
Invert logos in inner pages.

Before:
<img width="213" alt="Screenshot_20230118_081547" src="https://user-images.githubusercontent.com/1006477/213109865-19741968-c5eb-496b-a2ad-55d09119a87c.png">

After:
<img width="216" alt="Screenshot_20230118_081535" src="https://user-images.githubusercontent.com/1006477/213109896-4c1e7025-b410-4bb6-8e0e-5da44076ccc5.png">
