### PR TITLE
feat(dark-sites.config): adds `ahwx.org` to list of already dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -25,6 +25,7 @@ advanceds.me
 adventofcode.com
 agent-stats.com
 agfy.co
+ahwx.org
 airconsole.com
 ajay.app
 albony.xyz


### PR DESCRIPTION
[ahwx.org](https://ahwx.org) is already dark, no need for using Dark Reader.