### PR TITLE
Remove jsfiddle.net from global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -459,7 +459,6 @@ join-lemmy.org
 jonahsnider.com
 jqbx.fm
 jsben.ch
-jsfiddle.net
 jsitor.com
 json-diff.com
 jsongoku.com


### PR DESCRIPTION
Because https://docs.jsfiddle.net isn't dark.

Thanks