### PR TITLE
Change burgundy backgrounds to dark for theguardian.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1010,14 +1010,14 @@ theguardian.com
 
 CSS
 gu-island li div {
-    background-color: #222526 !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 aside,
 section,
 article,
 article gu-island li div,
 section gu-island li div {
-    background-color: #181A1B !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1006,6 +1006,22 @@ embed
 
 ================================
 
+theguardian.com
+
+CSS
+gu-island li div {
+    background-color: #222526 !important;
+}
+aside,
+section,
+article,
+article gu-island li div,
+section gu-island li div {
+    background-color: #181A1B !important;
+}
+
+================================
+
 habitica.com
 
 INVERT


### PR DESCRIPTION
While most Guardian articles end up with a nice dark background, like [this one](https://www.theguardian.com/law/2023/jul/09/supreme-court-reform-conservative-justices), a few end up with a burgundy background, like [this one](https://www.theguardian.com/world/2023/jul/09/sunak-needs-all-his-persuasive-powers-to-sway-biden-on-ukraines-nato-membership).

This PR fixes the latter.