### PR TITLE
Fix for celum.ssg-service.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4481,6 +4481,15 @@ INVERT
 
 ================================
 
+celum.ssg-service.com
+
+CSS
+:hover {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 ceneo.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4484,7 +4484,7 @@ INVERT
 celum.ssg-service.com
 
 CSS
-:hover {
+body:hover {
     color: var(--darkreader-neutral-text) !important;
 }
 


### PR DESCRIPTION
On some webpages under celum.ssg-service.com, all text is displayed in dark colors when the page is hovered over. Colors are fine when the cursor is not over the page.

This change causes the affected text to be displayed in light colors at all times.

Admittedly, there is a subtle difference in text color between the hovered and non-hovered states of the page; however, similar behaviour is displayed even on the original webpage without Dark Reader.

Note: This CSS rule was found on the webpage. When disabled, the problem does not occur:
``` CSS
:hover {
  color: inherit;
}
```

Example page: https://celum.ssg-service.com/smartViews/view?view=bergamont-bike-b2c-manuals