### PR TITLE
Fix for draw.io embedded in Confluence page.

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -589,8 +589,8 @@ draw.io
 INVERT
 text
 CSS 
-body{
- background-color:#151515
+body {
+    background-color: #151515 !important;
 } 
 
 ================================

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -588,6 +588,7 @@ draw.io
 
 INVERT
 text
+
 CSS 
 body {
     background-color: #151515 !important;

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -592,6 +592,7 @@ CSS
 body{
  background-color:#151515
 } 
+
 ================================
 drive.google.com
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -584,6 +584,15 @@ INVERT
 
 ================================
 
+draw.io
+
+INVERT
+text
+CSS 
+body{
+ background-color:#151515
+} 
+================================
 drive.google.com
 
 INVERT


### PR DESCRIPTION
This fixes:

- The text color has been inverted in the diagrams
- change the background color to enhance the visibility of other elements in diagrams

These changes are related to issue #11481 and apply to Confluence, a collaboration and documentation tool developed by Atlassian

Draw.io already has a dark mode accessible through the toggle button, the feature of embedding an existing draw.io Diagram in Confluence does not currently support dark mode.

**Before**:
![Before](https://github.com/darkreader/darkreader/assets/57489689/9e88d213-e643-4973-a0d9-1142b5369cde)

**After**:
![Enab](https://github.com/darkreader/darkreader/assets/57489689/e1e384b2-25b3-48d3-808a-91ef538a8930)
