### PR TITLE
Bump TypeScript config from ES2017 to ES2022

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,7 +5,7 @@
         "module": "ES2015",
         "moduleResolution": "node",
         "lib": [
-            "ES2017",
+            "ES2022",
             "Dom",
             "DOM.Iterable"
         ],

--- a/tests/inject/tsconfig.json
+++ b/tests/inject/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "ES2019",
         "module": "ES2015",
         "lib": [
-            "ES2017",
+            "ES2022",
             "DOM",
             "DOM.Iterable"
         ],

--- a/tests/project/__snapshots__/tsconf.tests.ts.snap
+++ b/tests/project/__snapshots__/tsconf.tests.ts.snap
@@ -10,7 +10,7 @@ exports[`TypeScript project config file should parse and resolve correctly: src 
     "jsx": "react",
     "jsxFactory": "m",
     "lib": [
-      "es2017",
+      "es2022",
       "dom",
       "dom.iterable",
     ],
@@ -243,7 +243,7 @@ exports[`TypeScript project config file should parse and resolve correctly: src/
     "jsx": "react",
     "jsxFactory": "m",
     "lib": [
-      "es2017",
+      "es2022",
       "dom",
       "dom.iterable",
     ],
@@ -279,7 +279,7 @@ exports[`TypeScript project config file should parse and resolve correctly: test
     "jsx": "react",
     "jsxFactory": "m",
     "lib": [
-      "es2017",
+      "es2022",
       "dom",
       "dom.iterable",
     ],


### PR DESCRIPTION
This does not change built output. This will allow us to use ES2022 features in source code while outputting the builds in older formats as before this change.