### PR TITLE
feat: invert unsplash logo and navbar selected

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24307,6 +24307,16 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+unsplash.com
+
+INVERT
+svg[aria-labelledby="unsplash-home"]
+
+CSS
+li > a[aria-current="page"] {box-shadow: rgb(230,230,230) 0px -2px inset;}
+
+================================
+
 uokik.gov.pl
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24313,7 +24313,7 @@ INVERT
 svg[aria-labelledby="unsplash-home"]
 
 CSS
-li > a[aria-current="page"] {box-shadow: rgb(230,230,230) 0px -2px inset;}
+li > a[aria-current="page"] {box-shadow: ${rgb(25,25,25)} 0px -2px inset;}
 
 ================================
 


### PR DESCRIPTION
As the title says, it'll invert the unsplash logo and the color of the navbar when the item is selected
Before:
![image](https://github.com/darkreader/darkreader/assets/57800056/bbbbb9f8-979c-40ca-a95b-083cd52376c1)

After:
![image](https://github.com/darkreader/darkreader/assets/57800056/79062464-ad87-43c2-b4ed-4d7cd45a2a3f)
