### PR TITLE
Add zkillboard.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -986,6 +986,7 @@ yuzu-emu.org
 zaufanatrzeciastrona.pl
 zee5.com
 zerodayinitiative.com
+zkillboard.com
 zombsroyale.io
 zt64.github.io
 ztdp.ca


### PR DESCRIPTION
The site is dark mode by default.

https://zkillboard.com/

Thanks.