### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10558,6 +10558,13 @@ img[src*="bookmark.png"]
 
 ================================
 
+goproblems.com
+
+IGNORE INLINE STYLE
+<div class="player-container">
+
+================================
+
 gorod.gov.spb.ru
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10560,6 +10560,9 @@ img[src*="bookmark.png"]
 
 goproblems.com
 
+INVERT
+.navbar-brand
+
 IGNORE INLINE STYLE
 <div class="player-container">
 


### PR DESCRIPTION
Added goproblems.com and  ignored inline style on the playing field so that the board is readable and the piece color is not inverted.