### PR TITLE
Training.moodys.com white background fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22043,6 +22043,15 @@ CSS
 
 ================================
 
+training.moodys.com
+
+CSS
+body.frameless {
+    background-image: none;
+}
+
+================================
+
 transifex.com
 
 INVERT


### PR DESCRIPTION
Set white background-image to none on dark mode for training.moodys.com