### PR TITLE
Fixed inversion classes for learnyouahaskell.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13004,6 +13004,14 @@ CSS
 
 ================================
 
+learnyouahaskell.com
+
+INVERT
+.bgwrapper
+.dp-highlighter
+
+================================
+
 leetcode.com
 leetcode-cn.com
 


### PR DESCRIPTION
Seems to render as intended. Both the background and the rendered code examples (dp-highlighter) seem to work with no further tweaking.