### PR TITLE
dark-sites.config: Add gerrit.wikmedia.org

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -422,6 +422,7 @@ geektyper.com
 genshin-impact.fandom.com
 genshin.gg
 geocities.restorativland.org
+gerrit.wikimedia.org
 getaether.net
 getdweb.net
 gethalfmoon.com


### PR DESCRIPTION
It's already using dark mode, there is no need for Darkreader to interfere with it.