### PR TITLE
Fix Norton SafeWeb

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17761,6 +17761,13 @@ INVERT
 
 ================================
 
+safeweb.norton.com
+
+INVERT
+.logo img
+
+================================
+
 saladelcembalo.org
 
 INVERT


### PR DESCRIPTION
Logo/link in upper-left corner.

Example URL:
https://safeweb.norton.com