### PR TITLE
Fix for sciencedirect.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21108,10 +21108,22 @@ body, .gh-nav .gh-nav-action, .search-button-link>.link-button.search-button-out
 }
 #gh-cnt, .accessbar-sticky, .search-button-link>.link-button.search-button-outline,
 .link-button-secondary:not(.on-dark-background) {
-    background: ${#fff};
+    background-color: var(--darkreader-neutral-background) !important;
 }
 .u-bg-grey1, .u-bg-white, .cookie-btn {
     background-color: ${#f5f5f5} !important;
+}
+.u-margin-s-bottom, .authors, .publication-title-link, .gh-nav-help-anchor {
+    color: var(--darkreader-neutral-text) !important;
+}
+.author-highlights, #gh-drawer, .popover-content-inner {
+    background-color: var(--darkreader-neutral-background) !important;
+} 
+.popover-content {
+    background: rgba(50, 50, 50, .85) !important;
+}
+#gh-overlay {
+    background-color: rgba(20, 20, 20, .85) !important;
 }
 
 ================================


### PR DESCRIPTION
Various fixes for text, background, and overlay colors.

Example Webpage: https://www.sciencedirect.com/science/article/abs/pii/S1877343513001796

Before: 
<img width="1404" alt="Before" src="https://github.com/darkreader/darkreader/assets/34804579/3f70d629-6145-4bb8-b3e8-6e9f62d297d7">

After: 
<img width="1405" alt="After" src="https://github.com/darkreader/darkreader/assets/34804579/73582763-e58e-4881-9a8b-e503c978d6e1">
