### PR TITLE
Update fix for bing.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2604,6 +2604,7 @@ INVERT
 canvas[id^="Microsoft.Maps"]
 cib-background
 cib-serp
+cib-see-more-container
 
 CSS
 .b_searchboxForm,


### PR DESCRIPTION
Inverts the text box to match dark theme.

**Old:**
![image](https://github.com/darkreader/darkreader/assets/8893451/5e820e94-7258-4fe4-bcf1-2b86685dd88c)

**New:**
![image](https://github.com/darkreader/darkreader/assets/8893451/651579ad-cde2-446f-b0ac-9b2a96a39499)
