### PR TITLE
Fix search header in fontawesome.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9049,6 +9049,9 @@ CSS
 .doc-nav > div {
     background-color: var(--darkreader-bg--background-norm) !important;
 }
+#search-header {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Link: https://fontawesome.com/search

Before | After
--- | ---
![fontawesome com_search (1)](https://github.com/darkreader/darkreader/assets/30190448/6aa1f02c-a3e3-4059-97aa-13b521516775) | ![After fix](https://github.com/darkreader/darkreader/assets/30190448/663b577d-fe01-4990-a5a2-884255943ef9)
