### PR TITLE
Refactor: explicitly compile out eval() only used in tests

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -190,6 +190,7 @@ if (__TEST__) {
                     chrome.storage[region].get(keys, respond);
                     break;
                 }
+                // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
                 case 'createTab':
                     chrome.tabs.update(testTabId!, {url: message.data, active: true}, () => respond());
                     break;

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -226,6 +226,7 @@ if (__TEST__) {
         }));
     };
 
+    // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
     if (__FIREFOX__) {
         function expectPageStyles(data: any) {
             const errors = [];

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -124,6 +124,17 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
     const bundle = await rollup.rollup({
         input: rootPath(src),
         plugins: [
+            // Firefox does not currently support tab.eval() functions fully, so we have to manually polyfill it via
+            // regular eval().
+            // This plugin is necessary to avoid (benign) warnings in the console during builds, it just replaces
+            // literally one occurence of eval() in our code even before TypeSctipt even encounters it.
+            // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
+            getRollupPluginInstance('removeEval', '', () => !debug && entry.src === 'src/background/index.ts' &&
+                rollupPluginReplace({
+                    preventAssignment: true,
+                    'eval(': 'void(',
+                })
+            ),
             getRollupPluginInstance('nodeResolve', '', rollupPluginNodeResolve),
             getRollupPluginInstance('typesctipt', rollupPluginTypesctiptInstanceKey, () =>
                 rollupPluginTypescript({
@@ -159,6 +170,8 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
             ),
         ].filter((x) => x)
     });
+    // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
+    freeRollupPluginInstance('removeEval', '');
     freeRollupPluginInstance('nodeResolve', '');
     freeRollupPluginInstance('typesctipt', rollupPluginTypesctiptInstanceKey);
     freeRollupPluginInstance('replace', rollupPluginReplaceInstanceKey);

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -124,12 +124,12 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
     const bundle = await rollup.rollup({
         input: rootPath(src),
         plugins: [
-            // Firefox does not currently support tab.eval() functions fully, so we have to manually polyfill it via
-            // regular eval().
+            // Firefox WebDriver implementation does not currently support tab.eval() functions fully,
+            // so we have to manually polyfill it via regular eval().
             // This plugin is necessary to avoid (benign) warnings in the console during builds, it just replaces
             // literally one occurence of eval() in our code even before TypeSctipt even encounters it.
             // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
-            getRollupPluginInstance('removeEval', '', () => !debug && entry.src === 'src/background/index.ts' &&
+            getRollupPluginInstance('removeEval', '', () => !test && entry.src === 'src/background/index.ts' &&
                 rollupPluginReplace({
                     preventAssignment: true,
                     'eval(': 'void(',

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -128,8 +128,9 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
             // so we have to manually polyfill it via regular eval().
             // This plugin is necessary to avoid (benign) warnings in the console during builds, it just replaces
             // literally one occurence of eval() in our code even before TypeSctipt even encounters it.
+            // With this plugin, warning apprears only on Firefox test builds.
             // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
-            getRollupPluginInstance('removeEval', '', () => !test && entry.src === 'src/background/index.ts' &&
+            getRollupPluginInstance('removeEval', '', () => !(test && platform === PLATFORM.FIREFOX) && entry.src === 'src/background/index.ts' &&
                 rollupPluginReplace({
                     preventAssignment: true,
                     'eval(': 'void(',

--- a/tests/browser/environment.js
+++ b/tests/browser/environment.js
@@ -184,6 +184,7 @@ export default class CustomJestEnvironment extends TestEnvironment {
         const promise = this.awaitForEvent(`ready-${pathname}`);
         // Firefox does not resolve promise returned by page.goto()
         // Doesn't resolve due to https://github.com/puppeteer/puppeteer/issues/6616
+        // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
         if (this.global.product !== 'firefox') {
             await this.page.goto(url, gotoOptions);
         } else {


### PR DESCRIPTION
After #10948, the following warning appeared in console:
> Use of eval in "src/inject/index.ts" is strongly discouraged as it poses security risks and may cause issues with minification.

This warning was meaningless on all builds besides test builds because the mentioned `eval()` was compiled out at a later stage. This commit adds another compilation step which just removes this one instance to avoid this warning altogether. In hindsight, I probably should have included this change in the original PR.