### PR TITLE
Add fishshell.com to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -337,6 +337,7 @@ filmmakermode.com
 filterblade.xyz
 filterlists.com
 fireship.io
+fishshell.com
 fleepy.tv
 flipperhub.com
 florr.io


### PR DESCRIPTION
Add https://fishshell.com (includes subpages such as https://fishshell.com/docs/current/index.html) to global dark sites.