### PR TITLE
Fix translations for Serbian language

### DIFF
--- a/src/_locales/sr.config
+++ b/src/_locales/sr.config
@@ -61,8 +61,8 @@ Koristite temu sistema
 Aktivacija kada sistem koristi tamni mod
 
 @system_dark_mode_chromium_warning
-This option might not work due to
-a bug in your browser
+Ova opcija možda neće raditi zbog greške
+u vašem pregledaču
 
 
 #==== Filter ====
@@ -212,7 +212,7 @@ Alatke za razvoj
 Конфигуришите пребацивање веб локације
 
 @site_toggle
-Сите Тогглинг
+Site Toggling
 
 @detect_dark_theme
 Откријте тамну тему


### PR DESCRIPTION
One translation was changed to translation on Serbian language, and one was replaced with English version/removed because it was wrong (letters were replaced with Serbian Cyrillic).