### PR TITLE
Remove flightradar24.com from global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -913,7 +913,6 @@ www.cc.com
 www.cjratliff.com
 www.digikam.org
 www.eveonline.com
-www.flightradar24.com
 www.justwatch.com
 www.kika.de/$
 www.kika.de/kika-live/*


### PR DESCRIPTION
Per git blame this seems to have been added in #10767 

I don't think this meets the criteria because pages like https://www.flightradar24.com/data/flights/ib8741 are not dark theme and never has been. The main page is dark theme, yes, but none of the other pages are.

![image](https://user-images.githubusercontent.com/13186147/230924081-149d0405-352e-4b69-95a3-204d3e2f1930.png)
