### PR TITLE
Fix for source.android.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5408,6 +5408,7 @@ h4, h5, h6, a,
 ================================
 
 developer.android.com
+source.android.com
 developer.android.google.cn
 tensorflow.org
 quantumai.google


### PR DESCRIPTION
They share the same code as the rest, so we can just add the domain