### PR TITLE
Add lishogi.org to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -557,6 +557,7 @@ linux.org.ru
 linuxgamingcentral.com
 lipu-linku.github.io
 liquidplus.com
+lishogi.org
 listen.moe
 livesplit.org
 liveweave.com


### PR DESCRIPTION
Similarly to lichess.org, darkreader inverts the pieces and some boards. The site is dark by default. Thanks!