### PR TITLE
Fix isitdownrightnow.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10774,6 +10774,52 @@ div.grey-gui-bg,
 
 ================================
 
+isitdownrightnow.com
+
+CSS
+.ts1,
+.ts2,
+.ts3,
+.ts4,
+.ts5,
+.ts6,
+.ts7,
+.ts8,
+.ts9,
+.ts10,
+.ts11,
+.ts12,
+.ts13,
+.ts14,
+.ts15,
+.ts16,
+.ts17,
+.ts18,
+.ts19,
+.ts20,
+.ts21,
+.ts22,
+.ts23,
+.ts24,
+.ts25,
+.ts26,
+.ts27,
+.ts28,
+.ts29,
+.ts30,
+.ts31,
+.ts32,
+.ts33,
+.ts34,
+.ts35,
+.ts36,
+.ts37,
+.ts38 {
+    background-image: none !important;
+}
+
+================================
+
 istanbulfm.com.tr
 
 CSS


### PR DESCRIPTION
Removes the additional gray boxes to the left of each host name.

Kept code formatting consistent, for better or worse.