### PR TITLE
Fix for chromeenterprise.google

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4092,7 +4092,7 @@ img[alt*="See how people"] {
     filter: invert(15%) !important;
 }
 #how-to-buy {
-    background-color: #181a1b !important;
+    background-color: var(--darkreader-background-neutral) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4052,6 +4052,51 @@ CSS
 
 ================================
 
+chromeenterprise.google
+
+INVERT
+#post-linkedin
+.ce-accordion--caret
+.glue-carousel__navigation > li
+.ce-device-card__details-title--icon
+img[src*="hackerone"]
+img[src*="blackberry"]
+img[src*="samsung-knox"]
+img[src*="paloalto"]
+img[src*="onelogin"]
+img[src*="splunk"]
+img[src*="climate"]
+img[src*="topcoder"]
+img[src*="bailey-nelson"]
+img[src*="colgate"]
+img[src*="square"]
+img[src*="getty-image"]
+img[alt*="romevo"]
+img[alt="Pythian"]
+img[alt="Amazon"]
+img[alt="Softbank"]
+img[alt="Cameyo"]
+img[alt="Citrix"]
+img[alt="Nutanix Frame"]
+img[alt="Dustin"]
+
+CSS
+img[alt="Onix"],
+img[alt="USEN"],
+img[alt="Inmac"],
+img[src*="first-ipo"],
+img[src*="compass-group"],
+img[src*="doctor-dot-com"],
+img[src*="devoted-health"],
+img[alt*="See how people"] {
+    filter: invert(15%) !important;
+}
+#how-to-buy {
+    background-color: #181a1b !important;
+}
+
+================================
+
 chtoes.li
 
 INVERT


### PR DESCRIPTION
In this pull request:
- Invert the color of some logos that are hard to see
- Fixed some elements that weren't inverted or hard to see

Before

![image](https://user-images.githubusercontent.com/87893636/231983013-bf9543f7-7c2e-4150-a365-d541dd213b9d.png)

After

![image](https://user-images.githubusercontent.com/87893636/231983098-7b530f9e-8d71-4abb-9b95-d2a844fd2070.png)

---

Before 

![image](https://user-images.githubusercontent.com/87893636/231983324-f0a063a5-dd64-4d3d-9512-650c937c0e99.png)

After

![image](https://user-images.githubusercontent.com/87893636/231983430-23e00609-4051-4875-9a2b-328401be7059.png)

---

Before

![image](https://user-images.githubusercontent.com/87893636/231983945-c3748c1a-d19e-4297-9fd2-303f58113994.png)

After

![image](https://user-images.githubusercontent.com/87893636/231984099-055343a1-f9e9-4f07-aa05-fdb6e5b7b2a9.png)

### Additional context
There are many more logos I fixed but only showed some of them.

