### PR TITLE
Don't Invert the Contents of the Video Player for Amazon

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -112,7 +112,7 @@ NO INVERT
 .av-hero-background
 .avu-content img
 .dv-tile img
-video
+.vjs-tech video
 
 CSS
 #nav-flyout-ewc {


### PR DESCRIPTION
Despite being in the "`NO INVERT`" section, the entire `video` tag was still inverted.

This change is more specific which includes the class.