### PR TITLE
Fix for boincstats.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3444,6 +3444,15 @@ CSS
 
 ================================
 
+boincstats.com
+
+CSS
+#sidebar {
+    background-image: none !important;
+}
+
+================================
+
 bol.com
 
 CSS


### PR DESCRIPTION
Remove background of sidebar.

Before:
<img width="435" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/907abe6b-3978-45f3-ae4b-ddf383241ed5">

After:
<img width="426" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/42e6bf17-6eb3-43a4-8717-a47cb04a28d8">
