### PR TITLE
Add oculus.com/experiences/quest/ to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -597,6 +597,7 @@ notebooks.quantumstat.com
 notiger.xyz
 nowplayi.ng
 nulledbb.com
+oculus.com/experiences/quest/
 odysee.com
 offshorecorptalk.com
 oldfag.org


### PR DESCRIPTION
https://www.oculus.com/experiences/quest/
is already dark

This leads to issues with the rating widget and the logo, which are fixed by disabling dark reader on this site.

Rating widget:
![image](https://github.com/darkreader/darkreader/assets/1422004/13c8eda6-ba86-41f1-a4c2-8731ec552432)

Logo - looking good:
![image](https://github.com/darkreader/darkreader/assets/1422004/dd3fdbab-284e-499a-b35a-038634134963)
