### PR TITLE
fix: change var tag color in tc39.es website to be visible in dark background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21843,6 +21843,16 @@ CSS
 
 ================================
 
+tc39.es
+
+CSS
+var {
+    color: ${#218379} !important;
+    mix-blend-mode: normal !important;
+}
+
+================================
+
 tcrf.net
 
 CSS


### PR DESCRIPTION
This PR changes var tag color on dark background
Fixes #11748 
![image](https://github.com/darkreader/darkreader/assets/61153966/17d10425-eb86-4e18-a5a2-b0ade345fb39)
