### PR TITLE
Refactor: simplify compilation constants

### DIFF
--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -230,8 +230,8 @@ export function manageStyle(element: StyleElement, {update, loadingStart, loadin
             }
 
             if (
-                (!cssRules && !accessError && !isSafari) ||
                 (isSafari && !element.sheet) ||
+                (!isSafari && !cssRules && !accessError) ||
                 isStillLoadingError(accessError!)
             ) {
                 try {

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -30,7 +30,6 @@ const platform = isNavigatorDefined ? (navigator.userAgentData && typeof navigat
 
 // Note: if you are using these constants in tests, make sure they are not compiled out by adding __TEST__ to them
 export const isChromium = __CHROMIUM_MV2__ || __CHROMIUM_MV3__ || (!__FIREFOX__ && !__THUNDERBIRD__ && (userAgent.includes('chrome') || userAgent.includes('chromium')));
-export const isThunderbird = __THUNDERBIRD__ || (!__CHROMIUM_MV2__ && !__CHROMIUM_MV3__ && userAgent.includes('thunderbird'));
 export const isFirefox = __FIREFOX__ || __THUNDERBIRD__ || ((__TEST__ || (!__CHROMIUM_MV2__ && !__CHROMIUM_MV3__)) && (userAgent.includes('firefox') || userAgent.includes('thunderbird') || userAgent.includes('librewolf')));
 export const isVivaldi = (__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && (!__FIREFOX__ && !__THUNDERBIRD__ && userAgent.includes('vivaldi'));
 export const isYaBrowser = (__CHROMIUM_MV2__ || __CHROMIUM_MV3__) && (!__FIREFOX__ && !__THUNDERBIRD__ && userAgent.includes('yabrowser'));


### PR DESCRIPTION
No substantial changes, here is the build diff:
```diff
diff -r build/release/chrome/inject/index.js build-old/release/chrome/inject/index.js
1294d1293
<     const isSafari = !true;
4839,4840c4838
<                     (!cssRules && !accessError && !isSafari) ||
<                     isSafari ||
---
>                     (!cssRules && !accessError) ||
diff -r build/release/chrome-mv3/inject/index.js build-old/release/chrome-mv3/inject/index.js
1296d1295
<     const isSafari = !true;
4814,4815c4813
<                     (!cssRules && !accessError && !isSafari) ||
<                     isSafari ||
---
>                     (!cssRules && !accessError) ||
Binary files build/release/darkreader-chrome-mv3.zip and build-old/release/darkreader-chrome-mv3.zip differ
Binary files build/release/darkreader-chrome.zip and build-old/release/darkreader-chrome.zip differ
Binary files build/release/darkreader-firefox.xpi and build-old/release/darkreader-firefox.xpi differ
Binary files build/release/darkreader-thunderbird.xpi and build-old/release/darkreader-thunderbird.xpi differ
diff -r build/release/firefox/background/index.js build-old/release/firefox/background/index.js
21d20
<     userAgent.includes("thunderbird");
diff -r build/release/firefox/inject/index.js build-old/release/firefox/inject/index.js
1290,1291d1289
<     userAgent.includes("thunderbird");
<     const isSafari = !true;
4844,4845c4842
<                     (!cssRules && !accessError && !isSafari) ||
<                     isSafari ||
---
>                     (!cssRules && !accessError) ||
diff -r build/release/firefox/ui/devtools/index.js build-old/release/firefox/ui/devtools/index.js
1296d1295
<     userAgent.includes("thunderbird");
diff -r build/release/firefox/ui/popup/index.js build-old/release/firefox/ui/popup/index.js
1210d1209
<     userAgent.includes("thunderbird");
diff -r build/release/firefox/ui/stylesheet-editor/index.js build-old/release/firefox/ui/stylesheet-editor/index.js
1246d1245
<     userAgent.includes("thunderbird");
diff -r build/release/thunderbird/inject/index.js build-old/release/thunderbird/inject/index.js
1290d1289
<     const isSafari = !true;
4839,4840c4838
<                     (!cssRules && !accessError && !isSafari) ||
<                     isSafari ||
---
>                     (!cssRules && !accessError) ||
```