### PR TITLE
Build: throw on Rollup warnings

### DIFF
--- a/tasks/bundle-api.js
+++ b/tasks/bundle-api.js
@@ -25,6 +25,9 @@ async function bundleAPI({debug, watch}) {
     const dest = 'darkreader.js';
     const bundle = await rollup.rollup({
         input: src,
+        onwarn: (error) => {
+            throw error;
+        },
         plugins: [
             rollupPluginNodeResolve(),
             rollupPluginTypescript({
@@ -49,12 +52,12 @@ async function bundleAPI({debug, watch}) {
                 __THUNDERBIRD__: false,
                 __TEST__: false,
             }),
-        ].filter((x) => x)
+        ].filter(Boolean)
     });
     watchFiles = bundle.watchFiles;
     await bundle.write({
         banner: `/**\n * Dark Reader v${await getVersion()}\n * https://darkreader.org/\n */\n`,
-        // TODO: Consider remving next line
+        // TODO: Consider removing next line
         esModule: true,
         file: dest,
         strict: true,

--- a/tasks/bundle-js.js
+++ b/tasks/bundle-js.js
@@ -123,13 +123,13 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
 
     // See comment below
     // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
-    const shouldPermitEval = test && (platform === PLATFORM.FIREFOX) && (entry.src === 'src/inject/index.ts');
+    const mustRemoveEval = !test && (platform === PLATFORM.FIREFOX) && (entry.src === 'src/inject/index.ts');
 
     const bundle = await rollup.rollup({
         input: rootPath(src),
         onwarn: (error) => {
             // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
-            if (error.code === 'EVAL' && shouldPermitEval) {
+            if (error.code === 'EVAL' && !mustRemoveEval) {
                 return;
             }
 
@@ -142,7 +142,7 @@ async function bundleJS(/** @type {JSEntry} */entry, platform, debug, watch, log
             // literally one occurence of eval() in our code even before TypeSctipt even encounters it.
             // With this plugin, warning apprears only on Firefox test builds.
             // TODO(anton): remove this once Firefox supports tab.eval() via WebDriver BiDi
-            getRollupPluginInstance('removeEval', '', () => !shouldPermitEval &&
+            getRollupPluginInstance('removeEval', '', () => mustRemoveEval &&
                 rollupPluginReplace({
                     preventAssignment: true,
                     'eval(': 'void(',


### PR DESCRIPTION
Throw on Rollup warings explicitly, this is mostly to avoid introducing implicit regressions on CI.