### PR TITLE
Fix atlassian.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2189,6 +2189,8 @@ INVERT
 img[src*="https://github.githubassets.com/favicon.ico"].smart-link-icon
 .sc-jTzLTM
 img[src^="https://latexmath.bolo-app.com/render/"]
+img[src*="MathJax-SVG"]
+span[aria-label="Confluence"]
 
 CSS
 span.code, code.code {
@@ -2262,6 +2264,7 @@ div.zgsxji-0.jMIyWM > div > div > div > div {
 
 IGNORE INLINE STYLE
 .ak-editor-content-area *
+span[aria-label="Jira Software"] *
 
 ================================
 


### PR DESCRIPTION
Invert the generated equations of a popular LaTeX math plugin and fix the logo inversion on Jira and Confluence