### PR TITLE
Fix elle.com logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -99,13 +99,6 @@ INVERT
 
 ================================
 
-elle.com
-
-INVERT
-.css-lgctud .e1ccpyf90
-
-================================
-
 *.service-now.com
 
 INVERT
@@ -7715,6 +7708,13 @@ eletimes.com
 
 INVERT
 .tdb-logo-img
+
+================================
+
+elle.com
+
+INVERT
+.css-lgctud .e1ccpyf90
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -99,6 +99,13 @@ INVERT
 
 ================================
 
+elle.com
+
+INVERT
+.css-lgctud .e1ccpyf90
+
+================================
+
 *.service-now.com
 
 INVERT


### PR DESCRIPTION
This PR inverts the color of ELLE logo on elle.com homepage from black to white when using Dark Reader in dynamic mode
Fixes #11747
![image](https://github.com/darkreader/darkreader/assets/61153966/995348d6-b8b0-4abe-aa4d-420a3503b6b4)