### PR TITLE
Fix mendeley.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13661,6 +13661,15 @@ INVERT
 
 mendeley.com
 
+INVERT
+#pdfcontainerId > div[class^="PDFReaderWithAnnotations"]
+.highlightLayer > *
+div[class^="AnnotationMenuStyle"]
+svg[class^="IconMendeley__Icon"]
+a[class^="TabCloseButton__CloseTabLink"]
+g#cross3
+svg[class^="ColourCircle"]
+
 CSS
 .highlightLayer * {
    background-color: var(--darkreader-selection-text) !important;


### PR DESCRIPTION
This edit makes PDFs dark and fixes some small UI bits.
This does also invert all images in the PDF and there is no way around this as each page of the PDF is an image.