### PR TITLE
Fixed another "close" button on wildberries.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24513,10 +24513,12 @@ ymaps[class$="svg-icon-content"] > ymaps
 
 CSS
 .popup__close-btn.j-close,
+.popup__close-btn.j-btn-close,
 .tooltip.tooltip-btn-edit {
     border: 1px solid rgb(59, 64, 66);
 }
 .popup__close-btn.j-close,
+.popup__close-btn.j-btn-close,
 .tooltip.tooltip-btn-edit .tooltip__content button {
     color: var(--darkreader-neutral-text);
 }


### PR DESCRIPTION
When you are not logged in & on the cart page with any item(s), you click on the selection of the shipping address:

![image](https://github.com/darkreader/darkreader/assets/37143421/be38d7e6-9d98-4909-a5a2-79ebf71bb43f)

And then it shows black (white) screen for some reason. And on this screen (popup) there is another button with slightly different class name (see #11568).

Before:

![image](https://github.com/darkreader/darkreader/assets/37143421/02d9b18c-a3a3-486c-867e-c80c2d29643f)


After:

![image](https://github.com/darkreader/darkreader/assets/37143421/3fc12204-4a1b-451f-af24-d84685a977cb)
