### PR TITLE
dark-sites: add aagaming.me

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -12,6 +12,7 @@
 9anime.gs
 9anime.pl
 9anime.to
+aagaming.me
 abletonbot.me
 about.benjithatbluefox.eu
 absolucy.moe


### PR DESCRIPTION
Main domain and all public subdomains are dark themed by default.
https://aagaming.me