### PR TITLE
fix for wikipedia math formulas (update)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25280,7 +25280,6 @@ wikiless.org
 *.wikipedia.org
 
 INVERT
-.mwe-math-fallback-image-display
 .mw-ext-score
 .mw-logo-wordmark
 .mw-logo-tagline


### PR DESCRIPTION
Fixes #12018 - as there was second class not needed in invert anymore.