### PR TITLE
Fix for fortune.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -806,6 +806,16 @@ NO INVERT
 
 ================================
 
+fortune.com
+
+CSS
+#content div div p,
+#content div div h2 {
+    color: rgb(221, 218, 214) !important;
+}
+
+================================
+
 forum.unity.com
 
 INVERT

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -811,7 +811,7 @@ fortune.com
 CSS
 #content div div p,
 #content div div h2 {
-    color: rgb(221, 218, 214) !important;
+    color: var(--darkreader-neutral-text) !important;
 }
 
 ================================


### PR DESCRIPTION
The text colour for articles under the `/well` subdirectory (such as [this article](https://fortune.com/well/2023/08/11/fall-winter-covid-forecast-2023-omicron-eris-united-states/)) appear blue. (Haven't checked, but it's possible that the text appears in other colours in other subdirectories as well).

![Xnapper-2023-08-13-10 33 32](https://github.com/darkreader/darkreader/assets/27488257/cb24fca3-3c91-437f-95d4-ce2648a3bcce)

This fixes the main text colour, although I've left the link colours alone.

![Xnapper-2023-08-13-10 34 22](https://github.com/darkreader/darkreader/assets/27488257/48bc95f4-6afc-48db-8838-71624f1c7b44)