### PR TITLE
Invert BBC logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2685,6 +2685,7 @@ INVERT
 .orb-nav-section .orb-nav-blocks
 .orb-icon .orb-icon-arrow
 [class*="NavigationLink-LogoLink"] > span > svg
+span[class*="LogoIconWrapper"]
 
 CSS
 .haCQWq, .fFEZuA {


### PR DESCRIPTION
BBC logo inverted (in the top-left corner), because it is blending in with the background.