### PR TITLE
Fix for spdx.org/licenses

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21502,6 +21502,14 @@ body {
 
 ================================
 
+spdx.org/licenses
+
+INVERT
+.gray-diagonal
+#logo
+
+================================
+
 spectrum.com
 
 INVERT


### PR DESCRIPTION
- Invert logo
- Improve readability of header and footer

Before:
<img width="434" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/9876fe97-3283-4618-8604-1eccf42f45fa">

After:
<img width="437" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/69b208d2-ccf7-4ce2-bec9-951542903f1a">
