### PR TITLE
Don't invert Bitwarden prompt

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5,7 +5,6 @@ INVERT
 .captcheck_answer_label > input + img
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
 span[data-href^="https://www.hcaptcha.com/"] > #icon
-#bit-notification-bar-iframe
 ::-webkit-calendar-picker-indicator
 img.Wirisformula
 


### PR DESCRIPTION
This reverts commit 1651031c from pull request #5401. Currently, with the dark theme selected from within the Bitwarden extension, one sees the following.
![with-inversion](https://github.com/darkreader/darkreader/assets/11367586/d0ee151d-b53d-4535-a357-74841e9a712c)
With this pull request the user-selected theme is respected.
![without-inversion](https://github.com/darkreader/darkreader/assets/11367586/bef7722d-1c25-4476-ac2e-57de59d0544f)
