### PR TITLE
fix for last.fm

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13233,6 +13233,7 @@ IGNORE IMAGE ANALYSIS
 .masthead-logo-loading
 .masthead-logo
 .tag-label--average-daily-scrobbles::before
+.report-headline-border
 
 ================================
 


### PR DESCRIPTION
Added one class to IGNORE IMAGE ANALYSIS as it was making very bright border in reports.