### PR TITLE
Invert Twitch's claim bonus button

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21862,6 +21862,7 @@ INVERT
 .seekbar-bar
 .mention-fragment--recipient
 .reply-line--mentioned
+.claimable-bonus__icon
 
 CSS
 .seekbar-segment {


### PR DESCRIPTION
Incorrect inversion on Twitch's claim bonus button reduces legibility on the button. This pull request will fix that mistake.