### PR TITLE
Fix for pianistdiscography.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17246,6 +17246,15 @@ img.math-display
 
 ================================
 
+pianistdiscography.com
+
+CSS
+.bg_white {
+    background-image: none !important;
+}
+
+================================
+
 piazza.com
 
 CSS


### PR DESCRIPTION
This is a proposed fix for darkreader/darkreader#11622, where the default `dynamic` mode is insufficient to make the site readable in dark mode. Since the background image doesn't bring any value to the site (and can't be fixed with `background-blend-mode`), the proposal here is to just remove bg altogether.

Before:

![image](https://github.com/darkreader/darkreader/assets/83110/7d868e63-34db-4aa1-943f-891b17c886ca)

After:

![image](https://github.com/darkreader/darkreader/assets/83110/471756e5-078c-498c-8c77-475a030ac177)
