### PR TITLE
Fix for astro.build

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1780,6 +1780,18 @@ h2[style*="color:var(--color-font-header)"] {
 
 ================================
 
+astro.build
+
+CSS
+hero-card .card {
+    --darkreader-bg--tw-gradient-stops:
+      var(--darkreader-bg--tw-gradient-from),
+      var(--darkreader-neutral-background),
+      var(--darkreader-bg--tw-gradient-to);
+}
+
+================================
+
 asus.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1784,11 +1784,11 @@ astro.build
 
 CSS
 hero-card .card {
-    --darkreader-bg--tw-gradient-stops:
-      var(--darkreader-bg--tw-gradient-from),
-      var(--darkreader-neutral-background),
-      var(--darkreader-bg--tw-gradient-to);
+    --darkreader-bg--tw-gradient-stops: var(--darkreader-bg--tw-gradient-from), var(--darkreader-neutral-background), var(--darkreader-bg--tw-gradient-to) !important;
 }
+
+IGNORE INLINE STYLE
+#navlogo svg path
 
 ================================
 


### PR DESCRIPTION
Fixes logo and gradient for the hero card for [astro.build](https://astro.build/).

![astro build_ (5)](https://user-images.githubusercontent.com/16837066/215867703-79bc0e78-1e8f-48f4-80dc-e8c517c223e2.png)
![astro build_ (4)](https://user-images.githubusercontent.com/16837066/215867726-fafdb028-3a14-4314-96db-4c411968d8a5.png)

