### PR TITLE
fixes for identity.kde.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11711,6 +11711,16 @@ CSS
 
 ================================
 
+identity.kde.org
+
+CSS
+body, .navbar-inner, .navbar
+{
+    background-image: none !important;
+}
+
+================================
+
 ieee.org
 
 INVERT


### PR DESCRIPTION
remove the grainy background images in the header and body