### PR TITLE
pixilart.com gallery images fix and logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16038,6 +16038,24 @@ body {
 
 ================================
 
+pixilart.com
+
+CSS
+.dark-mode-visible {
+    display: inline-block;
+}
+.light-mode-visible {
+    display: none;
+}
+.navbar-nav > .nav-item > .navbar-brand > img {
+    content: url("/images/public/logo_pixilart_simple_white.png?v=1.1");
+}
+
+IGNORE IMAGE ANALYSIS
+#image-art-modal
+
+================================
+
 pixiv.net
 
 CSS


### PR DESCRIPTION
Reverting image inversion of gallery images. In some cases one can hide their "light mode" logo and replace it with their in-built "dark-mode" one. In other cases (the homepage) there does not exist a second element to swap to. Instead I change the src to point to the "dark mode" image they host.