### PR TITLE
Fix SeaLegacy (sealegacy.org)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18159,6 +18159,13 @@ INVERT
 
 ================================
 
+sealegacy.org
+
+INVERT
+.custom-logo
+
+================================
+
 seamonkey-project.org
 
 INVERT


### PR DESCRIPTION
Fix main logo/link in upper-left corner

Example URL:
https://sealegacy.org