### PR TITLE
Fix contrast for mermaid diagram elements in dark-mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -75,6 +75,9 @@ svg g g.nodes rect, svg g g.nodes polygon {
 svg g rect.task {
   fill: var(--darkreader-selection-background) !important;
 }
+svg line.messageLine0 {
+  stroke: var(--darkreader-neutral-text) !important;
+}
 
 IGNORE INLINE STYLE
 .sr-wrapper *

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -50,8 +50,8 @@ gr-main-header {
     background-color: ${rgb(133, 195, 216)} !important;
 }
 div.mermaid-viewer-control-panel .btn {
-  fill: var(--darkreader-text--color-fg-muted);
-  background-color: var(--darkreader-bg--color-btn-bg);
+  fill: var(--darkreader-neutral-text);
+  background-color: var(--darkreader-neutral-background);
 }
 svg g rect.er {
   fill: var(--darkreader-neutral-background) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -75,7 +75,7 @@ svg g g.nodes rect, svg g g.nodes polygon {
 svg g rect.task {
   fill: var(--darkreader-selection-background) !important;
 }
-svg line.messageLine0 {
+svg line.messageLine0, svg line.messageLine1 {
   stroke: var(--darkreader-neutral-text) !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -78,6 +78,9 @@ svg g rect.task {
 svg line.messageLine0, svg line.messageLine1 {
   stroke: var(--darkreader-neutral-text) !important;
 }
+div.mermaid .actor {
+  fill: var(--darkreader-neutral-background) !important;
+}
 
 IGNORE INLINE STYLE
 .sr-wrapper *

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -49,6 +49,32 @@ gr-main-header {
 .tou-6i3zyv {
     background-color: ${rgb(133, 195, 216)} !important;
 }
+div.mermaid-viewer-control-panel .btn {
+  fill: var(--darkreader-text--color-fg-muted);
+  background-color: var(--darkreader-bg--color-btn-bg);
+}
+svg g rect.er {
+  fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.er.entityBox {
+  fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.er.attributeBoxOdd {
+  fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.er.attributeBoxEven {
+  fill-opacity: 0.8 !important;
+  fill: var(--darkreader-selection-background);
+}
+svg rect.er.relationshipLabelBox {
+  fill: var(--darkreader-neutral-background) !important;
+}
+svg g g.nodes rect, svg g g.nodes polygon {
+  fill: var(--darkreader-neutral-background) !important;
+}
+svg g rect.task {
+  fill: var(--darkreader-selection-background) !important;
+}
 
 IGNORE INLINE STYLE
 .sr-wrapper *


### PR DESCRIPTION
# Issue

When switching to dark mode on some diagram types, the backgrounds do not change to offer sufficient contrast to be able to read the text within some elements of those diagrams.

## Relevant or related issues

Noticed no recent open issues for Mermaid diagrams other than #7047 (which was just a listing of the mermaid websites) and a bunch of older issues https://github.com/darkreader/darkreader/issues?q=mermaid that didn't seem too relevant.

# Solution

Attempted to define generally applicable fixes for mermaid diagrams embedded in pages. Since mermaid diagrams can appear on a variety of pages, I reckoned that the top of the dynamic-theme-fixes.config file was a correct place for the changes. These fixes should be general enough but let me know if this design choice is not in line with the project design constraints/goals.

## Changes

- for mermaid controls: set the colors to the darkreader bg and fg values (mermaid adds navigation controls on some embedded diagrams)
- for ER: set fills on different element types
- for Gantt: set the task fill color to the darkreader selection bg
- more generally, but likely just for Flow diagrams: set fill for `rect`s and `polygon`s

# Testing

Tested on:
- Mermaid Live Editor (https://mermaid-js.github.io/mermaid-live-editor)
- mermaid in Markdown or Orgdown on GitHub
- mermaid in Markdown or Orgdown on GitLab (see some docs at https://about.gitlab.com/handbook/tools-and-tips/mermaid/)

# Examples

For the sake of completeness, I repeat some of the diagrams (from the live editor samples) that were causing issues for me in dark mode in Chromium. These show show up in GitHub with some elements having light backgrounds and light text, rendering the diagrams more-or-less unreadable (poor contrast between bg and text).

## Flowcharts
```mermaid
flowchart TD
    A[Christmas] -->|Get money| B(Go shopping)
    B --> C{Let me think}
    C -->|One| D[Laptop]
    C -->|Two| E[iPhone]
    C -->|Three| F[fa:fa-car Car]
```
<details>
  <summary>Problematic diagram</summary>

![2023-04-13-022203_2277x1913_scrot](https://user-images.githubusercontent.com/335406/231639977-5278b990-6f83-4ba5-adbb-274f90f9c99a.png)
](url)
</details>

<details>
  <summary>Fixed diagram</summary>

![2023-04-13-031842_2282x1118_scrot](https://user-images.githubusercontent.com/335406/231640153-1f2f5f07-e83d-4a87-9549-1841eb329cab.png)
</details>


## ER Diagrams

```mermaid
erDiagram
    CUSTOMER }|..|{ DELIVERY-ADDRESS : has
    CUSTOMER ||--o{ ORDER : places
    CUSTOMER ||--o{ INVOICE : "liable for"
    DELIVERY-ADDRESS ||--o{ ORDER : receives
    INVOICE ||--|{ ORDER : covers
    ORDER ||--|{ ORDER-ITEM : includes
    PRODUCT-CATEGORY ||--|{ PRODUCT : contains
    PRODUCT ||--o{ ORDER-ITEM : "ordered in"
```
<details>
  <summary>Problematic diagram</summary>

![2023-04-13-023357_2278x1110_scrot](https://user-images.githubusercontent.com/335406/231640325-40cbc5fc-ce78-4311-947a-da26b4c6a82e.png)
</details>

<details>
  <summary>Fixed diagram</summary>

![2023-04-13-023426_2279x1115_scrot](https://user-images.githubusercontent.com/335406/231640365-80d90b3a-85b7-41d9-8547-2ddda30342f0.png)
</details>

## Gantt Diagrams

```mermaid
gantt
    title A Gantt Diagram
    dateFormat  YYYY-MM-DD
    section Section
    A task           :a1, 2014-01-01, 30d
    Another task     :after a1  , 20d
    section Another
    Task in sec      :2014-01-12  , 12d
    another task      : 24d
```
<details>
  <summary>Problematic diagram</summary>

![2023-04-13-023434_2288x1112_scrot](https://user-images.githubusercontent.com/335406/231640216-0034c7ab-d0b2-4185-a0bf-6177027a8de9.png)
</details>

<details>
  <summary>Fixed diagram</summary>

![2023-04-13-023604_2290x1118_scrot](https://user-images.githubusercontent.com/335406/231640253-aa787e86-e3d7-4287-bf82-e87d53168252.png)
</details>

## Sequence Diagram

```mermaid
sequenceDiagram
    Alice->>+John: Hello John, how are you?
    Alice->>+John: John, can you hear me?
    John-->>-Alice: Hi Alice, I can hear you!
    John-->>-Alice: I feel great!
```

<details>
<summary>Problematic diagram</summary>

![2023-04-16-191753_1517x1250_scrot](https://user-images.githubusercontent.com/335406/232336811-7281b047-ed31-44c5-b0f4-ecf4aa27b9b2.png)
</details>

<details>
<summary>Solved diagram</summary>

![2023-04-16-192501_1523x800_scrot](https://user-images.githubusercontent.com/335406/232337171-c6ec4951-efbb-47bb-96ac-0dd43c2c6f44.png)
</details>