### PR TITLE
CI: switch to setup-xvfb action

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -93,19 +93,19 @@ jobs:
 
       - name: Run browser tests on Chromium MV2 build
         if: ${{ matrix.chrome }}
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: npm run test:chrome -- --json --outputFile=test-results-chrome.json
 
       - name: Run browser tests on Chromium MV3 build
         if: ${{ matrix.chrome }}
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: npm run test:chrome-mv3 -- --json --outputFile=test-results-chrome-mv3.json
 
       - name: Run browser tests on Firefox MV2 build
         if: ${{ matrix.firefox }}
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1
         with:
           run: npm run test:firefox -- --json --outputFile=test-results-firefox-mv2.json
 


### PR DESCRIPTION
The previously used action[1] is deprecated and uses deprecated NodeJS 12,[2] and it explicitly recommends to switch to the new one[3].

[1] https://github.com/marketplace/actions/gabrielbb-xvfb-action
[2] https://github.com/darkreader/darkreader/actions/runs/4589996263
[3] https://github.com/coactions/setup-xvfb