### PR TITLE
Add revanced.app to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -712,6 +712,7 @@ restream4me.com
 resurrectionremix.com
 retromusic.app
 returnyoutubedislike.com
+revanced.app
 reveddit.com
 richup.io
 ripped.guide


### PR DESCRIPTION
The site https://revanced.app is only dark and complete.