### PR TITLE
boardgamearena.com - Fixes for Tooltips and Little Factory

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2993,6 +2993,7 @@ INVERT
 ================================
 
 boardgamearena.com
+
 CSS
 .bg-bga-whitebg {
     background-color: rgb(35, 38, 39);

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2993,10 +2993,27 @@ INVERT
 ================================
 
 boardgamearena.com
-
 CSS
 .bg-bga-whitebg {
     background-color: rgb(35, 38, 39);
+}
+.bgagame-littlefactory .cardClay, .dijitTooltip .cardClay {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card2.jpg");
+}
+.bgagame-littlefactory .cardCotton, .dijitTooltip .cardCotton {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card4.jpg");
+}
+.bgagame-littlefactory .cardGrain, .dijitTooltip .cardGrain {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card1.jpg");
+}
+.bgagame-littlefactory .cardStone, .dijitTooltip .cardStone {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card5.jpg");
+}
+.bgagame-littlefactory .cardWood, .dijitTooltip .cardWood {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card3.jpg");
+}
+.bgagame-littlefactory .cell3 {
+    color: #000;
 }
 .nex_plname {
     color: #000;
@@ -3011,6 +3028,9 @@ CSS
 }
 .tactic-card .card-text {
     color: #404040;
+}
+.tundra .dijitTooltipContainer {
+    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAYCAYAAAA7zJfaAAAAIklEQVQIW2OQl5f/zwAm5OTkyCFkZWX/MxBByMjI/GeAEwB0riA1hmHf7AAAAABJRU5ErkJggg==");
 }
 
 ================================


### PR DESCRIPTION
Various boardgamearena.com fixes.
Fixes disappearing cards for Little Factory.
Fixes inverted gradient on the bottom of tooltip.