### PR TITLE
Fix docs.google/picker

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6396,7 +6396,7 @@ input.docs-title-input {
 docs.google.com/picker
 
 INVERT
-#doclist div > div + div div[style="user-select: none;"]:not([role="tab"]):not([role="menuitemradio"]):not([role^="menu"]) > div:not([aria-pressed]):not([role="tab"]):not([class$="highlightsgrid"]):first-of-type
+#doclist div > div + div div[style="user-select: none;"]:not([role="tab"]):not([role="listbox"]):not([role="menuitemradio"]):not([role^="menu"]) > div:not([aria-pressed]):not([role="tab"]):not([class$="highlightsgrid"]):first-of-type
 #doclist div > div + div div[role="menu"] div[role="menuitem"][style="user-select: none;"] div[aria-label] div[data-tooltip] + div
 #doclist div > div + div label + input + div[style]
 img[src$="search-black.png"]


### PR DESCRIPTION
Fixed the inversion in the "More fonts" browser (selected filter text color)

Before:
![DR-DYNAMIC-FIX__GDOCS--BEFORE](https://user-images.githubusercontent.com/15115669/233521715-0649374f-a5af-4015-a27a-721ff7945143.jpg)

After:
![DR-DYNAMIC-FIX__GDOCS--AFTER](https://user-images.githubusercontent.com/15115669/233521726-8de632a0-3244-4fd2-9c59-caf3defa134a.jpg)
