### PR TITLE
Update fix for lightning.force.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12309,7 +12309,7 @@ lightning.force.com
 
 CSS
 .slds-brand-band,
-.slds-brand-band:after,
+.slds-brand-band::after,
 .slds-brand-band_cover,
 .slds-brand-band_medium,
 .slds-page-header,
@@ -12321,7 +12321,7 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 .slds-card {
-    background-color: #333333 !important;
+    background-color: #333 !important;
 }
 .slds-button_neutral,
 .slds-button--neutral {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12321,7 +12321,7 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 .slds-card {
-    background-color: #333 !important;
+    background-color: #333333 !important;
 }
 .slds-button_neutral,
 .slds-button--neutral {


### PR DESCRIPTION
Fixes obsolete syntax for pseudo-element.

Also simplifies hex color.

BTW, might be an opportunity to change `#333` to `${#333}` for `.slds-card`, but I'll leave that decision to others.