### PR TITLE
Fix some inline icons on wikipedia mobile

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25300,6 +25300,8 @@ img[alt="audio speaker icon"]
 img[src*="Wiktionary-logo"]
 .locmap .pl
 .locmap .pr
+.mf-icon-expand
+.toc-title-icon
 
 CSS
 .mwe-popups-discreet > img,
@@ -25367,6 +25369,8 @@ IGNORE INLINE STYLE
 
 IGNORE IMAGE ANALYSIS
 .k-player .k-menu-bar li a
+.mf-icon-expand
+.toc-title-icon
 
 ================================
 


### PR DESCRIPTION
Currently the foldable section caret and TOC icon are invisible.

![Screenshot from 2023-12-28 10-59-08](https://github.com/darkreader/darkreader/assets/1381592/07e42f08-589c-4613-a1f3-d0a99ae57103)

Example: https://en.m.wikipedia.org/wiki/Firefox


As a fix I added both to `IGNORE IMAGE ANALYSIS` and `INVERT` sections, so that they get fully inverted without using the `feColorMatrix` while keeping the behavior dynamic for light and dark themes.

