### PR TITLE
Add dynamic-theme for video player on msnbc.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14804,6 +14804,12 @@ CSS
 .styles_progress__GFuLT {
     background-color: #666 !important;
 }
+.styles_volume__peSyL::-moz-range-thumb {
+  background: var(--darkreader-neutral-text) !important;
+}
+.styles_volume__peSyL::-moz-range-track {
+  background: #666 !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14795,6 +14795,18 @@ INVERT
 
 ================================
 
+msnbc.com
+
+CSS
+.styles_progress__GFuLT::-moz-progress-bar {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.styles_progress__GFuLT {
+    background-color: #666 !important;
+}
+
+================================
+
 msys2.org
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14805,10 +14805,10 @@ CSS
     background-color: #666 !important;
 }
 .styles_volume__peSyL::-moz-range-thumb {
-  background: var(--darkreader-neutral-text) !important;
+    background: var(--darkreader-neutral-text) !important;
 }
 .styles_volume__peSyL::-moz-range-track {
-  background: #666 !important;
+    background: #666 !important;
 }
 
 ================================


### PR DESCRIPTION
# About
The progress bar on the video player on msnbc.com was nearly impossible to see with DarkReader enabled.

# Summary of Changes
* Added foreground color override for progress bar. 
* Added background color override for progress bar. 
* Added color override for volume track .
* Added color override for volume thumb. 

# Assets



![256965541-c8f36843-9dfc-4e11-9475-7bff56d56b21](https://github.com/darkreader/darkreader/assets/2229408/ea579afa-9126-442d-9f79-10051c403a22)

![CleanShot X_002024_zbm](https://github.com/darkreader/darkreader/assets/2229408/5837926d-8136-4baa-b8c4-8c8556709172)
