### PR TITLE
correct pirateship.com pdf preview inversion

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17551,6 +17551,13 @@ INVERT
 
 ================================
 
+pirateship.com
+
+INVERT
+.pdf-preview
+
+================================
+
 pixabay.com
 
 INVERT


### PR DESCRIPTION
Prevents inversion of label preview shown before printing. While the inversion does properly take the previews from white to black, it breaks the ability to properly review the print.