### PR TITLE
Add exdigis.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -334,6 +334,7 @@ evewho.com
 evokemusic.ai
 evowars.io
 excel-dna.net
+exdigis.com
 extrememusic.com
 f.vision
 faceit-enhancer.com


### PR DESCRIPTION
The web site is dark by default, with an optional user button to switch between dark and light modes.