### PR TITLE
fix: change backblaze.com text color to be visible on dark background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2267,6 +2267,20 @@ INVERT
 
 ================================
 
+backblaze.com
+
+CSS
+.rt-headingxlred-bodym > p, a {
+    color: ${white} !important;
+}
+.nav2_link,
+.footer_link,
+.footer_textlink {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 bahnhof.net
 
 CSS


### PR DESCRIPTION
This PR changes backblaze.com text color to be visible on dark background
Fixes #11749