### PR TITLE
Add squidalytics.ink to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -780,6 +780,7 @@ splatoon3.ink
 sponsorshipshq.com
 spotfy.one
 spyware.neocities.org
+squidalytics.ink
 srrdb.com
 star-made.org
 starlink.com


### PR DESCRIPTION
Site is dark by default in both browser modes.