### PR TITLE
Fix for wikitech.wikimedia.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23731,6 +23731,7 @@ wikitech.wikimedia.org
 
 INVERT
 img[alt="audio speaker icon"]
+#p-logo-text
 
 IGNORE IMAGE ANALYSIS
 .mw.wiki-logo


### PR DESCRIPTION
Inverting the "Wikitech" word mark on the Timeless MediaWiki skin: https://wikitech.wikimedia.org/wiki/Main_Page?useskin=timeless

![wikitech_wordmark_before](https://github.com/darkreader/darkreader/assets/10338703/ee601754-2b76-4bdf-bf25-18b420f17c71)
![wikitech_wordmark_after](https://github.com/darkreader/darkreader/assets/10338703/7250e0cf-9559-404c-9a29-dc9a3c029e33)
