### PR TITLE
Fix: hide new design preview button on mobile

### DIFF
--- a/src/ui/devtools/components/body.tsx
+++ b/src/ui/devtools/components/body.tsx
@@ -6,7 +6,7 @@ import {ThemeEngine} from '../../../generators/theme-engines';
 import {DEVTOOLS_DOCS_URL} from '../../../utils/links';
 import type {DevToolsData, ExtWrapper} from '../../../definitions';
 import {getCurrentThemePreset} from '../../popup/theme/utils';
-import {isFirefox} from '../../../utils/platform';
+import {isFirefox, isMobile} from '../../../utils/platform';
 
 type BodyProps = ExtWrapper & {devtools: DevToolsData};
 
@@ -124,7 +124,7 @@ function Body({data, actions, devtools}: BodyProps) {
                     {dialog}
                 </Button>
                 <Button onclick={apply}>Apply</Button>
-                <Button class="preview-design-button" onclick={toggleDesign}>{previewButtonText}</Button>
+                {isMobile ? <Button class="preview-design-button" onclick={toggleDesign}>{previewButtonText}</Button> : null}
             </div>
             <p id="description">
                 Read about this tool <strong><a href={DEVTOOLS_DOCS_URL} target="_blank" rel="noopener noreferrer">here</a></strong>.


### PR DESCRIPTION
This button does nothing on mobile, so we should hide it. Specifically, `isMobile` overrides `previewNewDesign` in `src/ui/popup/components/body.tsx`