### PR TITLE
Bitbucket.org pipeline page hover fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2741,6 +2741,14 @@ code.code,
     box-shadow: ${rgba(33, 53, 89, 0.08)} 0px 0px 0px 1px,
                 ${rgba(33, 53, 89, 0.08)} 0px 2px 4px 1px !important;
 }
+[data-test="pipeline-row"]:hover {
+    box-shadow: -4px 0 0 0 var(--darkreader-neutral-background), 4px 0 0 0 var(--darkreader-neutral-background) !important;
+    background: var(--darkreader-neutral-background) !important;
+}
+[data-test="result-page"]>div>div:nth-child(3),
+[data-test="result-page"]>div>div:nth-child(3)>div {
+    background: var(--darkreader-neutral-background) !important;
+}
 
 IGNORE INLINE STYLE
 [role="presentation"] svg *


### PR DESCRIPTION
Unfortunately it seems that bitbucket uses hex color codes for this page so I think darkreader is not able to convert the colors...

# before
![Peek 2023-06-15 11-53](https://github.com/darkreader/darkreader/assets/9083012/fa0df684-e323-4381-8b71-aa6da912bfee)
![image](https://github.com/darkreader/darkreader/assets/9083012/d50da889-e9e2-4cbb-b2d5-2ecdc77d548e)



# after 
![Peek 2023-06-15 11-54](https://github.com/darkreader/darkreader/assets/9083012/5ddb57d6-f7e4-4477-be47-751a0bc945c4)
![image](https://github.com/darkreader/darkreader/assets/9083012/138678bd-9622-4cf6-8385-0e469054307e)

