### PR TITLE
Improve compatibility with Unpaywall extension

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -98,6 +98,9 @@ mitid-authenticators-code-app > .code-app-container {
     padding-top: 1rem;
     background-color: white !important;
 }
+iframe#unpaywall[src$="unpaywall.html"] {
+    color-scheme: light !important;
+}
 
 IGNORE INLINE STYLE
 .sr-wrapper *


### PR DESCRIPTION
[Unpaywall](https://unpaywall.org/products/extension) is an extension that gives links to legal open-access versions of journal articles. When an open-access version of an article is available, it adds an iframe to the page with an icon that links to the open-access version:
![20240126_11h24m50s_grim](https://github.com/darkreader/darkreader/assets/35371030/18e7f033-f053-4c29-987f-2113b56931a2)

However, when using Dark Reader in dynamic mode, there is a white border around the icon:

(dark mode)
![20240126_11h25m05s_grim](https://github.com/darkreader/darkreader/assets/35371030/e71492fa-085e-43f5-b094-9efc06a22051)

(light mode)
![20240126_11h25m17s_grim](https://github.com/darkreader/darkreader/assets/35371030/24b3481b-e940-492f-9981-03c877b4b7d8)

With this fix applied:

(dark mode)
![20240126_11h25m48s_grim](https://github.com/darkreader/darkreader/assets/35371030/f400ee82-9c8d-4b8d-a8be-3eafa604cc4b)

(light mode)
![20240126_11h26m01s_grim](https://github.com/darkreader/darkreader/assets/35371030/15996d65-6173-4f1f-8b35-7774da8f0df4)


I've applied the fix to all iframes with an id of `unpaywall` and a `src` ending in `unpaywall.html`. This is applied to all sites as the extension could add the iframe to any site, and (correct me if I'm wrong) there is no way to create fixes that apply directly to extension-local pages.