### PR TITLE
Fix vcalc.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22017,7 +22017,7 @@ CSS
 vcalc.com
 
 INVERT
-img[src="/static/images/logo.png"]
+.navbar-brand > img
 
 CSS
 .features-area {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22014,6 +22014,18 @@ CSS
 
 ================================
 
+vcalc.com
+
+INVERT
+img[src="/static/images/logo.png"]
+
+CSS
+.features-area {
+    background-image: none !important;
+}
+
+================================
+
 vcb-s.com
 
 CSS


### PR DESCRIPTION
Fixes:

1. Primary logo link in upper-left corner
2. Large bright background in middle of page

Example URL:
https://www.vcalc.com