### PR TITLE
Tests: avoid inline script

### DIFF
--- a/tests/inject/dynamic/media-query.tests.ts
+++ b/tests/inject/dynamic/media-query.tests.ts
@@ -42,7 +42,7 @@ describe('MEDIA QUERIES', () => {
 
     it('should style lazyloaded media', async () => {
         container.innerHTML = multiline(
-            '<style class="testcase-style" media="print" onload="this.media=`screen`">',
+            '<style class="testcase-style" media="print">',
             '    h1 { background: green; }',
             '    h1 strong { color: orange; }',
             '</style>',
@@ -51,7 +51,9 @@ describe('MEDIA QUERIES', () => {
 
         createOrUpdateDynamicTheme(theme, null, false);
 
+        (document.querySelector('.testcase-style') as HTMLStyleElement).media = 'screen';
         await timeout(0);
+        expect((document.querySelector('.testcase-style') as HTMLStyleElement).media).toBe('screen');
         expect(getComputedStyle(document.querySelector('h1')).backgroundColor).toBe('rgb(0, 102, 0)');
         expect(getComputedStyle(document.querySelector('h1 strong')).color).toBe('rgb(255, 174, 26)');
         expect(document.querySelector('.testcase-style').nextElementSibling.classList.contains('darkreader--sync')).toBe(true);


### PR DESCRIPTION
Inline script failed on Firefox 115 beta, specifically `115.0b1`, `115.0b2`, and `115.0b3`.

I probably also should file a Firefox bug for this.