### PR TITLE
Finalize the fix for bugs.chromium.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3513,6 +3513,7 @@ input#searchq:not(input[name="member_default_query"]) {
 input, select, textarea, fieldset,
 .MuiOutlinedInput-root:hover > fieldset {
     border-color: #3f3f3f75 !important;
+    color: var(--darkreader-neutral-text) !important;
 }
 select:not(select[aria-label="Search scope"]), select > *,
 textarea:not(.css-66dh3a-MuiInputBase-input-MuiInput-input),
@@ -3580,6 +3581,10 @@ input#filter, input[name="newHotlistName"], input[type="date"] {
 #issueHotlistsForm chops-button[class*="de-"] {
     background: transparent !important;
 }
+
+IGNORE INLINE STYLE
+.star
+#user_star
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3451,6 +3451,9 @@ bugs.chromium.org
 
 INVERT
 hr
+canvas
+.dialog-content
+input[type="date"]
 div[class$="MuiMobileStepper-dot"]:not(div[class*="MuiMobileStepper-dotActive"])
 
 CSS
@@ -3460,6 +3463,8 @@ CSS
     --darkreader-bg--chops-white: var(--chops-white) !important;
     --chops-blue-50: #032742 !important;
     --chops-blue-75: #021524 !important;
+    --darkreader-text--chops-blue-700: var(--chops-blue-700) !important;
+    --darkreader-border--chops-blue-100: #1b6099 !important;
     --chops-blue-gray-25: #1f1f1f !important;
     --darkreader-bg--chops-blue-gray-25: var(--chops-blue-gray-25) !important;
     --chops-card-details-bg: #1a1a1a !important;
@@ -3468,7 +3473,8 @@ CSS
     --chops-gray-400: #3f3f3f75 !important;
     --chops-gray-700: #989898 !important;
     --chops-gray-700-alpha: hsla(0, 0%, 100%, 0.62) !important;
-    --chops-primary-font-color: #e8e6e3 !important;
+    --darkreader-border--chops-gray-200: var(--chops-blue-gray-25) !important;
+    --chops-primary-font-color: var(--darkreader-selection-text) !important;
     --chops-gray-900: var(--chops-primary-font-color) !important;
     --chops-orange-50: #342213 !important;
     --chops-orange-200: #6f4106 !important;
@@ -3476,7 +3482,7 @@ CSS
     --darkreader-text--chops-link-color: var(--chops-blue-700) !important;
     --darkreader-text--chops-primary-icon-color: #909090 !important;
     --chops-choice-bg: #242628 !important;
-    --darkreader-bg--chops-primary-button-bg: #023d97 !important;
+    --darkreader-bg--chops-primary-button-bg: #003078 !important;
     --darkreader-bg--chops-active-choice-bg: #06243b !important;
     --chops-normal-border: 1px solid #3f3f3f75 !important;
     --chops-accessible-border: var(--chops-normal-border) !important;
@@ -3489,7 +3495,7 @@ body {
     background: none !important;
 }
 html {
-    background-color: #161616 !important;
+    background-color: var(--chops-white) !important;
 }
 .metadata-container, mr-issue-header {
     background: #141c14 !important;
@@ -3510,7 +3516,7 @@ input, select, textarea, fieldset,
 }
 select:not(select[aria-label="Search scope"]), select > *,
 textarea:not(.css-66dh3a-MuiInputBase-input-MuiInput-input),
-input[type="text"]:not(input[placeholder$="issues..."]) {
+input[type="text"]:not(*:is(input[placeholder$="issues..."], input[name*="Hotlist"])) {
     background-color: #262626 !important;
 }
 #wordmark {
@@ -3526,6 +3532,53 @@ div[class^="MuiDialogActions-root"] > button {
 }
 .__crdxFeedbackButton::after {
     color: #afafaf !important;
+}
+img[title="chromium"], img[title="v8"] {
+    filter: invert(100%) hue-rotate(180deg) contrast(83%) !important;
+}
+img[title="skia"] {
+    filter: invert(100%) hue-rotate(180deg) contrast(87.5%) !important;
+}
+.select-container i {
+    z-index: 4 !important;
+}
+.select-container select {
+    background: #1e1e1e !important;
+}
+.dialog-content {
+    background: #f5f5f5 !important;
+    box-shadow: rgba(255, 255, 255, 0.4) 0px 3px 20px 0px !important;
+}
+button[title^="Don't show"] {
+    color: var(--darkreader-text--chops-primary-font-color) !important;
+}
+chops-dialog *:is(i, th, td)  {
+    color: #22201f !important;
+    border-color: transparent !important;
+}
+.preview {
+    border: 2px solid rgb(24, 58, 114) !important;
+}
+.preview:hover {
+    border-color: #034587 !important;
+}
+table > tbody:not(:has(tr[draggable="false"])) th {
+    border-color: #161616 !important;
+}
+input#filter, input[name="newHotlistName"], input[type="date"] {
+    background-color: #e3e3e3 !important;
+    color: black !important;
+    border: 1px solid #d9d9d9 !important;
+    border-radius: 2px !important;
+}
+#issueHotlistsForm label {
+    color: black !important;
+}
+#issueHotlistsForm chops-button[class="emphasized"] {
+    background-color: #70a9fe !important;
+}
+#issueHotlistsForm chops-button[class*="de-"] {
+    background: transparent !important;
 }
 
 ================================


### PR DESCRIPTION
## What I fixed
Rest of things that can't be fixed in #11185 

## Feature request

Take a look at this image:

![image](https://github.com/darkreader/darkreader/assets/87893636/a22c224f-30fa-493d-a9be-685ac3cf2680)

Let say `dialog-content` isn't a unique class, the path to that element should be: `chops-dialog .dialog-content`

But that's only true when `.dialog-content` is a unique class in `shadow-root`. Why don't we add a way to make the path easier ?

Like this: `chops-dialog > shadow-root > dialog > .dialog-content`

Or even: `chops-dialog > dialog > .dialog-content`

That would be easier to work on some **_complex_** cases

## Additional context
Thank you @bershanskiy , everything works smoothly. Also pls close #11196
