### PR TITLE
Improve dynamic dark theme on read.amazon.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17044,6 +17044,11 @@ INVERT
 .header_bar_button
 #kindleReader_content
 .kg-full-page-img
+.side-menu-close
+.fixed-book-title
+ion-menu
+ion-header
+ion-title
 
 CSS
 .kr-renderer-container,


### PR DESCRIPTION
Currently, the sidebar menu and top menus show up in light mode. More inverted elements in this PR should fix this.

![New look for the site](https://user-images.githubusercontent.com/31703249/221978568-7d2f5427-18f8-4e93-8a5d-4519de4536f9.png)
