### PR TITLE
Update fix for openai.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16040,7 +16040,6 @@ openai.com
 
 INVERT
 figure.release-cover>div:first-of-type>img
-.math
 
 CSS
 body {


### PR DESCRIPTION
The text on chat.openai.com is too dark when displaying LaTeX Math due to a fix made 2 years ago: https://github.com/darkreader/darkreader/pull/5800

Before:
![image](https://github.com/darkreader/darkreader/assets/54639830/8c3ded53-a6e7-43ca-96e8-e82f088965fc)
Removing .math from INVERT:
![image](https://github.com/darkreader/darkreader/assets/54639830/1e27e1f6-032a-483b-a09c-5a4f6c369ef2)
