### PR TITLE
darken indent guide in atcoder.jp

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2280,6 +2280,9 @@ CSS
 #fixed-server-timer {
     color: #333;
 }
+.ace-tm .ace_indent-guide {
+    opacity: .3;
+}
 
 ================================
 


### PR DESCRIPTION
Before:
![image](https://github.com/darkreader/darkreader/assets/1135891/8f724177-f97e-4e1a-a0f4-4173f6706bfb)

After:
![image](https://github.com/darkreader/darkreader/assets/1135891/ae7046b5-0ffd-4bbc-8ab1-f3d9e6089cb4)

You can see this
https://atcoder.jp/contests/practice2/custom_test?lang=en (account required)