### PR TITLE
Add 1 site to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -557,6 +557,7 @@ nitter.net
 nitter.nixnet.services
 nitter.pussthecat.org
 nitter.snopyta.org
+obscuremail.org
 nomanssky.com
 northward.info
 nostv.pt


### PR DESCRIPTION
Add obscuremail.org to the global dark list