### PR TITLE
Fix for all mathbooks on digi.sets.fi

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5624,6 +5624,36 @@ CSS
 
 ================================
 
+digi.sets.fi/makortrep/ma-kort-repetition-1/
+digi.sets.fi/ma8kort/
+digi.sets.fi/ma7kort/
+digi.sets.fi/ma6kort/
+digi.sets.fi/ma5kort/
+digi.sets.fi/ma4kort/
+digi.sets.fi/ma3kort/
+digi.sets.fi/ma2kort/
+digi.sets.fi/ma1kort/
+digi.sets.fi/ma13lang/
+digi.sets.fi/ma12lang/
+digi.sets.fi/ma11lang/
+digi.sets.fi/ma10lang/
+digi.sets.fi/ma9lang/
+digi.sets.fi/ma8lang/
+digi.sets.fi/ma7lang/
+digi.sets.fi/ma6lang/
+digi.sets.fi/ma5lang/
+digi.sets.fi/ma4lang/
+digi.sets.fi/ma3lang/
+digi.sets.fi/ma2lang/
+digi.sets.fi/ma1lang/
+
+CSS
+.bi {
+    filter: invert(0.936);
+}
+
+================================
+
 disconnect.me
 
 INVERT


### PR DESCRIPTION
The pictures that covered almost the whole page werent being inverted at all and made the bright text above them really hard to read so I inverted them the exact amount so that it blends into the background.

Before:
![image](https://user-images.githubusercontent.com/44492823/217850901-020a5bb5-3771-41c3-a3e4-ce04ebf4c517.png)

After:
![image](https://user-images.githubusercontent.com/44492823/217850730-33993dbf-fa1a-4c36-805a-8ad3c14a0627.png)

This could probably also be done better, but it's better than being completely unusable :)