### PR TITLE
Add recipesage.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -776,6 +776,7 @@ raunaksitoula.com
 rawgiving.com
 ray.so
 razorsecure.com
+recipesage.com
 redacted.ch
 redasm.io
 redbox.com


### PR DESCRIPTION
Hi there! I'm the maintainer for [RecipeSage](https://github.com/julianpoy/recipesage). It automatically respects dark mode for the whole site/app, and darkreader can add some funky coloration.