### PR TITLE
Added mnsr.win to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -578,6 +578,7 @@ mit.gg
 mixxx.org
 mizik.eu
 mmorpg.com
+mnsr.win
 monitoror.com
 monkeytype.com
 moonwiz.io


### PR DESCRIPTION
I added my blog (mnsr.win) to dark-sites.config on line 581.