### PR TITLE
Fix math formulas on Wikipedia

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2951,6 +2951,7 @@ NO INVERT
 img[src*="svg.png"]
 img[alt^="Skeletal" i]
 img[alt^="Structural" i]
+img[src^="https://wikimedia.org/api/rest_v1/media/math/render/svg"]
 
 ================================
 


### PR DESCRIPTION
Some math formulas are not visible due to incorrect inversion, for instance:
https://en.wikipedia.org/wiki/Josephson_voltage_standard
This fixes inversion for `<img>` tags with a `src` that starts with `https://wikimedia.org/api/rest_v1/media/math/render/svg`