### PR TITLE
Fix colasoft.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4353,6 +4353,13 @@ svg[class^="desktop-navigationstyles__StyledLogo"]
 
 ================================
 
+colasoft.com
+
+INVERT
+img[alt="Colasoft"]
+
+================================
+
 color-hex.com
 
 INVERT


### PR DESCRIPTION
Fixes logo/link in upper-left corner

Example URL:
https://www.colasoft.com/capsa-free/