### PR TITLE
Apply inversion for GSuite images across GSuite

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4120,6 +4120,7 @@ calendar.google.com
 
 INVERT
 div[style*="gm_add_black"]
+img[src$="google_gsuite"]
 
 CSS
 div[role="checkbox"] > div > div > div {
@@ -5411,6 +5412,7 @@ contacts.google.com
 
 INVERT
 img[src*="rotate"]
+img[src$="google_gsuite"]
 
 CSS
 img[src^="https://ssl.gstatic.com/social/contactsui/images/emptycontacts/emptycontacts_animation_"],
@@ -7022,6 +7024,7 @@ INVERT
 .share-butter-copy-icon
 .doc-previews-indicator-popover .docs-link-bubble-mime-icon
 img[src$="googlelogo_dark_clr_74x24px.svg"]
+img[src$="google_gsuite"]
 .exportUnderline
 .freebirdMaterialIconIconEl
 .quantumWizTogglePapercheckboxCheckMark
@@ -7255,7 +7258,6 @@ INVERT
 drive.google.com
 
 INVERT
-img[src$="google_gsuite"]
 div[role="menuitem"] svg
 div[role="dialog"][style^="width: 350px;"] div[role="button"][tabindex="0"]
 div[role="dialog"] ~ div[role="menu"] > div[role="menuitem"] > div > div:not([style*="background-image"])
@@ -7266,6 +7268,7 @@ div[data-label="nd"] > div > div > svg > path[fill="#000000"]
 div[role="document"] > div[role="button"] .a-b-c
 div > svg > circle[fill="white"]
 img[src*="empty_state_trash"]
+img[src$="google_gsuite"]
 div[tabindex="-1"][role="toolbar"] > div > div > div > svg > path[d^="M10 18h4v-2h-4v2zM3"]
 
 CSS
@@ -12552,6 +12555,7 @@ CSS
 keep.google.com
 
 INVERT
+img[src$="google_gsuite"]
 .gb_hc
 
 ================================


### PR DESCRIPTION
Uses the existing gmail inversion to invert the GSuite image on 

- calendar.google.com
- contacts.google.com
- docs.google.com
- drive.google.com
- keep.google.com