### PR TITLE
HN background color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15468,6 +15468,11 @@ news.ycombinator.com
 INVERT
 .votearrow
 
+CSS
+#hnmain {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
 ================================
 
 newyorker.com


### PR DESCRIPTION
Added --darkreader-neutral-background CSS to news.ycombinator.com to remove ugly inverted background color.