### PR TITLE
fix for docs.rust-lang.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7277,6 +7277,15 @@ CSS
 
 ================================
 
+doc.rust-lang.org
+
+CSS
+mark {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 docs.codacy.com
 
 INVERT


### PR DESCRIPTION
fix contrast of text highlighted by search results