### PR TITLE
Update dynamic-theme-fixes.config to support Bing ChatGPT

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2558,6 +2558,7 @@ bing.com
 INVERT
 canvas[id^="Microsoft.Maps"]
 cib-background
+cib-serp
 
 CSS
 .b_searchboxForm,


### PR DESCRIPTION
Fixes Bing ChatGPT, available on https://www.bing.com/chat. 

I don't know if the person who added `cib-background` did it for that same reason--I'm guessing it is, because I tried the same thing--, but it does not work on my system. Only cib-serp does.