### PR TITLE
Fix cad.onshape.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3722,6 +3722,22 @@ INVERT
 
 ================================
 
+cad.onshape.com
+
+IGNORE INLINE STYLE
+#canvas
+
+INVERT
+#canvas
+.os-thumbnail-image
+
+CSS
+#canvas {
+    background-color: #fff !important;
+}
+
+================================
+
 caf.fr
 
 CSS


### PR DESCRIPTION
This fixes:
- sketch editing mode being very unreadable
- thumbnails having a black outline on dark background

This is related to  #10725, but this PR broke after I tried to rebase it and the changes were quite outdated.

This link can be used for testing: https://cad.onshape.com/documents/354728f5f71464187c094ae2/w/f727c899b6bbf374df58de10/e/e39054473ac3eed9d31449d4?renderMode=0&uiState=63e52244bb71826649fc0970
The main fixes are visible when unhiding a sketch and opening the tab manager with the lower left button.

The background is set to `#fff` because it inverting a color is not trivial with pure CSS and the set background color needs to be inverted.