### PR TITLE
Fixed logo for monde-diplomatique.fr

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14967,6 +14967,13 @@ body {
 
 ================================
 
+monde-diplomatique.fr
+
+INVERT
+.logodiplo
+
+================================
+
 money.pl
 
 CSS


### PR DESCRIPTION
Logo was originally black on black, fixed so that it's white on black

Before:
![image](https://github.com/darkreader/darkreader/assets/72905961/2a876403-a70a-41fc-a7eb-a52a580a3df1)

After:
![image](https://github.com/darkreader/darkreader/assets/72905961/35b19cfe-02de-4e05-9f41-e37243f6cd40)
