### PR TITLE
Fix myworkday.com dark mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -173,6 +173,22 @@ CSS
 
 ================================
 
+*.myworkday.com
+
+INVERT
+.WIF3
+.WIF3:hover
+.WIG3
+.WIG3:hover
+.WFD3 .WGL3
+.WAJS
+.WAJS:hover
+.WJG3
+.WHL3
+.WKFP
+
+================================
+
 *.service-now.com
 
 INVERT


### PR DESCRIPTION
Fixes the team absence calendar and the small three-dot icon which opens the context menu for an employee.