### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4512,7 +4512,8 @@ input
 
 ================================
 
-code.visualstudio.com
+code.visual
+io.com
 
 INVERT
 img[src="/assets/icons/download_dark.svg"]
@@ -18627,6 +18628,13 @@ CSS
 
 ================================
 
+sanomapro.fi
+
+INVERT
+.equation
+
+================================
+
 santander.pl
 
 INVERT
@@ -20303,6 +20311,13 @@ CSS
 #sidomeny .middle {
     background: var(--darkreader-neutral-background) !important;
 }
+
+================================
+
+studeo.fi
+
+INVERT
+.equation
 
 ================================
 


### PR DESCRIPTION
Equation images in a few digital schoolbooks blends with background and are hard to see.