### PR TITLE
Fix for warframe.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22080,6 +22080,9 @@ CSS
 
 warframe.com
 
+INVERT
+.HeaderNavigationBar-logo
+
 CSS
 .wrapper {
     background-image: none !important;


### PR DESCRIPTION
Invert logo.

Before:
<img width="209" alt="Screenshot_20230216_052259" src="https://user-images.githubusercontent.com/1006477/219261064-d35e87da-d012-4211-8fc5-98687bde45e7.png">

After:
<img width="209" alt="Screenshot_20230216_052307" src="https://user-images.githubusercontent.com/1006477/219261081-956ac11c-1982-4d3c-9bc6-f89df880080c.png">
