### PR TITLE
Fix: broken `document.styleSheets` proxy (#11454)

### DIFF
--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -107,7 +107,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean, enableCustomElement
             const docSheets: StyleSheetList = documentStyleSheetsDescriptor!.get!.call(this);
 
             const filteredSheets = [...docSheets].filter((styleSheet) =>
-                styleSheet.ownerNode && !(styleSheet.ownerNode as Exclude<typeof styleSheet.ownerNode, ProcessingInstruction>).classList && (styleSheet.ownerNode as Exclude<typeof styleSheet.ownerNode, ProcessingInstruction>).classList.contains('darkreader')
+                styleSheet.ownerNode && !(styleSheet.ownerNode as Exclude<typeof styleSheet.ownerNode, ProcessingInstruction>).classList?.contains('darkreader')
             );
 
             (filteredSheets as unknown as StyleSheetList).item = (item: number) => filteredSheets[item];


### PR DESCRIPTION
A logic error introduced in bec13d4d1 breaks the `document.styleSheets` proxy, filtering out _all_ stylesheets and style tags, preventing sites from dynamically accessing and altering their own styles.

Fixes #11454 and #11446

Before:

<img width="647" src="https://github.com/darkreader/darkreader/assets/53660/b1b8dc0c-ecbb-4111-b5c0-41ebfac636a2">

After:

<img width="655" src="https://github.com/darkreader/darkreader/assets/53660/da4ecb9c-2b62-4e79-8939-e4d7f58b5a2f">

