### PR TITLE
Add overwrite of the background image for Monobook skin on Wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25374,6 +25374,10 @@ body.mediawiki,
   background-color: var(--darkreader-neutral-background);
   background-image: linear-gradient(rgb(24, 26, 27) 50%, var(--darkreader-neutral-background) 100%);
 }
+body.skin--responsive,
+#menus-cover-background {
+  background-image: linear-gradient(rgb(24, 26, 27) 50%, var(--darkreader-neutral-background) 100%) !important;
+}
 
 IGNORE INLINE STYLE
 .legend-color:not(table.wikitable .legend-color)


### PR DESCRIPTION
The Monobook skin loads an SVG image (https://en.wikipedia.org/w/skins/MonoBook/resources/images/headbg.svg) and plasters it as the background for the menu portion of the website (which on Monobook is at the top of the screen).

This replaces the image with a gradient, which I copied from the line previous.