### PR TITLE
Fix search text/results in Gmail

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1505,8 +1505,11 @@ CSS
 mail.google.com
 
 INVERT
-#aso_search_form_anchor [role='presentation']
 #aso_search_form_anchor [role='presentation'] tr td div
+#aso_search_form_anchor [role='presentation'] [role='listbox'] [role='option'] span
+
+NO INVERT
+#aso_search_form_anchor [role='presentation'] [role='listbox']
 
 ================================
 


### PR DESCRIPTION
This seems to properly invert the search text and results menu for me in Filter and Filter+ modes

Following up on #12052 and the discussion therein, this is the set of changes which seems to fix the issue on my machine (#12051)

Would appreciate getting another set of eyes on this, because it seems like this might not be as reproducible as I'd hoped:
https://github.com/darkreader/darkreader/pull/12052#issuecomment-1868378302