### PR TITLE
CI: use NodeJS 18 instead of NodeJS 16

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -13,7 +13,7 @@ on:
       node_version:
         description: 'NodeJS version'
         required: true
-        default: '16.x'
+        default: '18.x'
 
 jobs:
   build:
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.node_version || '16.x' }}
+          node-version: ${{ inputs.node_version || '18.x' }}
           cache: npm
 
       - name: Install npm dependencies

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -27,7 +27,7 @@ on:
       node_version:
         description: 'NodeJS version'
         required: true
-        default: '16.x'
+        default: '18.x'
 
 jobs:
   test-browser:
@@ -85,7 +85,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.node_version || '16.x' }}
+          node-version: ${{ inputs.node_version || '18.x' }}
           cache: npm
 
       - name: Install NPM dependencies

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -23,7 +23,7 @@ on:
       node_version:
         description: 'NodeJS version'
         required: true
-        default: '16.x'
+        default: '18.x'
 
 jobs:
   test:
@@ -38,7 +38,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.node_version || '16.x' }}
+          node-version: ${{ inputs.node_version || '18.x' }}
           cache: npm
 
       - name: Install npm dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
       node_version:
         description: 'NodeJS version'
         required: true
-        default: '16.x'
+        default: '18.x'
 
 jobs:
   test:
@@ -36,7 +36,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ inputs.node_version || '16.x' }}
+          node-version: ${{ inputs.node_version || '18.x' }}
           cache: npm
 
       - name: Install npm dependencies


### PR DESCRIPTION
NodeJS 16 EOL arrived on September 11, 2023. It was brought forward a 7 months to match OpenSSL 1.1.1 EOL. We shouldn't be using EOL software, especially networked one, even though technically we do not use it in a high exposure/risc manner (we don't run a publickly-facing server, just a client connecting to NPM to load packages and to GitHub to upload artifacts. 

Let's use NodeJS 18 which will be supported until 2025.

Also, Rollup 4 does not declare NodeJS 16 among compatible versions (although this combo works in practice).

Source: https://nodejs.org/en/blog/announcements/nodejs16-eol