### PR TITLE
Update dynamic-theme-fixes.config for towardsdatascience.com images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22343,6 +22343,15 @@ INVERT
 
 ================================
 
+towardsdatascience.com
+
+CSS
+img.bg.mc.md.c {
+    background-color: ${black} !important;
+}
+
+================================
+
 towersemi.com
 
 INVERT


### PR DESCRIPTION
PNG images in towardsdatascience.com with black text are unreadable due to the dark background. This change adds a white background to those images.

### Test URLs: 
* https://towardsdatascience.com/into-the-transformer-5ad892e0cee
* https://towardsdatascience.com/how-a-good-data-scientist-looks-at-matrix-multiplication-33a3128cd1bb
* https://towardsdatascience.com/your-first-step-into-the-field-of-computer-vision-f9928ecb313f

### Before:
![image](https://github.com/darkreader/darkreader/assets/17806916/a1e368cc-0ec6-435d-ac72-56d6b084e096)

### After:
![image](https://github.com/darkreader/darkreader/assets/17806916/1f686f65-6a6c-4d38-9839-0b43f68a4319)

**Note:** I'm unsure if the selector I'm using is appropriate but it seems to match PNG article images for multiple articles. Please suggest if you think I should change it.