### PR TITLE
Add robinhood.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -709,6 +709,7 @@ reveddit.com
 richup.io
 ripped.guide
 rl6mans.com
+robinhood.com
 roleypoly.com
 roman.hn
 roosterteeth.fandom.com


### PR DESCRIPTION
Site is already dark 👏
Dark reader (when on) messes up the buttons

With Dark Reader Disabled, this is what it looks like:
![image](https://github.com/darkreader/darkreader/assets/1422004/73e79705-52ff-4e38-bd0f-678f81614b64)
