### PR TITLE
Fix: YouTube livestream chat membership flickering

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25276,6 +25276,7 @@ a.yt-simple-endpoint.yt-formatted-string:hover {
 
 IGNORE INLINE STYLE
 yt-live-chat-ticker-paid-message-item-renderer *
+yt-live-chat-ticker-sponsor-item-renderer *
 #ytd-player + .efyt-control-bar > button path
 
 ================================


### PR DESCRIPTION
Added 1 line for youtube.com under IGNORE INLINE STYLE to fix flickering of membership joins/gifts for youtube livestream chat. Without the fix the flickering occurs while the video is playing but stops when the video is paused, but with the fix the flickering never happens even when the video is playing.


![Before](https://github.com/darkreader/darkreader/assets/134817452/204241de-bf60-4817-8e18-881df2338c9a)
![After](https://github.com/darkreader/darkreader/assets/134817452/dd5e32ff-8fc3-40ab-b670-192112569ddb)

