### PR TITLE
config: Globablly invert img.Wirisformula

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7,6 +7,7 @@ span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"
 span[data-href^="https://www.hcaptcha.com/"] > #icon
 #bit-notification-bar-iframe
 ::-webkit-calendar-picker-indicator
+img.Wirisformula
 
 CSS
 .vimvixen-hint {
@@ -21729,13 +21730,6 @@ studyflix.de
 
 INVERT
 img[title='Rendered by QuickLaTeX.com']
-
-================================
-
-studysmarter.de
-
-INVERT
-img.Wirisformula
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -25,6 +25,7 @@ NO INVERT
 input
 [background] *
 img[src^="https://s0.wp.com/latex.php"]
+img.Wirisformula
 twitterwidget .NaturalImage-image
 
 REMOVE BG


### PR DESCRIPTION
It always contains an image with black text on a transparent background, which can be seen in https://demo.wiris.com/integrations/ckeditor/

Prompted by https://opal.openu.ac.il having the same issue as https://studysmarter.de