### PR TITLE
Fix kitty doc code tags background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22384,6 +22384,9 @@ CSS
 .sidebar-tree label:hover {
   background: var(--darkreader-selection-background) !important;
 }
+code {
+  background: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Fixes kitty docs code tag background. Example website: https://sw.kovidgoyal.net/kitty/open_actions/

before:
![Screenshot from 2024-01-10 22-30-08](https://github.com/darkreader/darkreader/assets/58403773/4039a235-a35d-415b-a087-d7c579825166)
after:
![Screenshot from 2024-01-10 22-30-01](https://github.com/darkreader/darkreader/assets/58403773/9798ccfa-18f2-4720-b375-e0fa9aa13270)
