### PR TITLE
Fix for debian.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6297,8 +6297,6 @@ debian.org
 INVERT
 .community img
 #logo
-.os-dl-btn
-.os-img-container img
 
 CSS
 body {


### PR DESCRIPTION
I suspect that since the original debian.org fixes were written, the site has been updated. The two parts I've removed here were not necessary and made the site look odd. I've left the INVERT on the #logo though, since it still improves readability.