### PR TITLE
Fix for deftpdf.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5361,6 +5361,13 @@ CSS
 
 ================================
 
+deftpdf.com
+
+INVERT
+.header__logo
+
+================================
+
 dell.com
 
 INVERT


### PR DESCRIPTION
Fixes primary logo/link in upper-left corner.

Example URL:
https://deftpdf.com