### PR TITLE
Fix for jacobin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11493,6 +11493,8 @@ body {
 jacobin.com
 
 INVERT
+.hm-sd-b-ty
+.hm-sd-b-ty > *
 .po-cn .po-cn__intro
 .po-cn .po-cn__intro > *
 .po-cn .po-cn__rule


### PR DESCRIPTION
Fixes graphical element on home page.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/c7815e60-f7df-4633-861f-5da69576f691)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/6d1cdf5b-dd3e-4a07-914d-9d9570d7e895)