### PR TITLE
Fix scratch website selector and fix scratch color selectors

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18757,12 +18757,18 @@ INVERT
 
 ================================
 
-scratch.mit.edu/projects/editor
+scratch.mit.edu/projects/*
 
 CSS
 path.blocklyFlyoutBackground {
     fill: rgb(32, 32, 32);
 }
+
+IGNORE INLINE STYLE
+g[data-argument-type="colour"] > path
+.scratchColourPickerLabel + .goog-slider-horizontal
+.color-button_color-button-swatch_37evk
+.color-picker_row-header_173LQ + div > .slider_container_o2aIb
 
 ================================
 


### PR DESCRIPTION
1. `https://scratch.mit.edu/projects/editor` is for new projects, `https://scratch.mit.edu/projects/<project id>/editor` for already existing projects, and the previous selector only worked for new projects.
2. Added new selectors to ignore the inline style for the color display (that shows what color is currently selected) and the actual color picker, present in the costume editor and all "touching `color`"-type blocks