### PR TITLE
fix: inverted images on new github.blog layout

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9075,22 +9075,6 @@ body, #masthead {
 
 ================================
 
-github.blog
-
-INVERT
-a[href="https://github.com"]
-.site-branding > svg
-.icon-logo-github
-.aligncenter
-.wp-image-56594
-.wp-image-56590
-[src^="https://github.blog/wp-content/uploads/2019/03/BlogHeaders_Aligned_CHANGELOG"]
-[src^="https://i0.wp.com/user-images.githubusercontent.com/"]
-[src^="https://i1.wp.com/user-images.githubusercontent.com/"]
-[src^="https://i2.wp.com/user-images.githubusercontent.com/"]
-
-================================
-
 github.com
 github.*.*
 


### PR DESCRIPTION
Fixes: #11164 

Reverts: #5270 (more details in #11165)