### PR TITLE
Update detector-hints for github.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -201,6 +201,7 @@ html
 
 MATCH
 [data-color-mode="dark"]
+[data-color-mode="auto"]
 
 ================================
 


### PR DESCRIPTION
It would be better if the user selected the GitHub theme to be "Sync with system", the `darkreader` extension should not enable the dark theme in that case.

This also fixes the problem when `darkreader` enables a dark theme, when the GitHub theme is auto and the system theme is dark.