### PR TITLE
Fix for login QR Code on login.taobao.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21179,6 +21179,9 @@ CSS
 #q.search-combobox-input {
     background-color: var(--darkreader-neutral-background);
 }
+.qrcode-img{
+    background-color: white !important;
+}
 
 ================================
 


### PR DESCRIPTION
Without this fix the login QR Code at [login.taobao.com](https://login.taobao.com/) is unscannable

![image](https://github.com/darkreader/darkreader/assets/75155322/c0ae9bc9-9867-4695-8e4e-175382e114f6)

With this fix applied it's scannable

![image](https://github.com/darkreader/darkreader/assets/75155322/426ef8cd-5b25-43f8-929d-9aeeab727812)
