### PR TITLE
Update fix for myanimelist.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9895,7 +9895,7 @@ INVERT
 .box img
 
 CSS
-#box,.box {                                                                                                                                                                                                                                                                                                                       
+#box,.box {
     background-color: var(--darkreader-neutral-background) !important;
 }
 h2 {
@@ -14173,6 +14173,10 @@ CSS
 ================================
 
 myanimelist.net
+
+INVERT
+.link-provider img
+.theme-songs td[width="8%"]:first-child
 
 CSS
 body:not(.ownlist) {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9895,7 +9895,7 @@ INVERT
 .box img
 
 CSS
-#box,.box {
+#box,.box {                                                                                                                                                                                                                                                                                                                       
     background-color: var(--darkreader-neutral-background) !important;
 }
 h2 {


### PR DESCRIPTION
About each image, from top to bottom, it is the screenshot when DR is disable, when DR is enable, dark scheme with the fix, and light scheme with the fix.

For https://myanimelist.net/anime/40938/Hige_wo_Soru_Soshite_Joshikousei_wo_Hirou:

- "Play in circle" button `.theme-songs td[width="8%"]:first-child`.
I would like to keep the attribute `filter: opacity(9%);` of the inner element `.oped-preview-button-gray`.
![ảnh](https://user-images.githubusercontent.com/2577653/228921563-4cdcb821-2398-4468-8f93-fea32a865e5a.png)

For https://myanimelist.net/anime/40938/Hige_wo_Soru_Soshite_Joshikousei_wo_Hirou/video:

- "Provided by Crunchyroll" image link `.link-provider img`.
![ảnh](https://user-images.githubusercontent.com/2577653/228922214-add4dfd9-8caa-4c47-a03c-c2c915bf3882.png)
