### PR TITLE
fix for omarapollo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16586,6 +16586,18 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+omarapollo.com
+
+INVERT
+.header__heading-logo
+
+CSS
+.gradient {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 omgubuntu.co.uk
 
 CSS


### PR DESCRIPTION
makes the logo readable and fixes the background color

before:
![image](https://github.com/darkreader/darkreader/assets/98089351/c26fbdfe-201f-4a08-8b52-98547808ae5c)

after:
![image](https://github.com/darkreader/darkreader/assets/98089351/28d61c56-4140-4cf1-ae2b-46141ebb98da)
