### PR TITLE
Fixes for *.archlinux.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -114,6 +114,14 @@ IGNORE INLINE STYLE
 
 ================================
 
+*.archlinux.org
+
+INVERT
+img[src*="icons/"]
+img[src*="calendar.svg"]
+
+================================
+
 *.bitrix24.ru
 
 INVERT
@@ -20978,13 +20986,6 @@ CSS
 
 ================================
 
-reproducible.archlinux.org
-
-INVERT
-img[src*="icons/"]
-
-================================
-
 repubblica.it
 
 INVERT
@@ -24255,13 +24256,6 @@ terazwy.pl
 INVERT
 img[src*="img/loga"]
 img[src*="img/logotr.png"]
-
-================================
-
-terms.archlinux.org
-
-INVERT
-img[src="svg/calendar.svg"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -118,7 +118,7 @@ IGNORE INLINE STYLE
 
 INVERT
 img[src*="icons/"]
-img[src*="calendar.svg"]
+img[src="/svg/calendar.svg"]
 
 ================================
 


### PR DESCRIPTION
Merge the two rule sets for *.archlinux.org, fix the dark calender icon that wasn't being made pale by the previous rule.