### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR introduces the following changes:

* Add a Dependabot config to auto-update GitHub action versions

I noticed that some of the GitHub workflows reference out-of-date GitHub action versions, like `actions/checkout@v3`, which is currently at `v4`. Rather than updating the versions once, this PR introduces a Dependabot configuration that will keep all of the actions up-to-date.

If this merges, you can anticipate Dependabot opening a PR immediately to update out-of-date GitHub action versions, like `actions/checkout@v3`.