### PR TITLE
Update `pt-BR.config` to use "arquivos" instead of "ficheiros"

### DIFF
--- a/src/_locales/pt-BR.config
+++ b/src/_locales/pt-BR.config
@@ -48,7 +48,7 @@ pelo navegador
 
 @local_files_forbidden
 Não é permitido acessar
-ficheiros locais
+arquivos locais
 
 @page_in_dark_list
 Este site está na


### PR DESCRIPTION
This pull request updates the Brazilian Portuguese locale file to use the term "arquivos" instead of "ficheiros" for consistency with standard Brazilian Portuguese usage.