### PR TITLE
Fix text input area on chat.openai.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -345,6 +345,13 @@ NO INVERT
 
 ================================
 
+chat.openai.com
+
+INVERT
+.overflow-hidden:has(textarea)
+
+================================
+
 circleci.com
 
 INVERT


### PR DESCRIPTION
The text input area on chat.openai.com looks like this without the fix (in Filter/Filter+ mode):
<img width="1175" alt="Screenshot 2024-02-15 at 20 40 46" src="https://github.com/darkreader/darkreader/assets/17463710/ad290263-5928-4b42-9b98-9949452ab2d5">

and like this with it:
<img width="1177" alt="Screenshot 2024-02-15 at 20 41 00" src="https://github.com/darkreader/darkreader/assets/17463710/9ef91e05-f41f-4f1d-9132-59b75f3a1c7b">
