### PR TITLE
fix app/shortcuts active tab detection

### DIFF
--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -358,12 +358,25 @@ export default class TabManager {
             windowType: 'normal',
         }))[0];
         if (!tab) {
+            tab = (await TabManager.queryTabs({
+                active: true,
+                lastFocusedWindow: true,
+                windowType: 'app',
+            }))[0];
+        }
+        if (!tab) {
             // When Dark Reader's DevTools are open, last focused window might be the DevTools window
             // so we lift this restriction and try again (with the best guess)
             tab = (await TabManager.queryTabs({
                 active: true,
                 windowType: 'normal',
             }))[0];
+            if (!tab) {
+                tab = (await TabManager.queryTabs({
+                    active: true,
+                    windowType: 'app',
+                }))[0];
+            }
             logWarn('TabManager.getActiveTab() could not reliably find the active tab, picking the best guess', tab);
         }
         return tab;


### PR DESCRIPTION
You can't use more than one value for the windowType property.

You can use multiple values with chrome.windows.getAll() though

Might be able to make that work somehow, maybe it'll make this a bit cleaner.