### PR TITLE
fix: remove INVERT on svg images in khanacademy.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12449,7 +12449,6 @@ CSS
 khanacademy.org
 
 INVERT
-.svg-image
 .graphie-label
 
 ================================


### PR DESCRIPTION
This PR removes color inversion on khanacademy.org images
Fixes #11741
![image](https://github.com/darkreader/darkreader/assets/61153966/bc55c1ce-d031-4079-ba1b-68cdd8513117)
