### PR TITLE
Fix for Shipstation.com tag icons #10225

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20461,6 +20461,7 @@ INVERT
 
 ================================
 
+shipstation.com
 *.shipstation.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20461,7 +20461,7 @@ INVERT
 
 ================================
 
-shipstation.com
+*.shipstation.com
 
 INVERT
 [class*="sub-item-icon"]


### PR DESCRIPTION
Fixes issue #10225, shipstation needs a wildcard prefix otherwise the style changes aren't applied.