### PR TITLE
Add app.pianorhythm.io to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -42,6 +42,7 @@ aonprd.com
 app.destinyitemmanager.com
 app.keeweb.info
 app.mobalytics.gg
+app.pianorhythm.io
 app.plex.tv
 app.pluralsight.com
 app.revolt.chat


### PR DESCRIPTION
app.pianorhythm.io is by default in dark mode