### PR TITLE
Fix for warframe.huijiwiki.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25209,6 +25209,15 @@ CSS
 
 ================================
 
+warframe.huijiwiki.com
+
+CSS
+#wiki-outer-body {
+    background-image: none !important;
+}
+
+================================
+
 wasd.tv
 
 INVERT


### PR DESCRIPTION
Remove background to improve readability.

Note that this site has a dark mode selection on some of the pages, but not always (it remains unclear to me). Furthermore, even if the switch is present, it's applied when the whole page loading completes which is not very ideal.

Before:
<img width="465" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/63d63b94-cdde-41d7-bc6b-f3e720c381b9">

After:
<img width="559" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/c8170dde-fb14-461a-96f5-ac1c5a4bd227">

