### PR TITLE
Fix for kaava.mafynetti.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11115,6 +11115,10 @@ CSS
 .rich-text-editor img[src*="/math.svg"] {
     background-color: white !important;
 }
+.rich-text-editor-toolbar-equation {
+background-color: white;
+color: white;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11109,6 +11109,21 @@ CSS
 
 ================================
 
+kaava.mafynetti.fi
+
+CSS
+.rich-text-editor img[src*="/math.svg"] {
+    background-color: white;
+}
+.rich-text-editor:focus img[src*="/math.svg"] {
+    background-color: white; 
+}
+.rich-text-editor.rich-text-focused img[src*="/math.svg"] {
+    background-color: white;
+}
+
+================================
+
 kaggle.com
 kaggleusercontent.com
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11113,13 +11113,7 @@ kaava.mafynetti.fi
 
 CSS
 .rich-text-editor img[src*="/math.svg"] {
-    background-color: white;
-}
-.rich-text-editor:focus img[src*="/math.svg"] {
-    background-color: white; 
-}
-.rich-text-editor.rich-text-focused img[src*="/math.svg"] {
-    background-color: white;
+    background-color: white !important;
 }
 
 ================================


### PR DESCRIPTION
Fix for a math input site used in almost every finnish high school. 

Fixed so that you can see the text on the math input images, as it was black on a really dark background before which made this extension unusable on this website. It was the first time I tried changing anything on a website, and I didn't manage to change the color of the text in the image, so I managed to change the background in the images instead. 

Someone else could probably do this a lot better than me, but I don't think that is going to happen and this is much better than completely unusable :D

Screenshot of what it looked like before:
![image](https://user-images.githubusercontent.com/44492823/217834713-430503df-b487-4f67-840a-789e148be2a3.png)

Screenshot of what it looks like now:
![image](https://user-images.githubusercontent.com/44492823/217834955-ce87f38a-caec-4a42-8ed6-43ed76b993d5.png)

This is also my first time using GitHub so give me some slack :)