### PR TITLE
Refactor: consistently mark class members public and static

### DIFF
--- a/src/background/config-manager.ts
+++ b/src/background/config-manager.ts
@@ -47,15 +47,15 @@ interface Config extends LocalConfig {
 
 export default class ConfigManager {
     private static DARK_SITES_INDEX: SiteListIndex | null;
-    static DYNAMIC_THEME_FIXES_INDEX: SitePropsIndex<DynamicThemeFix> | null;
-    static DYNAMIC_THEME_FIXES_RAW: string | null;
-    static INVERSION_FIXES_INDEX: SitePropsIndex<InversionFix> | null;
-    static INVERSION_FIXES_RAW: string | null;
-    static STATIC_THEMES_INDEX: SitePropsIndex<StaticTheme> | null;
-    static STATIC_THEMES_RAW: string | null;
-    static COLOR_SCHEMES_RAW: ParsedColorSchemeConfig | null;
+    public static DYNAMIC_THEME_FIXES_INDEX: SitePropsIndex<DynamicThemeFix> | null;
+    public static DYNAMIC_THEME_FIXES_RAW: string | null;
+    public static INVERSION_FIXES_INDEX: SitePropsIndex<InversionFix> | null;
+    public static INVERSION_FIXES_RAW: string | null;
+    public static STATIC_THEMES_INDEX: SitePropsIndex<StaticTheme> | null;
+    public static STATIC_THEMES_RAW: string | null;
+    public static COLOR_SCHEMES_RAW: ParsedColorSchemeConfig | null;
 
-    static raw = {
+    public static raw = {
         darkSites: null as string | null,
         dynamicThemeFixes: null as string | null,
         inversionFixes: null as string | null,
@@ -63,7 +63,7 @@ export default class ConfigManager {
         colorSchemes: null as string | null,
     };
 
-    static overrides = {
+    public static overrides = {
         darkSites: null as string | null,
         dynamicThemeFixes: null as string | null,
         inversionFixes: null as string | null,
@@ -95,61 +95,61 @@ export default class ConfigManager {
     }
 
     private static async loadColorSchemes({local}: LocalConfig) {
-        const $config = await this.loadConfig({
+        const $config = await ConfigManager.loadConfig({
             name: 'Color Schemes',
             local,
             localURL: CONFIG_URLs.colorSchemes.local,
             remoteURL: CONFIG_URLs.colorSchemes.remote,
         });
-        this.raw.colorSchemes = $config;
-        this.handleColorSchemes();
+        ConfigManager.raw.colorSchemes = $config;
+        ConfigManager.handleColorSchemes();
     }
 
     private static async loadDarkSites({local}: LocalConfig) {
-        const sites = await this.loadConfig({
+        const sites = await ConfigManager.loadConfig({
             name: 'Dark Sites',
             local,
             localURL: CONFIG_URLs.darkSites.local,
             remoteURL: CONFIG_URLs.darkSites.remote,
         });
-        this.raw.darkSites = sites;
-        this.handleDarkSites();
+        ConfigManager.raw.darkSites = sites;
+        ConfigManager.handleDarkSites();
     }
 
     private static async loadDynamicThemeFixes({local}: LocalConfig) {
-        const fixes = await this.loadConfig({
+        const fixes = await ConfigManager.loadConfig({
             name: 'Dynamic Theme Fixes',
             local,
             localURL: CONFIG_URLs.dynamicThemeFixes.local,
             remoteURL: CONFIG_URLs.dynamicThemeFixes.remote,
         });
-        this.raw.dynamicThemeFixes = fixes;
-        this.handleDynamicThemeFixes();
+        ConfigManager.raw.dynamicThemeFixes = fixes;
+        ConfigManager.handleDynamicThemeFixes();
     }
 
     private static async loadInversionFixes({local}: LocalConfig) {
-        const fixes = await this.loadConfig({
+        const fixes = await ConfigManager.loadConfig({
             name: 'Inversion Fixes',
             local,
             localURL: CONFIG_URLs.inversionFixes.local,
             remoteURL: CONFIG_URLs.inversionFixes.remote,
         });
-        this.raw.inversionFixes = fixes;
-        this.handleInversionFixes();
+        ConfigManager.raw.inversionFixes = fixes;
+        ConfigManager.handleInversionFixes();
     }
 
     private static async loadStaticThemes({local}: LocalConfig) {
-        const themes = await this.loadConfig({
+        const themes = await ConfigManager.loadConfig({
             name: 'Static Themes',
             local,
             localURL: CONFIG_URLs.staticThemes.local,
             remoteURL: CONFIG_URLs.staticThemes.remote,
         });
-        this.raw.staticThemes = themes;
-        this.handleStaticThemes();
+        ConfigManager.raw.staticThemes = themes;
+        ConfigManager.handleStaticThemes();
     }
 
-    static async load(config?: LocalConfig) {
+    public static async load(config?: LocalConfig) {
         if (!config) {
             await UserStorage.loadSettings();
             config = {
@@ -158,49 +158,49 @@ export default class ConfigManager {
         }
 
         await Promise.all([
-            this.loadColorSchemes(config),
-            this.loadDarkSites(config),
-            this.loadDynamicThemeFixes(config),
-            this.loadInversionFixes(config),
-            this.loadStaticThemes(config),
+            ConfigManager.loadColorSchemes(config),
+            ConfigManager.loadDarkSites(config),
+            ConfigManager.loadDynamicThemeFixes(config),
+            ConfigManager.loadInversionFixes(config),
+            ConfigManager.loadStaticThemes(config),
         ]).catch((err) => console.error('Fatality', err));
     }
 
     private static handleColorSchemes() {
-        const $config = this.raw.colorSchemes;
+        const $config = ConfigManager.raw.colorSchemes;
         const {result, error} = ParseColorSchemeConfig($config || '');
         if (error) {
             logWarn(`Color Schemes parse error, defaulting to fallback. ${error}.`);
-            this.COLOR_SCHEMES_RAW = DEFAULT_COLORSCHEME;
+            ConfigManager.COLOR_SCHEMES_RAW = DEFAULT_COLORSCHEME;
             return;
         }
-        this.COLOR_SCHEMES_RAW = result;
+        ConfigManager.COLOR_SCHEMES_RAW = result;
     }
 
     private static handleDarkSites() {
-        const $sites = this.overrides.darkSites || this.raw.darkSites;
-        this.DARK_SITES_INDEX = indexSiteListConfig($sites || '');
+        const $sites = ConfigManager.overrides.darkSites || ConfigManager.raw.darkSites;
+        ConfigManager.DARK_SITES_INDEX = indexSiteListConfig($sites || '');
     }
 
-    static handleDynamicThemeFixes() {
-        const $fixes = this.overrides.dynamicThemeFixes || this.raw.dynamicThemeFixes || '';
-        this.DYNAMIC_THEME_FIXES_INDEX = indexSitesFixesConfig<DynamicThemeFix>($fixes);
-        this.DYNAMIC_THEME_FIXES_RAW = $fixes;
+    public static handleDynamicThemeFixes() {
+        const $fixes = ConfigManager.overrides.dynamicThemeFixes || ConfigManager.raw.dynamicThemeFixes || '';
+        ConfigManager.DYNAMIC_THEME_FIXES_INDEX = indexSitesFixesConfig<DynamicThemeFix>($fixes);
+        ConfigManager.DYNAMIC_THEME_FIXES_RAW = $fixes;
     }
 
-    static handleInversionFixes() {
-        const $fixes = this.overrides.inversionFixes || this.raw.inversionFixes || '';
-        this.INVERSION_FIXES_INDEX = indexSitesFixesConfig<InversionFix>($fixes);
-        this.INVERSION_FIXES_RAW = $fixes;
+    public static handleInversionFixes() {
+        const $fixes = ConfigManager.overrides.inversionFixes || ConfigManager.raw.inversionFixes || '';
+        ConfigManager.INVERSION_FIXES_INDEX = indexSitesFixesConfig<InversionFix>($fixes);
+        ConfigManager.INVERSION_FIXES_RAW = $fixes;
     }
 
-    static handleStaticThemes() {
-        const $themes = this.overrides.staticThemes || this.raw.staticThemes || '';
-        this.STATIC_THEMES_INDEX = indexSitesFixesConfig<StaticTheme>($themes);
-        this.STATIC_THEMES_RAW = $themes;
+    public static handleStaticThemes() {
+        const $themes = ConfigManager.overrides.staticThemes || ConfigManager.raw.staticThemes || '';
+        ConfigManager.STATIC_THEMES_INDEX = indexSitesFixesConfig<StaticTheme>($themes);
+        ConfigManager.STATIC_THEMES_RAW = $themes;
     }
 
-    static isURLInDarkList(url: string): boolean {
+    public static isURLInDarkList(url: string): boolean {
         return isURLInSiteList(url, ConfigManager.DARK_SITES_INDEX);
     }
 }

--- a/src/background/content-script-manager.ts
+++ b/src/background/content-script-manager.ts
@@ -34,9 +34,9 @@ export default class ContentScriptManager {
      * to be supported already...
      */
 
-    static state: ContentScriptManagerState;
+    public static state: ContentScriptManagerState;
 
-    static async registerScripts(updateContentScripts: () => Promise<void>) {
+    public static async registerScripts(updateContentScripts: () => Promise<void>) {
         if (!__CHROMIUM_MV3__) {
             logWarn('ContentScriptManager is useful only within MV3 builds.');
             return;
@@ -98,7 +98,7 @@ export default class ContentScriptManager {
             ));
     }
 
-    static async unregisterScripts() {
+    public static async unregisterScripts() {
         if (!__CHROMIUM_MV3__) {
             logWarn('ContentScriptManager is useful only within MV3 builds.');
             return;

--- a/src/background/devtools.ts
+++ b/src/background/devtools.ts
@@ -96,16 +96,16 @@ export default class DevTools {
     private static onChange: () => void;
     private static store: DevToolsStorage;
 
-    static init(onChange: () => void) {
+    public static init(onChange: () => void) {
         // Firefox don't seem to like using storage.local to store big data on the background-extension.
         // Disabling it for now and defaulting back to localStorage.
         if (typeof chrome.storage.local !== 'undefined' && chrome.storage.local !== null && !isFirefox) {
-            this.store = new PersistentStorageWrapper();
+            DevTools.store = new PersistentStorageWrapper();
         } else {
-            this.store = new TempStorage();
+            DevTools.store = new TempStorage();
         }
-        this.loadConfigOverrides();
-        this.onChange = onChange;
+        DevTools.loadConfigOverrides();
+        DevTools.onChange = onChange;
     }
 
     private static KEY_DYNAMIC = 'dev_dynamic_theme_fixes';
@@ -118,9 +118,9 @@ export default class DevTools {
             inversionFixes,
             staticThemes
         ] = await Promise.all([
-            this.getSavedDynamicThemeFixes(),
-            this.getSavedInversionFixes(),
-            this.getSavedStaticThemes(),
+            DevTools.getSavedDynamicThemeFixes(),
+            DevTools.getSavedInversionFixes(),
+            DevTools.getSavedStaticThemes(),
         ]);
         ConfigManager.overrides.dynamicThemeFixes = dynamicThemeFixes || null;
         ConfigManager.overrides.inversionFixes = inversionFixes || null;
@@ -128,15 +128,15 @@ export default class DevTools {
     }
 
     private static async getSavedDynamicThemeFixes() {
-        return this.store.get(DevTools.KEY_DYNAMIC);
+        return DevTools.store.get(DevTools.KEY_DYNAMIC);
     }
 
     private static saveDynamicThemeFixes(text: string) {
-        this.store.set(DevTools.KEY_DYNAMIC, text);
+        DevTools.store.set(DevTools.KEY_DYNAMIC, text);
     }
 
-    static async getDynamicThemeFixesText() {
-        let rawFixes = await this.getSavedDynamicThemeFixes();
+    public static async getDynamicThemeFixesText() {
+        let rawFixes = await DevTools.getSavedDynamicThemeFixes();
         if (!rawFixes) {
             await ConfigManager.load();
             rawFixes = ConfigManager.DYNAMIC_THEME_FIXES_RAW || '';
@@ -145,20 +145,20 @@ export default class DevTools {
         return formatDynamicThemeFixes(fixes);
     }
 
-    static resetDynamicThemeFixes() {
-        this.store.remove(DevTools.KEY_DYNAMIC);
+    public static resetDynamicThemeFixes() {
+        DevTools.store.remove(DevTools.KEY_DYNAMIC);
         ConfigManager.overrides.dynamicThemeFixes = null;
         ConfigManager.handleDynamicThemeFixes();
-        this.onChange();
+        DevTools.onChange();
     }
 
-    static applyDynamicThemeFixes(text: string) {
+    public static applyDynamicThemeFixes(text: string) {
         try {
             const formatted = formatDynamicThemeFixes(parseDynamicThemeFixes(text));
             ConfigManager.overrides.dynamicThemeFixes = formatted;
             ConfigManager.handleDynamicThemeFixes();
-            this.saveDynamicThemeFixes(formatted);
-            this.onChange();
+            DevTools.saveDynamicThemeFixes(formatted);
+            DevTools.onChange();
             return null;
         } catch (err) {
             return err;
@@ -173,8 +173,8 @@ export default class DevTools {
         this.store.set(DevTools.KEY_FILTER, text);
     }
 
-    static async getInversionFixesText() {
-        let rawFixes = await this.getSavedInversionFixes();
+    public static async getInversionFixesText() {
+        let rawFixes = await DevTools.getSavedInversionFixes();
         if (!rawFixes) {
             await ConfigManager.load();
             rawFixes = ConfigManager.INVERSION_FIXES_RAW || '';
@@ -183,20 +183,20 @@ export default class DevTools {
         return formatInversionFixes(fixes);
     }
 
-    static resetInversionFixes() {
-        this.store.remove(DevTools.KEY_FILTER);
+    public static resetInversionFixes() {
+        DevTools.store.remove(DevTools.KEY_FILTER);
         ConfigManager.overrides.inversionFixes = null;
         ConfigManager.handleInversionFixes();
-        this.onChange();
+        DevTools.onChange();
     }
 
-    static applyInversionFixes(text: string) {
+    public static applyInversionFixes(text: string) {
         try {
             const formatted = formatInversionFixes(parseInversionFixes(text));
             ConfigManager.overrides.inversionFixes = formatted;
             ConfigManager.handleInversionFixes();
-            this.saveInversionFixes(formatted);
-            this.onChange();
+            DevTools.saveInversionFixes(formatted);
+            DevTools.onChange();
             return null;
         } catch (err) {
             return err;
@@ -204,15 +204,15 @@ export default class DevTools {
     }
 
     private static async getSavedStaticThemes() {
-        return this.store.get(DevTools.KEY_STATIC);
+        return DevTools.store.get(DevTools.KEY_STATIC);
     }
 
     private static saveStaticThemes(text: string) {
-        this.store.set(DevTools.KEY_STATIC, text);
+        DevTools.store.set(DevTools.KEY_STATIC, text);
     }
 
-    static async getStaticThemesText() {
-        let rawThemes = await this.getSavedStaticThemes();
+    public static async getStaticThemesText() {
+        let rawThemes = await DevTools.getSavedStaticThemes();
         if (!rawThemes) {
             await ConfigManager.load();
             rawThemes = ConfigManager.STATIC_THEMES_RAW || '';
@@ -221,20 +221,20 @@ export default class DevTools {
         return formatStaticThemes(themes);
     }
 
-    static resetStaticThemes() {
-        this.store.remove(DevTools.KEY_STATIC);
+    public static resetStaticThemes() {
+        DevTools.store.remove(DevTools.KEY_STATIC);
         ConfigManager.overrides.staticThemes = null;
         ConfigManager.handleStaticThemes();
-        this.onChange();
+        DevTools.onChange();
     }
 
-    static applyStaticThemes(text: string) {
+    public static applyStaticThemes(text: string) {
         try {
             const formatted = formatStaticThemes(parseStaticThemes(text));
             ConfigManager.overrides.staticThemes = formatted;
             ConfigManager.handleStaticThemes();
-            this.saveStaticThemes(formatted);
-            this.onChange();
+            DevTools.saveStaticThemes(formatted);
+            DevTools.onChange();
             return null;
         } catch (err) {
             return err;

--- a/src/background/devtools.ts
+++ b/src/background/devtools.ts
@@ -99,7 +99,7 @@ export default class DevTools {
     public static init(onChange: () => void) {
         // Firefox don't seem to like using storage.local to store big data on the background-extension.
         // Disabling it for now and defaulting back to localStorage.
-        if (typeof chrome.storage.local !== 'undefined' && chrome.storage.local !== null && !isFirefox) {
+        if (!isFirefox && typeof chrome.storage.local !== 'undefined' && chrome.storage.local !== null) {
             DevTools.store = new PersistentStorageWrapper();
         } else {
             DevTools.store = new TempStorage();

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -66,37 +66,37 @@ export class Extension {
     private static initialized = false;
 
     // This sync initializer needs to run on every BG restart before anything else can happen
-    static init() {
-        if (this.initialized) {
+    public static init() {
+        if (Extension.initialized) {
             return;
         }
-        this.initialized = true;
+        Extension.initialized = true;
 
-        new Newsmaker();
-        DevTools.init(async () => this.onSettingsChanged());
-        Messenger.init(this.getMessengerAdapter());
+        Newsmaker.init();
+        DevTools.init(Extension.onSettingsChanged);
+        Messenger.init(Extension.getMessengerAdapter());
         TabManager.init({
-            getConnectionMessage: async (tabURL, url, isTopFrame) => this.getConnectionMessage(tabURL, url, isTopFrame),
-            getTabMessage: this.getTabMessage,
-            onColorSchemeChange: this.onColorSchemeChange,
+            getConnectionMessage: Extension.getConnectionMessage,
+            getTabMessage: Extension.getTabMessage,
+            onColorSchemeChange: Extension.onColorSchemeChange,
         });
 
-        this.startBarrier = new PromiseBarrier();
-        this.stateManager = new StateManager<ExtensionState>(Extension.LOCAL_STORAGE_KEY, this, {
+        Extension.startBarrier = new PromiseBarrier();
+        Extension.stateManager = new StateManager<ExtensionState>(Extension.LOCAL_STORAGE_KEY, Extension, {
             autoState: '',
             wasEnabledOnLastCheck: null,
             registeredContextMenus: null,
         }, logWarn);
 
-        chrome.alarms.onAlarm.addListener(this.alarmListener);
+        chrome.alarms.onAlarm.addListener(Extension.alarmListener);
 
         if (chrome.commands) {
             // Firefox Android does not support chrome.commands
             if (isFirefox) {
                 // Firefox may not register onCommand listener on extension startup so we need to use setTimeout
-                setTimeout(() => chrome.commands.onCommand.addListener(async (command) => this.onCommand(command as Command, null, null, null)));
+                setTimeout(() => chrome.commands.onCommand.addListener(async (command) => Extension.onCommand(command as Command, null, null, null)));
             } else {
-                chrome.commands.onCommand.addListener(async (command, tab) => this.onCommand(command as Command, tab && tab.id! || null, 0, null));
+                chrome.commands.onCommand.addListener(async (command, tab) => Extension.onCommand(command as Command, tab && tab.id! || null, 0, null));
             }
         }
 
@@ -106,7 +106,7 @@ export class Extension {
                 // is no browser UI for removing 'contextMenus' permission.
                 // This code exists for future-proofing in case browsers ever add such UI.
                 if (!permissions?.permissions?.includes('contextMenus')) {
-                    this.registeredContextMenus = false;
+                    Extension.registeredContextMenus = false;
                 }
             });
         }
@@ -116,32 +116,32 @@ export class Extension {
         if (!__CHROMIUM_MV3__) {
             return;
         }
-        if (!this.systemColorStateManager) {
-            this.systemColorStateManager = new StateManager<SystemColorState>(Extension.SYSTEM_COLOR_LOCAL_STORAGE_KEY, this, {
+        if (!Extension.systemColorStateManager) {
+            Extension.systemColorStateManager = new StateManager<SystemColorState>(Extension.SYSTEM_COLOR_LOCAL_STORAGE_KEY, Extension, {
                 wasLastColorSchemeDark: isDark,
             }, logWarn);
         }
         if (isDark === null) {
             // Attempt to restore data from storage
-            return this.systemColorStateManager.loadState();
-        } else if (this.wasLastColorSchemeDark !== isDark) {
-            this.wasLastColorSchemeDark = isDark;
-            return this.systemColorStateManager.saveState();
+            return Extension.systemColorStateManager.loadState();
+        } else if (Extension.wasLastColorSchemeDark !== isDark) {
+            Extension.wasLastColorSchemeDark = isDark;
+            return Extension.systemColorStateManager.saveState();
         }
     }
 
     private static alarmListener = (alarm: chrome.alarms.Alarm): void => {
         if (alarm.name === Extension.ALARM_NAME) {
-            this.loadData().then(() => this.handleAutomationCheck());
+            Extension.loadData().then(() => Extension.handleAutomationCheck());
         }
     };
 
     private static isExtensionSwitchedOn() {
         return (
-            this.autoState === 'turn-on' ||
-            this.autoState === 'scheme-dark' ||
-            this.autoState === 'scheme-light' ||
-            (this.autoState === '' && UserStorage.settings.enabled)
+            Extension.autoState === 'turn-on' ||
+            Extension.autoState === 'scheme-dark' ||
+            Extension.autoState === 'scheme-light' ||
+            (Extension.autoState === '' && UserStorage.settings.enabled)
         );
     }
 
@@ -159,16 +159,16 @@ export class Extension {
             }
             case AutomationMode.SYSTEM:
                 if (__CHROMIUM_MV3__) {
-                    isAutoDark = this.wasLastColorSchemeDark;
-                    if (this.wasLastColorSchemeDark === null) {
+                    isAutoDark = Extension.wasLastColorSchemeDark;
+                    if (Extension.wasLastColorSchemeDark === null) {
                         logWarn('System color scheme is unknown. Defaulting to Dark.');
                         isAutoDark = true;
                     }
                     break;
                 }
-                isAutoDark = this.wasLastColorSchemeDark === null
+                isAutoDark = Extension.wasLastColorSchemeDark === null
                     ? isSystemDarkModeEnabled()
-                    : this.wasLastColorSchemeDark;
+                    : Extension.wasLastColorSchemeDark;
                 if (isFirefox) {
                     runColorSchemeChangeDetector(Extension.onColorSchemeChange);
                 }
@@ -193,7 +193,7 @@ export class Extension {
                 state = isAutoDark ? 'scheme-dark' : 'scheme-light';
             }
         }
-        this.autoState = state;
+        Extension.autoState = state;
 
         if (nextCheck) {
             if (nextCheck < Date.now()) {
@@ -204,18 +204,18 @@ export class Extension {
         }
     }
 
-    static async start() {
-        this.init();
+    public static async start() {
+        Extension.init();
         await Promise.all([
             ConfigManager.load({local: true}),
-            this.MV3syncSystemColorStateManager(null),
+            Extension.MV3syncSystemColorStateManager(null),
             UserStorage.loadSettings()
         ]);
 
-        if (UserStorage.settings.enableContextMenus && !this.registeredContextMenus) {
+        if (UserStorage.settings.enableContextMenus && !Extension.registeredContextMenus) {
             chrome.permissions.contains({permissions: ['contextMenus']}, (permitted) => {
                 if (permitted) {
-                    this.registerContextMenus();
+                    Extension.registerContextMenus();
                 } else {
                     logWarn('User has enabled context menus, but did not provide permission.');
                 }
@@ -224,8 +224,8 @@ export class Extension {
         if (UserStorage.settings.syncSitesFixes) {
             await ConfigManager.load({local: false});
         }
-        this.updateAutoState();
-        this.onAppToggle();
+        Extension.updateAutoState();
+        Extension.onAppToggle();
         logInfo('loaded', UserStorage.settings);
 
         if (__THUNDERBIRD__) {
@@ -235,20 +235,20 @@ export class Extension {
         }
 
         UserStorage.settings.fetchNews && Newsmaker.subscribe();
-        this.startBarrier!.resolve();
+        Extension.startBarrier!.resolve();
     }
 
     private static getMessengerAdapter(): ExtensionAdapter {
         return {
             collect: async () => {
-                return await this.collectData();
+                return await Extension.collectData();
             },
             collectDevToolsData: async () => {
-                return await this.collectDevToolsData();
+                return await Extension.collectDevToolsData();
             },
-            changeSettings: async (settings) => this.changeSettings(settings),
-            setTheme: (theme) => this.setTheme(theme),
-            toggleActiveTab: async () => this.toggleActiveTab(),
+            changeSettings: async (settings) => Extension.changeSettings(settings),
+            setTheme: (theme) => Extension.setTheme(theme),
+            toggleActiveTab: async () => Extension.toggleActiveTab(),
             markNewsAsRead: async (ids) => await Newsmaker.markAsRead(...ids),
             markNewsAsDisplayed: async (ids) => await Newsmaker.markAsDisplayed(...ids),
             loadConfig: async (options) => await ConfigManager.load(options),
@@ -262,15 +262,15 @@ export class Extension {
     }
 
     private static onCommandInternal = async (command: Command, tabId: number | null, frameId: number | null, frameURL: string | null) => {
-        if (this.startBarrier!.isPending()) {
-            await this.startBarrier!.entry();
+        if (Extension.startBarrier!.isPending()) {
+            await Extension.startBarrier!.entry();
         }
-        this.stateManager!.loadState();
+        Extension.stateManager!.loadState();
         switch (command) {
             case 'toggle':
                 logInfo('Toggle command entered');
-                this.changeSettings({
-                    enabled: !this.isExtensionSwitchedOn(),
+                Extension.changeSettings({
+                    enabled: !Extension.isExtensionSwitchedOn(),
                     automation: {...UserStorage.settings.automation, ...{enable: false}},
                 });
                 break;
@@ -305,9 +305,9 @@ export class Extension {
 
                 const pdf = async () => isPDF(frameURL || await TabManager.getActiveTabURL());
                 if (((__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && await scriptPDF(tabId!, frameId!)) || await pdf()) {
-                    this.changeSettings({enableForPDF: !UserStorage.settings.enableForPDF});
+                    Extension.changeSettings({enableForPDF: !UserStorage.settings.enableForPDF});
                 } else {
-                    this.toggleActiveTab();
+                    Extension.toggleActiveTab();
                 }
                 break;
             }
@@ -316,7 +316,7 @@ export class Extension {
                 const engines = Object.values(ThemeEngine);
                 const index = engines.indexOf(UserStorage.settings.theme.engine);
                 const next = engines[(index + 1) % engines.length];
-                this.setTheme({engine: next});
+                Extension.setTheme({engine: next});
                 break;
             }
         }
@@ -324,13 +324,13 @@ export class Extension {
 
     // 75 is small enough to not notice it, and still catches when someone
     // is holding down a certain shortcut.
-    private static onCommand = debounce(75, this.onCommandInternal);
+    private static onCommand = debounce(75, Extension.onCommandInternal);
 
     private static registerContextMenus() {
         chrome.contextMenus.onClicked.addListener(async ({menuItemId, frameId, frameUrl, pageUrl}, tab) =>
-            this.onCommand(menuItemId as Command, tab && tab.id || null, frameId || null, frameUrl || pageUrl));
+            Extension.onCommand(menuItemId as Command, tab && tab.id || null, frameId || null, frameUrl || pageUrl));
         chrome.contextMenus.removeAll(() => {
-            this.registeredContextMenus = false;
+            Extension.registeredContextMenus = false;
             chrome.contextMenus.create({
                 id: 'DarkReader-top',
                 title: 'Dark Reader'
@@ -357,7 +357,7 @@ export class Extension {
                     parentId: 'DarkReader-top',
                     title: msgSwitchEngine || 'Switch engine',
                 });
-                this.registeredContextMenus = true;
+                Extension.registeredContextMenus = true;
             });
         });
     }
@@ -367,8 +367,8 @@ export class Extension {
         return commands.reduce((map, cmd) => Object.assign(map, {[cmd.name!]: cmd.shortcut}), {} as Shortcuts);
     }
 
-    static async collectData(): Promise<ExtensionData> {
-        await this.loadData();
+    public static async collectData(): Promise<ExtensionData> {
+        await Extension.loadData();
         const [
             news,
             shortcuts,
@@ -376,24 +376,24 @@ export class Extension {
             isAllowedFileSchemeAccess,
         ] = await Promise.all([
             Newsmaker.getLatest(),
-            this.getShortcuts(),
-            this.getActiveTabInfo(),
+            Extension.getShortcuts(),
+            Extension.getActiveTabInfo(),
             new Promise<boolean>((r) => chrome.extension.isAllowedFileSchemeAccess(r)),
         ]);
         return {
-            isEnabled: this.isExtensionSwitchedOn(),
+            isEnabled: Extension.isExtensionSwitchedOn(),
             isReady: true,
             isAllowedFileSchemeAccess,
             settings: UserStorage.settings,
             news,
             shortcuts,
             colorScheme: ConfigManager.COLOR_SCHEMES_RAW!,
-            forcedScheme: this.autoState === 'scheme-dark' ? 'dark' : this.autoState === 'scheme-light' ? 'light' : null,
+            forcedScheme: Extension.autoState === 'scheme-dark' ? 'dark' : Extension.autoState === 'scheme-light' ? 'light' : null,
             activeTab,
         };
     }
 
-    static async collectDevToolsData(): Promise<DevToolsData> {
+    public static async collectDevToolsData(): Promise<DevToolsData> {
         const [
             dynamicFixesText,
             filterFixesText,
@@ -411,9 +411,9 @@ export class Extension {
     }
 
     private static async getActiveTabInfo() {
-        await this.loadData();
+        await Extension.loadData();
         const tabURL = await TabManager.getActiveTabURL();
-        const info = this.getTabInfo(tabURL);
+        const info = Extension.getTabInfo(tabURL);
         info.isInjected = await TabManager.canAccessActiveTab();
         if (UserStorage.settings.detectDarkTheme) {
             info.isDarkThemeDetected = await TabManager.isActiveTabDarkThemeDetected();
@@ -422,51 +422,51 @@ export class Extension {
     }
 
     private static async getConnectionMessage(tabURL: string, url: string, isTopFrame: boolean) {
-        await this.loadData();
-        return this.getTabMessage(tabURL, url, isTopFrame);
+        await Extension.loadData();
+        return Extension.getTabMessage(tabURL, url, isTopFrame);
     }
 
     private static async loadData() {
-        this.init();
+        Extension.init();
         await Promise.all([
-            this.stateManager!.loadState(),
+            Extension.stateManager!.loadState(),
             UserStorage.loadSettings(),
         ]);
     }
 
     private static onColorSchemeChange = async (isDark: boolean) => {
-        if (this.wasLastColorSchemeDark === isDark) {
+        if (Extension.wasLastColorSchemeDark === isDark) {
             // If color scheme was already correct, we do not need to do anyhting
             return;
         }
-        this.wasLastColorSchemeDark = isDark;
-        this.MV3syncSystemColorStateManager(isDark);
-        await this.loadData();
+        Extension.wasLastColorSchemeDark = isDark;
+        Extension.MV3syncSystemColorStateManager(isDark);
+        await Extension.loadData();
         if (UserStorage.settings.automation.mode !== AutomationMode.SYSTEM) {
             return;
         }
-        this.handleAutomationCheck();
+        Extension.handleAutomationCheck();
     };
 
     private static handleAutomationCheck = () => {
-        this.updateAutoState();
+        Extension.updateAutoState();
 
-        const isSwitchedOn = this.isExtensionSwitchedOn();
+        const isSwitchedOn = Extension.isExtensionSwitchedOn();
         if (
-            this.wasEnabledOnLastCheck === null ||
-            this.wasEnabledOnLastCheck !== isSwitchedOn ||
-            this.autoState === 'scheme-dark' ||
-            this.autoState === 'scheme-light'
+            Extension.wasEnabledOnLastCheck === null ||
+            Extension.wasEnabledOnLastCheck !== isSwitchedOn ||
+            Extension.autoState === 'scheme-dark' ||
+            Extension.autoState === 'scheme-light'
         ) {
-            this.wasEnabledOnLastCheck = isSwitchedOn;
-            this.onAppToggle();
+            Extension.wasEnabledOnLastCheck = isSwitchedOn;
+            Extension.onAppToggle();
             TabManager.sendMessage();
-            this.reportChanges();
-            this.stateManager!.saveState();
+            Extension.reportChanges();
+            Extension.stateManager!.saveState();
         }
     };
 
-    static async changeSettings($settings: Partial<UserSettings>, onlyUpdateActiveTab = false) {
+    public static async changeSettings($settings: Partial<UserSettings>, onlyUpdateActiveTab = false) {
         const promises = [];
         const prev = {...UserStorage.settings};
 
@@ -482,14 +482,14 @@ export class Extension {
             (prev.location.latitude !== UserStorage.settings.location.latitude) ||
             (prev.location.longitude !== UserStorage.settings.location.longitude)
         ) {
-            this.updateAutoState();
-            this.onAppToggle();
+            Extension.updateAutoState();
+            Extension.onAppToggle();
         }
         if (prev.syncSettings !== UserStorage.settings.syncSettings) {
             const promise = UserStorage.saveSyncSetting(UserStorage.settings.syncSettings);
             promises.push(promise);
         }
-        if (this.isExtensionSwitchedOn() && $settings.changeBrowserTheme != null && prev.changeBrowserTheme !== $settings.changeBrowserTheme) {
+        if (Extension.isExtensionSwitchedOn() && $settings.changeBrowserTheme != null && prev.changeBrowserTheme !== $settings.changeBrowserTheme) {
             if ($settings.changeBrowserTheme) {
                 setWindowTheme(UserStorage.settings.theme);
             } else {
@@ -502,12 +502,12 @@ export class Extension {
 
         if (prev.enableContextMenus !== UserStorage.settings.enableContextMenus) {
             if (UserStorage.settings.enableContextMenus) {
-                this.registerContextMenus();
+                Extension.registerContextMenus();
             } else {
                 chrome.contextMenus.removeAll();
             }
         }
-        const promise = this.onSettingsChanged(onlyUpdateActiveTab);
+        const promise = Extension.onSettingsChanged(onlyUpdateActiveTab);
         promises.push(promise);
         await Promise.all(promises);
     }
@@ -515,21 +515,21 @@ export class Extension {
     private static setTheme($theme: Partial<FilterConfig>) {
         UserStorage.set({theme: {...UserStorage.settings.theme, ...$theme}});
 
-        if (this.isExtensionSwitchedOn() && UserStorage.settings.changeBrowserTheme) {
+        if (Extension.isExtensionSwitchedOn() && UserStorage.settings.changeBrowserTheme) {
             setWindowTheme(UserStorage.settings.theme);
         }
 
-        this.onSettingsChanged();
+        Extension.onSettingsChanged();
     }
 
     private static async reportChanges() {
-        const info = await this.collectData();
+        const info = await Extension.collectData();
         Messenger.reportChanges(info);
     }
 
     private static async toggleActiveTab() {
         const settings = UserStorage.settings;
-        const tab = await this.getActiveTabInfo();
+        const tab = await Extension.getActiveTabInfo();
         const {url} = tab;
         const isInDarkList = ConfigManager.isURLInDarkList(url);
         const host = getURLHostOrProtocol(url);
@@ -548,12 +548,12 @@ export class Extension {
         const darkThemeDetected = !settings.applyToListedOnly && settings.detectDarkTheme && tab.isDarkThemeDetected;
         if (isInDarkList || darkThemeDetected || settings.siteListEnabled.includes(host)) {
             const toggledList = getToggledList(settings.siteListEnabled);
-            this.changeSettings({siteListEnabled: toggledList}, true);
+            Extension.changeSettings({siteListEnabled: toggledList}, true);
             return;
         }
 
         const toggledList = getToggledList(settings.siteList);
-        this.changeSettings({siteList: toggledList}, true);
+        Extension.changeSettings({siteList: toggledList}, true);
     }
 
     //------------------------------------
@@ -562,7 +562,7 @@ export class Extension {
     //
 
     private static onAppToggle() {
-        if (this.isExtensionSwitchedOn()) {
+        if (Extension.isExtensionSwitchedOn()) {
             if (__CHROMIUM_MV3__) {
                 ContentScriptManager.registerScripts(async () => TabManager.updateContentScript({runOnProtectedPages: UserStorage.settings.enableForProtectedPages}));
             }
@@ -575,7 +575,7 @@ export class Extension {
         }
 
         if (UserStorage.settings.changeBrowserTheme) {
-            if (this.isExtensionSwitchedOn() && this.autoState !== 'scheme-light') {
+            if (Extension.isExtensionSwitchedOn() && Extension.autoState !== 'scheme-light') {
                 setWindowTheme(UserStorage.settings.theme);
             } else {
                 resetWindowTheme();
@@ -584,12 +584,12 @@ export class Extension {
     }
 
     private static async onSettingsChanged(onlyUpdateActiveTab = false) {
-        await this.loadData();
-        this.wasEnabledOnLastCheck = this.isExtensionSwitchedOn();
+        await Extension.loadData();
+        Extension.wasEnabledOnLastCheck = Extension.isExtensionSwitchedOn();
         TabManager.sendMessage(onlyUpdateActiveTab);
-        this.saveUserSettings();
-        this.reportChanges();
-        this.stateManager!.saveState();
+        Extension.saveUserSettings();
+        Extension.reportChanges();
+        Extension.stateManager!.saveState();
     }
 
     //----------------------
@@ -612,13 +612,13 @@ export class Extension {
 
     private static getTabMessage = (tabURl: string, url: string, isTopFrame: boolean): TabData => {
         const settings = UserStorage.settings;
-        const tabInfo = this.getTabInfo(tabURl);
-        if (this.isExtensionSwitchedOn() && isURLEnabled(tabURl, settings, tabInfo)) {
+        const tabInfo = Extension.getTabInfo(tabURl);
+        if (Extension.isExtensionSwitchedOn() && isURLEnabled(tabURl, settings, tabInfo)) {
             const custom = settings.customThemes.find(({url: urlList}) => isURLInList(tabURl, urlList));
             const preset = custom ? null : settings.presets.find(({urls}) => isURLInList(tabURl, urls));
             let theme = custom ? custom.theme : preset ? preset.theme : settings.theme;
-            if (this.autoState === 'scheme-dark' || this.autoState === 'scheme-light') {
-                const mode = this.autoState === 'scheme-dark' ? 1 : 0;
+            if (Extension.autoState === 'scheme-dark' || Extension.autoState === 'scheme-light') {
+                const mode = Extension.autoState === 'scheme-dark' ? 1 : 0;
                 theme = {...theme, mode};
             }
             const detectDarkTheme = isTopFrame && settings.detectDarkTheme && !isURLInList(tabURl, settings.siteListEnabled) && !isPDF(tabURl);

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -72,7 +72,6 @@ export class Extension {
         }
         Extension.initialized = true;
 
-        Newsmaker.init();
         DevTools.init(Extension.onSettingsChanged);
         Messenger.init(Extension.getMessengerAdapter());
         TabManager.init({
@@ -246,18 +245,18 @@ export class Extension {
             collectDevToolsData: async () => {
                 return await Extension.collectDevToolsData();
             },
-            changeSettings: async (settings) => Extension.changeSettings(settings),
-            setTheme: (theme) => Extension.setTheme(theme),
-            toggleActiveTab: async () => Extension.toggleActiveTab(),
-            markNewsAsRead: async (ids) => await Newsmaker.markAsRead(...ids),
-            markNewsAsDisplayed: async (ids) => await Newsmaker.markAsDisplayed(...ids),
-            loadConfig: async (options) => await ConfigManager.load(options),
-            applyDevDynamicThemeFixes: (text) => DevTools.applyDynamicThemeFixes(text),
-            resetDevDynamicThemeFixes: () => DevTools.resetDynamicThemeFixes(),
-            applyDevInversionFixes: (text) => DevTools.applyInversionFixes(text),
-            resetDevInversionFixes: () => DevTools.resetInversionFixes(),
-            applyDevStaticThemes: (text) => DevTools.applyStaticThemes(text),
-            resetDevStaticThemes: () => DevTools.resetStaticThemes(),
+            changeSettings: Extension.changeSettings,
+            setTheme: Extension.setTheme,
+            toggleActiveTab: Extension.toggleActiveTab,
+            markNewsAsRead: Newsmaker.markAsRead,
+            markNewsAsDisplayed: Newsmaker.markAsDisplayed,
+            loadConfig: ConfigManager.load,
+            applyDevDynamicThemeFixes: DevTools.applyDynamicThemeFixes,
+            resetDevDynamicThemeFixes: DevTools.resetDynamicThemeFixes,
+            applyDevInversionFixes: DevTools.applyInversionFixes,
+            resetDevInversionFixes: DevTools.resetInversionFixes,
+            applyDevStaticThemes: DevTools.applyStaticThemes,
+            resetDevStaticThemes: DevTools.resetStaticThemes,
         };
     }
 

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -66,7 +66,7 @@ export class Extension {
     private static initialized = false;
 
     // This sync initializer needs to run on every BG restart before anything else can happen
-    public static init() {
+    private static init() {
         if (Extension.initialized) {
             return;
         }

--- a/src/background/icon-manager.ts
+++ b/src/background/icon-manager.ts
@@ -48,7 +48,7 @@ export default class IconManager {
         }
     }
 
-    static setActive() {
+    public static setActive() {
         if (__THUNDERBIRD__ || !chrome.browserAction.setIcon) {
             // Fix for Firefox Android and Thunderbird.
             return;
@@ -60,7 +60,7 @@ export default class IconManager {
         IconManager.handleUpdate();
     }
 
-    static setInactive() {
+    public static setInactive() {
         if (__THUNDERBIRD__ || !chrome.browserAction.setIcon) {
             // Fix for Firefox Android and Thunderbird.
             return;
@@ -72,14 +72,14 @@ export default class IconManager {
         IconManager.handleUpdate();
     }
 
-    static showBadge(text: string) {
+    public static showBadge(text: string) {
         IconManager.iconState.badgeText = text;
         chrome.browserAction.setBadgeBackgroundColor({color: '#e96c4c'});
         chrome.browserAction.setBadgeText({text});
         IconManager.handleUpdate();
     }
 
-    static hideBadge() {
+    public static hideBadge() {
         IconManager.iconState.badgeText = '';
         chrome.browserAction.setBadgeText({text: ''});
         IconManager.handleUpdate();

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -4,7 +4,6 @@ import {canInjectScript} from '../background/utils/extension-api';
 import type {ExtensionData, Message, UserSettings} from '../definitions';
 import {MessageType} from '../utils/message';
 import {makeChromiumHappy} from './make-chromium-happy';
-import DevTools from './devtools';
 import {logInfo} from './utils/log';
 import {sendLog} from './utils/sendLog';
 

--- a/src/background/newsmaker.ts
+++ b/src/background/newsmaker.ts
@@ -21,7 +21,7 @@ export default class Newsmaker {
     private static latest: News[];
     private static latestTimestamp: number | null;
 
-    constructor() {
+    public static init() {
         if (Newsmaker.initialized) {
             // This path is never taken since Extension.constructor() ever creates one instance.
             logWarn('Attempting to re-initialize Newsmaker. Doing nothing.');
@@ -42,7 +42,7 @@ export default class Newsmaker {
         IconManager.hideBadge();
     }
 
-    static async getLatest(): Promise<News[]> {
+    public static async getLatest(): Promise<News[]> {
         await Newsmaker.stateManager.loadState();
         return Newsmaker.latest;
     }
@@ -53,7 +53,7 @@ export default class Newsmaker {
         }
     };
 
-    static subscribe() {
+    public static subscribe() {
         if ((Newsmaker.latestTimestamp === null) || (Newsmaker.latestTimestamp + Newsmaker.UPDATE_INTERVAL < Date.now())) {
             Newsmaker.updateNews();
         }
@@ -61,7 +61,7 @@ export default class Newsmaker {
         chrome.alarms.create(Newsmaker.ALARM_NAME, {periodInMinutes: Newsmaker.UPDATE_INTERVAL});
     }
 
-    static unSubscribe() {
+    public static unSubscribe() {
         chrome.alarms.onAlarm.removeListener(Newsmaker.alarmListener);
         chrome.alarms.clear(Newsmaker.ALARM_NAME);
     }
@@ -129,7 +129,7 @@ export default class Newsmaker {
         }
     }
 
-    static async markAsRead(...ids: string[]) {
+    public static async markAsRead(...ids: string[]) {
         const readNews = await Newsmaker.getReadNews();
         const results = readNews.slice();
         let changed = false;
@@ -154,7 +154,7 @@ export default class Newsmaker {
         }
     }
 
-    static async markAsDisplayed(...ids: string[]) {
+    public static async markAsDisplayed(...ids: string[]) {
         const displayedNews = await Newsmaker.getDisplayedNews();
         const results = displayedNews.slice();
         let changed = false;
@@ -179,11 +179,11 @@ export default class Newsmaker {
         }
     }
 
-    static wasRead(id: string, readNews: string[]) {
+    public static wasRead(id: string, readNews: string[]) {
         return readNews.includes(id);
     }
 
-    static wasDisplayed(id: string, displayedNews: string[]) {
+    public static wasDisplayed(id: string, displayedNews: string[]) {
         return displayedNews.includes(id);
     }
 }

--- a/src/background/newsmaker.ts
+++ b/src/background/newsmaker.ts
@@ -190,11 +190,11 @@ export default class Newsmaker {
         }
     }
 
-    public static wasRead(id: string, readNews: string[]) {
+    private static wasRead(id: string, readNews: string[]) {
         return readNews.includes(id);
     }
 
-    public static wasDisplayed(id: string, displayedNews: string[]) {
+    private static wasDisplayed(id: string, displayedNews: string[]) {
         return displayedNews.includes(id);
     }
 }

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -53,10 +53,10 @@ export default class TabManager {
     private static timestamp = 0;
     private static readonly LOCAL_STORAGE_KEY = 'TabManager-state';
 
-    static init({getConnectionMessage, onColorSchemeChange, getTabMessage}: TabManagerOptions) {
-        this.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0}, logWarn);
-        this.tabs = {};
-        this.getTabMessage = getTabMessage;
+    public static init({getConnectionMessage, onColorSchemeChange, getTabMessage}: TabManagerOptions) {
+        TabManager.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0}, logWarn);
+        TabManager.tabs = {};
+        TabManager.getTabMessage = getTabMessage;
 
         chrome.runtime.onMessage.addListener(async (message: Message, sender, sendResponse) => {
             if (isFirefox && makeFirefoxHappy(message, sender, sendResponse)) {
@@ -65,7 +65,7 @@ export default class TabManager {
             switch (message.type) {
                 case MessageType.CS_FRAME_CONNECT: {
                     onColorSchemeChange(message.data.isDark);
-                    await this.stateManager.loadState();
+                    await TabManager.stateManager.loadState();
                     const reply = (tabURL: string, url: string, isTopFrame: boolean) => {
                         getConnectionMessage(tabURL, url, isTopFrame).then((message) => {
                             message && chrome.tabs.sendMessage<Message>(sender.tab!.id!, message, {frameId: sender.frameId});
@@ -96,10 +96,10 @@ export default class TabManager {
                     const {frameId} = sender;
                     const url = sender.url!;
 
-                    this.addFrame(tabId, frameId!, url, this.timestamp);
+                    TabManager.addFrame(tabId, frameId!, url, TabManager.timestamp);
 
                     reply(tabURL, url, frameId === 0);
-                    this.stateManager.saveState();
+                    TabManager.stateManager.saveState();
                     break;
                 }
                 case MessageType.CS_FRAME_FORGET:
@@ -107,37 +107,37 @@ export default class TabManager {
                         logWarn('Unexpected message', message, sender);
                         break;
                     }
-                    this.removeFrame(sender.tab!.id!, sender.frameId!);
+                    TabManager.removeFrame(sender.tab!.id!, sender.frameId!);
                     break;
                 case MessageType.CS_FRAME_FREEZE: {
-                    await this.stateManager.loadState();
-                    const info = this.tabs[sender.tab!.id!][sender.frameId!];
+                    await TabManager.stateManager.loadState();
+                    const info = TabManager.tabs[sender.tab!.id!][sender.frameId!];
                     info.state = DocumentState.FROZEN;
                     info.url = null;
-                    this.stateManager.saveState();
+                    TabManager.stateManager.saveState();
                     break;
                 }
                 case MessageType.CS_FRAME_RESUME: {
                     onColorSchemeChange(message.data.isDark);
-                    await this.stateManager.loadState();
+                    await TabManager.stateManager.loadState();
                     const tabId = sender.tab!.id!;
                     const tabURL = sender.tab!.url!;
                     const frameId = sender.frameId!;
                     const url = sender.url!;
-                    if (this.tabs[tabId][frameId].timestamp < this.timestamp) {
-                        const message = this.getTabMessage(tabURL, url, frameId === 0);
+                    if (TabManager.tabs[tabId][frameId].timestamp < TabManager.timestamp) {
+                        const message = TabManager.getTabMessage(tabURL, url, frameId === 0);
                         chrome.tabs.sendMessage<Message>(tabId, message, {frameId});
                     }
-                    this.tabs[sender.tab!.id!][sender.frameId!] = {
+                    TabManager.tabs[sender.tab!.id!][sender.frameId!] = {
                         url: sender.url,
                         state: DocumentState.ACTIVE,
-                        timestamp: this.timestamp,
+                        timestamp: TabManager.timestamp,
                     };
-                    this.stateManager.saveState();
+                    TabManager.stateManager.saveState();
                     break;
                 }
                 case MessageType.CS_DARK_THEME_DETECTED:
-                    this.tabs[sender.tab!.id!][sender.frameId!].darkThemeDetected = true;
+                    TabManager.tabs[sender.tab!.id!][sender.frameId!].darkThemeDetected = true;
                     break;
 
                 case MessageType.CS_FETCH: {
@@ -158,10 +158,10 @@ export default class TabManager {
                     }
                     try {
                         const {url, responseType, mimeType, origin} = message.data;
-                        if (!this.fileLoader) {
-                            this.fileLoader = createFileLoader();
+                        if (!TabManager.fileLoader) {
+                            TabManager.fileLoader = createFileLoader();
                         }
-                        const response = await this.fileLoader.get({url, responseType, mimeType, origin});
+                        const response = await TabManager.fileLoader.get({url, responseType, mimeType, origin});
                         sendResponse({data: response});
                     } catch (err) {
                         sendResponse({error: err && err.message ? err.message : err});
@@ -188,7 +188,7 @@ export default class TabManager {
                 }
 
                 case MessageType.UI_REQUEST_EXPORT_CSS: {
-                    const activeTab = await this.getActiveTab();
+                    const activeTab = await TabManager.getActiveTab();
                     chrome.tabs.sendMessage<Message>(activeTab.id!, {type: MessageType.BG_EXPORT_CSS}, {frameId: 0});
                     break;
                 }
@@ -198,7 +198,7 @@ export default class TabManager {
             }
         });
 
-        chrome.tabs.onRemoved.addListener(async (tabId) => this.removeFrame(tabId, 0));
+        chrome.tabs.onRemoved.addListener(async (tabId) => TabManager.removeFrame(tabId, 0));
     }
 
     private static async queryTabs(query: chrome.tabs.QueryInfo = {}) {
@@ -209,11 +209,11 @@ export default class TabManager {
 
     private static addFrame(tabId: number, frameId: number, url: string, timestamp: number) {
         let frames: {[frameId: number]: FrameInfo};
-        if (this.tabs[tabId]) {
-            frames = this.tabs[tabId];
+        if (TabManager.tabs[tabId]) {
+            frames = TabManager.tabs[tabId];
         } else {
             frames = {};
-            this.tabs[tabId] = frames;
+            TabManager.tabs[tabId] = frames;
         }
         frames[frameId] = {
             url,
@@ -223,26 +223,26 @@ export default class TabManager {
     }
 
     private static async removeFrame(tabId: number, frameId: number) {
-        await this.stateManager.loadState();
+        await TabManager.stateManager.loadState();
 
         if (frameId === 0) {
-            delete this.tabs[tabId];
+            delete TabManager.tabs[tabId];
         }
 
-        if (this.tabs[tabId] && this.tabs[tabId][frameId]) {
+        if (TabManager.tabs[tabId] && TabManager.tabs[tabId][frameId]) {
             // We need to use delete here because Object.entries()
             // in sendMessage() would enumerate undefined as well.
-            delete this.tabs[tabId][frameId];
+            delete TabManager.tabs[tabId][frameId];
         }
 
-        this.stateManager.saveState();
+        TabManager.stateManager.saveState();
     }
 
     private static async getTabURL(tab: chrome.tabs.Tab): Promise<string> {
         if (__CHROMIUM_MV3__) {
             try {
-                if (this.tabs[tab.id!] && this.tabs[tab.id!][0]) {
-                    return this.tabs[tab.id!][0].url || 'about:blank';
+                if (TabManager.tabs[tab.id!] && TabManager.tabs[tab.id!][0]) {
+                    return TabManager.tabs[tab.id!][0].url || 'about:blank';
                 }
                 return (await chrome.scripting.executeScript({
                     target: {
@@ -261,10 +261,10 @@ export default class TabManager {
         return tab.url || 'about:blank';
     }
 
-    static async updateContentScript(options: {runOnProtectedPages: boolean}) {
-        (await this.queryTabs())
+    public static async updateContentScript(options: {runOnProtectedPages: boolean}) {
+        (await TabManager.queryTabs())
             .filter((tab) => __CHROMIUM_MV3__ || options.runOnProtectedPages || canInjectScript(tab.url))
-            .filter((tab) => !Boolean(this.tabs[tab.id!]))
+            .filter((tab) => !Boolean(TabManager.tabs[tab.id!]))
             .forEach((tab) => {
                 if (!tab.discarded) {
                     if (__CHROMIUM_MV3__) {
@@ -287,7 +287,7 @@ export default class TabManager {
             });
     }
 
-    static async registerMailDisplayScript() {
+    public static async registerMailDisplayScript() {
         await (chrome as any).messageDisplayScripts.register({
             js: [
                 {file: '/inject/fallback.js'},
@@ -302,26 +302,26 @@ export default class TabManager {
     // has multiple tabs of the same website, every tab will receive the new message
     // and not just that tab as Dark Reader currently doesn't have per-tab operations,
     // this should be the expected behavior.
-    static async sendMessage(onlyUpdateActiveTab = false) {
-        this.timestamp++;
+    public static async sendMessage(onlyUpdateActiveTab = false) {
+        TabManager.timestamp++;
 
-        const activeTabHostname = onlyUpdateActiveTab ? getURLHostOrProtocol(await this.getActiveTabURL()) : null;
+        const activeTabHostname = onlyUpdateActiveTab ? getURLHostOrProtocol(await TabManager.getActiveTabURL()) : null;
 
-        (await this.queryTabs())
-            .filter((tab) => Boolean(this.tabs[tab.id!]))
+        (await TabManager.queryTabs())
+            .filter((tab) => Boolean(TabManager.tabs[tab.id!]))
             .forEach((tab) => {
-                const frames = this.tabs[tab.id!];
+                const frames = TabManager.tabs[tab.id!];
                 Object.entries(frames)
                     .filter(([, {state}]) => state === DocumentState.ACTIVE || state === DocumentState.PASSIVE)
                     .forEach(async ([id, {url}]) => {
                         const frameId = Number(id);
-                        const tabURL = await this.getTabURL(tab);
+                        const tabURL = await TabManager.getTabURL(tab);
                         // Check if hostname are equal when we only want to update active tab.
                         if (onlyUpdateActiveTab && getURLHostOrProtocol(tabURL) !== activeTabHostname) {
                             return;
                         }
 
-                        const message = this.getTabMessage(tabURL, url!, frameId === 0);
+                        const message = TabManager.getTabMessage(tabURL, url!, frameId === 0);
                         if (tab.active && frameId === 0) {
                             chrome.tabs.sendMessage<Message>(tab.id!, message, {frameId});
                         } else {
@@ -329,29 +329,29 @@ export default class TabManager {
                                 chrome.tabs.sendMessage<Message>(tab.id!, message, {frameId});
                             });
                         }
-                        if (this.tabs[tab.id!][frameId]) {
-                            this.tabs[tab.id!][frameId].timestamp = this.timestamp;
+                        if (TabManager.tabs[tab.id!][frameId]) {
+                            TabManager.tabs[tab.id!][frameId].timestamp = TabManager.timestamp;
                         }
                     });
             });
     }
 
-    static async canAccessActiveTab(): Promise<boolean> {
-        const tab = await this.getActiveTab();
-        return Boolean(this.tabs[tab.id!]);
+    public static async canAccessActiveTab(): Promise<boolean> {
+        const tab = await TabManager.getActiveTab();
+        return Boolean(TabManager.tabs[tab.id!]);
     }
 
-    static async isActiveTabDarkThemeDetected(): Promise<boolean | null> {
-        const tab = await this.getActiveTab();
-        return this.tabs[tab.id!] && this.tabs[tab.id!][0] && this.tabs[tab.id!][0].darkThemeDetected || null;
+    public static async isActiveTabDarkThemeDetected(): Promise<boolean | null> {
+        const tab = await TabManager.getActiveTab();
+        return TabManager.tabs[tab.id!] && TabManager.tabs[tab.id!][0] && TabManager.tabs[tab.id!][0].darkThemeDetected || null;
     }
 
-    static async getActiveTabURL() {
-        return this.getTabURL(await this.getActiveTab());
+    public static async getActiveTabURL() {
+        return TabManager.getTabURL(await TabManager.getActiveTab());
     }
 
-    static async getActiveTab() {
-        let tab = (await this.queryTabs({
+    public static async getActiveTab() {
+        let tab = (await TabManager.queryTabs({
             active: true,
             lastFocusedWindow: true,
             // Explicitly exclude Dark Reader's Dev Tools and other special windows from the query
@@ -360,7 +360,7 @@ export default class TabManager {
         if (!tab) {
             // When Dark Reader's DevTools are open, last focused window might be the DevTools window
             // so we lift this restriction and try again (with the best guess)
-            tab = (await this.queryTabs({
+            tab = (await TabManager.queryTabs({
                 active: true,
                 windowType: 'normal',
             }))[0];

--- a/src/background/user-storage.ts
+++ b/src/background/user-storage.ts
@@ -12,9 +12,9 @@ const SAVE_TIMEOUT = 1000;
 export default class UserStorage {
     private static loadBarrier: PromiseBarrier<UserSettings, void>;
     private static saveStorageBarrier: PromiseBarrier<void, void> | null;
-    static settings: Readonly<UserSettings>;
+    public static settings: Readonly<UserSettings>;
 
-    static async loadSettings() {
+    public static async loadSettings() {
         if (!UserStorage.settings) {
             UserStorage.settings = await UserStorage.loadSettingsFromStorage();
         }
@@ -99,7 +99,7 @@ export default class UserStorage {
         return $sync;
     }
 
-    static async saveSettings() {
+    public static async saveSettings() {
         if (!UserStorage.settings) {
             // This path is never taken because Extension always calls UserStorage.loadSettings()
             // before calling UserStorage.saveSettings().
@@ -109,7 +109,7 @@ export default class UserStorage {
         await UserStorage.saveSettingsIntoStorage();
     }
 
-    static async saveSyncSetting(sync: boolean) {
+    public static async saveSyncSetting(sync: boolean) {
         const obj = {syncSettings: sync};
         await writeLocalStorage(obj);
         try {
@@ -145,7 +145,7 @@ export default class UserStorage {
         UserStorage.saveStorageBarrier = null;
     });
 
-    static set($settings: Partial<UserSettings>) {
+    public static set($settings: Partial<UserSettings>) {
         if (!UserStorage.settings) {
             // This path is never taken because Extension always calls UserStorage.loadSettings()
             // before calling UserStorage.set().

--- a/src/background/utils/network.ts
+++ b/src/background/utils/network.ts
@@ -100,11 +100,11 @@ class LimitedCacheStorage {
         }
     }
 
-    has(url: string) {
+    public has(url: string) {
         return this.records.has(url);
     }
 
-    get(url: string) {
+    public get(url: string) {
         if (this.records.has(url)) {
             const record = this.records.get(url)!;
             record.expires = Date.now() + LimitedCacheStorage.TTL;
@@ -115,7 +115,7 @@ class LimitedCacheStorage {
         return null;
     }
 
-    set(url: string, value: string) {
+    public set(url: string, value: string) {
         LimitedCacheStorage.ensureAlarmIsScheduled();
 
         const size = getStringSize(value);

--- a/src/background/utils/sendLog.ts
+++ b/src/background/utils/sendLog.ts
@@ -7,9 +7,10 @@ function createSocket() {
     if (socket) {
         return;
     }
-    socket = new WebSocket(`ws://localhost:${9000}`);
-    socket.addEventListener('open', () => {
-        messageQueue.forEach((message) => this.send(message));
+    const newSocket = new WebSocket(`ws://localhost:${9000}`);
+    socket = newSocket;
+    newSocket.addEventListener('open', () => {
+        messageQueue.forEach((message) => newSocket.send(message));
         messageQueue = [];
     });
 }

--- a/src/utils/async-queue.ts
+++ b/src/utils/async-queue.ts
@@ -29,7 +29,7 @@ export default class AsyncQueue {
         this.timerId = requestAnimationFrame(() => {
             this.timerId = null;
             const start = Date.now();
-            let cb: (() => void) | undefined;
+            let cb: QueueEntry | undefined;
             while ((cb = this.queue.shift())) {
                 cb();
                 if (Date.now() - start >= this.frameDuration) {

--- a/src/utils/async-queue.ts
+++ b/src/utils/async-queue.ts
@@ -8,12 +8,12 @@ export default class AsyncQueue {
     private timerId: number | null = null;
     private frameDuration = 1000 / 60;
 
-    addToQueue(entry: QueueEntry) {
+    public addToQueue(entry: QueueEntry) {
         this.queue.push(entry);
         this.startQueue();
     }
 
-    stopQueue() {
+    public stopQueue() {
         if (this.timerId !== null) {
             cancelAnimationFrame(this.timerId);
             this.timerId = null;


### PR DESCRIPTION
1. replace `this` with actual class names. Safari struggles with combination of `this` and `static` keywords. We can either remove `static` annotation or use the direct class name.
2. Add `public` to member names for clarity