### PR TITLE
Fix fly.io dynamic mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8286,6 +8286,15 @@ body.html #page.page #subslogan {
 
 ================================
 
+fly.io
+
+CSS
+.post :not(a):not(pre):not(.changelog-item) > code {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
 flyzipline.com
 
 INVERT


### PR DESCRIPTION
This should fix the unreadable html code tag on fly.io article pages.

Example problematic page: https://fly.io/blog/python-async-workers-on-fly-machines/

Before:
![image](https://github.com/darkreader/darkreader/assets/23237214/3d9c0616-c6d9-40bd-b0d1-aea19b17729f)

After:
![image](https://github.com/darkreader/darkreader/assets/23237214/05b333d9-da2c-4e85-97a1-d9ac132f942e)
