### PR TITLE
Add Chrono Divide game page to globally dark sites as DarkReader breaks the UI

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -409,6 +409,7 @@ funnyjunk.com
 furt.app
 fusengine.github.io/apaxy-v2
 galacticabot.vercel.app
+game.chronodivide.com
 gamebanana.com
 gamejolt.com
 gamersnexus.net


### PR DESCRIPTION
Enabling dark mode is kind of redundant there (except one subpage for file browser) and it seems to break some of the game's UI.