### PR TITLE
Update fix for boardgamearena.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3196,6 +3196,9 @@ body {
 .bgagame-takaraisland .woundtoken {
     background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/takaraisland/170709-1847/img/wound.png);
 }
+:is(.bgagame-thegnomesofzavandor, .dijitTooltip) :is(.helper, .helper2) {
+    color: #000;
+}
 .bgagame-tickettoride .train-car-group-counter {
     -webkit-text-stroke: 3px #000;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3157,6 +3157,9 @@ body {
 .bgagame-catcafe .ctc_column_scoring {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/column_scoring.png");
 }
+.bgagame-catcafe .ctc_txt_flash {
+    color: #007f37;
+}
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-name,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-type-text,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-bottom-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3236,6 +3236,9 @@ body {
 .bgagame-riftvalleyreserve #rvr-score-ref-holder {
     background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/riftvalleyreserve/221228-1440/img/score_ref_vert.png);
 }
+.bgagame-riichimahjong :is(.JMJ_tile_other_annot, .JMJ_tile_self_annot) {
+   background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/riichimahjong/220818-0132/img/mahjongg_japan_annot.png");
+}
 :is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
     color: #000;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3171,6 +3171,12 @@ body {
 .bgagame-littlefactory .cell3 {
     color: #000;
 }
+.bgagame-microdojo .barrak {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/microdojo/221116-1802/img/barraks.png);
+}
+.bgagame-microdojo :is(.barrak, .Objname) {
+    color: #000;
+}
 .bgagame-splashdown .sd_playerinfo_icon,
 .bgagame-splashdown .lilypad,
 .bgagame-splashdown .fly,
@@ -3178,14 +3184,11 @@ body {
 .bgagame-splashdown .possibleMove {
     background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/splashdown/230808-1947/img/tokens.png);
 }
-.bgagame-microdojo .barrak {
-    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/microdojo/221116-1802/img/barraks.png);
-}
-.bgagame-microdojo :is(.barrak, .Objname) {
-    color: #000;
-}
 :is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
     color: #000;
+}
+.bgagame-takaraisland .woundtoken {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/takaraisland/170709-1847/img/wound.png);
 }
 .bgagame-tickettoride .train-car-group-counter {
     -webkit-text-stroke: 3px #000;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3212,6 +3212,9 @@ body {
 .bgagame-rainforest .token {
     background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/rainforest/230403-1628/img/Tokens.png);
 }
+.bgagame-riftvalleyreserve #rvr-score-ref-holder {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/riftvalleyreserve/221228-1440/img/score_ref_vert.png);
+}
 :is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
     color: #000;
 }
