### PR TITLE
Add dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -15,8 +15,8 @@ abletonbot.me
 about.benjithatbluefox.eu
 absolucy.moe
 account.bhvr.com
-aceship.github.io
 aceattorneyonline.com
+aceship.github.io
 addictinggames.com
 adridoesthings.com
 advanceds.me


### PR DESCRIPTION
`aceattorneyonline.com`: also covers `web.acettorneyonline.com`. Dark Reader causes site breakage, and the site is dark by default.

`deceiveinc.com`: dark by default. Also covers `support.deceiveinc.com`.

`dota2.fandom.com`: has a light theme toggle but is dark by default.

`support.deadbydaylight.com`: no light theme toggle and dark by default.