### PR TITLE
Add dynamic theme fixes for article "How Computers Use Numbers"

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13745,6 +13745,39 @@ CSS
 
 ================================
 
+mabi.tmpinc.io/numbers/
+
+INVERT
+button
+img.lock
+div.line
+
+CSS
+.bit.blue,
+.bit.red,
+.bit.green {
+    border-bottom: 3px solid var(--bit-color) !important;
+}
+.bit.gray {
+    background-color: ${lightgray} !important;
+}
+label:first-of-type {
+    border-left: 1px solid var(--darkreader-neutral-text) !important;
+}
+label {
+    border-top: 1px solid var(--darkreader-neutral-text) !important;
+    border-right: 1px solid var(--darkreader-neutral-text) !important;
+    border-bottom: 1px solid var(--darkreader-neutral-text) !important;
+}
+.demo {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+:root {
+    --darkreader-border--bit-color: var(--darkreader-neutral-text);
+}
+
+================================
+
 machinelearningmastery.com
 
 INVERT


### PR DESCRIPTION
[This article](https://mabi.tmpinc.io/numbers/) is one of the five winners of [SoME3](https://some.3b1b.co/). I think it deserves a pretty dark version.

Original:
![Screenshot 2023-11-10 200026](https://github.com/darkreader/darkreader/assets/4391024/9989b81f-a6e6-477c-80d6-07e579411ed9)

Dark without fixes:
![Screenshot 2023-11-10 200017](https://github.com/darkreader/darkreader/assets/4391024/0424e539-0419-4fb1-a887-f4a3f2223a30)

Dark with fixes:
![Screenshot 2023-11-10 195920](https://github.com/darkreader/darkreader/assets/4391024/9b7b681a-f4a3-4d92-badf-6e43e10f1e2e)
