### PR TITLE
Update dark-sites.config to include RHWiki

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -768,6 +768,7 @@ retromusic.app
 returnyoutubedislike.com
 revanced.app
 reveddit.com
+rhwiki.net
 richup.io
 ripped.guide
 rl6mans.com


### PR DESCRIPTION
Add rhwiki.net (Rhythm Heaven Wiki) to the list of dark sites