### PR TITLE
Fix for translifeline.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21835,6 +21835,17 @@ INVERT
 
 ================================
 
+translifeline.org
+
+INVERT
+.resource-breadcrumbs p
+.resource-title h2
+
+IGNORE INLINE STYLE
+#resource-header
+
+================================
+
 transport.orgp.spb.ru
 
 INVERT


### PR DESCRIPTION
Fixes text on "Resources" pages.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/2f7f52f4-1c01-4877-ab8d-c2fe5eb52636)
![2](https://github.com/darkreader/darkreader/assets/6563728/2e5d6298-9e3e-4631-9202-42e710f04965)

After:
![3](https://github.com/darkreader/darkreader/assets/6563728/afed57d2-f2a3-4f45-8888-01a52eaca281)
![4](https://github.com/darkreader/darkreader/assets/6563728/ad4029d2-184c-484b-929b-342e72f4569a)