### PR TITLE
fix for pocketbase.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17050,6 +17050,21 @@ ymaps[class$="ground-pane"]
 
 ================================
 
+pocketbase.io
+
+INVERT
+.landing-hero
+
+CSS
+.landing-hero div.wrapper:nth-child(2), .page-header {
+    filter: inherit !important;
+}
+div.eye-socket {
+     background-color: #fff !important;
+}
+
+================================
+
 podium.com
 
 INVERT


### PR DESCRIPTION
Inverts the background of the landing page of [PocketBase](https://pocketbase.io) and fixes the eye color of the gopher.