### PR TITLE
Fix for namecheap.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14312,6 +14312,13 @@ INVERT
 
 ================================
 
+namecheap.com
+
+INVERT
+.whoisguard-img
+
+================================
+
 naps2.com
 
 CSS


### PR DESCRIPTION
Invert whois guard logo on domain management page.

Before:
![Screenshot_20230310_051533](https://user-images.githubusercontent.com/1006477/224214501-ca7a0d0a-84cc-4622-a5bb-31920b12b40d.png)

After:
![Screenshot_20230310_051601](https://user-images.githubusercontent.com/1006477/224214516-ae546112-553f-41f5-afb2-638b95f7cff3.png)
