### PR TITLE
fix(wildberries.ru): fixed textarea colors

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24858,6 +24858,10 @@ CSS
 .dropdown-filter__btn {
     color: var(--darkreader-neutral-text);
 }
+#Item_Text {
+    background: #181a1b;
+    color: #d1cdc7;
+}
 
 ================================
 


### PR DESCRIPTION
Before:

![image](https://github.com/darkreader/darkreader/assets/37143421/eea291ae-b952-4e9b-889b-e466d48f6e7d)

After:

![image](https://github.com/darkreader/darkreader/assets/37143421/b8c4c42b-9c65-420e-bb85-d256d7cbf61d)

Text color is also fixed.