### PR TITLE
Update dynamic-theme-fixes.config -> Dictionary.com changes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6104,6 +6104,13 @@ dictionary.cambridge.org
 INVERT
 .cb.hao.lpt-2
 .cb.hv-2.lmr-10
+================================
+
+dictionary.com
+
+INVERT
+.elu13lxtzrRO8E8WYUVn
+.tFCOipZXVYJAiob7tOp0
 
 ================================
 


### PR DESCRIPTION
A brief adjustment was made on Dictionary.com/. The title "Dictionary.com," and "Thesaurus.com" are now inverted! Previously they were a black text, in a black background. Also, a sound button used to pronounce words are now inverted, easier to see in dark environments.