### PR TITLE
Update dynamic-theme-fixes.config: 2700chess.com black chess pieace fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -242,6 +242,17 @@ body {
 
 ================================
 
+2700chess.com
+
+INVERT
+.cg-wrap piece.queen.black
+.cg-wrap piece.bishop.black
+.cg-wrap piece.rook.black
+.cg-wrap piece.knight.black
+.cg-wrap piece.pawn.black
+
+================================
+
 2gis.*
 
 INVERT


### PR DESCRIPTION
Fixes unnecessary inversion of black pieces (except king) on the chessboard