### PR TITLE
Fix for jacobin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11259,9 +11259,16 @@ body {
 
 ================================
 
-jacobinmag.com
+jacobin.com
 
 INVERT
+.po-cn .po-cn__intro
+.po-cn .po-cn__intro > *
+.po-cn .po-cn__rule
+.po-hr-cn
+.po-hr-cn > *
+.pq::after
+.pq::before
 .si-hr-nv__icon--menu
 
 ================================


### PR DESCRIPTION
Fixes graphical elements on most article pages.

Before:
![1](https://user-images.githubusercontent.com/6563728/235310876-1448fceb-bd99-4573-be9f-ff9b2b1685ec.png)
![2](https://user-images.githubusercontent.com/6563728/235310881-8ccc0960-244e-4039-bf2e-e95105be5aee.png)

After:
![3](https://user-images.githubusercontent.com/6563728/235310885-7410e869-6ffd-4a94-affb-543af54ebf68.png)
![4](https://user-images.githubusercontent.com/6563728/235310897-e6aac09a-f149-4a1c-8928-e8db09fda930.png)