### PR TITLE
Fix for amazon.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1163,6 +1163,8 @@ span.milestone-bar_background {
 }
 img {
     border-radius: 5% !important;
+    mix-blend-mode: unset !important;
+    background-blend-mode: unset !important;
 }
 
 ================================


### PR DESCRIPTION
Fix issues with some of the images being barely visible when dark mode enabled.

Example of the issue:
![image](https://github.com/darkreader/darkreader/assets/70995308/ca0efbf9-2db2-4cff-8e2f-4ead050605d4)
