### PR TITLE
Fix for derStandard.at

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5287,6 +5287,27 @@ body {
 
 ================================
 
+derStandard.at
+
+CSS
+:root {
+    --theme-background: var(--darkreader-bg--theme-background) !important;
+    --theme-sidebar: var(--darkreader-bg--theme-sidebar) !important;
+    --theme--primary: var(--darkreader-bg--theme--primary) !important;
+    --theme--secondary: var(--darkreader-bg--theme--secondary) !important;
+    --theme--secondary: var(--darkreader-bg--theme--secondary) !important;
+    --theme--on-secondary: none !important;
+    --theme--surface-2dp: var(--darkreader-bg--theme--surface-2dp) !important;
+    --theme--on-surface: var(--darkreader-text--theme--on-surface) !important;
+    --theme--on-base: var(--darkreader-text--theme--on-base) !important;
+    --theme--on-base--hls: var(--darkreader-text--theme--on-base--hls) !important;
+    --theme--surface-2dp-border: var(--darkreader-text--theme--surface-2dp-border) !important;
+    --mut-header-compact-desktop-base: var(--darkreader-neutral-background) !important;
+    --darkreader-bg--mut-header-compact-desktop-base: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 designobserver.com
 
 INVERT


### PR DESCRIPTION
This is an Austrian newspaper that uses many colors on their homepage. Fixed sidebar, several versions of title bars, some buttons, pop-ups, etc.