### PR TITLE
Fix for id.fedoraproject.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11538,6 +11538,13 @@ CSS
 
 ================================
 
+id.fedoraproject.org
+
+INVERT
+img[alt="logo"]
+
+================================
+
 id.unity.com
 
 CSS


### PR DESCRIPTION
Invert logo

Before:
<img width="311" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/8c0cbf0e-b226-444b-9deb-597363f5193d">

After:
<img width="268" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/fdf19862-91fe-4846-aed7-682d0b1b3a86">
