### PR TITLE
Fix invisible text in Bing AI chat box on Bing search

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2662,6 +2662,10 @@ div.icon > svg > g:nth-child(1) > path:nth-child(1) {
     fill: var(--cib-color-neutral-primary-background) !important;
 }
 
+.content > .ac-container{
+    color: var(--darkreader-neutral-text)
+}
+
 IGNORE INLINE STYLE
 .b_header_bg
 .sp-tpwebicons.WIKI *

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2662,7 +2662,7 @@ div.icon > svg > g:nth-child(1) > path:nth-child(1) {
     fill: var(--cib-color-neutral-primary-background) !important;
 }
 .content > .ac-container {
-    color: var(--darkreader-neutral-text)
+    color: var(--darkreader-neutral-text);
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2661,8 +2661,7 @@ div.icon > svg > g:nth-child(1) > path:nth-child(1) {
 .container > button:hover > svg-icon {
     fill: var(--cib-color-neutral-primary-background) !important;
 }
-
-.content > .ac-container{
+.content > .ac-container {
     color: var(--darkreader-neutral-text)
 }
 


### PR DESCRIPTION
Updated the CSS to show the text in the new Bing AI chat window.

Currently the text is invisible.

![image](https://github.com/darkreader/darkreader/assets/8893451/daad8444-01b8-4476-905d-f1538c4f3152)

With this change, the text is now visible.

![image](https://github.com/darkreader/darkreader/assets/8893451/0b43bd4f-9180-40b0-a711-58d2344b8ee5)