@@ -3257,6 +3260,9 @@ body {
 .tundra .dijitTooltipContainer {
     background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAAYCAYAAAA7zJfaAAAAIklEQVQIW2OQl5f/zwAm5OTkyCFkZWX/MxBByMjI/GeAEwB0riA1hmHf7AAAAABJRU5ErkJggg==");
 }
+
+IGNORE INLINE STYLE
+.bgagame-riftvalleyreserve :is(.rvr-rift, .rvr-stop, .rvr-svg-border)
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3120,7 +3120,7 @@ body {
 .bg-bga-gray-204 {
     background-color: rgb(57, 61, 62);
 }
-.bgagame-agricola .game-content, #right-side, .agricola_popin_container, .dijitTooltip .action-holder, .dijitTooltip .player-card {
+.bgagame-agricola .game-content, .bgagame-agricola #right-side, .agricola_popin_container, .dijitTooltip .action-holder, .dijitTooltip .player-card {
     color: #000;
 }
 :is(.bgagame-agricola, .dijitTooltip .action-component-tooltip) .action-card-holder .action-card .action-header,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3227,6 +3227,9 @@ body {
 .bgagame-microdojo :is(.barrak, .Objname) {
     color: #000;
 }
+.bgagame-patchwork .cost-label {
+    color: #222;
+}
 .bgagame-rainforest .token {
     background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/rainforest/230403-1628/img/Tokens.png);
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3159,6 +3159,9 @@ body {
 .bgagame-evergreen .eve_remaining-actions .stockitem {
     filter: invert(100%);
 }
+.bgagame-legendraiders #bag {
+    background-image: url("https://i.imgur.com/ptX6Fv7.png");
+}
 .bgagame-littlefactory .cardClay, .dijitTooltip .cardClay {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card2.jpg");
 }
@@ -3175,6 +3178,14 @@ body {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card3.jpg");
 }
 .bgagame-littlefactory .cell3 {
+    color: #000;
+}
+.bgagame-lox :is(
+    .coinCountA, .coinCountB, .coinCountC, .coinCountD,
+    .figurineCountA, .figurineCountB, .figurineCountC, .figurineCountD,
+    .guildCountA, .guildCountB, .guildCountC, .guildCountD,
+    .reputationCountA, .reputationCountB, .reputationCountC, .reputationCountD
+) {
     color: #000;
 }
 .bgagame-microdojo .barrak {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3114,8 +3114,11 @@ CSS
 body {
     background:none;
 }
-.bg-bga-whitebg {
+.bga-dropdown__list.bg-bga-whitebg {
     background-color: rgb(35, 38, 39);
+}
+.bg-bga-gray-204 {
+    background-color: rgb(57, 61, 62);
 }
 .bgagame-agricola .game-content, #right-side, .agricola_popin_container, .dijitTooltip .action-holder, .dijitTooltip .player-card {
     color: #000;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3160,6 +3160,9 @@ body {
 .bgagame-catcafe .ctc_txt_flash {
     color: #007f37;
 }
+.bgagame-catcafe .ctc_sub_scoring {
+    color: #000;
+}
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-name,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-type-text,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-bottom-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3110,6 +3110,9 @@ INVERT
 
 boardgamearena.com
 
+INVERT
+.bgagame-kingoftokyo .player-board .player-hand-card
+
 CSS
 body {
     background:none;
@@ -3158,6 +3161,18 @@ body {
 }
 .bgagame-evergreen .eve_remaining-actions .stockitem {
     filter: invert(100%);
+}
+.bgagame-kingoftokyo .player-evolution-card {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/kingoftokyo/230710-1229/img/evolution-cards.jpg");
+}
+.bgagame-kingoftokyo .kot-evolution {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/kingoftokyo/230710-1229/img/evolution-cards.jpg");
+}
+.bgagame-kingoftokyo .kot-evolution .description-wrapper {
+    color: #000;
+}
+.bgagame-kingoftokyo #table .player-table .player-name .outline {
+    -webkit-text-stroke: 4px #000;
 }
 .bgagame-legendraiders #bag {
     background-image: url("https://i.imgur.com/ptX6Fv7.png");

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3145,6 +3145,9 @@ body {
 .bgagame-carnegie .cng_timeline_image {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/carnegie/210812-1806/img/timelines.png");
 }
+.bgagame-catcafe .ctc_player_board {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/catcafe_sheet.jpg");
+}
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-name,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-type-text,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-bottom-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3218,7 +3218,7 @@ body {
 :is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
     color: #000;
 }
-.bgagame-sixtyone .sxt_leave {
+.bgagame-sixtyone :is(.sxt_leave, .sxt_location) {
     color: #000;
 }
 .bgagame-splashdown .sd_playerinfo_icon,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3156,6 +3156,9 @@ body {
 .bgagame-doglover .DOG-unfed .DOG-played-dog-card .DOG-card-placeholder .DOG-unfed-border {
     border-color: #7e0000;
 }
+.bgagame-evergreen .eve_remaining-actions .stockitem {
+    filter: invert(100%);
+}
 .bgagame-littlefactory .cardClay, .dijitTooltip .cardClay {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/littlefactory/220227-0736/img/Card2.jpg");
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3151,6 +3151,9 @@ body {
 .bgagame-catcafe .ctc_square {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/drawings_black.png");
 }
+.bgagame-catcafe .ctc_cat_footprint {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/catfootprint.png");
+}
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-name,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-type-text,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-bottom-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3148,6 +3148,9 @@ body {
 .bgagame-catcafe .ctc_player_board {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/catcafe_sheet.jpg");
 }
+.bgagame-catcafe .ctc_square {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/drawings_black.png");
+}
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-name,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-type-text,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-bottom-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3209,15 +3209,18 @@ body {
 .bgagame-microdojo :is(.barrak, .Objname) {
     color: #000;
 }
+:is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
+    color: #000;
+}
+.bgagame-sixtyone .sxt_leave {
+    color: #000;
+}
 .bgagame-splashdown .sd_playerinfo_icon,
 .bgagame-splashdown .lilypad,
 .bgagame-splashdown .fly,
 .bgagame-splashdown .frog,
 .bgagame-splashdown .possibleMove {
     background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/splashdown/230808-1947/img/tokens.png);
-}
-:is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
-    color: #000;
 }
 .bgagame-takaraisland .woundtoken {
     background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/takaraisland/170709-1847/img/wound.png);

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3154,6 +3154,9 @@ body {
 .bgagame-catcafe .ctc_cat_footprint {
     background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/catfootprint.png");
 }
+.bgagame-catcafe .ctc_column_scoring {
+    background-image: url("https://x.boardgamearena.net/data/themereleases/current/games/catcafe/221108-0942/img/column_scoring.png");
+}
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-name,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-type-text,
 :is(.bgagame-doglover, .dijitTooltip) .DOG-card-bottom-text,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3193,6 +3193,12 @@ body {
 .bgagame-tickettoride .train-car-group-counter {
     -webkit-text-stroke: 3px #000;
 }
+.bgagame-tobago .clue_card {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/tobago/190401-1859/img/clue_cards.png);
+}
+.bgagame-tobago .hut  {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/tobago/190401-1859/img/hut.png);
+}
 .nex_plname {
     color: #000;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3209,6 +3209,9 @@ body {
 .bgagame-microdojo :is(.barrak, .Objname) {
     color: #000;
 }
+.bgagame-rainforest .token {
+    background-image: url(https://x.boardgamearena.net/data/themereleases/current/games/rainforest/230403-1628/img/Tokens.png);
+}
 :is(.bgagame-sevenwondersduel, .dijitTooltip) :is(.swd_title, .coin > span) {
     color: #000;
 }


### PR DESCRIPTION
Updated style fixes for the following games on boardgamearena.com:

- Cat Cafe
- Evergreen
- King of Tokyo
- Legend Raiders
- Legends of Xidit
- Patchwork
- Rainforest
- Rift Valley Reserve
- Riichi Mahjong
- Sixty One Autumn Leaves
- Splashdown
- Takara Island
- The Gnomes of Zavandor
- Tobago