### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -111,6 +111,7 @@ betterdiscord.app
 betterttv.com
 bg3.wiki
 bherila.net
+bidet.gg
 bin.disroot.org
 bin.veracry.pt
 birdie0.github.io


### PR DESCRIPTION
Verified bidet.gg is a fully dark page so adding it to dark list.