### PR TITLE
Fixes for 10ten-ja-reader extension

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -106,6 +106,7 @@ IGNORE INLINE STYLE
 .sr-wrapper *
 .sr-reader *
 .diigoHighlight
+div[id^="tenten-"]
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -16,6 +16,7 @@ twitterwidget
 .sr-backdrop
 iframe:fullscreen
 [class="opinary-iframe"]
+div[id^="tenten-"]
 
 NO INVERT
 [style*="background:url"] *


### PR DESCRIPTION
https://github.com/birchill/10ten-ja-reader

The extension provides a popup dictionary for quickly looking up Japanese words. These fixes exclude the extension's popup, which has it's own dark mode, from being restyled by Dark Reader.

Related issue: https://github.com/birchill/10ten-ja-reader/issues/1549