### PR TITLE
Added Reniguide.info to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -759,6 +759,7 @@ redeclipse.net
 reelgood.com
 relay.firefox.com/faq
 renderlab.net
+reniguide.info
 renkon.github.io/lolbacktracker-frontend
 replit.com
 replugged.dev


### PR DESCRIPTION
https://reniguide.info/

Websites in Dark mode and dark mode only. Enabling DarkReader screws with the readeability.