### PR TITLE
Fix GCP (Google Cloud Platform) BigQuery

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5593,6 +5593,12 @@ CSS
 input[type=text] {
     color: var(--darkreader-neutral-text) !important;
 }
+.cfc-outline-focus-indicator {
+    background: var(--darkreader-neutral-background) !important;
+}
+.bq-results-table-header-cell {
+    background: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Query Results rendering regression issue.
- Force header (top and left) to render with a black background so the column names and row numbers are readable.

***Note:  I am new to CSS so there could certainly be a more optimal solution than what I've proposed.

**Before:**
<img width="1652" alt="BigQuery Dark Reader Issue (Before)" src="https://github.com/darkreader/darkreader/assets/64706344/2d88dac1-ad1a-4a8e-a437-53edeed11414">

**After:**
<img width="1400" alt="BigQuery Dark Reader Issue (After)" src="https://github.com/darkreader/darkreader/assets/64706344/9888782f-ef9a-40f9-8fdd-118249fb7ccd">



