### PR TITLE
fix for wikipedia.org (fixes bug #12001)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25186,7 +25186,6 @@ wikiless.org
 *.wikipedia.org
 
 INVERT
-.mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
 .mw-ext-score
 .mw-logo-wordmark


### PR DESCRIPTION
Removed .mwe-math-fallback-image-inline from INVERT as it was making formulas darker after invert.
Fixes #12001