### PR TITLE
Add learn.microsoft.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -576,6 +576,7 @@ landchad.net
 larbs.xyz
 lazer.ppy.sh
 lbrynomics.com
+learn.microsoft.com
 lecantiche.com
 lemm.ee
 lemmi.no


### PR DESCRIPTION
[learn.microsoft.com](https://learn.microsoft.com/en-us/) has built-in dark mode that defaults to the system setting.