### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2388,6 +2388,16 @@ INVERT
 
 ================================
 
+baselinker.com
+
+CSS
+.form-control {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: ${black} !important;
+}
+
+================================
+
 bayfiles.com
 
 INVERT


### PR DESCRIPTION
After site updated with its own dark mode, some form fields on dark reader appeared white on dynamic dark mode.  The fix overwrites them to neutral background color as was the case in the past.