### PR TITLE
Update dynamic-theme-fixes.config: Invert gene schema figure

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17381,6 +17381,13 @@ CSS
 
 ================================
 
+ncbi.nlm.nih.gov
+
+INVERT
+.gene-genomic-context p.withnote img
+
+================================
+
 nec.com
 
 INVERT


### PR DESCRIPTION
Inverts the gene schema figure which shows the genes names, their extend as double-headed arrows and the base-pair range of the locus.

Before
<img width="1124" alt="Screenshot 2024-03-14 at 15 08 14" src="https://github.com/darkreader/darkreader/assets/7249350/8274d777-8adf-4033-b2ed-a39cfef88f7f">

After 
<img width="1124" alt="Screenshot 2024-03-14 at 15 07 23" src="https://github.com/darkreader/darkreader/assets/7249350/8065b694-8020-4f23-b894-034806f8bd5e">

Example URL: https://www.ncbi.nlm.nih.gov/gene/66354