### PR TITLE
Update dynamic-theme-fixes.config (Add community.mimecast.com/s/knowledge-hub)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5389,10 +5389,12 @@ CSS
 
 ================================
 
-community.mimecast.com/s/knowledge-hub
+community.mimecast.com
 
-INVERT
-.cb-section_background
+CSS
+.cb-section_background {
+    background-image: none !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5393,7 +5393,7 @@ community.mimecast.com
 
 CSS
 .cb-section_background {
-    background-image: none !important;
+    mix-blend-mode: multiply !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5389,6 +5389,13 @@ CSS
 
 ================================
 
+community.mimecast.com/s/knowledge-hub
+
+INVERT
+.cb-section_background
+
+================================
+
 community.notepad-plus-plus.org
 
 INVERT


### PR DESCRIPTION
Background at the top of community.mimecast.com/s/knowledge-hub is not properly inverted, and is largely white with gray text, "Welcome to the Mimecast Knowledge Hub" 

Added INVERT for .cb-section_background 

This does also invert the image in the background, but I wasn't able to find a source for the image to fix that and it seems better than having a whole background in white while the rest of the page is properly inverted in black.