### PR TITLE
Update fix for sellercentral.amazon.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1042,6 +1042,7 @@ img[src*="smile-logo"]
 div.vse-video-title
 div.vse-video-labels
 i.a-icon-search
+.utility-bar-icon
 
 CSS
 .banner-border {


### PR DESCRIPTION
Fixes the black icons on dark background on sellercentral.amazon.com by inverting the icon color.

Original:
![image](https://github.com/darkreader/darkreader/assets/8893451/33790fd7-ce34-412e-9431-d29996d225c6)

Fixed:
![image](https://github.com/darkreader/darkreader/assets/8893451/873e417e-4071-4ac3-9923-def5a36d3a4a)
