### PR TITLE
Fix border colors for developer.android.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5412,9 +5412,29 @@ devsite-search .devsite-searchbox::before {
 .devsite-wrapper,
 button {
     background-color: inherit !important;
+    border-color: rgba(255, 255, 255, 0.1) !important;
+}
+devsite-header .devsite-top-logo-row-wrapper-wrapper,
+.devsite-article {
+    border-color: rgba(255, 255, 255, 0.05) !important;
 }
 code {
     background-color: rgba(255, 255, 255, 0.05) !important;
+    border-color: rgba(255, 255, 255, 0.1) !important;
+}
+[role="menu"],
+devsite-book-nav .devsite-book-nav-filter,
+.devsite-nav-accordion,
+tr,
+devsite-code,
+devsite-selector,
+devsite-selector devsite-tabs[connected],
+devsite-recommendations,
+devsite-footer-promos .devsite-footer-promos-list,
+devsite-footer-utility .devsite-footer-sites,
+devsite-footer-linkboxes .devsite-footer-linkboxes-list,
+devsite-footer-promos {
+    border-color: rgba(255, 255, 255, 0.1) !important;
 }
 .devsite-breadcrumb-list {
     background: none !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5418,14 +5418,11 @@ devsite-header .devsite-top-logo-row-wrapper-wrapper,
 .devsite-article {
     border-color: rgba(255, 255, 255, 0.05) !important;
 }
-code {
-    background-color: rgba(255, 255, 255, 0.05) !important;
-    border-color: rgba(255, 255, 255, 0.1) !important;
-}
 [role="menu"],
 devsite-book-nav .devsite-book-nav-filter,
 .devsite-nav-accordion,
 tr,
+code,
 devsite-code,
 devsite-selector,
 devsite-selector devsite-tabs[connected],

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5419,6 +5419,7 @@ devsite-header .devsite-top-logo-row-wrapper-wrapper,
     border-color: rgba(255, 255, 255, 0.05) !important;
 }
 [role="menu"],
+.toggle-button,
 devsite-book-nav .devsite-book-nav-filter,
 .devsite-nav-accordion,
 tr,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5431,6 +5431,7 @@ devsite-recommendations,
 devsite-footer-promos .devsite-footer-promos-list,
 devsite-footer-utility .devsite-footer-sites,
 devsite-footer-linkboxes .devsite-footer-linkboxes-list,
+devsite-playlist .devsite-playlist--section-quiz,
 devsite-footer-promos {
     border-color: rgba(255, 255, 255, 0.1) !important;
 }


### PR DESCRIPTION
Fixes the white borders around various UI elements in the docs.

Example page for comparison of before/after: https://developer.android.com/guide/topics/resources/providing-resources