### PR TITLE
Add andrew-j-larson.github.io to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -32,6 +32,7 @@ alfawal.dev
 ameliorated.info
 amp-what.com
 an3x.org
+andrew-j-larson.github.io
 andrewleguay.com
 andrewthedev.com
 animepahe.com
@@ -843,7 +844,6 @@ tetr.io
 textfiles.com
 tf2mart.net
 tgw1916.net/bacteria_abis.html
-thealiendrew.github.io
 thelinuxcast.org
 theme-park.dev
 themes.vscode.one


### PR DESCRIPTION
I've rebranded my GitHub account (including the github.io page), so the name change has affected where my website is now.