### PR TITLE
Add developer.mozilla.org to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -262,6 +262,7 @@ destiny.gg
 destinytracker.com
 devanbuggay.com
 devart.withgoogle.com
+developer.mozilla.org
 developer.valvesoftware.com
 developerinsider.co
 developers.cloudflare.com


### PR DESCRIPTION
[developer.mozilla.org](https://developer.mozilla.org/en-US/) has built in dark mode that defaults to system theme.