### PR TITLE
Fix sitecheck.sucuri.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18468,6 +18468,14 @@ INVERT
 
 ================================
 
+sitecheck.sucuri.net
+
+INVERT
+.icon
+.logo
+
+================================
+
 sklepbiegacza.pl
 
 INVERT


### PR DESCRIPTION
Fixes:

1. Icons throughout page
2. Logo/link in upper-left corner

Example url:
https://sitecheck.sucuri.net