### PR TITLE
Fix for azurlane.koumakan.jp

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2132,6 +2132,26 @@ INVERT
 
 azurlane.koumakan.jp
 
+INVERT
+.mwe-math-element
+
+CSS
+.rarity-1,.rarity-2 {
+    background: #999 !important;
+}
+.rarity-3 {
+    background: #5fa8bf !important;
+}
+.rarity-4 {
+    background: #846dbf !important;
+}
+.rarity-5 {
+    background: #aa5 !important;
+}
+.rarity-6 {
+    background: linear-gradient(120deg,#bbbf8a,#7abf7f,#67afbf,#bf6bbf) !important;
+}
+
 IGNORE IMAGE ANALYSIS
 .mw-wiki-logo
 


### PR DESCRIPTION
Invert some math equation elements (not sure about the svg fallback)

Restore rarity background colors, slightly darkened, for better clarity in stat charts and other places where grays were ambiguous.