### PR TITLE
Chore: update license copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Dark Reader Ltd.
+Copyright (c) 2023 Dark Reader Ltd.
 
 All rights reserved.
 


### PR DESCRIPTION
It is 2023 already, so let's update the year.

Also, we might not need to include the year at all and just write "Copyright (c) Dark Reader Ltd.", but that's for future discussion.