### PR TITLE
fix: webistes - novinky.cz, garaz.cz, seznamzpravy.cz

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15394,6 +15394,20 @@ a#commonLogo {
 
 ================================
 
+novinky.cz
+garaz.cz
+seznamzpravy.cz
+
+CSS
+.ribbon, .szn-input-with-suggest-list {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.szn-input-with-suggest-list {
+    border-color: ${gray} !important;
+}
+
+================================
+
 nowafarmacja.pl
 
 INVERT


### PR DESCRIPTION
these changes fix dark style for navbars on webpages https://www.seznamzpravy.cz/ https://www.novinky.cz/ https://www.garaz.cz/

both of the web pages have same owner company and use shared navbar as a component (with the same CSS classes)