### PR TITLE
Fix for wayfarer.nianticlabs.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24610,6 +24610,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+wayfarer.nianticlabs.com
+
+INVERT
+wf-logo
+
+================================
+
 waze.com
 
 INVERT


### PR DESCRIPTION
Invert logo.

Before:
<img width="138" alt="2023-12-14-17-32-29" src="https://github.com/darkreader/darkreader/assets/1006477/4010f7bf-9ad6-4102-b2c8-1ed4f41234d0">

After:
<img width="133" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/b0506147-6fdb-4077-931f-7a70490bff27">
