### PR TITLE
Fix for goodreads.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9718,6 +9718,13 @@ CSS
 
 ================================
 
+goodreads.com
+
+INVERT
+.responsiveSiteFooter__socialLinkWrapper
+
+================================
+
 google.*/chrome
 
 INVERT


### PR DESCRIPTION
Invert social media image icons (at site footer) that were already dark.