### PR TITLE
Fix for postcrossing.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20559,6 +20559,20 @@ INVERT
 
 ================================
 
+westlaw.com
+
+CSS
+.co_hl.blue,
+.highlightBox.blueBox {
+   background-color: ${lightblue} !important;
+}
+.co_hl.purple,
+.highlightBox.purpleBox {
+   background-color: ${#bd73bd} !important;
+}
+
+================================
+
 what-if.xkcd.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15123,6 +15123,13 @@ body {
 
 ================================
 
+postcrossing.com
+
+IGNORE IMAGE ANALYSIS
+.flag
+
+================================
+
 postnauka.ru
 
 INVERT
@@ -20549,20 +20556,6 @@ westerndigital.com
 
 INVERT
 #Header_Main_Logo
-
-================================
-
-westlaw.com
-
-CSS
-.co_hl.blue,
-.highlightBox.blueBox {
-   background-color: ${lightblue} !important;
-}
-.co_hl.purple,
-.highlightBox.purpleBox {
-   background-color: ${#bd73bd} !important;
-}
 
 ================================
 


### PR DESCRIPTION
All the white parts of country flags on Postcrossing.com were inverted to black. This fix prevents that, so that the site displays correct flags.

(The change with westlaw.com wasn't my intention; I think Git wasn't properly synchronised? I don't really understand Git extremely well, could you tell me what happened?)