### PR TITLE
Fixes for zotero.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28519,6 +28519,13 @@ img[alt="Windows to Zorin OS"]
 
 ================================
 
+zotero.org
+
+INVERT
+.brand
+
+================================
+
 zrzutka.pl
 
 INVERT


### PR DESCRIPTION
INVERT main logo in top-left corner because it was dark text on a dark background.