### PR TITLE
Fix for acmicpc.net

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -58,6 +58,17 @@ INVERT
 
 ================================
 
+acmicpc.net
+
+INVERT
+.wrapper
+.parallax-counter-v1
+.CodeMirror
+.footer
+.copyright
+
+================================
+
 airbnb.com
 
 INVERT


### PR DESCRIPTION
Dark reader extention not working on [acmicpc.net](https://www.acmicpc.net/) at all. So I fix it. Reverse wrapper color except footer and code part.

- Original:
  ![Screenshot 2023-11-29 at 22-04-30 64885851번 소스 코드](https://github.com/darkreader/darkreader/assets/61987505/d3daf50e-bf84-487f-a756-436c2a4efaba)
- Before:
  ![Screenshot 2023-11-29 at 22-04-53 64885851번 소스 코드](https://github.com/darkreader/darkreader/assets/61987505/920ab5e5-a016-4158-916f-0043d6a4ac93)
- After:
  ![Screenshot 2023-11-29 at 22-05-10 64885851번 소스 코드](https://github.com/darkreader/darkreader/assets/61987505/6dccd9fa-359c-4113-898a-c688dcc37265)
