### PR TITLE
Add brianlovin.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -129,6 +129,7 @@ bouncingdvdlogo.com
 brawldb.com
 brew.sh
 bri.io
+brianlovin.com
 brianpmaher.com
 broadcasthe.net
 brodierobertson.xyz


### PR DESCRIPTION
Site natively supports dark mode

![image](https://github.com/darkreader/darkreader/assets/1422004/26e26060-97cd-4fda-926c-4f23c98c4bcc)
