### PR TITLE
Fix for host-c.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11501,6 +11501,13 @@ img[src$="hootsuite_white_form3.png"]
 
 ================================
 
+host-c.com
+
+INVERT
+.logo
+
+================================
+
 hotcrp.com
 
 CSS


### PR DESCRIPTION
Invert logo

Before:
<img width="178" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/19d8ae36-f419-4764-8a2e-4faa9b848e60">

After:
<img width="184" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/ef7e50cd-e3c5-4c6f-8d6e-6ebc67dba666">
