### PR TITLE
Fix gmail: selecting users in compose (to, cc, bcc)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14608,7 +14608,8 @@ CSS
 .buj {
     background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_compact_v1_1x.png) !important;
 }
-div[class*="bym"][role="navigation"], .afC, .agJ {
+div[class*="bym"][role="navigation"],
+.afC {
     background-color: var(--darkreader-neutral-background) !important;
 }
 .ain .TO,
@@ -14618,7 +14619,11 @@ div[class*="bym"][role="navigation"], .afC, .agJ {
 ::-webkit-scrollbar-thumb {
     background-color: #424242 !important;
 }
-::-webkit-scrollbar, .agh, .afV {
+::-webkit-scrollbar,
+.afV,
+.agh,
+.bbV,
+.afC * {
     background-color: transparent !important
 }
 .aRg,


### PR DESCRIPTION
In the interface for adding and removing users in a new email, the background is white.

Before:
<img width="373" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/5f1905b0-5c59-44c9-9a88-8bb19ba9226f">


After:
<img width="373" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/b19630d1-9aa1-42a4-b6cd-6a17d2e9d851">
