### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19266,7 +19266,15 @@ CSS
 sanomapro.fi
 
 INVERT
-.equation
+img
+
+CSS
+.rich-text-editor img[src^="data:image/svg+xml"] {
+background: #FFFFFF !important;
+}
+.rich-text-editor:focus img[src^="data:image/svg+xml"] {
+background: #FFFFFF !important;
+}
 
 ================================
 


### PR DESCRIPTION
Fixed math and symbols not showing properly on sanomapro.fi. Inverts all images because of lazyness, but it's fine.