### PR TITLE
Fix inversion highlight of instructure.com (Canvas) embedded files

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10893,7 +10893,13 @@ instructure.com
 
 INVERT
 .equation_image
-.Page-container
+.Page_container
+
+CSS
+.textLayer ::selection {
+    color: inherit !important;
+    background: rgb(0, 0, 255) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Previously, the dynamic highlight inversion has a weird color and is misaligned with the background text.

<img width="775" alt="image" src="https://user-images.githubusercontent.com/28827171/231343794-2dc04d5d-ded6-494c-8051-a565c96477cf.png">


Now, the color is the usual blue on the inverted dark theme (fixed in background: CSS), and the misalignment is hidden (color).

<img width="778" alt="image" src="https://user-images.githubusercontent.com/28827171/231343729-2b1660c6-e656-4681-adf1-435c518a894d.png">
