### PR TITLE
Fix gmail search text for filter[+] mode

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1505,6 +1505,7 @@ CSS
 mail.google.com
 
 INVERT
+#aso_search_form_anchor [role='presentation']
 #aso_search_form_anchor [role='presentation'] tr td div
 
 ================================

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1505,7 +1505,7 @@ CSS
 mail.google.com
 
 INVERT
-#aso_search_form_anchor [role='presentation']
+#aso_search_form_anchor [role='presentation'] tr td div
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1502,6 +1502,13 @@ CSS
 
 ================================
 
+mail.google.com
+
+INVERT
+#aso_search_form_anchor [role='presentation']
+
+================================
+
 mail.live.com
 
 INVERT


### PR DESCRIPTION
The search text in Gmail is black [again] in Filter and Filter+ modes, making it pretty much impossible to see. This is a best effort attempt at inverting the text element in a way that [hopefully] won't break too soon.

Fixes #12051 