### PR TITLE
Fix for mail.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12842,6 +12842,7 @@ mail.google.com
 
 INVERT
 .asor_t0
+.asor_i1 > img
 .asor_i4
 .d-Na-Jo.d-Na-N-ax3
 .RK-QJ-Jk


### PR DESCRIPTION
Profile pictures in the "Search mail" dropdown were previously inverted, this uninverts them.