### PR TITLE
Fixes for usosweb

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24021,12 +24021,12 @@ timetable-entry
 
 CSS
 :root {
-    --background: var(--darkreader-neutral-background) !important;
+    --background: var(--darkreader-bg--background) !important;
     --background-secondary: var(--darkreader-bg--background-secondary) !important;
     --font-color: var(--darkreader-neutral-text) !important;
 }
 #page-body {
-    background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-bg--background) !important;
 }
 usos-module-link-tile:hover {
     background-color: var(--darkreader-border--border) !important;
@@ -24054,7 +24054,7 @@ timetable-entry {
     background-color: var(--darkreader-neutral-background) !important;
 }
 body {
-    background: #333 !important;
+    background: ${#d8d8d8} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24005,6 +24005,60 @@ nav .menu-icon .i
 
 ================================
 
+usosweb.*.edu.pl
+usosweb.*.pl
+usosweb.*.*.pl
+usos.*.*.pl
+web.usos.*.edu.pl
+
+INVERT
+.icons-fontcolor
+.schedimg
+.rejestracja-ikona
+#titlebar > #close:hover
+usos-module-link-tile-container > usos-module-link-tile > h2
+timetable-entry
+
+CSS
+:root {
+    --background: var(--darkreader-neutral-background) !important;
+    --background-secondary: var(--darkreader-bg--background-secondary) !important;
+    --font-color: var(--darkreader-neutral-text) !important;
+}
+#page-body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+usos-module-link-tile:hover {
+    background-color: var(--darkreader-border--border) !important;
+}
+#close:hover {
+    background-color: var(--darkreader-text--on-primary) !important;
+}
+#close:focus {
+    background-color: #888 !important;
+}
+#layoutCopyright {
+    color: var(--darkreader-neutral-text) !important;
+}
+div > #icon {
+    background: rgb(94, 136, 213) !important;
+}
+timetable-day {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+timetable-entry {
+    color: #111 !important;
+}
+#titlebar {
+    color: var(--darkreader-neutral-text) !important;
+    background-color: var(--darkreader-neutral-background) !important;
+}
+body {
+    background: #333 !important;
+}
+
+================================
+
 uspassporthelpguide.com
 
 CSS


### PR DESCRIPTION
USOS is a Polish university platform usually accessible through a subdomain of university's website - for example usosweb.uj.edu.pl in case of UJ whose main domain is uj.edu.pl.
As of right now, the background of many elements in the platform is not reversed.

![firefox_LafaL41Hn8](https://github.com/darkreader/darkreader/assets/44444384/e9cb6a53-fb0a-4e73-b3ff-09927d2d8fb2)

This pull request corrects the background of main panels, tables, and a few others.

![firefox_vhGMiwez7v](https://github.com/darkreader/darkreader/assets/44444384/a8124379-078e-49ef-9ea3-40fa776c4c00)
