### PR TITLE
fix(typst.app): made copy/link buttons visible

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23497,6 +23497,16 @@ CSS
 
 ================================
 
+typst.app
+
+CSS
+.package-list > tbody:nth-child(2) > tr > td:nth-child(4),
+.package-list > tbody:nth-child(2) > tr > td:nth-child(5) {
+    filter: invert();
+}
+
+================================
+
 ubank.com.au
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23499,11 +23499,8 @@ CSS
 
 typst.app
 
-CSS
-.package-list > tbody:nth-child(2) > tr > td:nth-child(4),
-.package-list > tbody:nth-child(2) > tr > td:nth-child(5) {
-    filter: invert();
-}
+INVERT
+img[src$=".svg"]:not([alt="Typst"])
 
 ================================
 


### PR DESCRIPTION
https://typst.app/docs/packages/:

Before:

![image](https://github.com/darkreader/darkreader/assets/37143421/78204871-d92a-45fd-abbe-98d64bdf0e3c)

After:

![image](https://github.com/darkreader/darkreader/assets/37143421/256de785-3ea5-4e2d-9e3a-32b4ca3b69a0)

