### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23802,9 +23802,18 @@ theguardian.com
 INVERT
 .inline-the-guardian-logo__svg
 a[data-link-name$="logo"] svg
+a[href="https://www.theguardian.com/documentaries"] > svg
 .crossword__grid .crossword__cell-text
 .crossword__cell-number
-.most-popular__number
+ol[data-link-name="Most viewed"] > li > a > span > svg
+
+CSS
+section[id="documentaries"] p {
+    border-top: 1px solid #ffffff50 !important;
+}
+section[id="documentaries"] path[fill="#121212"] {
+    fill: #121212 !important;
+}
 
 ================================
 


### PR DESCRIPTION
- Fixes Guardian Documentaries logo on home page.
- Updates fix in #10330 for "Most viewed" section on home page.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/1721e224-f1b8-4175-baff-01b06cc5dc64)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/ae0834d7-3c9a-47c6-905e-aab09f847874)