### PR TITLE
Fix for devterms.io

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -550,6 +550,13 @@ NO INVERT
 
 ================================
 
+devterms.io
+
+INVERT
+.dark .text-gradient
+
+================================
+
 disqus.com/embed/
 
 INVERT


### PR DESCRIPTION
This PR inverts the gradient text on [devterms.io](https://devterms.io) so it becomes visible again.