### PR TITLE
Tests: disable tests on Firefox Beta

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -49,7 +49,8 @@ jobs:
           # Beta releases
           - channel: beta
             chrome: beta
-            firefox: latest-beta
+            # disable Firefox Beta because it fails to install extension
+            # firefox: latest-beta
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Firefox Beta `115.0b1` and `115.0b2` consistently fails with error
> WebExtError: installTemporaryAddon: Error: Error: Could not install add-on at '/home/runner/work/darkreader/darkreader/build/debug/firefox': [Exception... "AddonManager is not initialized"  nsresult: "0xc1f30001 (NS_ERROR_NOT_INITIALIZED)"  location: "JS frame :: resource://gre/modules/AddonManager.sys.mjs :: installTemporaryAddon :: line 2658"  data: no]

