### PR TITLE
bugfix: Google Search Generative AI beta

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27024,9 +27024,6 @@ www.google.*
 www.google.*.*
 
 INVERT
-.OZ9ddf
-.s7d4ef
-.X6JNf
 .gb_hc
 .gb_ec
 .gb_x.gb_Vb
@@ -27073,7 +27070,7 @@ img[src^="https://www.google.com/maps"]
 #shield-ok-fill-shield
 
 CSS
-.X6JNf:not(.NKrsie) {
+.X6JNf {
     background: var(--darkreader-neutral-background) !important;
 }
 .RNNXgb,


### PR DESCRIPTION
Previous attempt included two methods of inverting background, canceling or masking eachothers affects and leaving and a white background. Sticking with --darkreader-neutral-background as it seems more seamless