### PR TITLE
Tests: add color scheme emulation for Firefox

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,12 +1,13 @@
 import {Extension} from './extension';
 import {getHelpURL, UNINSTALL_URL} from '../utils/links';
 import {canInjectScript} from '../background/utils/extension-api';
-import type {ExtensionData, Message, UserSettings} from '../definitions';
+import type {ColorScheme, ExtensionData, Message, UserSettings} from '../definitions';
 import {MessageType} from '../utils/message';
 import {makeChromiumHappy} from './make-chromium-happy';
 import {ASSERT, logInfo} from './utils/log';
 import {sendLog} from './utils/sendLog';
 import {isFirefox} from '../utils/platform';
+import {emulateColorScheme} from 'utils/media-query';
 
 type TestMessage = {
     type: 'getManifest';
@@ -38,6 +39,10 @@ type TestMessage = {
     id: number;
 } | {
     type: 'firefox-getColorScheme';
+    id: number;
+} | {
+    type: 'firefox-emulateColorScheme';
+    data: ColorScheme;
     id: number;
 };
 
@@ -206,6 +211,11 @@ if (__TEST__) {
                     ASSERT('Firefox-specific function', isFirefox);
                     const isDark = matchMedia('(prefers-color-scheme: dark)').matches;
                     respond(isDark ? 'dark' : 'light');
+                    break;
+                }
+                case 'firefox-emulateColorScheme': {
+                    emulateColorScheme(message.data);
+                    respond();
                     break;
                 }
             }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,7 +7,7 @@ import {makeChromiumHappy} from './make-chromium-happy';
 import {ASSERT, logInfo} from './utils/log';
 import {sendLog} from './utils/sendLog';
 import {isFirefox} from '../utils/platform';
