### PR TITLE
Fix for tails.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23339,9 +23339,10 @@ INVERT
 
 ================================
 
-tails.boum.org
+tails.net
 
 INVERT
+.blocks .block img
 .laptop
 
 CSS


### PR DESCRIPTION
Fixes images on "Support" and "Contribute" pages.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/19ed96c1-221b-428a-86b2-5379a2038275)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/fb6e232d-035f-413f-a246-56738339840b)