### PR TITLE
fix for vowi.fsinf.at

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24656,6 +24656,14 @@ INVERT
 
 ================================
 
+vowi.fsinf.at
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+
+================================
+
 vox.com
 
 INVERT


### PR DESCRIPTION
Vowi is a student-hosted wikipedia-like site for the technical university of vienna.

Formulas were not readable before the fix.

Example:
https://vowi.fsinf.at/wiki/TU_Wien:Algebra_und_Diskrete_Mathematik_VU_(diverse)/%C3%9Cbungen_2023WS/Beispiel_522

Proposed changes to previous pull request were applied.