### PR TITLE
 Add lazer.ppy.sh to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -690,6 +690,7 @@ openrazer.github.io
 orama-interactive.itch.io/pixelorama
 orteil.dashnet.org/cookieclicker
 osu.ppy.sh
+lazer.ppy.sh
 osumatrix.me
 otzdarva.com
 ovagames.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -542,6 +542,7 @@ lagom.nl/lcd-test
 lainchan.org
 landchad.net
 larbs.xyz
+lazer.ppy.sh
 lbrynomics.com
 lecantiche.com
 lemm.ee
@@ -690,7 +691,6 @@ openrazer.github.io
 orama-interactive.itch.io/pixelorama
 orteil.dashnet.org/cookieclicker
 osu.ppy.sh
-lazer.ppy.sh
 osumatrix.me
 otzdarva.com
 ovagames.com


### PR DESCRIPTION
Hello everyone!
I have noticed that osu.ppy.sh is in the global dark list, but lazer.ppy.sh is not in it.
It is basically the same website, but it has access from different type of data from a newer version of the osu! client. 
A lot of users will start to use lazer.ppy.sh or even migrate to it very soon.
Thank you!