### PR TITLE
Refactor: specify namespace for NodeJS modules

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -12,11 +12,11 @@ import codeStyle from './code-style.js';
 import zip from './zip.js';
 import {runTasks} from './task.js';
 import {log} from './utils.js';
-import {fork} from 'child_process';
+import {fork} from 'node:child_process';
 import paths from './paths.js';
 const {PLATFORM} = paths;
 
-import {fileURLToPath} from 'url';
+import {fileURLToPath} from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 
 const standardTask = [

--- a/tasks/bundle-api.js
+++ b/tasks/bundle-api.js
@@ -6,8 +6,8 @@ import rollupPluginReplace from '@rollup/plugin-replace';
 /** @type {any} */
 import rollupPluginTypescript from '@rollup/plugin-typescript';
 import typescript from 'typescript';
-import fs from 'fs';
-import os from 'os';
+import fs from 'node:fs';
+import os from 'node:os';
 import {createTask} from './task.js';
 import paths from './paths.js';
 const {rootDir, rootPath} = paths;

--- a/tasks/bundle-css.js
+++ b/tasks/bundle-css.js
@@ -1,6 +1,6 @@
 // @ts-check
 import less from 'less';
-import path from 'path';
+import path from 'node:path';
 import paths from './paths.js';
 import * as reload from './reload.js';
 import {createTask} from './task.js';

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -1,6 +1,6 @@
 // @ts-check
-import fs from 'fs';
-import os from 'os';
+import fs from 'node:fs';
+import os from 'node:os';
 import * as rollup from 'rollup';
 import rollupPluginNodeResolve from '@rollup/plugin-node-resolve';
 /** @type {any} */

--- a/tasks/bundle-locales.js
+++ b/tasks/bundle-locales.js
@@ -1,6 +1,6 @@
 // @ts-check
-import fs from 'fs/promises';
-import path from 'path';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import paths from './paths.js';
 import * as reload from './reload.js';
 import {createTask} from './task.js';

--- a/tasks/check-exists.js
+++ b/tasks/check-exists.js
@@ -1,6 +1,6 @@
 // @ts-check
-import {existsSync} from 'fs';
-import {fileURLToPath} from 'url';
+import {existsSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 

--- a/tasks/log.js
+++ b/tasks/log.js
@@ -1,4 +1,4 @@
-import {createWriteStream} from 'fs';
+import {createWriteStream} from 'node:fs';
 import {WebSocketServer} from 'ws';
 import {createTask} from './task.js';
 import {log} from './utils.js';

--- a/tasks/paths.js
+++ b/tasks/paths.js
@@ -1,5 +1,5 @@
-import {dirname, join} from 'path';
-import {createRequire} from 'module';
+import {dirname, join} from 'node:path';
+import {createRequire} from 'node:module';
 const rootDir = dirname(createRequire(import.meta.url).resolve('../package.json'));
 const rootPath = (...paths) => join(rootDir, ...paths);
 

--- a/tasks/translate.js
+++ b/tasks/translate.js
@@ -1,5 +1,5 @@
 // @ts-check
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import {readFile, writeFile, httpsRequest, timeout, log} from './utils.js';
 
 // To use this tool:

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -1,7 +1,7 @@
 // @ts-check
-import fs from 'fs/promises';
-import https from 'https';
-import path from 'path';
+import fs from 'node:fs/promises';
+import https from 'node:https';
+import path from 'node:path';
 
 /** @type {{[color: string]: (text: string) => string}} */
 const colors = Object.entries({

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -1,6 +1,6 @@
 // @ts-check
-import fs from 'fs';
-import {exec} from 'child_process';
+import fs from 'node:fs';
+import {exec} from 'node:child_process';
 import yazl from 'yazl';
 import paths from './paths.js';
 import {createTask} from './task.js';


### PR DESCRIPTION
I'm experimenting with supporting Deno runtime as an alternative to NodeJS. This makes imports of NodeJS standard functions a bit simpler (requires Deno 1.30.x and higher).