### PR TITLE
fix mail.google.com: selecting contacts when composing an email

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14612,10 +14612,10 @@ div[class*="bym"][role="navigation"], .afC, .agJ {
     background-color: var(--darkreader-neutral-background) !important;
 }
 .agJ:hover, .ag5 {
-    background-color: #181A1B !important;
+    background-color: ${#E8E6E5} !important;
 }
 .agJ.bjE {
-    background-color: #1D1F20 !important;
+    background-color: ${#E3E1E0} !important;
 }
 .ain .TO,
 .TO.ol {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14611,6 +14611,12 @@ CSS
 div[class*="bym"][role="navigation"], .afC, .agJ {
     background-color: var(--darkreader-neutral-background) !important;
 }
+.agJ:hover, .ag5 {
+    background-color: #181A1B !important;
+}
+.agJ.bjE {
+    background-color: #1D1F20 !important;
+}
 .ain .TO,
 .TO.ol {
     background-color: rgba(255,255,255,0.05) !important;
@@ -14618,7 +14624,7 @@ div[class*="bym"][role="navigation"], .afC, .agJ {
 ::-webkit-scrollbar-thumb {
     background-color: #424242 !important;
 }
-::-webkit-scrollbar, .agh, .afV {
+::-webkit-scrollbar, .agh, .afV, .afA, .bbV {
     background-color: transparent !important
 }
 .aRg,


### PR DESCRIPTION
Light mode:
<img width="495" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/634d7360-aea4-4e21-b4a9-faf75181583e">

Dark mode before fix:
<img width="486" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/7d9d396f-a059-4896-968e-67edbba56f42">

Dark mode after fix:
<img width="486" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/850b76c3-e10f-4ab2-a4a2-3dff3ca4e682">

I removed the white backgrounds and added new background colors for the focused option and the hovered option. Just like in the light mode, I matched the hover background color with the checkmark circle background color.