### PR TITLE
Fix for protect-eu.ismartlife.me

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17143,6 +17143,18 @@ body {
 
 ================================
 
+protect-eu.ismartlife.me/login
+
+CSS
+div[class^=login_login] {
+    background-image: none !important;
+}
+div[class^=login_qc-code-content] {
+    background-color: white !important;
+}
+
+================================
+
 protocol.com
 
 INVERT


### PR DESCRIPTION
Fixes #11183

 - make QR code background white to facilitate code recognition
 - remove light full-page background image