### PR TITLE
Add ashishpanigrahi.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -63,6 +63,7 @@ artixlinux.org
 arweave.app
 asciimation.co.nz
 ashcam.xyz
+ashishpanigrahi.com
 asoftmurmur.com
 assassins-creed.de
 astronvim.github.io


### PR DESCRIPTION
Adding ashishpanigrahi.com to the list of dark sites.
The website is dark by default.

Thanks.