### PR TITLE
[Broken Website] Leroy Merlin

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12445,6 +12445,15 @@ CSS
 
 ================================
 
+leroymerlin.fr
+
+CSS
+.kl-tile__group {
+  filter: invert(0%) !important;
+}
+
+================================
+
 lesbonscomptes.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12449,7 +12449,7 @@ leroymerlin.fr
 
 CSS
 .kl-tile__group {
-  filter: invert(0%) !important;
+    filter: invert(0%) !important;
 }
 
 ================================


### PR DESCRIPTION
Fixes #11493 - I used a 0% filter to force the images to load. I noticed that doing an INVERT allowed the images to load. If there's a better way let me know, I'm interested to know why this works.

0% Filter css
![image](https://github.com/darkreader/darkreader/assets/8893451/bfe6ad65-a83d-44e4-8613-a9dd72ecd904)


INVERT instead
![image](https://github.com/darkreader/darkreader/assets/8893451/106815d9-67f8-4749-814c-eb157798526a)
