### PR TITLE
Fix Arkadium support

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19511,6 +19511,13 @@ INVERT
 
 ================================
 
+support.arkadium.com
+
+INVERT
+img[alt="Logo"]
+
+================================
+
 support.discord.com
 
 INVERT


### PR DESCRIPTION
Logo/link in upper-left corner

Example URL: https://support.arkadium.com/support/home