### PR TITLE
Build: support Deno runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ coverage/
 # V8 Profiler logs
 #-----------------------------------
 isolate-*-v8.log
+
+# Deno
+#-----------------------------------
+deno.lock
+deno.json

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Read more about contributing to Dark Reader in [CONTRIBUTING.md](https://github.
 
 ## Building for use
 
+Dark Reader build script requires a JavaScript runtime, either NodeJS or Deno. We recommend using NodeJS, Deno support is experimental.
+
+### Building with NodeJS
+
 You can install the extension from a file.
 Install [Node.js](https://nodejs.org/) (we recommend LTS or higher, but any version at or above 15 will work). Download the source code (or check out from git).
 Open the terminal in the root folder and run:
@@ -30,6 +34,12 @@ Open the terminal in the root folder and run:
 This will create a `build/release/darkreader-chrome.zip` file for use in a Chromium-based browser and a `build/release/darkreader-firefox.xpi` file for use in Firefox.
 
 You can customize build process by passing flags to build script. To see all flags, run `npm run build -- --help`.
+
+### Building with Deno
+
+You can build Dark Reader with alternative runtime called [Deno](https://deno.land/). For this run `deno:bootstrap` script (e.g., via `npm run deno:bootstrap` or manually copy the command from `package.json`). Then run the same commands described above.
+
+Please note that if you encounter error `Too many open files (os error 24)`, then you should use the newer version of Deno (preferably built from source or canary).
 
 ## Using Dark Reader for a website
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:unit": "jest --config=tests/unit/jest.config.mjs",
     "test:unit:debug": "node --inspect-brk ./node_modules/jest/bin/jest --config=tests/unit/jest.config.mjs --runInBand --no-cache --watch",
     "test:update-snapshots": "npm run test -- --updateSnapshot && npm run test:project -- --updateSnapshot",
-    "translate-line": "node ./tasks/translate.js --line"
+    "translate-line": "node ./tasks/translate.js --line",
+    "deno:bootstrap": "deno run --allow-read=./ --allow-sys=uid --allow-write=deno.json tasks/deno.js"
   },
   "main": "darkreader.js",
   "repository": {

--- a/tasks/bundle-manifest.js
+++ b/tasks/bundle-manifest.js
@@ -2,20 +2,10 @@
 import path from './paths.js';
 import * as reload from './reload.js';
 import {createTask} from './task.js';
-import {readFile, writeFile} from './utils.js';
+import {readJSON, writeJSON} from './utils.js';
 const {PLATFORM, getDestDir} = path;
 
 const srcDir = 'src';
-
-async function readJSON(path) {
-    const file = await readFile(path);
-    return JSON.parse(file);
-}
-
-async function writeJSON(path, json) {
-    const content = JSON.stringify(json, null, 4);
-    return await writeFile(path, content);
-}
 
 async function patchManifest(platform, debug, watch, test) {
     const manifest = await readJSON(`${srcDir}/manifest.json`);

--- a/tasks/deno.js
+++ b/tasks/deno.js
@@ -1,0 +1,47 @@
+import {readJSON, writeJSON} from './utils.js';
+import {resolve} from 'node:path';
+
+function resolvePath(path) {
+    return resolve(import.meta.url.replace('file:/', ''), '../../', path);
+}
+
+function createImports(dependencies) {
+    const imports = {};
+    for (const name in dependencies) {
+        imports[name] = `npm:${name}@${dependencies[name]}`;
+    }
+    return imports;
+}
+
+function createTasks(scripts) {
+    const tasks = {};
+    for (const name in scripts) {
+        const command = scripts[name];
+        tasks[name] = command
+            .replace('--max-old-space-size=3072', '')
+            .replace('node ', 'deno run -A ')
+            .replaceAll('npm run ', 'deno task ');
+    }
+    return tasks;
+}
+
+async function writeDenoJSON() {
+    const packageJSON = resolvePath('package.json');
+    const denoJSON = await resolvePath('deno.json');
+    const pkg = await readJSON(packageJSON);
+
+    if (pkg.dependencies) {
+        console.error('TODO: support dependencies key in createImports()');
+    }
+    const imports = createImports(pkg.devDependencies);
+
+    const tasks = createTasks(pkg.scripts);
+
+    writeJSON(denoJSON, {imports, tasks});
+}
+
+async function main() {
+    await writeDenoJSON();
+}
+
+main();

--- a/tasks/log.js
+++ b/tasks/log.js
@@ -1,4 +1,5 @@
 import {createWriteStream} from 'node:fs';
+import process from 'node:process';
 import {WebSocketServer} from 'ws';
 import {createTask} from './task.js';
 import {log} from './utils.js';

--- a/tasks/reload.js
+++ b/tasks/reload.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import {WebSocketServer} from 'ws';
 import {log} from './utils.js';
 

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -93,6 +93,25 @@ export async function writeFile(dest, content) {
 }
 
 /**
+ * @param {string} path
+ * @returns {Promise<Object>}
+ */
+export async function readJSON(path) {
+    const file = await readFile(path);
+    return JSON.parse(file);
+}
+
+/**
+ * @param {string} dest
+ * @param {string} content
+ * @returns {Promise<void>}
+ */
+export async function writeJSON(dest, content) {
+    const string = JSON.stringify(content, null, 4);
+    return await writeFile(dest, string);
+}
+
+/**
  * @param {string | string[]} patterns
  * @returns {Promise<string[]>}
  */


### PR DESCRIPTION
## What
[Deno](https://deno.land/) is an alternative runtime to NodeJS created by Ryan Dahl as a follow-up to NodeJS. If you haven't seen 2018 presentation called ["10 things I regret about Node"](https://www.youtube.com/watch?v=M3BM9TB-8yA) ([slides](https://tinyclouds.org/jsconf2018.pdf)) I recommend watching it. Deno is essentially NodeJS but with a reasonable permission system, simpler error handling, and written in Rust instead of C++.

Deno might one day become a drop-in replacement for NodeJS, but right now it requires some adjustments. This PR provides these adjustments: adds `deno.json` and removes reliance on `module`. Also, I'm looking into Deno's limit on the number of watched files. 

## Motivation
### Reproducible builds
Supporting Deno would allow us to advance reproducible builds (two runtimes instead of one!).
### Side-by-side debugging
I noticed that NodeJS occasionally had bugs which were nearly impossible to diagnose. If we have two different runtimes, we will have twice the number of bugs!

## This is still WIP
This works with a slightly modified version of Deno. If anyone is interested, I can provide the details, patch, and build instructions.