### PR TITLE
CI: add stricter timeouts

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -32,6 +32,7 @@ on:
 jobs:
   test-browser:
     name: Run browser tests
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -28,6 +28,7 @@ on:
 jobs:
   test:
     name: Run tests
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   test:
     name: Run tests
+    timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
By default, GitHub Actions set job timeout limits to 6 hours (360 minutes) [(source)](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes). This is rather wasteful if a job hangs, which integration tests with real browsers have a proclivity to do. This commit limits browser test jobs to 10 mins, lint jobs to 5 mins, unit test jobs to 2 mins.