### PR TITLE
fix for strava.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20202,7 +20202,6 @@ svg {
 IGNORE IMAGE ANALYSIS
 .app-icon.icon-fb
 .app-icon.icon-rowing
-.app-icon.icon-nordicski
 
 ================================
 


### PR DESCRIPTION
Removed .app-icon.icon-nordicski from IGNORE IMAGE ANALYSIS now it works fine without this