### PR TITLE
Corrected light translation from "let" to "lyst"

### DIFF
--- a/src/_locales/da-DK.config
+++ b/src/_locales/da-DK.config
@@ -200,7 +200,7 @@ Auto (dag på stedet)
 Auto (systemet er mørkt)
 
 @auto_system_is_light
-Auto (systemet er let)
+Auto (systemet er lyst)
 
 @click_to_set_shortcut
 Klik for at indstille genvejen


### PR DESCRIPTION
Corrected a small mistake from the Google Translate translation.