### PR TITLE
Update dynamic-theme-fixes.config: Player-colour fix on chess-results…

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4765,6 +4765,13 @@ INVERT
 
 ================================
 
+chess-results.com
+
+INVERT
+.FarbewT
+
+================================
+
 chessprogramming.org
 
 INVERT


### PR DESCRIPTION
….com

Fixing the unnecessary inversion of the box indicating color of the pieces of the player, on the games summary page for each player in a tournament, on the chess-results.com. Only needed for the white player.