### PR TITLE
Update dynamic-theme-fixes.config - Guardian crossword

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22199,6 +22199,7 @@ INVERT
 .inline-the-guardian-logo__svg
 a[data-link-name$="logo"] svg
 .crossword__grid .crossword__cell-text
+.crossword__cell-number
 .most-popular__number
 
 ================================


### PR DESCRIPTION
With Dark Reader enabled, the clue numbers in the cell are inverted to white. This inverts them back.

Example page: https://www.theguardian.com/crosswords/quiptic/1000