### PR TITLE
[#12214] more fixes for fyziklani

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9809,12 +9809,20 @@ img[src$="future-logo.svg"]
 
 ================================
 
-fyziklani.cz
+fyziklani.*
+online.fyziklani.cz
+physicsbrawl.org
 
 IGNORE IMAGE ANALYSIS
-.flag-icon-sk
 .flag-icon-bg
+.flag-icon-co
+.flag-icon-fi
+.flag-icon-jp
+.flag-icon-kr
+.flag-icon-lt
 .flag-icon-pl
+.flag-icon-ru
+.flag-icon-sk
 
 ================================
 


### PR DESCRIPTION
Proposed changes are related to #12214 and just expand changes already done in #12222 

This PR
- adds additional flags I found broken
- adds more websites with the same problem (`fyziklani.*` to address both `fyziklani.cz` and `fyziklani.org`)