-import {emulateColorScheme} from 'utils/media-query';
+import {emulateColorScheme, isSystemDarkModeEnabled, } from 'utils/media-query';
 
 type TestMessage = {
     type: 'getManifest';
@@ -209,8 +209,7 @@ if (__TEST__) {
                     break;
                 case 'firefox-getColorScheme': {
                     ASSERT('Firefox-specific function', isFirefox);
-                    const isDark = matchMedia('(prefers-color-scheme: dark)').matches;
-                    respond(isDark ? 'dark' : 'light');
+                    respond(isSystemDarkModeEnabled() ? 'dark' : 'light');
                     break;
                 }
                 case 'firefox-emulateColorScheme': {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -7,7 +7,7 @@ import {makeChromiumHappy} from './make-chromium-happy';
 import {ASSERT, logInfo} from './utils/log';
 import {sendLog} from './utils/sendLog';
 import {isFirefox} from '../utils/platform';
-import {emulateColorScheme, isSystemDarkModeEnabled, } from 'utils/media-query';
+import {emulateColorScheme, isSystemDarkModeEnabled} from '../utils/media-query';
 
 type TestMessage = {
     type: 'getManifest';

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -4,7 +4,7 @@ import type {FetchRequestParameters} from './utils/network';
 import type {Message} from '../definitions';
 import {isFirefox} from '../utils/platform';
 import {MessageType} from '../utils/message';
-import {logInfo, logWarn} from './utils/log';
+import {ASSERT, logInfo, logWarn} from './utils/log';
 import {StateManager} from '../utils/state-manager';
 import {getURLHostOrProtocol} from '../utils/url';
 import {isPanel} from './utils/tab';
@@ -58,13 +58,15 @@ export default class TabManager {
     private static tabs: {[tabId: tabId]: {[frameId: frameId]: DocumentInfo}};
     private static stateManager: StateManager<TabManagerState>;
     private static fileLoader: {get: (params: FetchRequestParameters) => Promise<string | null>} | null = null;
-    private static getTabMessage: (tabURL: string, url: string, isTopFrame: boolean) => Message;
+    private static onColorSchemeChange: TabManagerOptions['onColorSchemeChange'];
+    private static getTabMessage: TabManagerOptions['getTabMessage'];
     private static timestamp = 0;
     private static readonly LOCAL_STORAGE_KEY = 'TabManager-state';
 
     public static init({getConnectionMessage, onColorSchemeChange, getTabMessage}: TabManagerOptions): void {
         TabManager.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0}, logWarn);
         TabManager.tabs = {};
+        TabManager.onColorSchemeChange = onColorSchemeChange;
         TabManager.getTabMessage = getTabMessage;
 
         chrome.runtime.onMessage.addListener(async (message: Message, sender, sendResponse) => {
@@ -73,7 +75,7 @@ export default class TabManager {
             }
             switch (message.type) {
                 case MessageType.CS_FRAME_CONNECT: {
-                    onColorSchemeChange(message.data.isDark);
+                    TabManager.onColorSchemeMessage(message, sender);
                     await TabManager.stateManager.loadState();
                     const reply = (tabURL: string, url: string, isTopFrame: boolean) => {
                         getConnectionMessage(tabURL, url, isTopFrame).then((message) => {
@@ -132,7 +134,7 @@ export default class TabManager {
                 }
 
                 case MessageType.CS_FRAME_RESUME: {
-                    onColorSchemeChange(message.data.isDark);
+                    TabManager.onColorSchemeMessage(message, sender);
                     await TabManager.stateManager.loadState();
                     const tabId = sender.tab!.id!;
                     const tabURL = sender.tab!.url!;
@@ -191,7 +193,7 @@ export default class TabManager {
                 case MessageType.UI_COLOR_SCHEME_CHANGE:
                     // fallthrough
                 case MessageType.CS_COLOR_SCHEME_CHANGE:
-                    onColorSchemeChange(message.data.isDark);
+                    TabManager.onColorSchemeMessage(message, sender);
                     break;
 
                 case MessageType.UI_SAVE_FILE: {
@@ -218,6 +220,18 @@ export default class TabManager {
         });
 
         chrome.tabs.onRemoved.addListener(async (tabId) => TabManager.removeFrame(tabId, 0));
+    }
+
+    private static onColorSchemeMessage(message: Message, sender: chrome.runtime.MessageSender) {
+        ASSERT('TabManager.onColorSchemeMessage is set', Boolean(TabManager.onColorSchemeChange));
+
+        // We honor only messages which come from tab's top frame
+        // because sub-frames color scheme can be overridden by style with prefers-color-scheme
+        // TODO(MV3): instead of dropping these messages, consider making a query to an authoritative source
+        // like offscreen document
+        if (sender && sender.frameId === 0) {
+            TabManager.onColorSchemeChange(message.data.isDark);
+        }
     }
 
     private static async queryTabs(query: chrome.tabs.QueryInfo = {}) {

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -4,7 +4,7 @@ import type {FetchRequestParameters} from './utils/network';
 import type {Message} from '../definitions';
 import {isFirefox} from '../utils/platform';
 import {MessageType} from '../utils/message';
-import {ASSERT, logInfo, logWarn} from './utils/log';
+import {logInfo, logWarn} from './utils/log';
 import {StateManager} from '../utils/state-manager';
 import {getURLHostOrProtocol} from '../utils/url';
 import {isPanel} from './utils/tab';
@@ -58,15 +58,13 @@ export default class TabManager {
     private static tabs: {[tabId: tabId]: {[frameId: frameId]: DocumentInfo}};
     private static stateManager: StateManager<TabManagerState>;
     private static fileLoader: {get: (params: FetchRequestParameters) => Promise<string | null>} | null = null;
-    private static onColorSchemeChange: TabManagerOptions['onColorSchemeChange'];
-    private static getTabMessage: TabManagerOptions['getTabMessage'];
+    private static getTabMessage: (tabURL: string, url: string, isTopFrame: boolean) => Message;
     private static timestamp = 0;
     private static readonly LOCAL_STORAGE_KEY = 'TabManager-state';
 
     public static init({getConnectionMessage, onColorSchemeChange, getTabMessage}: TabManagerOptions): void {
         TabManager.stateManager = new StateManager<TabManagerState>(TabManager.LOCAL_STORAGE_KEY, this, {tabs: {}, timestamp: 0}, logWarn);
         TabManager.tabs = {};
-        TabManager.onColorSchemeChange = onColorSchemeChange;
         TabManager.getTabMessage = getTabMessage;
 
         chrome.runtime.onMessage.addListener(async (message: Message, sender, sendResponse) => {
@@ -75,7 +73,7 @@ export default class TabManager {
             }
             switch (message.type) {
                 case MessageType.CS_FRAME_CONNECT: {
-                    TabManager.onColorSchemeMessage(message, sender);
+                    onColorSchemeChange(message.data.isDark);
                     await TabManager.stateManager.loadState();
                     const reply = (tabURL: string, url: string, isTopFrame: boolean) => {
                         getConnectionMessage(tabURL, url, isTopFrame).then((message) => {
@@ -134,7 +132,7 @@ export default class TabManager {
                 }
 
                 case MessageType.CS_FRAME_RESUME: {
-                    TabManager.onColorSchemeMessage(message, sender);
+                    onColorSchemeChange(message.data.isDark);
                     await TabManager.stateManager.loadState();
                     const tabId = sender.tab!.id!;
                     const tabURL = sender.tab!.url!;
@@ -193,7 +191,7 @@ export default class TabManager {
                 case MessageType.UI_COLOR_SCHEME_CHANGE:
                     // fallthrough
                 case MessageType.CS_COLOR_SCHEME_CHANGE:
-                    TabManager.onColorSchemeMessage(message, sender);
+                    onColorSchemeChange(message.data.isDark);
                     break;
 
                 case MessageType.UI_SAVE_FILE: {
@@ -220,18 +218,6 @@ export default class TabManager {
         });
 
         chrome.tabs.onRemoved.addListener(async (tabId) => TabManager.removeFrame(tabId, 0));
-    }
-
-    private static onColorSchemeMessage(message: Message, sender: chrome.runtime.MessageSender) {
-        ASSERT('TabManager.onColorSchemeMessage is set', Boolean(TabManager.onColorSchemeChange));
-
-        // We honor only messages which come from tab's top frame
-        // because sub-frames color scheme can be overridden by style with prefers-color-scheme
-        // TODO(MV3): instead of dropping these messages, consider making a query to an authoritative source
-        // like offscreen document
-        if (sender && sender.frameId === 0) {
-            TabManager.onColorSchemeChange(message.data.isDark);
-        }
     }
 
     private static async queryTabs(query: chrome.tabs.QueryInfo = {}) {

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -4,6 +4,8 @@ import type {MessageType} from './utils/message';
 import type {AutomationMode} from './utils/automation';
 import type {ThemeEngine} from './generators/theme-engines';
 
+export type ColorScheme = 'dark' | 'light';
+
 export interface ExtensionData {
     isEnabled: boolean;
     isReady: boolean;

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -295,6 +295,7 @@ if (__TEST__) {
 
                     const interval: number = setInterval(checkPageStylesNow, 200);
                     checkPageStylesNow();
+                    break;
                 }
             }
         };

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -3,7 +3,7 @@ import {createOrUpdateSVGFilter, removeSVGFilter} from './svg-filter';
 import {runDarkThemeDetector, stopDarkThemeDetector} from './detector';
 import {createOrUpdateDynamicTheme, removeDynamicTheme, cleanDynamicThemeCache} from './dynamic-theme';
 import {logWarn, logInfoCollapsed} from './utils/log';
-import {isSystemDarkModeEnabled, runColorSchemeChangeDetector, stopColorSchemeChangeDetector} from '../utils/media-query';
+import {isSystemDarkModeEnabled, runColorSchemeChangeDetector, stopColorSchemeChangeDetector, emulateColorScheme} from '../utils/media-query';
 import {collectCSS} from './dynamic-theme/css-collection';
 import type {DynamicThemeFix, Message, Theme} from '../definitions';
 import {MessageType} from '../utils/message';
@@ -295,6 +295,11 @@ if (__TEST__) {
 
                     const interval: number = setInterval(checkPageStylesNow, 200);
                     checkPageStylesNow();
+                    break;
+                }
+                case 'firefox-emulateColorScheme': {
+                    emulateColorScheme(data);
+                    respond(undefined);
                     break;
                 }
             }

--- a/src/utils/media-query.ts
+++ b/src/utils/media-query.ts
@@ -1,5 +1,8 @@
 import {isMatchMediaChangeEventListenerSupported} from './platform';
 
+declare const __TEST__: boolean;
+let override: boolean | null = null;
+
 let query: MediaQueryList | null = null;
 const onChange: ({matches}: {matches: boolean}) => void = ({matches}) => listeners.forEach((listener) => listener(matches));
 const listeners = new Set<(isDark: boolean) => void>();
@@ -31,4 +34,12 @@ export function stopColorSchemeChangeDetector(): void {
     query = null;
 }
 
-export const isSystemDarkModeEnabled = (): boolean => (query || matchMedia('(prefers-color-scheme: dark)')).matches;
+export function emulateColorScheme(colorScheme: 'light' | 'dark') {
+    if (__TEST__) {
+        const isDark = colorScheme === 'dark';
+        override = isDark;
+        listeners.forEach((l) => l(isDark));
+    }
+}
+
+export const isSystemDarkModeEnabled = (): boolean => (__TEST__ && typeof override === 'boolean') ? override : (query || matchMedia('(prefers-color-scheme: dark)')).matches;

--- a/src/utils/media-query.ts
+++ b/src/utils/media-query.ts
@@ -34,7 +34,7 @@ export function stopColorSchemeChangeDetector(): void {
     query = null;
 }
 
-export function emulateColorScheme(colorScheme: 'light' | 'dark') {
+export function emulateColorScheme(colorScheme: 'light' | 'dark'): void {
     if (__TEST__) {
         const isDark = colorScheme === 'dark';
         override = isDark;

--- a/tests/browser/dynamic/inline-override.tests.ts
+++ b/tests/browser/dynamic/inline-override.tests.ts
@@ -35,7 +35,7 @@ describe('Inline style override', () => {
 
         await expectStyles(['span', 'color', 'rgb(255, 26, 26)']);
 
-        await expect(evaluateScript(async () => {
+        await expect(pageUtils.evaluateScript(async () => {
             const span = document.querySelector('span');
             span.style.color = 'green';
             await new Promise((resolve) => setTimeout(resolve));

--- a/tests/browser/dynamic/style-override.tests.ts
+++ b/tests/browser/dynamic/style-override.tests.ts
@@ -74,7 +74,7 @@ describe('Style override', () => {
             ),
         });
 
-        await evaluateScript(() => {
+        await pageUtils.evaluateScript(() => {
             const styleElement = document.createElement('style');
             styleElement.classList.add('testcase-style');
             document.head.append(styleElement);
@@ -87,7 +87,7 @@ describe('Style override', () => {
             ['h1 strong', 'color', 'rgb(255, 26, 26)']
         ]);
 
-        await expect(evaluateScript(async () => {
+        await expect(pageUtils.evaluateScript(async () => {
             const style = document.querySelector('.testcase-style');
             style.nextSibling.remove();
             await new Promise((resolve) => setTimeout(resolve));
@@ -109,7 +109,7 @@ describe('Style override', () => {
             ),
         });
 
-        await evaluateScript(() => {
+        await pageUtils.evaluateScript(() => {
             const styleElement = document.createElement('style');
             styleElement.classList.add('testcase-style');
             document.head.append(styleElement);
@@ -117,7 +117,7 @@ describe('Style override', () => {
             styleElement.sheet.insertRule('strong { color: red } ');
         });
 
-        await expect(evaluateScript(async () => {
+        await expect(pageUtils.evaluateScript(async () => {
             const style = document.querySelector('.testcase-style');
             document.body.append(style);
             await new Promise((resolve) => setTimeout(resolve));
@@ -139,7 +139,7 @@ describe('Style override', () => {
             ),
         });
 
-        await evaluateScript(() => {
+        await pageUtils.evaluateScript(() => {
             const styleElement = document.createElement('style');
             styleElement.classList.add('testcase-style');
             document.head.append(styleElement);
@@ -147,7 +147,7 @@ describe('Style override', () => {
             styleElement.sheet.insertRule('strong { color: red }');
         });
 
-        await expect(evaluateScript(async () => {
+        await expect(pageUtils.evaluateScript(async () => {
             const style = document.querySelector('.testcase-style');
             const sibling = style.nextSibling;
             style.remove();
@@ -174,7 +174,7 @@ describe('Style override', () => {
             ),
         });
 
-        await evaluateScript(() => {
+        await pageUtils.evaluateScript(() => {
             const styleElement = document.createElement('style');
             styleElement.classList.add('testcase-style');
             document.head.append(styleElement);
@@ -182,7 +182,7 @@ describe('Style override', () => {
             styleElement.sheet.insertRule('strong { color: red }');
         });
 
-        await expect(evaluateScript(async () => {
+        await expect(pageUtils.evaluateScript(async () => {
             const style = document.querySelector('.testcase-style');
             (style as HTMLStyleElement).sheet.insertRule('html { background-color: pink }');
             await new Promise((resolve) => setTimeout(resolve));
@@ -204,7 +204,7 @@ describe('Style override', () => {
             ),
         });
 
-        await expect(evaluateScript(async () => {
+        await expect(pageUtils.evaluateScript(async () => {
             const styleElement = document.createElement('style');
             styleElement.classList.add('testcase-style');
             document.head.append(styleElement);
@@ -233,7 +233,7 @@ describe('Style override', () => {
             ),
         });
 
-        evaluateScript(async () => {
+        pageUtils.evaluateScript(async () => {
             class CustomElement extends HTMLElement {
                 constructor() {
                     super();

--- a/tests/browser/e2e/environment.tests.ts
+++ b/tests/browser/e2e/environment.tests.ts
@@ -32,16 +32,18 @@ describe('Test environment', () => {
         const overrideColorScheme = initialColorScheme === 'dark' ? 'light' : 'dark';
 
         expect(initialColorScheme === 'light' || initialColorScheme === 'dark');
-        /*
-        await expect(backgroundUtils.getColorScheme()).resolves.toBe(initialColorScheme);
+        if (product === 'firefox') {
+            await expect(backgroundUtils.getColorScheme()).resolves.toBe(initialColorScheme);
+        }
         console.error(2, initialColorScheme);
 
         await emulateColorScheme(overrideColorScheme);
         console.error(3, initialColorScheme);
         await expect(getColorScheme()).resolves.toBe(overrideColorScheme);
         console.error(4, initialColorScheme);
-        await expect(backgroundUtils.getColorScheme()).resolves.toBe(overrideColorScheme);
+        if (product === 'firefox') {
+            await expect(backgroundUtils.getColorScheme()).resolves.toBe(overrideColorScheme);
+        }
         console.error(5, initialColorScheme);
-        */
     });
 });

--- a/tests/browser/e2e/environment.tests.ts
+++ b/tests/browser/e2e/environment.tests.ts
@@ -28,22 +28,17 @@ describe('Test environment', () => {
         await loadBasicPage();
 
         const initialColorScheme = await getColorScheme();
-        console.error(1, initialColorScheme);
         const overrideColorScheme = initialColorScheme === 'dark' ? 'light' : 'dark';
 
         expect(initialColorScheme === 'light' || initialColorScheme === 'dark');
         if (product === 'firefox') {
             await expect(backgroundUtils.getColorScheme()).resolves.toBe(initialColorScheme);
         }
-        console.error(2, initialColorScheme);
 
         await emulateColorScheme(overrideColorScheme);
-        console.error(3, initialColorScheme);
         await expect(getColorScheme()).resolves.toBe(overrideColorScheme);
-        console.error(4, initialColorScheme);
         if (product === 'firefox') {
             await expect(backgroundUtils.getColorScheme()).resolves.toBe(overrideColorScheme);
         }
-        console.error(5, initialColorScheme);
     });
 });

--- a/tests/browser/e2e/environment.tests.ts
+++ b/tests/browser/e2e/environment.tests.ts
@@ -1,0 +1,47 @@
+import {multiline} from '../../support/test-utils';
+
+async function loadBasicPage(header = 'E2E test page') {
+    await loadTestPage({
+        '/': multiline(
+            '<!DOCTYPE html>',
+            '<html>',
+            '<head>',
+            '    <style>',
+            '        h1 { color: red; }',
+            '    </style>',
+            '</head>',
+            '<body>',
+            `    <h1>${header}</h1>`,
+            '    <p>Text</p>',
+            '    <a href="#">Link</a>',
+            '</body>',
+            '</html>',
+        ),
+    });
+}
+
+describe('Test environment', () => {
+    // TODO: remove flakes and remove this line
+    jest.retryTimes(10, {logErrorsBeforeRetry: true});
+
+    it('should turn On/Off', async () => {
+        await loadBasicPage();
+
+        const initialColorScheme = await getColorScheme();
+        console.error(1, initialColorScheme);
+        const overrideColorScheme = initialColorScheme === 'dark' ? 'light' : 'dark';
+
+        expect(initialColorScheme === 'light' || initialColorScheme === 'dark');
+        /*
+        await expect(backgroundUtils.getColorScheme()).resolves.toBe(initialColorScheme);
+        console.error(2, initialColorScheme);
+
+        await emulateColorScheme(overrideColorScheme);
+        console.error(3, initialColorScheme);
+        await expect(getColorScheme()).resolves.toBe(overrideColorScheme);
+        console.error(4, initialColorScheme);
+        await expect(backgroundUtils.getColorScheme()).resolves.toBe(overrideColorScheme);
+        console.error(5, initialColorScheme);
+        */
+    });
+});

--- a/tests/browser/e2e/shadow-dom.tests.ts
+++ b/tests/browser/e2e/shadow-dom.tests.ts
@@ -27,7 +27,7 @@ describe('Custom HTML elements', () => {
             ),
         });
 
-        await evaluateScript(async () => {
+        await pageUtils.evaluateScript(async () => {
             class ElementWitAsync extends HTMLElement {
                 constructor() {
                     super();

--- a/tests/browser/e2e/toggle.tests.ts
+++ b/tests/browser/e2e/toggle.tests.ts
@@ -67,10 +67,6 @@ describe('Toggling the extension', () => {
     });
 
     it('should follow system color scheme', async () => {
-        if (product === 'firefox') {
-            expect(true);
-            return;
-        }
         await loadBasicPage('Automation (color scheme)');
 
         const automationMenuSelector = '.header__more-settings-button';

--- a/tests/browser/e2e/toggle.tests.ts
+++ b/tests/browser/e2e/toggle.tests.ts
@@ -5,7 +5,7 @@ async function expectStyles(styles: StyleExpectations) {
     await expectPageStyles(expect, styles);
 }
 
-async function loadBasicPage(header = 'E2E test page') {
+async function loadBasicPage(header: string) {
     await loadTestPage({
         '/': multiline(
             '<!DOCTYPE html>',
@@ -24,6 +24,23 @@ async function loadBasicPage(header = 'E2E test page') {
         ),
     });
 }
+
+/*
+
+        '/subframe.html': multiline(
+            '<!DOCTYPE html>',
+            '<html>',
+            '<head>',
+            '</head>',
+            '<body>',
+            `    <h1>Subframe color: ${color}</h1>`,
+            '</body>',
+            '</html>',
+        ),
+    })
+];
+}
+*/
 
 describe('Toggling the extension', () => {
     // TODO: remove flakes and remove this line
@@ -99,6 +116,134 @@ describe('Toggling the extension', () => {
             ['h1', 'color', 'rgb(255, 0, 0)'],
             ['a', 'color', 'rgb(0, 0, 238)'],
         ]);
+
+        await emulateMedia('prefers-color-scheme', 'dark');
+        await expect(getColorScheme()).resolves.toBe('dark');
+
+        await expectStyles([
+            ['document', 'background-color', 'rgb(24, 26, 27)'],
+            ['document', 'color', 'rgb(232, 230, 227)'],
+            ['body', 'background-color', 'rgb(24, 26, 27)'],
+            ['body', 'color', 'rgb(232, 230, 227)'],
+            ['h1', 'color', 'rgb(255, 26, 26)'],
+            ['a', 'color', 'rgb(51, 145, 255)'],
+        ]);
+
+        await emulateMedia('prefers-color-scheme', 'light');
+        await expect(getColorScheme()).resolves.toBe('light');
+
+        await expectStyles([
+            ['document', 'background-color', 'rgba(0, 0, 0, 0)'],
+            ['document', 'color', 'rgb(0, 0, 0)'],
+            ['body', 'background-color', 'rgba(0, 0, 0, 0)'],
+            ['body', 'color', 'rgb(0, 0, 0)'],
+            ['h1', 'color', 'rgb(255, 0, 0)'],
+            ['a', 'color', 'rgb(0, 0, 238)'],
+        ]);
+
+        await popupUtils.click(automationSystemSelector);
+
+        await expectStyles([
+            ['document', 'background-color', 'rgb(24, 26, 27)'],
+            ['document', 'color', 'rgb(232, 230, 227)'],
+            ['body', 'background-color', 'rgb(24, 26, 27)'],
+            ['body', 'color', 'rgb(232, 230, 227)'],
+            ['h1', 'color', 'rgb(255, 26, 26)'],
+            ['a', 'color', 'rgb(51, 145, 255)'],
+        ]);
+
+        await emulateMedia('prefers-color-scheme', 'dark');
+    });
+
+    // Note: this test is relevant only to Firefox and Thunderbird
+    // which do not support color schmeme overrides the way we use them
+    // Instead, we query the current system color scheme and adjust the test accordingly
+    // Test will fail if user changes system color scheme mid-way through the test
+    it('should ignore color watcher messages from subframes', async () => {
+        const darkPageExpectations: StyleExpectations = [
+            ['document', 'background-color', 'rgb(24, 26, 27)'],
+            ['document', 'color', 'rgb(232, 230, 227)'],
+            ['body', 'background-color', 'rgb(24, 26, 27)'],
+            ['body', 'color', 'rgb(232, 230, 227)'],
+            ['h1', 'color', 'rgb(255, 26, 26)'],
+            ['a', 'color', 'rgb(51, 145, 255)'],
+        ];
+
+        const lightPageExpectations: StyleExpectations = [
+            ['document', 'background-color', 'rgba(0, 0, 0, 0)'],
+            ['document', 'color', 'rgb(0, 0, 0)'],
+            ['body', 'background-color', 'rgba(0, 0, 0, 0)'],
+            ['body', 'color', 'rgb(0, 0, 0)'],
+            ['h1', 'color', 'rgb(255, 0, 0)'],
+            ['a', 'color', 'rgb(0, 0, 238)'],
+        ];
+
+        let subframeBarrier: () => void = null;
+        await loadTestPage({
+            '/': multiline(
+                '<!DOCTYPE html>',
+                '<html>',
+                '<head>',
+                '    <style>',
+                '        h1 { color: red; }',
+                '    </style>',
+                '</head>',
+                '<body>',
+                `    <h1>Color scheme detector</h1>`,
+                '    <p>Text</p>',
+                '    <a href="#">Link</a>',
+                '</body>',
+                '</html>',
+                ),
+            '/subframe.html': async (_, res) => {
+                res.statusCode = 200;
+                res.setHeader('Content-Type', 'text/html');
+    
+                await new Promise<void>((resolve) => subframeBarrier = resolve);
+    
+                res.end(
+                    multiline(
+                        '<!DOCTYPE html>',
+                        '<html>',
+                        '<head>',
+                        '    <style>',
+                        '        h1 { color: red; }',
+                        '    </style>',
+                        '</head>',
+                        '<body>',
+                        '    <h1>header</h1>',
+                        '    <p>Text</p>',
+                        '    <a href="#">Link</a>',
+                        '</body>',
+                        '</html>',
+                    ),
+                    'utf8'
+                );
+            },
+        }, {
+            waitUntil: 'domcontentloaded',
+        });
+
+        // Note: this call needs to be after loadTestPage() since
+        // on Firefox we query color scheme from page context
+        const systemColorScheme = await getColorScheme(); // TODO
+
+        const initialPageExpectations = systemColorScheme === 'dark' ? darkPageExpectations : lightPageExpectations;
+
+        const automationMenuSelector = '.header__more-settings-button';
+        const automationSystemSelector = '.header__more-settings__system-dark-mode__checkbox .checkbox__input';
+
+        await expect(getColorScheme()).resolves.toBe(systemColorScheme);
+
+        await expectStyles(darkPageExpectations);
+
+        await popupUtils.click(automationMenuSelector);
+        await popupUtils.click(automationSystemSelector);
+
+        await expectStyles(initialPageExpectations);
+
+        console.error(123);
+
 
         await emulateMedia('prefers-color-scheme', 'dark');
         await expect(getColorScheme()).resolves.toBe('dark');

--- a/tests/browser/e2e/toggle.tests.ts
+++ b/tests/browser/e2e/toggle.tests.ts
@@ -5,7 +5,7 @@ async function expectStyles(styles: StyleExpectations) {
     await expectPageStyles(expect, styles);
 }
 
-async function loadBasicPage(header: string) {
+async function loadBasicPage(header = 'E2E test page') {
     await loadTestPage({
         '/': multiline(
             '<!DOCTYPE html>',
@@ -24,23 +24,6 @@ async function loadBasicPage(header: string) {
         ),
     });
 }
-
-/*
-
-        '/subframe.html': multiline(
-            '<!DOCTYPE html>',
-            '<html>',
-            '<head>',
-            '</head>',
-            '<body>',
-            `    <h1>Subframe color: ${color}</h1>`,
-            '</body>',
-            '</html>',
-        ),
-    })
-];
-}
-*/
 
 describe('Toggling the extension', () => {
     // TODO: remove flakes and remove this line
@@ -93,7 +76,7 @@ describe('Toggling the extension', () => {
         const automationMenuSelector = '.header__more-settings-button';
         const automationSystemSelector = '.header__more-settings__system-dark-mode__checkbox .checkbox__input';
 
-        await emulateMedia('prefers-color-scheme', 'light');
+        await emulateColorScheme('light');
         await expect(getColorScheme()).resolves.toBe('light');
 
         await expectStyles([
@@ -117,7 +100,7 @@ describe('Toggling the extension', () => {
             ['a', 'color', 'rgb(0, 0, 238)'],
         ]);
 
-        await emulateMedia('prefers-color-scheme', 'dark');
+        await emulateColorScheme('dark');
         await expect(getColorScheme()).resolves.toBe('dark');
 
         await expectStyles([
@@ -129,7 +112,7 @@ describe('Toggling the extension', () => {
             ['a', 'color', 'rgb(51, 145, 255)'],
         ]);
 
-        await emulateMedia('prefers-color-scheme', 'light');
+        await emulateColorScheme('light');
         await expect(getColorScheme()).resolves.toBe('light');
 
         await expectStyles([
@@ -152,135 +135,7 @@ describe('Toggling the extension', () => {
             ['a', 'color', 'rgb(51, 145, 255)'],
         ]);
 
-        await emulateMedia('prefers-color-scheme', 'dark');
-    });
-
-    // Note: this test is relevant only to Firefox and Thunderbird
-    // which do not support color schmeme overrides the way we use them
-    // Instead, we query the current system color scheme and adjust the test accordingly
-    // Test will fail if user changes system color scheme mid-way through the test
-    it('should ignore color watcher messages from subframes', async () => {
-        const darkPageExpectations: StyleExpectations = [
-            ['document', 'background-color', 'rgb(24, 26, 27)'],
-            ['document', 'color', 'rgb(232, 230, 227)'],
-            ['body', 'background-color', 'rgb(24, 26, 27)'],
-            ['body', 'color', 'rgb(232, 230, 227)'],
-            ['h1', 'color', 'rgb(255, 26, 26)'],
-            ['a', 'color', 'rgb(51, 145, 255)'],
-        ];
-
-        const lightPageExpectations: StyleExpectations = [
-            ['document', 'background-color', 'rgba(0, 0, 0, 0)'],
-            ['document', 'color', 'rgb(0, 0, 0)'],
-            ['body', 'background-color', 'rgba(0, 0, 0, 0)'],
-            ['body', 'color', 'rgb(0, 0, 0)'],
-            ['h1', 'color', 'rgb(255, 0, 0)'],
-            ['a', 'color', 'rgb(0, 0, 238)'],
-        ];
-
-        let subframeBarrier: () => void = null;
-        await loadTestPage({
-            '/': multiline(
-                '<!DOCTYPE html>',
-                '<html>',
-                '<head>',
-                '    <style>',
-                '        h1 { color: red; }',
-                '    </style>',
-                '</head>',
-                '<body>',
-                `    <h1>Color scheme detector</h1>`,
-                '    <p>Text</p>',
-                '    <a href="#">Link</a>',
-                '</body>',
-                '</html>',
-                ),
-            '/subframe.html': async (_, res) => {
-                res.statusCode = 200;
-                res.setHeader('Content-Type', 'text/html');
-    
-                await new Promise<void>((resolve) => subframeBarrier = resolve);
-    
-                res.end(
-                    multiline(
-                        '<!DOCTYPE html>',
-                        '<html>',
-                        '<head>',
-                        '    <style>',
-                        '        h1 { color: red; }',
-                        '    </style>',
-                        '</head>',
-                        '<body>',
-                        '    <h1>header</h1>',
-                        '    <p>Text</p>',
-                        '    <a href="#">Link</a>',
-                        '</body>',
-                        '</html>',
-                    ),
-                    'utf8'
-                );
-            },
-        }, {
-            waitUntil: 'domcontentloaded',
-        });
-
-        // Note: this call needs to be after loadTestPage() since
-        // on Firefox we query color scheme from page context
-        const systemColorScheme = await getColorScheme(); // TODO
-
-        const initialPageExpectations = systemColorScheme === 'dark' ? darkPageExpectations : lightPageExpectations;
-
-        const automationMenuSelector = '.header__more-settings-button';
-        const automationSystemSelector = '.header__more-settings__system-dark-mode__checkbox .checkbox__input';
-
-        await expect(getColorScheme()).resolves.toBe(systemColorScheme);
-
-        await expectStyles(darkPageExpectations);
-
-        await popupUtils.click(automationMenuSelector);
-        await popupUtils.click(automationSystemSelector);
-
-        await expectStyles(initialPageExpectations);
-
-        console.error(123);
-
-
-        await emulateMedia('prefers-color-scheme', 'dark');
-        await expect(getColorScheme()).resolves.toBe('dark');
-
-        await expectStyles([
-            ['document', 'background-color', 'rgb(24, 26, 27)'],
-            ['document', 'color', 'rgb(232, 230, 227)'],
-            ['body', 'background-color', 'rgb(24, 26, 27)'],
-            ['body', 'color', 'rgb(232, 230, 227)'],
-            ['h1', 'color', 'rgb(255, 26, 26)'],
-            ['a', 'color', 'rgb(51, 145, 255)'],
-        ]);
-
-        await emulateMedia('prefers-color-scheme', 'light');
-        await expect(getColorScheme()).resolves.toBe('light');
-
-        await expectStyles([
-            ['document', 'background-color', 'rgba(0, 0, 0, 0)'],
-            ['document', 'color', 'rgb(0, 0, 0)'],
-            ['body', 'background-color', 'rgba(0, 0, 0, 0)'],
-            ['body', 'color', 'rgb(0, 0, 0)'],
-            ['h1', 'color', 'rgb(255, 0, 0)'],
-            ['a', 'color', 'rgb(0, 0, 238)'],
-        ]);
-
-        await popupUtils.click(automationSystemSelector);
-
-        await expectStyles([
-            ['document', 'background-color', 'rgb(24, 26, 27)'],
-            ['document', 'color', 'rgb(232, 230, 227)'],
-            ['body', 'background-color', 'rgb(24, 26, 27)'],
-            ['body', 'color', 'rgb(232, 230, 227)'],
-            ['h1', 'color', 'rgb(255, 26, 26)'],
-            ['a', 'color', 'rgb(51, 145, 255)'],
-        ]);
-
-        await emulateMedia('prefers-color-scheme', 'dark');
+        await emulateColorScheme('dark');
     });
 
     it('should have new design button on desktop', async () => {

--- a/tests/browser/environment.js
+++ b/tests/browser/environment.js
@@ -272,7 +272,7 @@ export default class CustomJestEnvironment extends TestEnvironment {
             return isDark ? 'dark' : 'light';
         };
 
-        this.global.evaluateScript = async (script) => {
+        this.global.pageUtils.evaluateScript = async (script) => {
             if (this.global.product === 'firefox') {
                 if (typeof script !== 'function') {
                     throw new Error('Not implemented');
@@ -296,14 +296,14 @@ export default class CustomJestEnvironment extends TestEnvironment {
             expect(errors.length).toBe(0);
         };
 
-        this.global.emulateMedia = async (name, value) => {
+        this.global.emulateColorScheme = async (value) => {
             if (this.global.product === 'firefox') {
                 return;
             }
-            await this.page.emulateMediaFeatures([{name, value}]);
+            await this.page.emulateMediaFeatures([{name: 'prefers-color-scheme', value}]);
             if (this.global.product === 'chrome') {
                 const page = await this.getChromiumMV2BackgroundPage();
-                await page.emulateMediaFeatures([{name, value}]);
+                await page.emulateMediaFeatures([{name: 'prefers-color-scheme', value}]);
             }
         };
 

--- a/tests/browser/environment.js
+++ b/tests/browser/environment.js
@@ -48,7 +48,7 @@ export default class CustomJestEnvironment extends TestEnvironment {
 
         // Wait for tabs to load?
 
-        this.assignTestGlobals();
+        this.assignTestGlobals(this.global, this.testServer, this.corsServer, this.page);
     }
 
     /**
@@ -261,60 +261,57 @@ export default class CustomJestEnvironment extends TestEnvironment {
         return errors;
     }
 
-    assignTestGlobals() {
-        this.global.getColorScheme = async () => {
-            if (this.global.product === 'firefox') {
-                console.error('HELLO');
-                //console.error(Boolean(this, this.page)
-                return await this.global.backgroundUtils.getColorScheme();
+    assignTestGlobals(global, testServer, corsServer, page) {
+        global.getColorScheme = async () => {
+            if (global.product === 'firefox') {
+                return await global.backgroundUtils.getColorScheme();
             }
-            const isDark = await this.page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches);
+            const isDark = await page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches);
             return isDark ? 'dark' : 'light';
         };
 
-        this.global.pageUtils.evaluateScript = async (script) => {
-            if (this.global.product === 'firefox') {
+        global.pageUtils.evaluateScript = async (script) => {
+            if (global.product === 'firefox') {
                 if (typeof script !== 'function') {
                     throw new Error('Not implemented');
                 }
-                return await this.global.pageUtils.evaluate(`(${script.toString()})()`);
+                return await global.pageUtils.evaluate(`(${script.toString()})()`);
             }
-            return await this.page.evaluate(script);
+            return await page.evaluate(script);
         };
 
-        this.global.expectPageStyles = async (expect, expectations) => {
-            if (this.global.product === 'firefox') {
-                const errors = await this.global.pageUtils.expectPageStyles(expectations);
+        global.expectPageStyles = async (expect, expectations) => {
+            if (global.product === 'firefox') {
+                const errors = await global.pageUtils.expectPageStyles(expectations);
                 expect(errors.length).toBe(0);
                 return;
             }
             if (!Array.isArray(expectations[0])) {
                 expectations = [expectations];
             }
-            const errors = await this.page.evaluate(this.checkPageStylesInBrowserContext, expectations);
-            if (errors.length) {console.error(errors)}
+            const errors = await page.evaluate(this.checkPageStylesInBrowserContext, expectations);
             expect(errors.length).toBe(0);
         };
 
-        this.global.emulateColorScheme = async (value) => {
-            if (this.global.product === 'firefox') {
+        global.emulateColorScheme = async (value) => {
+            if (global.product === 'firefox') {
                 return;
             }
-            await this.page.emulateMediaFeatures([{name: 'prefers-color-scheme', value}]);
-            if (this.global.product === 'chrome') {
+            await page.emulateMediaFeatures([{name: 'prefers-color-scheme', value}]);
+            if (global.product === 'chrome') {
                 const page = await this.getChromiumMV2BackgroundPage();
                 await page.emulateMediaFeatures([{name: 'prefers-color-scheme', value}]);
             }
         };
 
-        this.global.loadTestPage = async (paths, gotoOptions) => {
+        global.loadTestPage = async (paths, gotoOptions) => {
             const {cors, ...testPaths} = paths;
-            this.testServer.setPaths(testPaths);
-            cors && this.corsServer.setPaths(cors);
+            testServer.setPaths(testPaths);
+            cors && corsServer.setPaths(cors);
             await this.openTestPage(`http://localhost:${TEST_SERVER_PORT}`, gotoOptions);
         };
 
-        this.global.corsURL = this.corsServer.url;
+        global.corsURL = corsServer.url;
     }
 
     /**
@@ -427,8 +424,18 @@ export default class CustomJestEnvironment extends TestEnvironment {
                 changeChromeStorage: async (region, data) => await sendToBackground('changeChromeStorage', {region, data}),
                 getChromeStorage: async (region, keys) => await sendToBackground('getChromeStorage', {region, keys}),
                 getManifest: async () => await sendToBackground('getManifest'),
-                getColorScheme: async () => await sendToBackground('firefox-getColorScheme'),
-                createTab: async (url) => await sendToBackground('firefox-createTab', url),
+                getColorScheme: async () => {
+                    if (this.global.product !== 'firefox') {
+                        throw new Error('Not supported');
+                    }
+                    return await sendToBackground('firefox-getColorScheme');
+                },
+                createTab: async (url) => {
+                    if (this.global.product !== 'firefox') {
+                        throw new Error('Not supported');
+                    }
+                    await sendToBackground('firefox-createTab', url);
+                }
             };
 
             this.global.pageUtils = {

--- a/tests/browser/environment.js
+++ b/tests/browser/environment.js
@@ -264,7 +264,9 @@ export default class CustomJestEnvironment extends TestEnvironment {
     assignTestGlobals() {
         this.global.getColorScheme = async () => {
             if (this.global.product === 'firefox') {
-                throw new Error('Firefox does not support page.evaluate()');
+                console.error('HELLO');
+                //console.error(Boolean(this, this.page)
+                return await this.global.backgroundUtils.getColorScheme();
             }
             const isDark = await this.page.evaluate(() => matchMedia('(prefers-color-scheme: dark)').matches);
             return isDark ? 'dark' : 'light';
@@ -290,6 +292,7 @@ export default class CustomJestEnvironment extends TestEnvironment {
                 expectations = [expectations];
             }
             const errors = await this.page.evaluate(this.checkPageStylesInBrowserContext, expectations);
+            if (errors.length) {console.error(errors)}
             expect(errors.length).toBe(0);
         };
 
@@ -424,7 +427,8 @@ export default class CustomJestEnvironment extends TestEnvironment {
                 changeChromeStorage: async (region, data) => await sendToBackground('changeChromeStorage', {region, data}),
                 getChromeStorage: async (region, keys) => await sendToBackground('getChromeStorage', {region, keys}),
                 getManifest: async () => await sendToBackground('getManifest'),
-                createTab: async (url) => await sendToBackground('createTab', url),
+                getColorScheme: async () => await sendToBackground('firefox-getColorScheme'),
+                createTab: async (url) => await sendToBackground('firefox-createTab', url),
             };
 
             this.global.pageUtils = {

--- a/tests/browser/globals.d.ts
+++ b/tests/browser/globals.d.ts
@@ -1,12 +1,10 @@
 import type {RequestListener} from 'http';
 import type {WaitForOptions} from 'puppeteer-core';
-import type {ExtensionData, UserSettings} from '../../src/definitions';
+import type {ColorScheme, ExtensionData, UserSettings} from '../../src/definitions';
 
 type PathsObject = {[path: string]: string | RequestListener | PathsObject};
 type OneStyleExpectation = [selector: string | string[], cssAttributeName: string, expectedValue: string];
 type StyleExpectations = OneStyleExpectation[] | OneStyleExpectation;
-
-type ColorScheme = 'dark' | 'light';
 
 declare global {
     const loadTestPage: (paths: PathsObject & {cors?: PathsObject}, gotoOptions?: WaitForOptions) => Promise<void>;

--- a/tests/browser/globals.d.ts
+++ b/tests/browser/globals.d.ts
@@ -6,6 +6,8 @@ type PathsObject = {[path: string]: string | RequestListener | PathsObject};
 type OneStyleExpectation = [selector: string | string[], cssAttributeName: string, expectedValue: string];
 type StyleExpectations = OneStyleExpectation[] | OneStyleExpectation;
 
+type ColorScheme = 'dark' | 'light';
+
 declare global {
     const loadTestPage: (paths: PathsObject & {cors?: PathsObject}, gotoOptions?: WaitForOptions) => Promise<void>;
     const corsURL: string;
@@ -21,14 +23,17 @@ declare global {
         changeSettings: (settings: Partial<UserSettings>) => Promise<void>;
         collectData: () => Promise<ExtensionData>;
         changeChromeStorage: (region: 'local' | 'sync', data: {[key: string]: any}) => Promise<void>;
+        getColorScheme: () => Promise<ColorScheme>;
         getChromeStorage: (region: 'local' | 'sync', keys: string[]) => Promise<{[key: string]: any}>;
         getManifest: () => Promise<chrome.runtime.Manifest>;
         createTab: (url: string) => Promise<void>;
     };
-    const emulateMedia: (name: string, value: string) => Promise<void>;
+    const pageUtils: {
+        evaluateScript: (script: () => any) => Promise<any>;
+    };
+    const emulateColorScheme: (value: ColorScheme) => Promise<void>;
     const awaitForEvent: (uuid: string) => Promise<void>;
     const expectPageStyles: (expect: jest.Expect, expectations: StyleExpectations) => Promise<void>;
-    const getColorScheme: () => Promise<'dark' | 'light'>;
-    const evaluateScript: (script: () => any) => Promise<any>;
+    const getColorScheme: () => Promise<ColorScheme>;
     const product: 'firefox';
 }


### PR DESCRIPTION
This does not modify built output (treeshaking!). This adds color scheme emulation functionality for Firefox tests, which is very important for #11249.