### PR TITLE
added fixes for antagning.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1192,6 +1192,17 @@ header.section-header div.shard:before
 
 ================================
 
+antagning.se
+
+INVERT
+.a-logo
+.burger
+.uhrlogo
+.expand-icon
+.favourite-active
+
+================================
+
 antistorm.eu
 
 INVERT


### PR DESCRIPTION
antagning.se is Sweden's website for university applications, where all the universities in Sweden collect their programs and courses. Some buttons were not displaying correctly.