### PR TITLE
Fix: spurious color scheme changes when following system theme

### DIFF
--- a/src/inject/color-scheme-watcher.ts
+++ b/src/inject/color-scheme-watcher.ts
@@ -44,7 +44,10 @@ function notifyOfColorScheme(isDark: boolean): void {
 }
 
 function updateEventListeners(): void {
-    notifyOfColorScheme(isSystemDarkModeEnabled());
+    const isDark = isSystemDarkModeEnabled();
+    if (isDark !== undefined) {
+        notifyOfColorScheme(isDark);
+    }
     if (documentIsVisible()) {
         runColorSchemeChangeDetector(notifyOfColorScheme);
     } else {

--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -209,6 +209,15 @@ export function iterateShadowHosts(root: Node | null, iterator: (host: Element) 
     }
 }
 
+export const isTopFrame = (): boolean => {
+    try {
+        return window.self === window.top;
+    } catch (err) {
+        console.warn(err);
+        return false;
+    }
+};
+
 export let isDOMReady: () => boolean = () => {
     return document.readyState === 'complete' || document.readyState === 'interactive';
 };

--- a/src/utils/media-query.ts
+++ b/src/utils/media-query.ts
@@ -1,4 +1,5 @@
 import {isMatchMediaChangeEventListenerSupported} from './platform';
+import {isTopFrame} from '../inject/utils/dom';
 
 let query: MediaQueryList | null = null;
 const onChange: ({matches}: {matches: boolean}) => void = ({matches}) => listeners.forEach((listener) => listener(matches));
@@ -31,4 +32,15 @@ export function stopColorSchemeChangeDetector(): void {
     query = null;
 }
 
-export const isSystemDarkModeEnabled = (): boolean => (query || matchMedia('(prefers-color-scheme: dark)')).matches;
+export const isSystemDarkModeEnabled = (): boolean | undefined => {
+    /* prefers-color-scheme may be overridden in embedded frames, so we cannot
+     * know whether it truely reflects the system color scheme.
+     *
+     * to avoid emitting an incorrect value, we will return undefined if we are
+     * not in a top level frame.
+     */
+    if (isTopFrame()) {
+        return (query || matchMedia('(prefers-color-scheme: dark)')).matches;
+    }
+    return undefined;
+};


### PR DESCRIPTION
sites which [overrode `prefers-color-scheme` within iframes via the `color-scheme` property](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme#embedded_elements) would mislead darkreader into reacting to a system theme change when no such change really occurred. this commit avoids this issue by only checking `prefers-color-scheme` in top level frames.

fixes #10237