### PR TITLE
Update dynamic-theme-fixes.config (myacademy.oracle.com) fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16370,8 +16370,8 @@ INVERT
 .login-logo
 .logo--desktop
 .nav-control-mobile span
-.dynamic-widget__result .list-view .completion-bar .progress
 .splide--container button
+.dynamic-widget__result .list-view .completion-bar
 .course-details__cta > a.play::before
 .course-details__cta > div > a.play::before
 .thumb__background

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16378,7 +16378,6 @@ INVERT
 .slide-displays-root
 .slide-displays-root svg[viewBox="0 0 843 573"]
 .slide-displays-root > div:nth-child(3) > div > :last-child > div > :last-child img
-.slide-displays-root div[style="left:549.458px;top:688.32px;"]
 .slide-displays-root svg g g g :first-child
 .quiz-slide-visualizer
 .quiz-session-view .choice-view__active-element-container .inline-border
@@ -16388,12 +16387,11 @@ CSS
 header, #header {
     background: ${#ccc} !important;
 }
-.slide-displays-root span:not(.nokern[dir="auto"]) {
-    color: #4e3629 !important;
-}
+.slide-displays-root span:not(.nokern[dir="auto"]),
 .quiz-slide-visualizer span {
     color: #4e3629 !important;
 }
+.slide-displays-root div:nth-child(3) > div > :first-child > div > :last-child span,
 .quiz-slide-visualizer .slide-layout > div > :nth-child(3) span,
 .quiz-slide-visualizer .slide-layout > div > :nth-child(8) span {
     color: #fed6af !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16377,7 +16377,7 @@ INVERT
 .universal-side-panel__switcher button svg
 .slide-displays-root
 .slide-displays-root svg[viewBox="0 0 843 573"]
-.slide-displays-root > div:has(div) > div > :last-child img
+.slide-displays-root > div:nth-child(3) > div > :last-child > div > :last-child img
 .slide-displays-root svg g g g :first-child
 .quiz-slide-visualizer
 .quiz-session-view .choice-view__active-element-container .inline-border

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16369,6 +16369,7 @@ INVERT
 #logo
 .login-logo
 .logo--desktop
+.nav-control-mobile span
 .dynamic-widget__result .list-view .completion-bar .progress
 .splide--container button
 .course-details__cta > a.play::before

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16375,25 +16375,28 @@ INVERT
 .course-details__cta a.play::before
 .thumb__background
 .universal-side-panel__switcher button svg
-.slide-displays-root div:has(div) > div svg path:last-child
-.slide-displays-root div:has(div) > div :first-child > :first-child > img
-.slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(3) > img
-.slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(4) > img
-.slide-displays-root div:has(div) > div :first-child > :first-child > :last-child > img
+.slide-displays-root
+.slide-displays-root svg[viewBox="0 0 843 573"]
+.slide-displays-root > div:nth-child(3) > div > :last-child > div > :last-child img
+.slide-displays-root div[style="left:549.458px;top:688.32px;"]
+.slide-displays-root svg g g g :first-child
 .quiz-slide-visualizer
 .quiz-session-view .choice-view__active-element-container .inline-border
-.player-shape-view_button svg
 .slide-object-view-icon-placeholder
 
 CSS
 header, #header {
     background: ${#ccc} !important;
 }
-.quiz-slide-visualizer  * {
-    color: black !important;
+.slide-displays-root span:not(.nokern[dir="auto"]) {
+    color: #4e3629 !important;
 }
-.player-shape-view_button span {
-    color: ${white} !important;
+.quiz-slide-visualizer span {
+    color: #4e3629 !important;
+}
+.quiz-slide-visualizer .slide-layout > div > :nth-child(3) span,
+.quiz-slide-visualizer .slide-layout > div > :nth-child(8) span {
+    color: #fed6af !important;
 }
 .message-box__icon, .quiz-message-box__icon {
     background-color: white !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16369,11 +16369,12 @@ INVERT
 #logo
 .login-logo
 .logo--desktop
+.dynamic-widget__result .list-view .completion-bar .progress
 .splide--container button
 .course-details__cta > a.play::before
 .course-details__cta > div > a.play::before
+.thumb__background
 .universal-side-panel__switcher button svg
-.dynamic-widget__result .list-view .completion-bar .progress
 .slide-displays-root div:has(div) > div :first-child > :first-child > img
 .slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(3) > img
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16375,23 +16375,21 @@ INVERT
 .course-details__cta a.play::before
 .thumb__background
 .universal-side-panel__switcher button svg
-.slide-displays-root
-.slide-displays-root svg[viewBox="0 0 843 573"]
-.slide-displays-root > div:nth-child(3) > div > :last-child > div > :last-child img
-.slide-displays-root svg g g g :first-child
+.slide-displays-root img
+.slide-displays-root > div:nth-child(3) > div > :nth-child(2) > div > :nth-child(3)
+.slide-displays-root div:nth-child(3) > div > :first-child > div > :last-child span
+.slide-displays-root svg g g g :last-child
 .quiz-slide-visualizer
-.quiz-session-view .choice-view__active-element-container .inline-border
 .slide-object-view-icon-placeholder
+.quiz-session-view .choice-view__active-element-container .inline-border
 
 CSS
 header, #header {
     background: ${#ccc} !important;
 }
-.slide-displays-root span:not(.nokern[dir="auto"]),
 .quiz-slide-visualizer span {
     color: #4e3629 !important;
 }
-.slide-displays-root div:nth-child(3) > div > :first-child > div > :last-child span,
 .quiz-slide-visualizer .slide-layout > div > :nth-child(3) span,
 .quiz-slide-visualizer .slide-layout > div > :nth-child(8) span {
     color: #fed6af !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16382,6 +16382,8 @@ INVERT
 .slide-displays-root div:has(div) > div :first-child > :first-child > :last-child > img
 .quiz-slide-visualizer
 .quiz-session-view .choice-view__active-element-container .inline-border
+.player-shape-view_button svg
+.slide-object-view-icon-placeholder
 
 CSS
 header, #header {
@@ -16389,6 +16391,9 @@ header, #header {
 }
 .quiz-slide-visualizer  * {
     color: black !important;
+}
+.player-shape-view_button span {
+    color: ${white} !important;
 }
 .message-box__icon.message-box__icon_type_question {
     background-color: white !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16377,7 +16377,7 @@ INVERT
 .universal-side-panel__switcher button svg
 .slide-displays-root
 .slide-displays-root svg[viewBox="0 0 843 573"]
-.slide-displays-root > div:nth-child(3) > div > :last-child > div > :last-child img
+.slide-displays-root > div:has(div) > div > :last-child img
 .slide-displays-root svg g g g :first-child
 .quiz-slide-visualizer
 .quiz-session-view .choice-view__active-element-container .inline-border

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16378,10 +16378,17 @@ INVERT
 .universal-side-panel__switcher button svg
 .slide-displays-root div:has(div) > div :first-child > :first-child > img
 .slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(3) > img
+.slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(4) > img
+.slide-displays-root div:has(div) > div :first-child > :first-child > :last-child > img
+.quiz-slide-visualizer
+.quiz-session-view .choice-view__active-element-container .inline-border
 
 CSS
 header, #header {
     background: ${#ccc} !important;
+}
+.quiz-slide-visualizer  * {
+    color: black !important;
 }
 .message-box__icon.message-box__icon_type_question {
     background-color: white !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16372,10 +16372,10 @@ INVERT
 .nav-control-mobile span
 .splide--container button
 .dynamic-widget__result .list-view .completion-bar
-.course-details__cta > a.play::before
-.course-details__cta > div > a.play::before
+.course-details__cta a.play::before
 .thumb__background
 .universal-side-panel__switcher button svg
+.slide-displays-root div:has(div) > div svg path:last-child
 .slide-displays-root div:has(div) > div :first-child > :first-child > img
 .slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(3) > img
 .slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(4) > img
@@ -16395,7 +16395,7 @@ header, #header {
 .player-shape-view_button span {
     color: ${white} !important;
 }
-.message-box__icon.message-box__icon_type_question {
+.message-box__icon, .quiz-message-box__icon {
     background-color: white !important;
     border: 2px solid white !important;
     border-radius: 50%;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16366,24 +16366,25 @@ body {
 myacademy.oracle.com
 
 INVERT
-button svg
-.slide-displays-root div:has(div) > div :first-child > :first-child > img
+#logo
+.login-logo
+.logo--desktop
+.splide--container button
 .course-details__cta > a.play::before
 .course-details__cta > div > a.play::before
-[data-module="display-views"] .dynamic-widget__result .list-view .completion-bar .progress
+.universal-side-panel__switcher button svg
+.dynamic-widget__result .list-view .completion-bar .progress
+.slide-displays-root div:has(div) > div :first-child > :first-child > img
 .slide-displays-root div:has(div) > div :first-child > :first-child > :nth-child(3) > img
-.logo--desktop
-.login-logo
-#logo
 
 CSS
 header, #header {
     background: ${#ccc} !important;
 }
-.message-box__icon.message-box__icon_type_question, .splide__arrow {
-    background-color: ${black} !important;
+.message-box__icon.message-box__icon_type_question {
+    background-color: white !important;
+    border: 2px solid white !important;
     border-radius: 50%;
-    border: 2px solid ${black} !important;
 }
 .slide-displays-root div:has(div) > div :first-child > :first-child > :last-child > svg {
     opacity: 0 !important;


### PR DESCRIPTION
reordered code by specificity and fixed some inconsistencies between dark and light theme icons

before fix (light theme):
![image](https://github.com/darkreader/darkreader/assets/58079015/8c591460-4c9d-4691-aa24-c8053ccb3204)
![image](https://github.com/darkreader/darkreader/assets/58079015/c659711d-479c-4b77-99f5-a86dbe152c2a)

after fix (light theme):
![image](https://github.com/darkreader/darkreader/assets/58079015/245642d8-4678-4da6-870c-559ca72a451d)
![image](https://github.com/darkreader/darkreader/assets/58079015/b91b6f22-96b5-42e9-af5b-ad0447ffa403)

and dark theme have same icons thats why the CSS white color is hard coded