### PR TITLE
Force to Use Collect Icon Font in Google Translation

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -91,6 +91,9 @@ div.mermaid .actor {
 .google-symbols {
     font-family: 'Google Symbols' !important;
 }
+.material-icons-extended {
+    font-family: 'Material Icons Extended' !important;
+}
 
 IGNORE INLINE STYLE
 .sr-wrapper *


### PR DESCRIPTION
Like #12097, focing Google’s icon fonts to be used in Google Translation page.