### PR TITLE
Fix for login-widget.privatbank.ua on otp24.privatbank.ua

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13469,6 +13469,15 @@ div.art-Header-jpeg
 
 ================================
 
+login-widget.privatbank.ua
+
+CSS
+div[class*="qrContainer"] > div > div {
+    background-color: white !important;
+}
+
+================================
+
 login.assetpanda.com
 
 CSS


### PR DESCRIPTION
The top-level URL is https://otp24.privatbank.ua
The actual breakage occurs in a frame on https://login-widget.privatbank.ua

Before:
![image](https://github.com/darkreader/darkreader/assets/45960703/e8fcc284-7908-4c8e-8b57-f686bb80da9c)

After:
![image](https://github.com/darkreader/darkreader/assets/45960703/dbc784d3-b9c3-4649-9cb7-c717d5027f07)
