### PR TITLE
fix rollup typescript2 race condition

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -48,6 +48,7 @@ async function build({platforms, debug, watch, log: logging, test}) {
             log.ok('MISSION PASSED! RESPECT +');
         }
     } catch (err) {
+        console.log(err);
         log.error(`MISSION FAILED!`);
         process.exit(13);
     }

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -144,7 +144,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
                     sourceMap: debug ? true : false,
                     inlineSources: debug ? true : false,
                     noEmitOnError: watch ? false : true,
-                    cacheDir: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache` : undefined,
+                    cacheRoot: debug ? `${fs.realpathSync(os.tmpdir())}/darkreader_typescript_cache/${rollupPluginTypesctiptInstanceKey}` : undefined,
                 };
                 if (debug) {
                     config.verbosty = 3;


### PR DESCRIPTION
rollup-plugin-typescript2 has a race condition when using the same cacheRoot in parallel; see https://github.com/ezolenko/rollup-plugin-typescript2/issues/15.

this PR overrides `cacheRoot` and includes `rollupPluginTypesctiptInstanceKey` in the path to work around this.

fixes #10949

----

incidentally, bundle-js.js has multiple references to "typesctipt", is this a typo for "typescript" or intentional? i didn't want to fix it in this PR but i thought it was worth mentioning just in case.