### PR TITLE
Fix for *.gamer.com.tw

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25785,7 +25785,7 @@ CSS
 
 ================================
 
-www.gamer.com.tw
+*.gamer.com.tw
 
 CSS
 body {


### PR DESCRIPTION
Closes #11974.

The only rest problem is home.gamer.com.tw/homeindex.php can have user-customized themes, but it seems impossible to apply dark theme without breaking the themes.