### PR TITLE
Add raidenxd2.github.io to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -636,13 +636,13 @@ pxseu.com
 pylon.bot
 qalculator.xyz
 raidbots.com
+raidenxd2.github.io
 raidplan.io
 rate.house
 raunaksitoula.com
 rawgiving.com
 ray.so
 razorsecure.com
-raidenxd2.github.io
 redacted.ch
 redasm.io
 redbox.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -642,6 +642,7 @@ raunaksitoula.com
 rawgiving.com
 ray.so
 razorsecure.com
+raidenxd2.github.io
 redacted.ch
 redasm.io
 redbox.com


### PR DESCRIPTION
raidenxd2.github.io Supports dark mode and it is the default.