### PR TITLE
Fix for canvas.*.edu

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3751,6 +3751,7 @@ canvas.*.edu
 
 INVERT
 .file_download_btn
+.ic-DashboardCard__action-badge
 
 ================================
 


### PR DESCRIPTION
Fixing inversion issue for unread notifications banner.

Pre-fix:
<img width="317" alt="pre-fix" src="https://github.com/darkreader/darkreader/assets/76989051/32260c11-cfa0-4b8f-93f5-6c937087beaa">

post-fix:
<img width="310" alt="post-fix" src="https://github.com/darkreader/darkreader/assets/76989051/2b192eb8-a4ae-44e8-9e44-28bf04fad0b8">