### PR TITLE
Remove paniash.gitlab.io from dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -652,7 +652,6 @@ overdodactyl.github.io/ShadowFox
 oxide.computer
 paimon.moe
 pandadev.tk
-paniash.gitlab.io
 paniash.netlify.app
 paper-io.com
 parahumans.wordpress.com


### PR DESCRIPTION
Removed https://paniash.gitlab.io which no longer exists.