### PR TITLE
Fix instructables.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10478,6 +10478,13 @@ div > span > a[tabindex] {
 
 ================================
 
+instructables.com
+
+INVERT
+.site-logo
+
+================================
+
 instructure.com
 
 INVERT


### PR DESCRIPTION
Fix main header logo, which is also a link.

Example page:
https://www.instructables.com/how-to-recover-a-dry-printer-head/