### PR TITLE
Fix banner for economist.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7562,6 +7562,11 @@ economist.com
 INVERT
 #ds-wordmark-1843 path:nth-child(5)
 
+CSS
+.css-1xqo7ld {
+	color: transparent;
+}
+
 IGNORE INLINE STYLE
 #ds-economist-logo > path
 .ds-share-link > svg > g > circle


### PR DESCRIPTION
Bottom borders on piano banner should be transparent

Before:
![image](https://github.com/darkreader/darkreader/assets/72905961/5cf7af24-3b95-4ce5-b534-732c67dc8b7b)

After:
![image](https://github.com/darkreader/darkreader/assets/72905961/790aaa0d-bf3e-4c0c-ba15-02471649e2f6)
