### PR TITLE
allegro.pl smart savings value fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -924,6 +924,7 @@ a[data-analytics-click-label="offerClick"]
 img[src="https://assets.allegrostatic.com/freebox/icons/FREEBOX_NOMARGIN.svg"]
 img[src^="https://assets.allegrostatic.com/metrum/icon/smart-"]
 button[data-analytics-interaction-label="quantitySelector"]
+div[data-analytics-category="allegro.freebox.savings"] h6[class^=*]
 
 CSS
 #opbox-listing--base i,


### PR DESCRIPTION
Site allegro.pl/moje-allegro/zakupy/allegro-smart
Fix for savings delivery value. In default font is black  - not visible.

![20231002-1696273685](https://github.com/darkreader/darkreader/assets/9846948/a0f8e062-7a25-4a1a-9f15-8960bec846a3)
![20231002-1696273859](https://github.com/darkreader/darkreader/assets/9846948/968a159a-5b09-413f-8fb9-ffc25565ce08)
