### PR TITLE
Add codeberg.org to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -159,6 +159,7 @@ clashofstats.com
 clt.gg
 cncnet.org
 co.wukko.me
+codeberg.org
 codepen.io
 coder.com
 codesandbox.io


### PR DESCRIPTION
Codeberg is a popular site, and its theme is dark by default.