### PR TITLE
Refactor: use index for Dark Sites list

### DIFF
--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -1,8 +1,8 @@
 import {readText} from './utils/network';
 import {getDuration} from '../utils/time';
-import {indexSiteListConfig, indexSitesFixesConfig, isURLInSiteList, SiteListIndex} from '../generators/utils/parse';
+import {indexSiteListConfig, indexSitesFixesConfig, isURLInSiteList} from '../generators/utils/parse';
 import type {InversionFix, StaticTheme, DynamicThemeFix} from '../definitions';
-import type {SitePropsIndex} from '../generators/utils/parse';
+import type {SiteListIndex, SitePropsIndex} from '../generators/utils/parse';
 import type {ParsedColorSchemeConfig} from '../utils/colorscheme-parser';
 import {ParseColorSchemeConfig} from '../utils/colorscheme-parser';
 import {logWarn} from './utils/log';

--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -1,7 +1,6 @@
 import {readText} from './utils/network';
-import {parseArray} from '../utils/text';
 import {getDuration} from '../utils/time';
-import {indexSitesFixesConfig} from '../generators/utils/parse';
+import {indexSiteListConfig, indexSitesFixesConfig, isURLInSiteList, SiteListIndex} from '../generators/utils/parse';
 import type {InversionFix, StaticTheme, DynamicThemeFix} from '../definitions';
 import type {SitePropsIndex} from '../generators/utils/parse';
 import type {ParsedColorSchemeConfig} from '../utils/colorscheme-parser';
