### PR TITLE
Fix for my.nintendo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14791,6 +14791,7 @@ my.nintendo.com
 
 CSS
 .Layout-app,
+.Modal_contentInner,
 .signUpButton {
     background-image: none !important;
 }


### PR DESCRIPTION
Fix unreadable mission details popup.

Before:
![image](https://github.com/darkreader/darkreader/assets/1006477/bc6f8435-765d-437d-b729-d4b6051c5cab)

After:
![image](https://github.com/darkreader/darkreader/assets/1006477/d806ae1b-27db-48bf-83a4-106d89cd525a)
