### PR TITLE
Add gamersnexus.net to global dark list.

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -387,6 +387,7 @@ fusengine.github.io/apaxy-v2
 galacticabot.vercel.app
 gamebanana.com
 gamejolt.com
+gamersnexus.net
 gamescoper.com
 gaming.amazon.com
 garudalinux.org


### PR DESCRIPTION
Related: #11889