### PR TITLE
Fix for ifixit.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11866,6 +11866,9 @@ CSS
 
 ifixit.com
 
+INVERT
+a[aria-label="home page"] > svg > path:first-child
+
 IGNORE IMAGE ANALYSIS
 *
 


### PR DESCRIPTION
Invert logo.

Before:
<img width="254" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/641b3e54-778d-4837-a830-196590484c0c">

After:
<img width="249" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/5aaeeb85-0822-4933-8c8b-79092cd371e4">
