### PR TITLE
Add dark site scriptkit.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,3 +1,4 @@
+*.scriptkit.com
 0bin.net
 0x00sec.org
 12bytes.org
@@ -677,7 +678,6 @@ sauce420.github.io
 sauce420.gitlab.io
 sb.ltn.fi
 science-news.co
-scriptkit.com
 seaofthieves.fandom.com
 search.biboumail.fr
 search.nebulacentre.net

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -677,6 +677,7 @@ sauce420.github.io
 sauce420.gitlab.io
 sb.ltn.fi
 science-news.co
+scriptkit.com
 seaofthieves.fandom.com
 search.biboumail.fr
 search.nebulacentre.net


### PR DESCRIPTION
Added [scriptkit.com](https://www.scriptkit.com/) to global dark list.