### PR TITLE
Correct battlelog.battlefield.com dark site matching

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -93,7 +93,7 @@ baldursgate3.game
 banfeed.com
 based.cooking
 battle.net
-battlelog.battlefield.com
+battlelog.battlefield.com/bf4
 bbc.co.uk/iplayer
 bdeditor.dev
 beastskills.com


### PR DESCRIPTION
In the `battlelog.battlefield.com` domain, only `battlelog.battlefield.com/bf4` subpage is in dark mode. Other major subpages - `battlelog.battlefield.com/bf3` and `battlelog.battlefield.com/bfh` - are white theme.