### PR TITLE
Fix dynamic theme contrast issue in nextron.no's configurator summary

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16534,6 +16534,22 @@ IGNORE INLINE STYLE
 
 ================================
 
+nextron.no
+
+CSS
+.configurator .summary__titles .resource-row {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+.configurator .summary__titles .resource-row > .resource-shape {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+.configurator .summary__titles .resource-row > .resource-filled {
+    border-color: var(--darkreader-neutral-text) !important;
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 ngrok.com
 
 INVERT


### PR DESCRIPTION
The contrast for the borders in the summary page of nextron.no's configurator is too low in the dynamic theme. Manually setting these to the neutral text color fixes the issue while still looking right.

Before fix:
<img width="235" alt="image" src="https://github.com/darkreader/darkreader/assets/2367571/ffcc74e9-02e1-420d-a54e-19f27f31431d">

After fix:
<img width="228" alt="image" src="https://github.com/darkreader/darkreader/assets/2367571/ca72d75e-5af5-4d1f-b58c-1ca041e52dd7">
