### PR TITLE
change tradehub.pro => nvst.ly

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -643,6 +643,7 @@ notebooks.quantumstat.com
 notiger.xyz
 nowplayi.ng
 nulledbb.com
+nvst.ly
 obsidian.md
 oculus.com/experiences/quest/
 odysee.com
@@ -906,7 +907,6 @@ top.gg
 totems.me
 tov.monster
 tracker.gg
-tradehub.pro
 trblwlf.net
 trblwlf.tk
 trilon.io


### PR DESCRIPTION
tradehub.pro is the old website (redirects to nvst.ly now), nvst.ly is the new one