### PR TITLE
CI: set fail-fast to false for browser tests

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -33,6 +33,7 @@ jobs:
   test-browser:
     name: Run browser tests
     strategy:
+      fail-fast: false
       matrix:
         include:
 


### PR DESCRIPTION
Set `fail-fast` to `false` to continue running browser test jobs even if one of them fails.

This is useful for avoiding test harness flakes (e.g., when Puppeteer fails to connect to the browser).

More info:
 - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
 - https://www.edwardthomson.com/blog/github_actions_6_fail_fast_matrix_workflows.html