### PR TITLE
Add paniash.netlify.app to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -637,6 +637,7 @@ oxide.computer
 paimon.moe
 pandadev.tk
 paniash.gitlab.io
+paniash.netlify.app
 paper-io.com
 parahumans.wordpress.com
 paranoid.email


### PR DESCRIPTION
Added personal webpage for whitelisting.
The website is dark by default. Thanks!