### PR TITLE
Fix for omnicalculator.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15428,8 +15428,10 @@ CSS
 
 omnicalculator.com
 
-INVERT
-.GenericText
+CSS
+.GenericText {
+    color: var(--darkreader-neutral-text) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Inversion of .GenericText caused the text to blend into background completely.
Changing it to use --darkreader-neutral-text fixes the issue.