### PR TITLE
Improve French translation

### DIFF
--- a/src/_locales/fr.config
+++ b/src/_locales/fr.config
@@ -188,8 +188,7 @@ Auto (le système est clair)
 Cliquez pour définir le raccourci
 
 @extension_toggle_shortcut
-Raccourci clavier d'activation/désactivation
-de l'extension
+Raccourci clavier d'activation/désactivation de l'extension
 
 @configure_site_toggle
 Configurer l'activation des sites

--- a/src/_locales/fr.config
+++ b/src/_locales/fr.config
@@ -11,21 +11,21 @@ Actif
 Inactif
 
 @toggle_current_site
-Activer/Désactiver sur le site actuel
+Activer/Désactiver sur ce site
 
 @setup_hotkey_toggle_site
 Configurer le raccourci clavier
-pour activer/désactiver sur le site actuel
+pour activer/désactiver sur ce site
 
 @toggle_extension
 Activer/Désactiver l'extension
 
 @setup_hotkey_toggle_extension
-Configurer l'extension
-Raccourci clavier pour activer/désactiver
+Configurer le raccourci clavier
+pour activer/désactiver l'extension
 
 @automation
-Réglage automatique
+Automatisation
 
 @set_active_hours
 Définir les heures d’activité
@@ -44,7 +44,7 @@ Cette page est protégée
 par le navigateur
 
 @local_files_forbidden
-Accès interdit
+Accès interdit aux
 fichiers locaux
 
 @page_in_dark_list
@@ -55,7 +55,7 @@ liste noire de l'extension
 Utiliser les couleurs du système
 
 @system_dark_mode_description
-Actif lorsque le mode sombre du système est actif
+Activer lorsque le mode sombre du système est actif
 
 @system_dark_mode_chromium_warning
 Cette option pourrait ne pas fonctionner
@@ -80,7 +80,7 @@ Luminosité
 Contraste
 
 @grayscale
-N/B
+Niveaux de gris
 
 @sepia
 Sépia
@@ -89,16 +89,16 @@ Sépia
 Uniquement
 
 @only_for_description
-Appliquer les paramètres au site actuel uniquement
+Appliquer les paramètres sur ce site uniquement
 
 @site_list
 Liste des sites
 
 @invert_listed_only
-Inversé seul
+Inverser uniquement
 
 @not_invert_listed
-Non-inversé
+Ne pas inverser
 
 @add_site_to_list
 Ajouter un site à la liste
@@ -113,7 +113,7 @@ Plus
 Choisir une police
 
 @text_stroke
-Trait du texte
+Épaisseur du texte
 
 @try_experimental_theme_engines
 Essayez les moteurs de thème **expérimentaux**:
@@ -137,7 +137,7 @@ Dynamiq.
 Mode de génération de thème
 
 @custom_browser_theme_on
-Custom.
+Custom
 
 @custom_browser_theme_off
 Défaut
@@ -146,7 +146,7 @@ Défaut
 Modifier le thème du navigateur
 
 @privacy
-Confid.
+Confidentialité
 
 @help
 Aide
@@ -161,7 +161,7 @@ Actus
 Lire la suite
 
 @open_dev_tools
-Dévelop.
+Outils de développement
 
 @configure_automation
 Configurer l'automatisation
@@ -188,40 +188,41 @@ Auto (le système est clair)
 Cliquez pour définir le raccourci
 
 @extension_toggle_shortcut
-Raccourci clavier d'activation/désactivation de l'extension
+Raccourci clavier d'activation/désactivation
+de l'extension
 
 @configure_site_toggle
-Configurer le basculement de site Web
+Configurer l'activation des sites
 
 @site_toggle
-Basculement de site
+Activation des sites
 
 @enabled_by_default
 Activé par défaut
 
 @enable_for_all_sites_by_default
-Activé pour tous les sites Web par défaut
+Activé pour tous les sites par défaut
 
 @detect_dark_theme
 Détecter le thème sombre
 
 @detect_website_dark_theme
-Détecter le thème sombre du site Web
+Détecter le thème sombre du site
 
 @dark_theme_detected
 Thème sombre détecté
 
 @website_toggle_shortcut
-Raccourci clavier pour basculer vers le site Web
+Raccourci clavier pour activer/désactiver sur le site
 
 @support_out_work
 Soutenez notre travail
 
 @mobile_link
-Mobile Dark Reader est disponible. Apprendre encore plus
+Dark Reader pour mobile est disponible. En savoir plus
 
 @store_listing
-Cette extension de navigateur implémente un thème sombre global en créant à la volée des thèmes sombres pour chaque site Web que vous visitez. Dark Reader augmente le contraste des couleurs vives pour les rendre plus agréables à la vue la nuit.
+Cette extension de navigateur implémente un thème sombre global en créant à la volée des thèmes sombres pour chaque site que vous visitez. Dark Reader augmente le contraste des couleurs vives pour les rendre plus agréables à la vue la nuit.
 
 Vous pouvez également ajuster la luminosité, le contraste, le filtre sépia, le thème sombre, la police du texte ainsi que la liste des sites ignorés par l'extension.
 


### PR DESCRIPTION
Just various improvements:
- weird wordings (eg. "basculement" is never used as a translation for "toggle", there's no 1 to 1 translation for that unfortunately)
- shorten some translations ("le site actuel" -> "ce site")
- fix some labels (@setup_hotkey_toggle_extension translation was wrong)
- make some labels clearer ("Confid." and "N/B" are not really common so a bit hard to understand)