### PR TITLE
Border around 2FA QR code for Unity ID

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10623,6 +10623,15 @@ CSS
 
 ================================
 
+id.unity.com
+
+CSS
+.qr-code {
+    border: calc(150px * 1/45) solid #f5f8f9;
+}
+
+================================
+
 ieee.org
 
 INVERT


### PR DESCRIPTION
Add a border around the QR code so that it can be read by conventional QR readers. The border is the width of one block of the QR code, which is on average 1/45th the width/height of the code.