### PR TITLE
Update dynamic-theme-fixes.config for Web of Science

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25844,7 +25844,7 @@ www.webofscience.com
 CSS
 .hh, .labl, mark{
     color: var(--darkreader-neutral-text) !important;
-    background-color: ${COLOR} !important;
+    background-color: gray !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25842,7 +25842,7 @@ IGNORE INLINE STYLE
 www.webofscience.com
 
 CSS
-.hh, .labl, mark{
+.hh, .labl, mark {
     color: var(--darkreader-neutral-text) !important;
     background-color: gray !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25839,6 +25839,16 @@ IGNORE INLINE STYLE
 
 ================================
 
+www.webofscience.com
+
+CSS
+.hh, .labl, mark{
+    color: var(--darkreader-neutral-text) !important;
+    background-color: ${COLOR} !important;
+}
+
+================================
+
 www.wikihow.com
 
 INVERT


### PR DESCRIPTION
Web of Science search function dynamically marks search text with yellow background color. This creates bad contrast with default color of article headings in purple text color. Which makes reading the highlighted text difficult to read in dark mode.

This fix is to solve the visibility problem. 
Specifically changes the color of text that is dynamically marked to darkreader-neutral-text.