### PR TITLE
fix(market.yandex.*): fixed images and buttons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14154,6 +14154,20 @@ CSS
 a[data-zone-name="offerLink"]:has(img) {
     background-color: #fff !important;
 }
+[data-baobab-name="picture"],
+[data-zone-name="picture"] > div > div,
+[data-zone-name="picture"] img {
+    mix-blend-mode: unset !important;
+}
+[data-zone-name="offer"] > div > div:nth-child(1) > div:nth-child(1) {
+    background-color: white;
+}
+[data-zone-name="cartButton"] button {
+    background-color: rgb(136, 109, 0) !important;
+}
+
+IGNORE INLINE STYLE
+[data-zone-name="offer"] > div > div:nth-child(1) > div:nth-child(1)
 
 ================================
 


### PR DESCRIPTION
- Fixed super dark images.
- Fixed different button color in "Popular offers" section.

Yandex.Market has, what is seems like, a very unstable for CSS select rules DOM. I tried avoiding temporary-looking class names (they persist after reload, but maybe will change after website update). Let's hope that it won't break in a few days.

Before:

![image](https://github.com/darkreader/darkreader/assets/37143421/87894dac-85fd-4bf9-80b4-28a56f7d03da)

After:

![image](https://github.com/darkreader/darkreader/assets/37143421/3288ff52-0276-4517-a3ff-85599ad82be4)