@@ -47,7 +46,7 @@ interface Config extends LocalConfig {
 }
 
 export default class ConfigManager {
-    static DARK_SITES: string[];
+    private static DARK_SITES_INDEX: SiteListIndex | null;
     static DYNAMIC_THEME_FIXES_INDEX: SitePropsIndex<DynamicThemeFix> | null;
     static DYNAMIC_THEME_FIXES_RAW: string | null;
     static INVERSION_FIXES_INDEX: SitePropsIndex<InversionFix> | null;
@@ -180,7 +179,7 @@ export default class ConfigManager {
 
     private static handleDarkSites() {
         const $sites = this.overrides.darkSites || this.raw.darkSites;
-        this.DARK_SITES = parseArray($sites || '');
+        this.DARK_SITES_INDEX = indexSiteListConfig($sites || '');
     }
 
     static handleDynamicThemeFixes() {
@@ -199,5 +198,9 @@ export default class ConfigManager {
         const $themes = this.overrides.staticThemes || this.raw.staticThemes || '';
         this.STATIC_THEMES_INDEX = indexSitesFixesConfig<StaticTheme>($themes);
         this.STATIC_THEMES_RAW = $themes;
+    }
+
+    static isURLInDarkList(url: string): boolean {
+        return isURLInSiteList(url, ConfigManager.DARK_SITES_INDEX);
     }
 }

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -531,7 +531,7 @@ export class Extension {
         const settings = UserStorage.settings;
         const tab = await this.getActiveTabInfo();
         const {url} = tab;
-        const isInDarkList = isURLInList(url, ConfigManager.DARK_SITES);
+        const isInDarkList = ConfigManager.isURLInDarkList(url);
         const host = getURLHostOrProtocol(url);
 
         function getToggledList(sourceList: string[]) {
@@ -599,8 +599,7 @@ export class Extension {
     //----------------------
 
     private static getTabInfo(tabURL: string): TabInfo {
-        const {DARK_SITES} = ConfigManager;
-        const isInDarkList = isURLInList(tabURL, DARK_SITES);
+        const isInDarkList = ConfigManager.isURLInDarkList(tabURL);
         const isProtected = !canInjectScript(tabURL);
         return {
             url: tabURL,

--- a/tests/unit/generators/utils/parse.tests.ts
+++ b/tests/unit/generators/utils/parse.tests.ts
@@ -42,7 +42,7 @@ test('Index config', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixes = getSitesFixesFor('example.com', config, index, options);
+    const fixes = getSitesFixesFor<TestFix>('example.com', config, index, options);
     fixes.sort();
     expect(fixes).toEqual([
         {
@@ -85,8 +85,8 @@ test('Empty config', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixesGeneric = getSitesFixesFor('example.com', config, index, options);
-    const fixesInvalid = getSitesFixesFor('invalid.example', config, index, options);
+    const fixesGeneric = getSitesFixesFor<TestFix>('example.com', config, index, options);
+    const fixesInvalid = getSitesFixesFor<TestFix>('invalid.example', config, index, options);
     expect(fixesGeneric).toEqual([{
         'url': ['*'],
         'directive': 'hello world',
@@ -143,8 +143,8 @@ test('Domain appearing in multiple records', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixesFQD = getSitesFixesFor('example.com', config, index, options);
-    const fixesWildcard = getSitesFixesFor('sub.example.net', config, index, options);
+    const fixesFQD = getSitesFixesFor<TestFix>('example.com', config, index, options);
+    const fixesWildcard = getSitesFixesFor<TestFix>('sub.example.net', config, index, options);
     fixesFQD.sort();
     expect(fixesFQD).toEqual([
         {
@@ -213,8 +213,8 @@ test('Domain appearing multiple times within the same record', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixesFQD = getSitesFixesFor('example.com', config, index, options);
-    const fixesWildcard = getSitesFixesFor('sub.example.net', config, index, options);
+    const fixesFQD = getSitesFixesFor<TestFix>('example.com', config, index, options);
+    const fixesWildcard = getSitesFixesFor<TestFix>('sub.example.net', config, index, options);
     fixesFQD.sort();
     expect(fixesFQD).toEqual([
         {
@@ -293,7 +293,7 @@ test('BACKWARDS COMPATIBILITY: The generic fix appears first', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixesFQD = getSitesFixesFor('long.sub.example.com', config, index, options);
+    const fixesFQD = getSitesFixesFor<TestFix>('long.sub.example.com', config, index, options);
     expect(fixesFQD[0]).toEqual({
         'url': ['*'],
         'directive': 'hello world'
@@ -349,7 +349,7 @@ test('Fixes appear only once', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixes = getSitesFixesFor('www.example.com', config, index, options);
+    const fixes = getSitesFixesFor<TestFix>('www.example.com', config, index, options);
     expect(fixes).toEqual([
         {
             'url': ['*'],
@@ -395,7 +395,7 @@ describe('Explicit wildcard domain patterns', () => {
 
         const index = indexSitesFixesConfig<TestFix>(config);
 
-        const fixes = getSitesFixesFor('www.example.com', config, index, options);
+        const fixes = getSitesFixesFor<TestFix>('www.example.com', config, index, options);
         expect(fixes).toEqual([
             {
                 'url': ['*'],
@@ -434,7 +434,7 @@ describe('Explicit wildcard domain patterns', () => {
 
         const index = indexSitesFixesConfig<TestFix>(config);
 
-        const fixes = getSitesFixesFor('example.other.com', config, index, options);
+        const fixes = getSitesFixesFor<TestFix>('example.other.com', config, index, options);
         // Ensure that label 'example.com' does appear in the index
         expect(index.domainLabels).toEqual({
             '*': [0],
@@ -481,7 +481,7 @@ describe('Backwards compatibility', () => {
         };
         const index = indexSitesFixesConfig<TestFix>(config);
 
-        const fixes = getSitesFixesFor('other.net', config, index, options);
+        const fixes = getSitesFixesFor<TestFix>('other.net', config, index, options);
         expect(fixes).toEqual([
             {
                 'url': ['*'],
@@ -528,7 +528,7 @@ test('Implied wildcards', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixes = getSitesFixesFor('www.example.com', config, index, options);
+    const fixes = getSitesFixesFor<TestFix>('www.example.com', config, index, options);
     expect(fixes).toEqual([
         {
             'url': ['*'],
@@ -579,7 +579,7 @@ test('Base64 in CSS', () => {
     };
     const index = indexSitesFixesConfig<TestFix>(config);
 
-    const fixes = getSitesFixesFor('www.example.com', config, index, options);
+    const fixes = getSitesFixesFor<TestFix>('www.example.com', config, index, options);
     expect(fixes).toEqual([
         {
             'url': ['*'],


### PR DESCRIPTION
When we compute a the style for a frame, we need to determine whether the frame URL is in the Dark Sites list or not. Previously, every calculation of `isInDarkList` would iterate over the entire list of dark sites and would construct regexes for each, without any caches. After this commit, we index the list ahead of time and then lookup this index and then iterate and construct regexes only for the patterns which matched.

Previously, constructing the entire style for a frame took up to 2 or even sometimes 3 ms, now it is consistently less than 1 ms.