### PR TITLE
Fix for gorod.gov.spb.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9381,6 +9381,7 @@ INVERT
 .map-with-address
 .problem-details__map
 .problem-map-page__map
+.evtmap canvas
 
 ================================
 


### PR DESCRIPTION
- Invert map.

Example of page: https://gorod.gov.spb.ru/maps/stats/