### PR TITLE
Restore Twitch chat's mention highlighting

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21314,6 +21314,8 @@ twitch.tv
 INVERT
 .volume-slider__slider-container
 .seekbar-bar
+.mention-fragment--recipient
+.reply-line--mentioned
 
 CSS
 .seekbar-segment {


### PR DESCRIPTION
When using Twitch chat, a message fragment containing your username will be highlighted whenever another user mentions or replies you. Using dark reader, this highlight blends in with the chat background. This pull request will restore that functionality.