### PR TITLE
Fixes for crowdin.com/editor

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5960,8 +5960,42 @@ INVERT
 .crowdin-navbar__logo
 svg.logo-icon-projects
 .file_type.file_folder.file_branch
-#master-loader > .master-loader-logo
-#master-loader-progress.bar
+.static-icon
+.static-icon-back
+.static-icon-next
+.static-icon-dots-v
+.static-icon-menu
+.static-icon-filter
+.static-icon-case-sensitive
+.static-icon-search-full-match
+.static-icon-search-strict
+.static-icon-comfortable-view
+.static-icon-pane-opened-left
+.static-icon-pane-opened-right
+.static-icon-command-palette
+.static-icon-keyboard
+.static-icon-cog
+.static-icon-file
+.static-icon-web
+.static-icon-inbox
+.static-icon-view
+.static-icon-circled-help
+.file_type
+.static-icon-comments
+.static-icon-tms
+.static-icon-terms
+.static-icon-file-context
+.static-icon-plus
+.static-icon-chevron-right
+.static-icon-pin
+.static-icon-copy-source
+.static-icon-trash
+.static-icon-textbox
+
+CSS
+.main-menu-wrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
In the translation editor, most icons were dark in dark theme (i.e. invisible) and the left-hand menu background was white. INVERT the icons and make the menu have a dark background.

Also delete incorrectly INVERTed page load progress spinner.

Requires log in and affiliation with a project to see the changes.