### PR TITLE
Fix for  ip-api.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12412,6 +12412,13 @@ INVERT
 
 ================================
 
+ip-api.com
+
+INVERT
+img[alt="logo"]
+
+================================
+
 ipinfo.io
 
 INVERT


### PR DESCRIPTION
Invert logos.

Before:
<img width="231" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/f6aa8c23-adfe-4ab7-a119-2cff70781d89">
<img width="225" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/17d483f1-1d7d-478f-aa73-5b0007acf4c2">

After:
<img width="250" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/d5d1e117-381b-4703-b970-59932715d080">
<img width="209" alt="image" src="https://github.com/darkreader/darkreader/assets/1006477/a0ad37b3-6766-4c6f-b59b-d04991286393">
