### PR TITLE
Add website to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -207,6 +207,7 @@ darkreader.org
 dartpad.dev
 dash.cavebot.xyz
 datomatic.no-intro.org
+davros.netlify.app
 dbdicontoolbox.com/web
 dblstatistics.com
 ddpe.androz2091.fr


### PR DESCRIPTION
Add davros.netlify.app (davrOS's official website) to the global dark list.