### PR TITLE
Refactor: avoid type casts

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -57,8 +57,8 @@ declare const __FIREFOX__: boolean;
 if (__CHROMIUM_MV3__) {
     chrome.runtime.onInstalled.addListener(async () => {
         try {
-            (chrome.scripting as any).unregisterContentScripts(() => {
-                (chrome.scripting as any).registerContentScripts([{
+            chrome.scripting.unregisterContentScripts(() => {
+                chrome.scripting.registerContentScripts([{
                     id: 'proxy',
                     matches: [
                         '<all_urls>'

--- a/src/inject/dynamic-theme/fixes.ts
+++ b/src/inject/dynamic-theme/fixes.ts
@@ -45,7 +45,7 @@ export function combineFixes(fixes: DynamicThemeFix[]): DynamicThemeFix | null {
     }
 
     function combineArrays(arrays: string[][]): string[] {
-        return (arrays.filter(Boolean) as any).flat();
+        return arrays.filter(Boolean).flat();
     }
 
     return {

--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -28,7 +28,7 @@ declare const __TEST__: boolean;
 declare const __CHROMIUM_MV3__: boolean;
 const INSTANCE_ID = generateUID();
 const styleManagers = new Map<StyleElement, StyleManager>();
-const adoptedStyleManagers = [] as AdoptedStyleSheetManager[];
+const adoptedStyleManagers: AdoptedStyleSheetManager[] = [];
 let filter: FilterConfig | null = null;
 let fixes: DynamicThemeFix | null = null;
 let isIFrame: boolean | null = null;
@@ -246,7 +246,7 @@ function createDynamicStyleOverrides() {
             push(inlineStyleElements, elements);
         }
     });
-    inlineStyleElements.forEach((el) => overrideInlineStyle(el as HTMLElement, filter!, ignoredInlineSelectors, ignoredImageAnalysisSelectors));
+    inlineStyleElements.forEach((el: HTMLElement) => overrideInlineStyle(el, filter!, ignoredInlineSelectors, ignoredImageAnalysisSelectors));
     handleAdoptedStyleSheets(document);
 }
 
@@ -399,7 +399,7 @@ function watchForUpdates() {
         createShadowStaticStyleOverrides(root);
         const inlineStyleElements = root.querySelectorAll(INLINE_STYLE_SELECTOR);
         if (inlineStyleElements.length > 0) {
-            forEach(inlineStyleElements, (el) => overrideInlineStyle(el as HTMLElement, filter!, ignoredInlineSelectors, ignoredImageAnalysisSelectors));
+            forEach(inlineStyleElements, (el: HTMLElement) => overrideInlineStyle(el, filter!, ignoredInlineSelectors, ignoredImageAnalysisSelectors));
         }
     });
 

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -276,7 +276,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, i
         // Such that `as ReturnType<CSSVariableModifier>` won't error about the possible
         // string type.
         if (isPropertyVariable && typeof value === 'object') {
-            const typedValue = value as ReturnType<CSSVariableModifier>;
+            const typedValue: ReturnType<CSSVariableModifier> = value;
             typedValue.declarations.forEach(({property, value}) => {
                 !(value instanceof Promise) && element.style.setProperty(property, value);
             });

--- a/src/inject/dynamic-theme/meta-theme-color.ts
+++ b/src/inject/dynamic-theme/meta-theme-color.ts
@@ -19,7 +19,7 @@ function changeMetaThemeColor(meta: HTMLMetaElement, theme: FilterConfig) {
 }
 
 export function changeMetaThemeColorWhenAvailable(theme: FilterConfig) {
-    const meta = document.querySelector(metaThemeColorSelector) as HTMLMetaElement;
+    const meta: HTMLMetaElement = document.querySelector(metaThemeColorSelector)!;
     if (meta) {
         changeMetaThemeColor(meta, theme);
     } else {

--- a/src/inject/dynamic-theme/style-manager.ts
+++ b/src/inject/dynamic-theme/style-manager.ts
@@ -74,7 +74,7 @@ export function shouldManageStyle(element: Node | null): boolean {
     );
 }
 
-export function getManageableStyles(node: Node | null, results = [] as StyleElement[], deep = true) {
+export function getManageableStyles(node: Node | null, results: StyleElement[] = [], deep = true) {
     if (shouldManageStyle(node)) {
         results.push(node as StyleElement);
     } else if (node instanceof Element || (isShadowDomSupported && node instanceof ShadowRoot) || node === document) {

--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -218,7 +218,7 @@ export function createStyleSheetModifier() {
             }
 
             function handleVarDeclarations(property: string, modified: ReturnType<CSSVariableModifier>, important: boolean, sourceValue: string) {
-                const {declarations: varDecs, onTypeChange} = modified as ReturnType<CSSVariableModifier>;
+                const {declarations: varDecs, onTypeChange} = modified;
                 const varKey = ++varDeclarationCounter;
                 const currentRenderId = renderId;
                 const initialIndex = readyDeclarations.length;
@@ -293,7 +293,7 @@ export function createStyleSheetModifier() {
                         const t = createTarget(r, target);
                         iterateReadyRules(r, t, styleIterator);
                     } else {
-                        styleIterator(r as ReadyStyleRule, target);
+                        styleIterator(r, target);
                     }
                 });
             }

--- a/src/inject/dynamic-theme/stylesheet-modifier.ts
+++ b/src/inject/dynamic-theme/stylesheet-modifier.ts
@@ -293,7 +293,7 @@ export function createStyleSheetModifier() {
                         const t = createTarget(r, target);
                         iterateReadyRules(r, t, styleIterator);
                     } else {
-                        styleIterator(r, target);
+                        styleIterator(r as ReadyStyleRule, target);
                     }
                 });
             }

--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -27,7 +27,7 @@ const VAR_TYPE_BGIMG = 1 << 3;
 
 export class VariablesStore {
     private varTypes = new Map<string, number>();
-    private rulesQueue = [] as CSSRuleList[];
+    private rulesQueue: CSSRuleList[] = [];
     private definedVars = new Set<string>();
     private varRefs = new Map<string, Set<string>>();
     private unknownColorVars = new Set<string>();
@@ -502,7 +502,7 @@ export class VariablesStore {
                 this.subscribeForVarTypeChange(property, this.onRootVariableDefined);
             }
         });
-        const cssLines = [] as string[];
+        const cssLines: string[] = [];
         cssLines.push(':root {');
         for (const [property, value] of declarations) {
             cssLines.push(`    ${property}: ${value};`);

--- a/src/inject/dynamic-theme/watch.ts
+++ b/src/inject/dynamic-theme/watch.ts
@@ -5,7 +5,7 @@ import type {StyleElement} from './style-manager';
 import {shouldManageStyle, getManageableStyles} from './style-manager';
 import {isDefinedSelectorSupported} from '../../utils/platform';
 
-const observers = [] as Array<{disconnect(): void}>;
+const observers: Array<{disconnect(): void}> = [];
 let observedRoots: WeakSet<Node>;
 
 interface ChangedStyles {

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -152,12 +152,12 @@ export function watchForNodePosition<T extends Node>(
     });
     const run = () => {
         // TODO: remove type cast after dependency update
-        observer.observe(parent as ParentNode, {childList: true});
+        observer.observe(parent!, {childList: true});
     };
 
     const stop = () => {
         // TODO: remove type cast after dependency update
-        clearTimeout(timeoutId as unknown as number);
+        clearTimeout(timeoutId!);
         observer.disconnect();
         restore.cancel();
     };

--- a/src/ui/controls/color-picker/hsb-picker.tsx
+++ b/src/ui/controls/color-picker/hsb-picker.tsx
@@ -114,7 +114,7 @@ function renderSB(hue: number, canvas: HTMLCanvasElement) {
 
 export default function HSBPicker(props: HSBPickerProps) {
     const context = getContext();
-    const store = context.getStore(hsbPickerDefaults) as HSBPickerState;
+    const store = context.getStore(hsbPickerDefaults);
     store.activeChangeHandler = props.onChange;
 
     const prevColor = context.prev && context.prev.props.color;

--- a/src/ui/controls/color-picker/index.tsx
+++ b/src/ui/controls/color-picker/index.tsx
@@ -26,7 +26,7 @@ function focusColorPicker(node: Node) {
 function ColorPicker(props: ColorPickerProps) {
     const context = getContext();
     context.onRender((node) => colorPickerFocuses.set(node, focus));
-    const store = context.store as {isFocused: boolean; textBoxNode: HTMLInputElement; previewNode: HTMLElement};
+    const store: {isFocused: boolean; textBoxNode: HTMLInputElement; previewNode: HTMLElement} = context.store;
 
     const isColorValid = isValidColor(props.color);
 

--- a/src/ui/controls/overlay/index.ts
+++ b/src/ui/controls/overlay/index.ts
@@ -40,7 +40,7 @@ interface OverlayPortalProps {
     onOuterClick?: () => void;
 }
 
-function Portal(props: OverlayPortalProps, ...content: Malevic.Child[]) {
+function Portal(props: OverlayPortalProps, ...content: Malevic.Child[]): void {
     const context = getContext();
 
     context.onRender(() => {
@@ -58,7 +58,7 @@ function Portal(props: OverlayPortalProps, ...content: Malevic.Child[]) {
         render(container, null);
     });
 
-    return context.leave() as void;
+    return context.leave();
 }
 
 export default Object.assign(Overlay, {Portal});

--- a/src/ui/controls/text-list/index.tsx
+++ b/src/ui/controls/text-list/index.tsx
@@ -49,7 +49,7 @@ export default function TextList(props: TextListProps) {
     let shouldFocus = false;
 
     const node = context.node;
-    const prevProps = context.prev ? context.prev.props as TextListProps : null;
+    const prevProps: TextListProps | null = context.prev ? context.prev.props : null;
     if (node && props.isFocused && (
         !prevProps ||
         !prevProps.isFocused ||

--- a/src/ui/devtools/components/body.tsx
+++ b/src/ui/devtools/components/body.tsx
@@ -12,7 +12,7 @@ type BodyProps = ExtWrapper & {devtools: DevToolsData};
 
 function Body({data, actions, devtools}: BodyProps) {
     const context = getContext();
-    const {state, setState} = useState({errorText: null as string | null});
+    const {state, setState} = useState<{errorText: string | null}>({errorText: null});
     let textNode: HTMLTextAreaElement;
     const previewButtonText = data.settings.previewNewDesign ? 'Switch to old design' : 'Preview new design';
     const {theme} = getCurrentThemePreset({data, actions});

--- a/src/ui/popup/body/index.tsx
+++ b/src/ui/popup/body/index.tsx
@@ -80,7 +80,7 @@ function Pages(props: ViewProps) {
 
     function goBack() {
         const activePage = store.activePage;
-        const settingsPageSubpages = ['automation', 'manage-settings', 'site-list'] as PageId[];
+        const settingsPageSubpages: PageId[] = ['automation', 'manage-settings', 'site-list'];
         if (settingsPageSubpages.includes(activePage)) {
             store.activePage = 'settings';
         } else {

--- a/src/ui/popup/theme/preset-picker/index.tsx
+++ b/src/ui/popup/theme/preset-picker/index.tsx
@@ -9,7 +9,7 @@ import type {DropDownOption} from '../../../controls/dropdown';
 
 function PresetItem(props: ViewProps & {preset: ThemePreset}) {
     const context = getContext();
-    const store = context.store as {isConfirmationVisible: boolean};
+    const store: {isConfirmationVisible: boolean} = context.store;
 
     function onRemoveClick(e: MouseEvent) {
         e.stopPropagation();

--- a/src/ui/utils.ts
+++ b/src/ui/utils.ts
@@ -78,7 +78,7 @@ function onSwipeStart(
         typeof TouchEvent !== 'undefined' &&
         startEventObj instanceof TouchEvent;
     const touchId = isTouchEvent
-        ? (startEventObj as TouchEvent).changedTouches[0].identifier
+        ? (startEventObj).changedTouches[0].identifier
         : null;
     const pointerMoveEvent = isTouchEvent ? 'touchmove' : 'mousemove';
     const pointerUpEvent = isTouchEvent ? 'touchend' : 'mouseup';

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -26,7 +26,7 @@ export function push<T>(array: T[], addition: Iterable<T> | ArrayLike<T>) {
 // https://jsben.ch/FJ1mO
 // https://jsben.ch/ZmViL
 export function toArray<T>(items: ArrayLike<T>) {
-    const results = [] as T[];
+    const results: T[] = [];
     for (let i = 0, len = items.length; i < len; i++) {
         results.push(items[i]);
     }

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -21,7 +21,7 @@ export function throttle<T extends(...args: any[]) => any>(callback: T) {
 
     const cancel = () => {
         // TODO: reove cast once types are updated
-        cancelAnimationFrame(frameId as number);
+        cancelAnimationFrame(frameId!);
         pending = false;
         frameId = null;
     };
@@ -58,7 +58,7 @@ export function createAsyncTasksQueue() {
     function cancel() {
         tasks.splice(0);
         // TODO: reove cast once types are updated
-        cancelAnimationFrame(frameId as number);
+        cancelAnimationFrame(frameId!);
         frameId = null;
     }
 

--- a/tests/inject/utils/url.tests.ts
+++ b/tests/inject/utils/url.tests.ts
@@ -3,166 +3,191 @@ import type {UserSettings} from '../../../src/definitions';
 import {isIPV6} from '../../../src/utils/ipv6';
 
 it('URL is enabled', () => {
+    function fillUserSettings(settings: Partial<UserSettings>): UserSettings {
+        return {
+            enabled: false,
+            fetchNews: false,
+            theme: null,
+            presets: [],
+            customThemes: [],
+            siteList: [],
+            siteListEnabled: [],
+            applyToListedOnly: false,
+            changeBrowserTheme: false,
+            syncSettings: false,
+            syncSitesFixes: false,
+            automation: null,
+            time: null,
+            location: null,
+            previewNewDesign: false,
+            enableForPDF: false,
+            enableForProtectedPages: false,
+            enableContextMenus: false,
+            detectDarkTheme: false,
+            ...settings,
+        };
+    }
+
     // Not invert listed
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['google.com'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['google.com'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['mail.google.com'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['mail.google.com'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['mail.google.*'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['mail.google.*'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['mail.google.*/mail'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['mail.google.*/mail'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['google.com/maps'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['google.com/maps'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
 
     // Invert listed only
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['google.com'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['google.com'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['google.*/mail'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['google.*/mail'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://mail.google.com/mail/u/0/',
-        {siteList: ['google.com/maps'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['google.com/maps'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
 
     // Special URLs
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
+        fillUserSettings({siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true}),
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true} as UserSettings,
+        fillUserSettings({siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true}),
         {isProtected: true, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: false}),
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://chrome.google.com/webstore',
-        {siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
+        fillUserSettings({siteList: ['chrome.google.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true}),
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://microsoftedge.microsoft.com/addons',
-        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
+        fillUserSettings({siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true}),
         {isProtected: true, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://microsoftedge.microsoft.com/addons',
-        {siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true} as UserSettings,
+        fillUserSettings({siteList: ['microsoftedge.microsoft.com'], siteListEnabled: [], applyToListedOnly: true, enableForProtectedPages: true}),
         {isProtected: true, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://duckduckgo.com',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false, enableForProtectedPages: true}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://darkreader.org/',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: true},
     )).toBe(false);
     expect(isURLEnabled(
         'https://darkreader.org/',
-        {siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: true},
     )).toBe(true);
     expect(isURLEnabled(
         'https://www.google.com/file.pdf',
-        {enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://www.google.com/file.pdf',
-        {enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://www.google.com/file.pdf',
-        {enableForPDF: false, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({enableForPDF: false, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://www.google.com/file.pdf/resource',
-        {enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://www.google.com/file.pdf/resource',
-        {enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({enableForPDF: true, siteList: ['darkreader.org'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://www.google.com/very/good/hidden/folder/pdf#file.pdf',
-        {enableForPDF: true, siteList: ['https://www.google.com/very/good/hidden/folder/pdf#file.pdf'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({enableForPDF: true, siteList: ['https://www.google.com/very/good/hidden/folder/pdf#file.pdf'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://leetcode.com/problems/two-sum/',
-        {enableForPDF: false, siteList: ['leetcode.com/problems/'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({enableForPDF: false, siteList: ['leetcode.com/problems/'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(false);
     expect(isURLEnabled(
         'https://leetcode.com/problemset/all/',
-        {enableForPDF: false, siteList: ['leetcode.com/problems/'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({enableForPDF: false, siteList: ['leetcode.com/problems/'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
 
     // Dark theme detection
     expect(isURLEnabled(
         'https://github.com/',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, detectDarkTheme: true} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false, detectDarkTheme: true}),
         {isProtected: false, isInDarkList: false, isDarkThemeDetected: true},
     )).toBe(false);
     expect(isURLEnabled(
         'https://github.com/',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, detectDarkTheme: false} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false, detectDarkTheme: false}),
         {isProtected: false, isInDarkList: false, isDarkThemeDetected: true},
     )).toBe(true);
     expect(isURLEnabled(
         'https://github.com/',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false, detectDarkTheme: true} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false, detectDarkTheme: true}),
         {isProtected: false, isInDarkList: false, isDarkThemeDetected: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://github.com/',
-        {siteList: [], siteListEnabled: ['github.com'], applyToListedOnly: false, detectDarkTheme: true} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: ['github.com'], applyToListedOnly: false, detectDarkTheme: true}),
         {isProtected: false, isInDarkList: false, isDarkThemeDetected: true},
     )).toBe(true);
 
@@ -195,42 +220,42 @@ it('URL is enabled', () => {
     // IPV6 Testing
     expect(isURLEnabled(
         '[::1]:1337',
-        {siteList: ['google.com'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['google.com'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         '[::1]:8080',
-        {siteList: ['[::1]:8080'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['[::1]:8080'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toEqual(false);
     expect(isURLEnabled(
         '[::1]:8080',
-        {siteList: ['[::1]:8081'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['[::1]:8081'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toEqual(false);
     expect(isURLEnabled(
         '[::1]:8080',
-        {siteList: ['[::1]:8081'], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: ['[::1]:8081'], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toEqual(true);
     expect(isURLEnabled(
         '[::1]:17',
-        {siteList: ['[::1]'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['[::1]'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toEqual(false);
     expect(isURLEnabled(
         '[2001:4860:4860::8888]',
-        {siteList: ['[2001:4860:4860::8888]'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['[2001:4860:4860::8888]'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: false},
     )).toEqual(true);
     expect(isURLEnabled(
         '[2001:4860:4860::8844]',
-        {siteList: ['[2001:4860:4860::8844]'], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: ['[2001:4860:4860::8844]'], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: true},
     )).toEqual(true);
     expect(isURLEnabled(
         '[2001:4860:4860::8844]',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: true},
     )).toEqual(false);
 
@@ -340,27 +365,27 @@ it('URL is enabled', () => {
     // Temporary Dark Sites list fix
     expect(isURLEnabled(
         'https://darkreader.org/',
-        {siteList: [], siteListEnabled: ['darkreader.org'], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: ['darkreader.org'], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: true},
     )).toBe(true);
     expect(isURLEnabled(
         'https://darkreader.org/',
-        {siteList: [], siteListEnabled: [], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: [], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: true},
     )).toBe(false);
     expect(isURLEnabled(
         'https://google.com/',
-        {siteList: [], siteListEnabled: ['darkreader.org'], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({siteList: [], siteListEnabled: ['darkreader.org'], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: false},
     )).toBe(true);
     expect(isURLEnabled(
         'https://netflix.com',
-        {enableForPDF: true, siteList: [''], siteListEnabled: ['netflix.com'], applyToListedOnly: true} as UserSettings,
+        fillUserSettings({enableForPDF: true, siteList: [''], siteListEnabled: ['netflix.com'], applyToListedOnly: true}),
         {isProtected: false, isInDarkList: true},
     )).toBe(true);
     expect(isURLEnabled(
         'https://netflix.com',
-        {enableForPDF: true, siteList: [''], siteListEnabled: ['netflix.com'], applyToListedOnly: false} as UserSettings,
+        fillUserSettings({enableForPDF: true, siteList: [''], siteListEnabled: ['netflix.com'], applyToListedOnly: false}),
         {isProtected: false, isInDarkList: true},
     )).toBe(true);
 });


### PR DESCRIPTION
Slightly stricter type checks. The only difference in built output:
```diff
5292,5293c5292,5294
<                         var varDecs = modified.declarations,
<                             onTypeChange = modified.onTypeChange;
---
>                         var _a = modified,
>                             varDecs = _a.declarations,
>                             onTypeChange = _a.onTypeChange;
```