### PR TITLE
Fixed review stars on dns-shop.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6757,6 +6757,19 @@ body {
 
 ================================
 
+dns-shop.ru
+
+CSS
+.star-rating__star svg g path {
+    --darkreader-inline-fill: #afafaf !important;
+    stroke: var(--darkreader-inline-fill) !important;
+}
+.star-rating__star[data-state="selected"] svg g path {
+    --darkreader-inline-fill: #ffa319 !important;
+}
+
+================================
+
 dnscrypt.pl
 
 INVERT


### PR DESCRIPTION
This fixes the white fill (and different stroke) color of each star of each review.

Before:
![image](https://github.com/darkreader/darkreader/assets/37143421/708ce4c0-9fc6-41ec-bb79-1cf553af375f)

After:
![image](https://github.com/darkreader/darkreader/assets/37143421/27bce4a1-222f-4e0f-81af-705d1978564c)

I don't know how to disable  `--darkreader-inline-fill` so I just forcefully overrode it.