### PR TITLE
Fix for digitalextremes.zendesk.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5994,6 +5994,13 @@ body.not-front {
 
 ================================
 
+digitalextremes.zendesk.com
+
+INVERT
+.logo
+
+================================
+
 disconnect.me
 
 INVERT


### PR DESCRIPTION
Invert logo

Before:
<img width="332" alt="Screenshot_20230504_170103" src="https://user-images.githubusercontent.com/1006477/236231207-4f6745bd-1b18-48d0-baca-f6e1396e79c7.png">

After:
<img width="347" alt="Screenshot_20230504_170141" src="https://user-images.githubusercontent.com/1006477/236231241-e00e9dd6-9bb7-4e49-b53d-1791064a2fa9.png">
