### PR TITLE
Fixes underlines for theverge.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2394,6 +2394,15 @@ img
 
 ================================
 
+theverge.com
+
+CSS
+.\[\&_a\]\:shadow-underline-black a {
+    --darkreader-bg--tw-shadow: inset 0 -1px 0 0 #E7E6E2;
+}
+
+================================
+
 thomann.de
 thomann.ae
 thomannmusic.ch


### PR DESCRIPTION
It's virtually impossible to see underlines of links within articles on theverge.com (they're black on the dark background).

![Xnapper-2023-07-11-19 24 46](https://github.com/darkreader/darkreader/assets/27488257/7a8ef462-5610-4bda-b7f1-2f608f03b885)

This matches the underline colour to the text colour.

![Xnapper-2023-07-11-19 25 02](https://github.com/darkreader/darkreader/assets/27488257/5c362f92-a8c4-4154-9d1e-4b5c7c3e5615)