### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5444,7 +5444,6 @@ video#vjs_video_3_html5_api.vjs-tech {
     transform: translate(0px, 0px) !important;
     background-color: rgb(175, 175, 175, 0.5);
 }
-
 .css-hu6jey code {
      mix-blend-mode: normal;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5445,6 +5445,10 @@ video#vjs_video_3_html5_api.vjs-tech {
     background-color: rgb(175, 175, 175, 0.5);
 }
 
+.css-hu6jey code {
+     mix-blend-mode: normal;
+}
+
 ================================
 
 daum.net


### PR DESCRIPTION
Datacamp.com CSS "code" element was not working (dark text on dark background was invisible) due to mix-blend-mode being set to 'multiply'