### PR TITLE
Removed `freecodecamp.org` from global dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -357,7 +357,6 @@ fpn.firefox.com
 fragment.com
 framp.me
 frankerfacez.com/$
-freecodecamp.org
 freespeechextremist.com
 frozensand.com
 funnyjunk.com


### PR DESCRIPTION
https://freecodecamp.org is not dark by default

Eg: https://www.freecodecamp.org/news/how-to-sync-your-fork-with-the-original-git-repository/