### PR TITLE
Refactor: use unique content script context identifier for messaging

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -108,9 +108,12 @@ if (__WATCH__) {
                     break;
                 case 'reload:full':
                     chrome.tabs.query({}, (tabs) => {
+                        const message: Message = {type: MessageType.BG_RELOAD};
+                        // Some contexts are not considered to be tabs and can not receive regular messages
+                        chrome.runtime.sendMessage<Message>(message);
                         for (const tab of tabs) {
                             if (canInjectScript(tab.url)) {
-                                chrome.tabs.sendMessage<Message>(tab.id!, {type: MessageType.BG_RELOAD});
+                                chrome.tabs.sendMessage<Message>(tab.id!, message);
                             }
                         }
                         chrome.runtime.reload();

--- a/src/background/messenger.ts
+++ b/src/background/messenger.ts
@@ -44,7 +44,7 @@ export default class Messenger {
         const allowedSenderURL = [
             chrome.runtime.getURL('/ui/popup/index.html'),
             chrome.runtime.getURL('/ui/devtools/index.html'),
-            chrome.runtime.getURL('/ui/stylesheet-editor/index.html')
+            chrome.runtime.getURL('/ui/stylesheet-editor/index.html'),
         ];
         if (allowedSenderURL.includes(sender.url!)) {
             Messenger.onUIMessage(message, sendResponse);
@@ -168,7 +168,7 @@ export default class Messenger {
         if (Messenger.changeListenerCount > 0) {
             chrome.runtime.sendMessage<Message>({
                 type: MessageType.BG_CHANGES,
-                data
+                data,
             });
         }
     }

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -138,7 +138,7 @@ export default class TabManager {
                     const tabURL = sender.tab!.url!;
                     const frameId = sender.frameId!;
                     const url = sender.url!;
-                    const documentId: documentId = isFirefox ? (sender as any).contextId : (sender as any).documentId;
+                    const documentId: documentId = (__CHROMIUM_MV3__ || __CHROMIUM_MV2__ && (sender as any).documentId) ? (sender as any).documentId : null;
                     if (TabManager.tabs[tabId][frameId].timestamp < TabManager.timestamp) {
                         const message = TabManager.getTabMessage(tabURL, url, frameId === 0);
                         chrome.tabs.sendMessage<Message>(tabId, message,

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -12,6 +12,7 @@ import {makeFirefoxHappy} from './make-firefox-happy';
 
 declare const __CHROMIUM_MV2__: boolean;
 declare const __CHROMIUM_MV3__: boolean;
+declare const __FIREFOX__: boolean;
 declare const __THUNDERBIRD__: boolean;
 
 // ContextId is a number on Firefox and is a string in Chromium
@@ -103,8 +104,9 @@ export default class TabManager {
                     const tabURL = sender.tab!.url!;
                     const {frameId} = sender;
                     const url = sender.url!;
+                    const contextId: contextId = (__CHROMIUM_MV3__ || __CHROMIUM_MV2__) ? (sender as any).documentId : ((__FIREFOX__ || __THUNDERBIRD__) ? (sender as any).contextId : null);
 
-                    TabManager.addFrame(tabId, frameId!, '', url, TabManager.timestamp);
+                    TabManager.addFrame(tabId, frameId!, contextId, url, TabManager.timestamp);
 
                     reply(tabURL, url, frameId === 0);
                     TabManager.stateManager.saveState();

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -110,6 +110,7 @@ export default class TabManager {
                     TabManager.stateManager.saveState();
                     break;
                 }
+
                 case MessageType.CS_FRAME_FORGET:
                     if (!sender.tab) {
                         logWarn('Unexpected message', message, sender);
@@ -117,6 +118,7 @@ export default class TabManager {
                     }
                     TabManager.removeFrame(sender.tab!.id!, sender.frameId!);
                     break;
+
                 case MessageType.CS_FRAME_FREEZE: {
                     await TabManager.stateManager.loadState();
                     const info = TabManager.tabs[sender.tab!.id!][sender.frameId!];
@@ -125,6 +127,7 @@ export default class TabManager {
                     TabManager.stateManager.saveState();
                     break;
                 }
+
                 case MessageType.CS_FRAME_RESUME: {
                     onColorSchemeChange(message.data.isDark);
                     await TabManager.stateManager.loadState();
@@ -148,6 +151,7 @@ export default class TabManager {
                     TabManager.stateManager.saveState();
                     break;
                 }
+
                 case MessageType.CS_DARK_THEME_DETECTED:
                     TabManager.tabs[sender.tab!.id!][sender.frameId!].darkThemeDetected = true;
                     break;

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -30,7 +30,7 @@ interface FrameInfo {
     url: string | null;
     state: DocumentState;
     timestamp: number;
-    darkThemeDetected?: boolean;
+    darkThemeDetected: boolean;
 }
 
 interface TabManagerState extends Record<string, unknown> {
@@ -142,6 +142,7 @@ export default class TabManager {
                         contextId,
                         url,
                         state: DocumentState.ACTIVE,
+                        darkThemeDetected: false,
                         timestamp: TabManager.timestamp,
                     };
                     TabManager.stateManager.saveState();
@@ -230,6 +231,7 @@ export default class TabManager {
             contextId,
             url,
             state: DocumentState.ACTIVE,
+            darkThemeDetected: false,
             timestamp,
         };
     }

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -15,8 +15,9 @@ declare const __CHROMIUM_MV3__: boolean;
 declare const __FIREFOX__: boolean;
 declare const __THUNDERBIRD__: boolean;
 
-// ContextId is a number on Firefox and is a string in Chromium
-type documentId = string | number;
+// ContextId is a number on Firefox and documentId is a string in Chromium,
+// let's use string for simplicity
+type documentId = string;
 type tabId = number;
 type frameId = number;
 

--- a/src/inject/dynamic-theme/network.ts
+++ b/src/inject/dynamic-theme/network.ts
@@ -1,3 +1,4 @@
+import {generateRandomId} from '../../utils/uid';
 import type {Message} from '../../definitions';
 import {MessageType} from '../../utils/message';
 
@@ -8,13 +9,12 @@ interface FetchRequest {
     origin?: string;
 }
 
-let counter = 0;
 const resolvers = new Map<number, (data: string) => void>();
 const rejectors = new Map<number, (reason?: any) => void>();
 
 export async function bgFetch(request: FetchRequest) {
     return new Promise<string>((resolve, reject) => {
-        const id = ++counter;
+        const id = generateRandomId();
         resolvers.set(id, resolve);
         rejectors.set(id, reject);
         chrome.runtime.sendMessage<Message>({type: MessageType.CS_FETCH, data: request, id});

--- a/src/inject/utils/log.ts
+++ b/src/inject/utils/log.ts
@@ -7,6 +7,7 @@ declare const __LOG__: 'info' | 'warn';
 
 function sendLogToBG(level: 'info' | 'warn', ...args: any[]) {
     if (__WATCH__ && __LOG__ && (__LOG__ === 'info' || level === 'warn')) {
+        // No need to generate contextId since we do not expect a response
         chrome.runtime.sendMessage<Message>({type: MessageType.CS_LOG, data: {level, log: args}});
     }
 }

--- a/src/manifest-chrome-mv3.json
+++ b/src/manifest-chrome-mv3.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "minimum_chrome_version": "102.0.0.0",
+    "minimum_chrome_version": "106.0.0.0",
     "action": {
         "default_title": "Dark Reader",
         "default_icon": {

--- a/src/utils/uid.ts
+++ b/src/utils/uid.ts
@@ -10,3 +10,7 @@ export function generateUID(): string {
 
     return Array.from((crypto as Crypto).getRandomValues(new Uint8Array(16))).map((x) => hexify(x)).join('');
 }
+
+export function generateRandomId(): number {
+    return Math.floor(Math.random() * 2 ** 55);
+}


### PR DESCRIPTION
Prior to this PR, Dark Reader used only tabId and frameId for identifying message recipients. These attributes are not unique since the same frame can navigate to a different document. We already have some checks for preventing this race condition from delivering unexpected messages to a wrong context, this just adds one more check wherever documentId is available (Chromium 106+ so far, with Firefox expected to follow soon).

Follow-up PR will add ability to fall back to ids (tokens) generated by content script in cases when browser-generated ids are not available or if messages come from context lacking a tab id (for example, in sidebars).

This bumps Chromium MV3 build to Chromium 106+ to remove the fallback path in MV3 builds.