### PR TITLE
Fix for play.google.com/store/paymentmethods

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16727,6 +16727,15 @@ a[title="Google apps"]
 
 ================================
 
+play.google.com/store/paymentmethods
+
+CSS
+body {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 playstation.com
 
 CSS


### PR DESCRIPTION
Fix unreadable text.

Before:

<img width="593" alt="image" src="https://user-images.githubusercontent.com/1006477/233068564-0441f100-cd3d-4aeb-a0a5-4f9e5b278e9c.png">

After:

<img width="593" alt="image" src="https://user-images.githubusercontent.com/1006477/233068629-6eadc954-0c65-4966-800a-87e96cd93f5c.png">
