### PR TITLE
fix bbc.com placeholder images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2622,6 +2622,16 @@ div[class^='scrollableList'] {
 ================================
 
 bbc.co.uk
+bbc.com
+
+CSS
+.haCQWq, .fFEZuA {
+    filter: invert(90%) !important;
+}
+
+================================
+
+bbc.co.uk
 bbc.co.uk/weather
 bbc.com/weather
 
@@ -2643,6 +2653,9 @@ CSS
 .wr-c-environmental-data__icon-text {
     color: ${#dcd9d4} !important;
 }
+.haCQWq, .fFEZuA {
+    filter: invert(90%) !important;
+}
 
 ================================
 
@@ -2662,6 +2675,11 @@ INVERT
 .orb-nav-section .orb-nav-blocks
 .orb-icon .orb-icon-arrow
 [class*="NavigationLink-LogoLink"] > span > svg
+
+CSS
+.haCQWq, .fFEZuA {
+    filter: invert(90%) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2622,16 +2622,6 @@ div[class^='scrollableList'] {
 ================================
 
 bbc.co.uk
-bbc.com
-
-CSS
-.haCQWq, .fFEZuA {
-    filter: invert(90%) !important;
-}
-
-================================
-
-bbc.co.uk
 bbc.co.uk/weather
 bbc.com/weather
 
@@ -2653,6 +2643,15 @@ CSS
 .wr-c-environmental-data__icon-text {
     color: ${#dcd9d4} !important;
 }
+.haCQWq, .fFEZuA {
+    filter: invert(90%) !important;
+}
+
+================================
+
+bbc.com
+
+CSS
 .haCQWq, .fFEZuA {
     filter: invert(90%) !important;
 }


### PR DESCRIPTION
Light mode:
<img width="638" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/fbbeeae1-9f12-4fee-b61a-c6546bebf70c">

Dark mode before fix:
<img width="635" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/9c9ed741-90cd-42c8-a8ad-e344fe9881d7">

Dark mode after fix:
<img width="639" alt="image" src="https://github.com/darkreader/darkreader/assets/22121365/e4695dda-5dbe-454b-8cb3-9894f68ba8d1">
