### PR TITLE
make background of page darker to make the white text visible

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25049,6 +25049,15 @@ CSS
 
 ================================
 
+wrestlezone.com
+
+CSS
+main, footer, body{
+    background-color: #181a1b !important;
+}
+
+================================
+
 writefreely.org
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25052,8 +25052,10 @@ CSS
 wrestlezone.com
 
 CSS
-main, footer, body{
-    background-color: #181a1b !important;
+main,
+footer,
+body {
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
This PR makes the background of wrestlezone.com darker so that the white text is visible in dynamic mode of dark reader
Fixes #11756 
![image](https://github.com/darkreader/darkreader/assets/61153966/e4cb3487-be2f-4e9b-aa19-6b2b4d0bebe5)