### PR TITLE
Unify globo.com websites fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9872,17 +9872,6 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 
-================================
-
-ge.globo.com
-
-CSS
-.glb-grid .tabela-body {
-    background-color: var(--darkreader-neutral-background) !important;
-}
-
-================================
-
 geekflare.com
 
 INVERT
@@ -10388,7 +10377,7 @@ body
 
 ================================
 
-globo.com
+*.globo.com
 
 CSS
 .bar-scrubber .bar-scrubber-icon,
@@ -10404,6 +10393,9 @@ CSS
 }
 span.bstn-hl-summary {
     color: var(--darkreader-neutral-text) !important;
+}
+.glb-grid .tabela-body {
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -122,6 +122,32 @@ CSS
 
 ================================
 
+*.globo.com
+
+CSS
+.bar-scrubber .bar-scrubber-icon,
+.bar-background .bar-fill-2 {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+.bar-background .bar-fill-1 {
+    background-color: rgba(255, 255, 255, .3) !important;
+}
+.multicontent {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+span.bstn-hl-summary {
+    color: var(--darkreader-neutral-text) !important;
+}
+.glb-grid .tabela-body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+IGNORE INLINE STYLE
+.poster__play-wrapper *
+
+================================
+
 *.maricopa.edu
 
 CSS
@@ -10374,32 +10400,6 @@ global.gotomeeting.com/join/*
 
 IGNORE IMAGE ANALYSIS
 body
-
-================================
-
-*.globo.com
-
-CSS
-.bar-scrubber .bar-scrubber-icon,
-.bar-background .bar-fill-2 {
-    background-color: var(--darkreader-neutral-text) !important;
-}
-.bar-background .bar-fill-1 {
-    background-color: rgba(255, 255, 255, .3) !important;
-}
-.multicontent {
-    background-color: var(--darkreader-neutral-background) !important;
-    color: var(--darkreader-neutral-text) !important;
-}
-span.bstn-hl-summary {
-    color: var(--darkreader-neutral-text) !important;
-}
-.glb-grid .tabela-body {
-    background-color: var(--darkreader-neutral-background) !important;
-}
-
-IGNORE INLINE STYLE
-.poster__play-wrapper *
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9898,6 +9898,8 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 
+================================
+
 geekflare.com
 
 INVERT


### PR DESCRIPTION
Since the change of how Dark Reader treats URL patterns, the fixes for `globo.com` websites do not work anymore.

`globo.com` by itself doesn't have any content. The contents are stored in subdomains (such as `g1.globo.com` and `ge.globo.com`).

For instance, https://github.com/darkreader/darkreader/pull/9704 used to work, but now does not.

Considering that all Globo sites use basically the same pattern for their subdomains, [and considering all the previous issues](https://github.com/darkreader/darkreader/issues?q=is%3Aissue+globo), it should not be a problem to unify the fixes.