### PR TITLE
fix(learn2.open.ac.uk): turn quoted text gray

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13169,8 +13169,9 @@ learn2.open.ac.uk
 
 CSS
 .oucontent-quote p {
-    color: grey !important;
+    color: ${grey} !important;
 }
+
 ================================
 
 learnopengl.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13165,6 +13165,14 @@ a {
 
 ================================
 
+learn2.open.ac.uk
+
+CSS
+.oucontent-quote p {
+    color: grey !important;
+}
+================================
+
 learnopengl.com
 
 CSS


### PR DESCRIPTION
In Open University materials hosted on learn2.open.ac.uk, quotes use black text, which Dark Reader doesn't seem to be able to do anything with.

Normal text on the dynamic theme is white, so I chose grey for quotes.