### PR TITLE
fix: getExtensionPageTabMV3config function performance

### DIFF
--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -150,29 +150,23 @@ export async function getFontList() {
 
 type page = 'devtools' | 'stylesheet-editor';
 
-// TODO(Anton): There must be a better way to do this
-// This function ping-pongs a message to possible DevTools popups.
-// This function should have reasonable performance since it sends
-// messages only to popups and not regular windows.
 async function getExtensionPageTabMV3(): Promise<chrome.tabs.Tab | null> {
     return new Promise((resolve) => {
-        chrome.windows.getAll({
-            populate: true,
-            windowTypes: ['popup'],
-        }, (w) => {
-            const responses: Array<Promise<string>> = [];
-            let found = false;
-            for (const window of w) {
-                const response = chrome.tabs.sendMessage<string, 'getExtensionPageTabMV3_pong'>(window.tabs![0]!.id!, 'getExtensionPageTabMV3_ping', {frameId: 0});
-                response.then((response) => {
+        chrome.tabs.query({
+            active: true,
+            currentWindow: true
+        }, (tabs) => {
+            if (tabs.length > 0) {
+                chrome.tabs.sendMessage(tabs[0].id as number, 'getExtensionPageTabMV3_ping', {frameId: 0}, (response)=>{
                     if (response === 'getExtensionPageTabMV3_pong') {
-                        found = true;
-                        resolve(window.tabs![0]);
+                        resolve(tabs[0]);
+                    } else {
+                        resolve(null);
                     }
                 });
-                responses.push(response);
+            } else {
+                resolve(null);
             }
-            Promise.all(responses).then(() => !found && resolve(null));
         });
     });
 }


### PR DESCRIPTION
This PR fixes the `TODO` of `getExtensionPageTabMV3()` in UI utils.

The `chrome.tabs.query` method was replaced by  `chrome.windows.getAll` and `chrome.tabs.sendMessage`.

This way, you can get the active tab of the current window and send the message to it, without the need to go through all the pop-up windows.

closes: #10665

