### PR TITLE
Fixes login QR Code on web.whatsapp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22236,6 +22236,14 @@ CSS
 
 ================================
 
+web.whatsapp.com
+
+CSS
+#app ._2I5ox {
+    border: 15px solid white !important;
+}
+================================
+
 webaim.org
 
 CSS


### PR DESCRIPTION
The QR code reader on the Android Whatsapp app requires the QR code to have a small white border.