### PR TITLE
Fix for tabs.ultimate-guitar.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23339,6 +23339,14 @@ INVERT
 
 ================================
 
+tabs.ultimate-guitar.com
+
+INVERT
+.ddUoc
+.JZg5a
+
+================================
+
 tails.boum.org
 
 INVERT


### PR DESCRIPTION
Fix for "chords" and "strumming" part of the website.

Example:
https://tabs.ultimate-guitar.com/tab/elvis-presley/cant-help-falling-in-love-chords-1086983

There's already a segment for "ultimate-guitar.com" in the file, however I have created a new one for "tabs.ultimate-guitar.com".
I think it's personal preference, but I wanted to narrow down the inversion to just where I need it (only tabs), so that I cannot potentially interfere with any other objects, that I have not taken into account.