### PR TITLE
Added ovosimpatico.com to Global Dark List

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -674,6 +674,7 @@ otzdarva.com
 ovagames.com
 overcoder.dev
 overdodactyl.github.io/ShadowFox
+ovosimpatico.com
 oxide.computer
 paimon.moe
 pandadev.tk


### PR DESCRIPTION
I'm the owner of ovosimpatico.com

The entire website, including subdomains, already are by default dark themed.

Dark Reader is used my many of my users, including myself, and if enabled, the websites "look bad" and even misbehave (images turning transparent on scroll on Ovo Play for logged-in users)

I'd like to add my website to the Global Dark List to avoid the aforementioned issues.