### PR TITLE
Make Amazon Wishlist Buttons Icons Visible

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -104,6 +104,7 @@ INVERT
 .controlsOverlayTopRight
 .pausedOverlay
 .nav-flyout
+.lists-desktop-rio-icons
 
 NO INVERT
 .DigitalVideoWebNodeLists_Item__itemImage


### PR DESCRIPTION
Amazon wishlist items have various actions that may be applied - Move, Share, and Delete.

The button icons for Share and Delete were not inverted and become completely invisible when using Filter method.

This update adds the button syle class name to INVERT section.

Before:
- 
![screenshot-amazon-wishlist-item-buttons-before-invisible_share_delete](https://github.com/darkreader/darkreader/assets/17682973/b6648362-17dc-4ae6-a802-d0e32e8b97c3)

After:
- 
![screenshot-amazon-wishlist-item-buttons-after-fixed_share_delete](https://github.com/darkreader/darkreader/assets/17682973/ad1334e8-aa71-447d-b02f-ddfb0f4a07e9)
