### PR TITLE
Add banfeed.com to global dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -71,6 +71,7 @@ avengedsevenfold.com
 axyl-os.github.io
 azeria-labs.com
 badboybill.com
+banfeed.com
 based.cooking
 battle.net
 battlelog.battlefield.com


### PR DESCRIPTION
I am the owner of banfeed.com. 
By default, the website uses your system theme to determine if it should default to dark mode. The dark mode is consistent through the entire site.