### PR TITLE
fixes for gp.se

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10585,6 +10585,21 @@ INVERT
 
 ================================
 
+gp.se
+
+CSS
+header nav {
+    border-top: unset !important;
+}
+header nav::after { 
+    background: linear-gradient( 90deg, hsl(0deg 0% 100% / 4%) 0, hsl(0deg 0% 30.39% / 40%) 25%, var(--darkreader-bg--white) ) !important; 
+}
+article.teaser-article {
+    --teaser-background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 grammarly.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10591,8 +10591,8 @@ CSS
 header nav {
     border-top: unset !important;
 }
-header nav::after { 
-    background: linear-gradient( 90deg, hsl(0deg 0% 100% / 4%) 0, hsl(0deg 0% 30.39% / 40%) 25%, var(--darkreader-bg--white) ) !important; 
+header nav::after {
+    background: linear-gradient( 90deg, hsl(0deg 0% 100% / 4%) 0, hsl(0deg 0% 30.39% / 40%) 25%, var(--darkreader-bg--white) ) !important;
 }
 article.teaser-article {
     --teaser-background-color: var(--darkreader-neutral-background) !important;


### PR DESCRIPTION
This fixes 3 issues on the [gp.se](https://www.gp.se/) news site.

```css
header nav {
    border-top: unset !important;
}
```
Removes the white border here:
![image](https://github.com/darkreader/darkreader/assets/31625202/66e95451-3e8e-4fa2-8fb4-5187ddaf1296)

```css
header nav::after { 
    background: linear-gradient( 90deg, hsl(0deg 0% 100% / 4%) 0, hsl(0deg 0% 30.39% / 40%) 25%, var(--darkreader-bg--white) ) !important; 
}
```
Makes the gradient here nicer:
![image](https://github.com/darkreader/darkreader/assets/31625202/713a9058-4154-4e77-8df3-f25d2dd5367c)

```css
article.teaser-article {
    --teaser-background-color: var(--darkreader-neutral-background) !important;
}
```
Fixes the background for certain articles on the frontpage:
![image](https://github.com/darkreader/darkreader/assets/31625202/c9a8d585-c5d3-4461-afb5-6cd4f3084e90)
