### PR TITLE
Fix for oed.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17466,6 +17466,21 @@ CSS
 
 ================================
 
+oed.com
+
+INVERT
+img[alt="search"]
+
+CSS
+.wordy {
+    color: var(--darkreader-neutral-text) !important;
+}
+#maincontainer {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 oeis.org
 
 INVERT


### PR DESCRIPTION
Fixes text color to make it more readable, and also inverts search icon. 
Example: 
Before: 
<img width="1190" alt="Before" src="https://github.com/darkreader/darkreader/assets/34804579/cb81877d-057b-4685-8f18-efbf6fb5bda4">

After
<img width="1173" alt="After" src="https://github.com/darkreader/darkreader/assets/34804579/7004a2d6-8ec7-412e-8d4b-d0d96bf88700">
