### PR TITLE
dark-sites: senkuro.com, senkognito.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -830,9 +830,9 @@ search.dr460nf1r3.org
 search.nebulacentre.net
 secrethitler.io
 secure.eveonline.com
-senpai.gg
 senkuro.com
 senkognito.com
+senpai.gg
 septatrix.github.io/prefers-color-scheme-test/
 serebii.net
 settings.gg

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -831,6 +831,8 @@ search.nebulacentre.net
 secrethitler.io
 secure.eveonline.com
 senpai.gg
+senkuro.com
+senkognito.com
 septatrix.github.io/prefers-color-scheme-test/
 serebii.net
 settings.gg

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -830,8 +830,8 @@ search.dr460nf1r3.org
 search.nebulacentre.net
 secrethitler.io
 secure.eveonline.com
-senkuro.com
 senkognito.com
+senkuro.com
 senpai.gg
 septatrix.github.io/prefers-color-scheme-test/
 serebii.net


### PR DESCRIPTION
Main domain and all public subdomains are dark themed by default.

https://senkuro.com
https://senkognito.com