### PR TITLE
Added nexangelus.github.io/dbd_PerkFinder/ to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -549,6 +549,7 @@ netzhack.de
 neundex.com
 neurocore.xyz
 newgrounds.com
+nexangelus.github.io/dbd_PerkFinder/
 nexusmods.com
 nfs.fandom.com
 nfspolska.pl


### PR DESCRIPTION
This is a website a friend and I made.
It's dark by default (there's no option to choose theme either way)