### PR TITLE
Lint: add import/no-unresolved exception for get-stream

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,7 +91,10 @@ config.overrides.push({
         }],
         'import/no-duplicates': 'error',
         'import/no-unresolved': ['error', {
-            ignore: ['^malevic\/'],
+            ignore: [
+                'get-stream',
+                '^malevic\/',
+            ],
         }],
         'import/no-restricted-paths': ['error', {
             zones: [{


### PR DESCRIPTION
This is a workaround for incompatibility of ESLint rule `import/no-unresolved` and `get-stream` version 8. The problem is caused by `import/no-unresolved` not supporting `package.json` field `"exports"` which was unflagged in NodeJS 13.7.0 and v12.17.0.

https://github.com/sindresorhus/get-stream/issues/109