### PR TITLE
Fix for rosepassion.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19760,7 +19760,7 @@ INVERT
 
 CSS
 #selectionner_voiture .bloc .image {
-mix-blend-mode: normal !important;
+    mix-blend-mode: normal !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19750,6 +19750,21 @@ span.caption-wrapper img {
 
 ================================
 
+rosepassion.com
+
+INVERT
+.imgmap
+.famille-content .image
+.les_schemas img
+.rpimage .follow-scroll
+
+CSS
+#selectionner_voiture .bloc .image {
+mix-blend-mode: normal !important;
+}
+
+================================
+
 roskomsvoboda.org
 
 INVERT


### PR DESCRIPTION
Fixes multiple problems on [rosepassion.com](https://www.rosepassion.com):
- missing background in model selection (resulting in poor visibility)
- not inverted pictograms in category selection ([example](https://www.rosepassion.com/en/parts-porsche-944-1988-eu-944-s-coupe-manual-gearbox-5-speed))
- poor visibility due to missing inversion in schema selection ([example](https://www.rosepassion.com/en/diagrams-porsche-944-1988-eu-944-s-coupe-manual-gearbox-5-speed/engine-and-fuel-feed-36))
- poor visibility due to missing inversion in the schemas themselves ([example](https://www.rosepassion.com/en/diagrams-porsche-944-1988-eu-944-s-coupe-manual-gearbox-5-speed/engine-and-fuel-feed-36/cylinder-head-valves-4624))