### PR TITLE
Fixes for uottawa.brightspace.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21293,6 +21293,44 @@ CSS
 
 ================================
 
+uottawa.brightspace.com
+
+INVERT
+.d2l-navigation-link-image-container
+
+CSS
+:host {
+    --d2l-button-icon-background-color-hover: var(--darkreader-bg--d2l-color-gypsum) !important;
+}
+d2l-card {
+    background: var(--darkreader-neutral-background) !important;
+    border-color: var(--darkreader-border--d2l-color-gypsum) !important;
+}
+d2l-dropdown-content > div,
+d2l-menu-item {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-radius: 10px !important;
+}
+d2l-empty-state-simple {
+    border-color: var(--darkreader-border--d2l-color-mica) !important;
+}
+.d2l-button-filter > ul > li > a.vui-button {
+    border-color: var(--darkreader-border--d2l-color-mica) !important;
+}
+.d2l-label-text:has(.d2l-button-subtle-content):hover,
+.d2l-label-text:has(.d2l-button-subtle-content):focus,
+.d2l-label-text:has(.d2l-button-subtle-content):active {
+    background-color: var(--darkreader-bg--d2l-color-gypsum) !important;
+}
+.d2l-navigation-centerer {
+    color: inherit !important;
+}
+.d2l-tabs-layout {
+    border-color: var(--darkreader-border--d2l-color-gypsum) !important;
+}
+
+================================
+
 ups.com
 
 CSS


### PR DESCRIPTION
- Fixed uOttawa logo on homepage
    - (amended) ~~Used filter in CSS instead of INVERT because the changes should only apply when dark~~ Just used normal INVERT as requested
- Fixed dropdown backgrounds
- Fixed course section cards on homepage
- Fixed borders on some buttons and headers
- Fixed certain button backgrounds on hover/focus