### PR TITLE
Add Pages Media to dark mode list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -735,6 +735,7 @@ overcoder.dev
 overdodactyl.github.io/ShadowFox
 ovosimpatico.com
 oxide.computer
+pages.media
 paimon.moe
 pandadev.net
 paniash.netlify.app


### PR DESCRIPTION
Add the pages.media website to dark mode list, this site is dark mode only.