### PR TITLE
Update dynamic-theme-fixes.config: fixing the inversion of genome-eur…

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10445,6 +10445,14 @@ INVERT
 
 ================================
 
+genome-euro.ucsc.edu
+
+INVERT
+td.tdData
+.tdLeft
+
+================================
+
 genshin-impact-map.appsample.com
 
 INVERT


### PR DESCRIPTION
…o.ucsc.edu genome browser track labels & annotations

The labels and annotations for the UCSC genome browser are inverted properly

Before
<img width="1512" alt="Screenshot 2024-03-14 at 17 09 46 2" src="https://github.com/darkreader/darkreader/assets/7249350/058d56fa-cb67-41c9-bf77-79bedf2fd2f7">

After 
<img width="1512" alt="Screenshot 2024-03-14 at 17 07 59" src="https://github.com/darkreader/darkreader/assets/7249350/e3714f6a-35d8-4723-b68e-c57f59fb5c4b">

Ex. URL:  https://genome-euro.ucsc.edu/cgi-bin/hgTracks?db=mm10&lastVirtModeType=default&lastVirtModeExtraState=&virtModeType=default&virtMode=0&nonVirtPosition=&position=chr12%3A87325000%2D88825000&hgsid=326186368_MUXf3a8dwsOfbiJ2tmUDRyHmfays

