### PR TITLE
Update fix for app.snowflake.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -157,6 +157,8 @@ app.snowflake.com
 
 INVERT
 [data-testid="avatar-block"]
+.cy
+.fz
 
 ================================
 


### PR DESCRIPTION
Fix for app.snowflake.com filter dark mode 'Role,' 'Warehouse,' and 'Share' buttons. Filter light mode does not work well, but this does not make it better or worse.

 - Fix Role, Warehouse, and Share buttons