### PR TITLE
Fix WebGL canvas on shadertoy.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2225,6 +2225,13 @@ img
 
 ================================
 
+shadertoy.com
+
+INVERT
+canvas#demogl
+
+================================
+
 shiyanlou.com
 
 INVERT


### PR DESCRIPTION
The WebGL canvas on shadertoy.com should not have its colors inverted

Example:
https://www.shadertoy.com/view/M3sGRl