### PR TITLE
Fix for forums.warframe.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9093,6 +9093,7 @@ forum.ithardware.pl
 forum.kaspersky.com
 forums.getpaint.net
 forums.laptopvideo2go.com
+forums.warframe.com
 nieidealny.pl/forum
 
 INVERT


### PR DESCRIPTION
Fix background of drop-down menus.

Before:
<img width="272" alt="2023-12-15-07-04-15" src="https://github.com/darkreader/darkreader/assets/1006477/9ae79bca-9236-4deb-bdd5-324a489c03af">

After:
<img width="260" alt="2023-12-15-07-06-30" src="https://github.com/darkreader/darkreader/assets/1006477/4f0197e9-2024-4e7e-9d56-882b09749f43">
