### PR TITLE
Add pracuj.pl dynamic theme fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17767,19 +17767,19 @@ CSS
 
 ================================
 
-prajwalkoirala.com
-
-INVERT
-svg
-
-================================
-
 pracuj.pl
 
 CSS
 [alt="background"] {
     display: none !important;
 }
+
+================================
+
+prajwalkoirala.com
+
+INVERT
+svg
 
 ================================
 


### PR DESCRIPTION
This Polish job board uses a white image with blurry, barely visible dots as background. They look ok in light mode, but not so much using Dark Reader because it was still white. I opted to use a plain background as it looked better than the inverted image.

Before: White background with barely visible pattern in dark mode
![Screenshot 2023-08-06 190734](https://github.com/darkreader/darkreader/assets/124526284/af16f372-3a29-48f4-9951-2a133db7afeb)

After: Dark plain background using dark mode. Vanilla website in light mode.
![Screenshot 2023-08-06 190652](https://github.com/darkreader/darkreader/assets/124526284/738f5586-07b8-47cd-8fcb-1064d8901579)
