### PR TITLE
Fix tex images in nethackwiki.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15848,6 +15848,16 @@ INVERT
 
 ================================
 
+nethackwiki.com
+
+INVERT
+.tex
+
+IGNORE IMAGE ANALYSIS
+.mw-wiki-logo
+
+================================
+
 netlify.com
 
 INVERT


### PR DESCRIPTION
Also fixes logo at top left corner of the page

Link: https://nethackwiki.com/wiki/Excalibur#Average_damage_calculation

| Before | After |
| ---------- | ------- |
| ![2023-10-29T22:03:13,494829834+05:30](https://github.com/darkreader/darkreader/assets/30190448/0e44d6f1-42d0-4196-a8e7-a350935a07e2) | ![2023-10-29T22:03:35,758960748+05:30](https://github.com/darkreader/darkreader/assets/30190448/ba64f3fd-4cac-45be-8dca-d8e58b865f5f) |
| ![2023-10-29T22:09:17,448641660+05:30](https://github.com/darkreader/darkreader/assets/30190448/03aa3bf8-2c83-43c8-b5bf-a32983d0bd2b) | ![2023-10-29T22:09:00,580371305+05:30](https://github.com/darkreader/darkreader/assets/30190448/748e2409-9f63-4aee-bf86-fd36e4f309d5) |