### PR TITLE
Fix for pkg.go.dev

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16536,6 +16536,16 @@ INVERT
 
 ================================
 
+pkg.go.dev
+
+CSS
+.go-Select {
+    background-position: right center;
+    background-repeat: no-repeat;
+}
+
+================================
+
 pkgs.org
 
 CSS


### PR DESCRIPTION
Found this bug while looking into #11113, but it is a different bug from the reported one in the issue.

 - do not repeat drop down indicator in select elements