### PR TITLE
feat: ignoreImageSelectors support regexp

### DIFF
--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -260,7 +260,7 @@ function shouldIgnoreInlineStyle(element: HTMLElement, selectors: string[]): boo
     return false;
 }
 
-export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, ignoreInlineSelectors: string[], ignoreImageSelectors: string[]): void {
+export function overrideInlineStyle(element: HTMLElement, theme: FilterConfig, ignoreInlineSelectors: string[], ignoreImageSelectors: Array<string | RegExp>): void {
     const cacheKey = getInlineStyleCacheKey(element, theme);
     if (cacheKey === inlineStyleCache.get(element)) {
         return;

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -47,7 +47,7 @@ export function getModifiableCSSDeclaration(
     value: string,
     rule: CSSStyleRule,
     variablesStore: VariablesStore,
-    ignoreImageSelectors: string[],
+    ignoreImageSelectors: Array<string | RegExp>,
     isCancelled: (() => boolean) | null,
 ): ModifiableCSSDeclaration | null {
     if (property.startsWith('--')) {
@@ -293,7 +293,7 @@ function getColorModifier(prop: string, value: string, rule: CSSStyleRule): stri
 const imageDetailsCache = new Map<string, ImageDetails>();
 const awaitingForImageLoading = new Map<string, Array<(imageDetails: ImageDetails | null) => void>>();
 
-function shouldIgnoreImage(selectorText: string, selectors: string[]) {
+function shouldIgnoreImage(selectorText: string, selectors: Array<string | RegExp>) {
     if (!selectorText || selectors.length === 0) {
         return false;
     }
@@ -303,7 +303,7 @@ function shouldIgnoreImage(selectorText: string, selectors: string[]) {
     const ruleSelectors = selectorText.split(/,\s*/g);
     for (let i = 0; i < selectors.length; i++) {
         const ignoredSelector = selectors[i];
-        if (ruleSelectors.some((s) => s === ignoredSelector)) {
+        if (ruleSelectors.some((s) => typeof ignoredSelector === 'string' ? s === ignoredSelector : ignoredSelector.test(s))) {
             return true;
         }
     }
@@ -322,7 +322,7 @@ interface BgImageMatches {
 export function getBgImageModifier(
     value: string,
     rule: CSSStyleRule,
-    ignoreImageSelectors: string[],
+    ignoreImageSelectors: Array<string | RegExp>,
     isCancelled: () => boolean,
 ): string | CSSValueModifier | null {
     try {
@@ -575,7 +575,7 @@ function getVariableModifier(
     prop: string,
     value: string,
     rule: CSSStyleRule,
-    ignoredImgSelectors: string[],
+    ignoredImgSelectors: Array<string | RegExp>,
     isCancelled: () => boolean,
 ): CSSVariableModifier {
     return variablesStore.getModifierForVariable({

--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -303,7 +303,12 @@ function shouldIgnoreImage(selectorText: string, selectors: Array<string | RegEx
     const ruleSelectors = selectorText.split(/,\s*/g);
     for (let i = 0; i < selectors.length; i++) {
         const ignoredSelector = selectors[i];
-        if (ruleSelectors.some((s) => typeof ignoredSelector === 'string' ? s === ignoredSelector : ignoredSelector.test(s))) {
+        if (ruleSelectors.some((s) => {
+            if (ignoredSelector && ignoredSelector.constructor === RegExp) {
+                return ignoredSelector.test(s);
+            }
+            return s === ignoredSelector;
+        })) {
             return true;
         }
     }

--- a/src/inject/dynamic-theme/variables.ts
+++ b/src/inject/dynamic-theme/variables.ts
@@ -134,7 +134,7 @@ export class VariablesStore {
         varName: string;
         sourceValue: string;
         rule: CSSStyleRule;
-        ignoredImgSelectors: string[];
+        ignoredImgSelectors: Array<string | RegExp>;
         isCancelled: () => boolean;
     }): CSSVariableModifier {
         return (theme) => {


### PR DESCRIPTION
Vue SPA, Scoped attribute that will be automatically assigned to the elements. 
String type conditions cannot be compared, because scoped attribute is generated by vue.
For example:

![image](https://github.com/darkreader/darkreader/assets/16830398/935ad91c-7d73-48f1-875f-f8b2641d56f6)

![image](https://github.com/darkreader/darkreader/assets/16830398/9fd1d378-00ea-47e0-aff4-38c51f553216)

So, support RegExp can handle this situation:

```ts
    enableDarkMode(
      {},
      { ignoreImageAnalysis: [/.xxx > section > header\[data-v-[^[\]]+\]/] },
    )
```