### PR TITLE
Fix code blocks on chat.openai.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -349,6 +349,7 @@ chat.openai.com
 
 INVERT
 .overflow-hidden:has(textarea)
+pre .dark
 
 ================================
 


### PR DESCRIPTION
The code blocks on [chat.openai.com](chat.openai.com) are already dark and prior to this change Filter/Filter+ mode would invert them.

Before:
![Screenshot 2024-03-08 at 20 49 05](https://github.com/darkreader/darkreader/assets/17463710/39bc30a4-95b9-4baf-bf21-991ee45c2fc9)

After:
![Screenshot 2024-03-08 at 20 48 55](https://github.com/darkreader/darkreader/assets/17463710/daa7a8e5-da6c-4af8-a02e-3b52f2163e88)
