### PR TITLE
Add craiyon.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -181,6 +181,7 @@ coriolis.io
 countermail.com
 cp.minetro.com
 cracked.to
+craiyon.com
 crazygames.com
 create.roblox.com/docs
 crontab.guru


### PR DESCRIPTION
Craiyon (AI picture generator) is dark without Dark Reader enabled, and has no options for theme switching.