### PR TITLE
fix: change text color of ezschoolpay.com side nav links to make them readable

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8050,6 +8050,18 @@ INVERT
 
 ================================
 
+ezschoolpay.com
+
+CSS
+.menuSideLabelSubHeader,
+.forgotPassword,
+.rememberMeCell > label,
+.rmText {
+    color: var(--darkreader-selection-text) !important;
+}
+
+================================
+
 f-droid.org
 
 INVERT


### PR DESCRIPTION
This PR changes the text color of side nav links to make them more readable
Fixes #11750
![image](https://github.com/darkreader/darkreader/assets/61153966/ad5872f4-66e5-472f-a651-a0e996d1daa5)