### PR TITLE
NU.nl images and white line fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15780,6 +15780,18 @@ CSS
 
 ================================
 
+nu.nl
+
+CSS
+.app-figure--caption-overlay {
+  background: linear-gradient(0deg, var(--darkreader-neutral-background), #fff 40%) !important;
+}
+.main-nav__main {
+  border-top: inherit !important;
+}
+
+================================
+
 nvidia.com
 nvidia.in
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15784,10 +15784,10 @@ nu.nl
 
 CSS
 .app-figure--caption-overlay {
-  background: linear-gradient(0deg, var(--darkreader-neutral-background), #fff 40%) !important;
+    background: linear-gradient(0deg, var(--darkreader-neutral-background), #fff 40%) !important;
 }
 .main-nav__main {
-  border-top: inherit !important;
+    border-top: inherit !important;
 }
 
 ================================


### PR DESCRIPTION
Prevents a gradient overlay from being inverted so images on top of news articles remain visible instead of disappearing behind the now almost black gradient.

Fixes a white line over the navigation menu at the top of the page.

Both issues don't appear on the main nu.nl page, but on subcategory pages and articles.