### PR TITLE
Fixes for battlelog.battlefield.com/bf3

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2527,6 +2527,7 @@ IGNORE IMAGE ANALYSIS
 .serverguide-headercells
 table.common-table > thead > tr > th
 .leaderboard-venice-specific thead tr th
+.base-item-ribbon-small
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2492,6 +2492,9 @@ INVERT
 :not(.active) > .serverguide-cell-type-wrapper > div
 .common-button-medium-grey
 .common-kittimes-overlay
+.serverguide-headercells
+table.common-table > thead > tr > th
+.leaderboard-venice-specific > thead > tr > th
 
 CSS
 .common-button-medium-grey > p {
@@ -2519,6 +2522,11 @@ CSS
 .common-percentbar-container div {
   background-color: ${#353535} !important;
 }
+
+IGNORE IMAGE ANALYSIS
+.serverguide-headercells
+table.common-table > thead > tr > th
+.leaderboard-venice-specific thead tr th
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2515,6 +2515,11 @@ CSS
     color: #262626 !important;
 }
 
+.progress-bar .progress-bar-inner,
+.common-percentbar-container div {
+  background-color: ${#353535} !important;
+}
+
 ================================
 
 bayfiles.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2491,6 +2491,7 @@ INVERT
 :not(.active) > .serverguide-cell-pb-wrapper > div
 :not(.active) > .serverguide-cell-type-wrapper > div
 .common-button-medium-grey
+.common-kittimes-overlay
 
 CSS
 .common-button-medium-grey > p {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2490,6 +2490,29 @@ INVERT
 :not(.active) > .serverguide-cell-ranked-wrapper > div
 :not(.active) > .serverguide-cell-pb-wrapper > div
 :not(.active) > .serverguide-cell-type-wrapper > div
+.common-button-medium-grey
+
+CSS
+.common-button-medium-grey > p {
+   color: #000 !important;
+}
+
+.base-button-arrow-almost-gigantic,
+.base-button-arrow-gigantic,
+.base-button-arrow-large,
+.btn.btn-primary,
+.base-button-arrow-large-drop {
+    color: #000 !important;
+}
+
+.common-button-medium > p,
+.common-button-large > p {
+   color: #000 !important;
+}
+
+.common-selector-alt li.selected {
+    color: #262626 !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2501,9 +2501,8 @@ table.common-table > thead > tr > th
 
 CSS
 .common-button-medium-grey > p {
-   color: #000 !important;
+    color: #000 !important;
 }
-
 .base-button-arrow-almost-gigantic,
 .base-button-arrow-gigantic,
 .base-button-arrow-large,
@@ -2511,21 +2510,17 @@ CSS
 .base-button-arrow-large-drop {
     color: #000 !important;
 }
-
 .common-button-medium > p,
 .common-button-large > p {
    color: #000 !important;
 }
-
 .common-selector-alt li.selected {
     color: #262626 !important;
 }
-
 .progress-bar .progress-bar-inner,
 .common-percentbar-container div {
-  background-color: ${#353535} !important;
+    background-color: ${#353535} !important;
 }
-
 #selected-server-settings .selected-server-setting{
     color: ${#888} !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2495,6 +2495,9 @@ INVERT
 .serverguide-headercells
 table.common-table > thead > tr > th
 .leaderboard-venice-specific > thead > tr > th
+#selected-server-settings .selected-server-setting
+.sodaSlider-arrow-left
+.sodaSlider-arrow-right
 
 CSS
 .common-button-medium-grey > p {
@@ -2521,6 +2524,10 @@ CSS
 .progress-bar .progress-bar-inner,
 .common-percentbar-container div {
   background-color: ${#353535} !important;
+}
+
+#selected-server-settings .selected-server-setting{
+    color: ${#888} !important;
 }
 
 IGNORE IMAGE ANALYSIS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2484,6 +2484,15 @@ CSS
 
 ================================
 
+battlelog.battlefield.com/bf3
+
+INVERT
+:not(.active) > .serverguide-cell-ranked-wrapper > div
+:not(.active) > .serverguide-cell-pb-wrapper > div
+:not(.active) > .serverguide-cell-type-wrapper > div
+
+================================
+
 bayfiles.com
 
 INVERT


### PR DESCRIPTION
Several fixes for Battlefield 3 Battlelog
- Corrected icons (which would not get reversed properly) and buttons for server lists. [Example site](https://battlelog.battlefield.com/bf3/servers/)
  <details> <summary>Images</summary>
  
  Vanilla: 
![firefox_oXzHQyvm7o](https://github.com/darkreader/darkreader/assets/44444384/49f8c0ac-8fcd-4e48-ae9a-84001f349936)

  Before: 
  ![image](https://github.com/darkreader/darkreader/assets/44444384/806e7c87-9e13-4634-8109-b69695ca1cf2) 
  
  After: 
  ![image](https://github.com/darkreader/darkreader/assets/44444384/1ea997c1-6eda-44cf-a358-8d78a6c0719e) 
  </details>
- Corrected sliders for servers details. [Example site](https://battlelog.battlefield.com/bf3/servers/show/pc/aaab2d41-9227-4c62-838e-95e83cea3915/JAH-Warriors-01-Metro-Only-All-Weapons-64-Slots/)
- Corrected table headers and progress bars. [Example site](https://battlelog.battlefield.com/bf3/soldier/Tajfun403/weapons/894851414/pc/)
  <details> <summary>Images</summary>
  
  Before: 
  ![firefox_kQ4dsTcqpU](https://github.com/darkreader/darkreader/assets/44444384/b0fd7450-cb84-42b0-a4e0-12c9788b10da)
  
  After:
  
  ![firefox_Qjirx56r0a](https://github.com/darkreader/darkreader/assets/44444384/8536596a-aef2-4364-aeda-7df3054be2df) </details>
- Corrected time pie chart background [Example site](https://battlelog.battlefield.com/bf3/soldier/Tajfun403/stats/894851414/pc/)
- Corrected ribbons [Example site](https://battlelog.battlefield.com/bf3/soldier/Tajfun403/awards/894851414/pc/)
