### PR TITLE
Fix code snippets on dev.to

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -479,6 +479,13 @@ INVERT
 
 ================================
 
+dev.to
+
+INVERT
+.js-code-highlight
+
+================================
+
 devdocs.io
 
 NO INVERT


### PR DESCRIPTION
Code samples on dev.to get inverted in spite of already having a dark theme. For instance:
https://dev.to/raineyanguoft/resolving-memory-fragmentation-for-linkedlist-heap-allocator-3j4a