### PR TITLE
Fix for schwab.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19551,6 +19551,15 @@ span.gs_in_cb
 
 ================================
 
+schwab.com
+
+CSS
+.highcharts-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 sci-hub.*
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
Fixes the account balance chart background color.

Before:

<img width="965" alt="Screenshot 2023-10-11 at 10 40 43" src="https://github.com/darkreader/darkreader/assets/1018784/dd27c6cd-7ffe-4160-8c19-1340c6ad0809">

After:

<img width="959" alt="Screenshot 2023-10-11 at 10 40 12" src="https://github.com/darkreader/darkreader/assets/1018784/da0ec042-e404-4b47-bbae-afefe195950f">