### PR TITLE
fix the wrong search result background in Bing

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2740,6 +2740,9 @@ div.icon > svg > g:nth-child(1) > path:nth-child(1) {
 .content > .ac-container {
     color: var(--darkreader-neutral-text);
 }
+#b_results .b_algo.b_deeplinks_bg_color_kc {
+    background-image: none !important;
+}
 
 IGNORE INLINE STYLE
 .b_header_bg


### PR DESCRIPTION
Bing's search result, now on sometimes, will have light and white background when use dynamic theme mode, like this:  

![Screenshot 2023-06-28 at 22-20-52 Bing - 必应](https://github.com/darkreader/darkreader/assets/25317916/bddf0f24-cd51-4620-a570-6963d5b84b10)

This pull request may fix it.
