### PR TITLE
Fix for www.tiktok.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26368,6 +26368,9 @@ INVERT
 .logo-link
 div[class*="DivSeekBarContainer"]
 div[class*="DivVolumeControlContainer"]
+div[class*="DivVolumeControlCircle"]
+div[class*="DivVolumeControlBar"]
+div[class*="DivVolumeControlProgress"]
 .video-control-container-browser
 .volume-control-container-browser
 .seek-bar-container

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26367,7 +26367,6 @@ INVERT
 .like-container .icon
 .logo-link
 div[class*="DivSeekBarContainer"]
-div[class*="DivVolumeControlContainer"]
 div[class*="DivVolumeControlCircle"]
 div[class*="DivVolumeControlBar"]
 div[class*="DivVolumeControlProgress"]


### PR DESCRIPTION
Inverted volume control

Shared link version

Before:
![image](https://github.com/darkreader/darkreader/assets/64931967/1d207f77-0dea-47ea-aea0-10829e9927d3)
After:
![image](https://github.com/darkreader/darkreader/assets/64931967/fce46e65-c9c4-49b9-9f40-a97fd7fe5b01)
URL to example video: https://www.tiktok.com/@livestream_fail_clips/video/7302110488295673119

Main page version

Before:
![image](https://github.com/darkreader/darkreader/assets/64931967/a27c519d-d34c-4286-a601-35fae32bdf31)
After:
![image](https://github.com/darkreader/darkreader/assets/64931967/42568e50-c58b-44a3-ac9a-b39976525b5e)
