### PR TITLE
Refactor: add default return to scripting.executeScript() callsites

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -316,7 +316,7 @@ export class Extension {
                         return (await chrome.scripting.executeScript({
                             target: {tabId, frameIds: [frameId]},
                             func: detectPDF,
-                        }))[0].result;
+                        }))[0].result || false;
                     } else if (__CHROMIUM_MV2__) {
                         return new Promise<boolean>((resolve) => chrome.tabs.executeScript(tabId, {
                             frameId,

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -309,7 +309,7 @@ export default class TabManager {
                         frameIds: [0],
                     },
                     func: () => window.location.href,
-                }))[0].result;
+                }))[0].result || 'about:blank';
             } catch (e) {
                 return 'about:blank';
             }


### PR DESCRIPTION
Recent change in `@types/chrome` version `0.0.259` cased build breakage. This PR is need to upgrade Dark Reader dep on `@types/chrome` from current `0.0.258` to `0.0.259`.

Relevant PR commit: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/47948ef38a763a3ef520867af2bc5a9db8f8c75d