### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,9 +9,6 @@ span[data-href^="https://www.hcaptcha.com/"] > #icon
 ::-webkit-calendar-picker-indicator
 
 CSS
-.mw-file-element {
-    background-color:white !important;
-}
 .vimvixen-hint {
     background-color: ${#ffd76e} !important;
     border-color: ${#c59d00} !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24984,7 +24984,7 @@ img[src*="Wiktionary-logo"]
 
 CSS
 .mw-file-element {
-    background-color:white !important;
+    background-color: white !important;
 }
 .mwe-popups-discreet > img,
 div .thumbimage[src$=".png"],

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,6 +9,9 @@ span[data-href^="https://www.hcaptcha.com/"] > #icon
 ::-webkit-calendar-picker-indicator
 
 CSS
+.mw-file-element {
+    background-color:white !important;
+}
 .vimvixen-hint {
     background-color: ${#ffd76e} !important;
     border-color: ${#c59d00} !important;
@@ -24983,6 +24986,9 @@ img[src*="Wiktionary-logo"]
 .locmap .pr
 
 CSS
+.mw-file-element {
+    background-color:white !important;
+}
 .mwe-popups-discreet > img,
 div .thumbimage[src$=".png"],
 div .thumbimage img[src$=".png"],


### PR DESCRIPTION
Fixes transparent images on wikipedia (and presumably wikiless) by drawing a white background behind them