### PR TITLE
Fix nonograms.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16789,6 +16789,15 @@ CSS
 
 ================================
 
+nonograms.org
+
+CSS
+.full_screen {
+    background-color: #404040 !important;
+}
+
+================================
+
 norton.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16792,7 +16792,7 @@ CSS
 nonograms.org
 
 CSS
-.full_screen {
+.nonogram_table {
     background-color: #404040 !important;
 }
 


### PR DESCRIPTION
The page's background color does not contrast with either the "X" images nor the filled squares ... making the "X" marks invisible, and thus the game unplayable.

This provides a balance between dark background and visible marks while playing the game by setting overall background color to 25% grey.