### PR TITLE
Fix charitynavigator.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3739,6 +3739,13 @@ CSS
 
 ================================
 
+charitynavigator.org
+
+INVERT
+img[alt="Charity Navigator Logo"]
+
+================================
+
 chase.com
 
 INVERT


### PR DESCRIPTION
Fix the main logo link in upper-left corner.

Example URL:
https://www.charitynavigator.org/ein/204846675