### PR TITLE
Fixes for *.debian.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6293,14 +6293,19 @@ INVERT
 ================================
 
 debian.org
+*.debian.org
 
 INVERT
 .community img
-#logo
+img[src*="openlogo-50.png"]
+img[src*="openlogo-nd-75.png"]
 
 CSS
 body {
     background-image: none !important;
+}
+.header-logged-out {
+    background-color: transparent !important;
 }
 
 IGNORE IMAGE ANALYSIS
@@ -18297,15 +18302,6 @@ CSS
 
 ================================
 
-packages.debian.org
-
-CSS
-body {
-    background-image: none !important;
-}
-
-================================
-
 packages.ubuntu.com
 
 CSS
@@ -20893,14 +20889,6 @@ button {
     background-color: transparent !important;
     color: var(--darkreader-neutral-text) !important;
 }
-
-================================
-
-salsa.debian.org
-
-INVERT
-a#logo
-img.brand-header-logo
 
 ================================
 


### PR DESCRIPTION
This removes the background header image from *.debian.org domains, and selectively inverts the page logo (some page logos [i.e. samba.debian.org] are white so no need to invert).

Subdomains affected that I've checked will display correctly:
bits.debian.org
lists.debian.org
micronews.debian.org
packages.debian.org
planet.debian.org
salsa.debian.org
wiki.debian.org