### PR TITLE
Fix for onedrive.live.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15943,6 +15943,15 @@ body {
 
 ================================
 
+onedrive.live.com
+
+CSS
+.ms-CommandBar {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 onelook.com
 
 INVERT


### PR DESCRIPTION
Fix inverted command bar when a file or folder is selected.

Before:
![Screenshot_20230524_235755](https://github.com/darkreader/darkreader/assets/1006477/0e8a2552-2542-4bbb-a0c9-d6ecdcb0c6bb)

After:
![Screenshot_20230524_235905](https://github.com/darkreader/darkreader/assets/1006477/df27ce8d-f917-4cd7-bfa1-e71b677cd969)
