### PR TITLE
wyborcza.pl fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26304,6 +26304,7 @@ img.logo
 .button svg
 .btn.pull-right.dismiss
 .slider_nekrologi p::before
+img[src*="WYBORCZA-NEKROLOGI.png"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26303,6 +26303,7 @@ a[title="Aplikacja wyborcza.pl"]
 img.logo
 .button svg
 .btn.pull-right.dismiss
+.slider_nekrologi p::before
 
 ================================
 


### PR DESCRIPTION
Obituaries section  graphic invert
https://wyborcza.pl/0,0.html
Scroll to end site

Also fix logo from sub site
https://nekrologi.wyborcza.pl/0,0.html

![20231125-1700938314](https://github.com/darkreader/darkreader/assets/9846948/f4d72c57-7eaf-451e-ba54-2205e6ff0312)

![20231125-1700938956](https://github.com/darkreader/darkreader/assets/9846948/898f10d7-24c7-44ad-b092-5d503fdbc133)


