### PR TITLE
Update scrollbar color for code blocks on stackoverflow

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20255,6 +20255,9 @@ div.h100.bar-lg.p-bs-wrapper:has(a[href="/questions"]) {
 div.h100.bar-lg.p-bs-wrapper:has(a[href="https://stackoverflow.co/teams"]) {
     background: linear-gradient(0deg, hsl(209,100%,26%) 30%, #FFFFFF) !important;
 }
+::-webkit-scrollbar-thumb {
+    background: #313537 !important;
+}
 
 IGNORE INLINE STYLE
 .chess-replayer-board td


### PR DESCRIPTION
Scrollbar on code blocks was not visible at all. Updated scrollbar color to be a lighter gray, visible against the background.