### PR TITLE
Hide vimvixen console

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14,6 +14,11 @@ CSS
     border-color: ${#c59d00} !important;
     color: ${#302505} !important;
 }
+
+#vimvixen-console-frame {
+    color-scheme: light !important
+}
+
 ::placeholder {
     opacity: 0.5 !important;
 }


### PR DESCRIPTION
Currently the vimvixen console always shows as a large white rectangle when running on a page in dark mode. This is a workaround I found online but I'm not sure if anyone has submitted it yet.