### PR TITLE
Invert potential article images in transparent background for common blogs including silent blogs

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10129,6 +10129,16 @@ body {
 
 ================================
 
+fritx.me
+*.fritx.me
+*.*.fritx.me
+fritx.github.io
+
+INVERT
+.main-page img
+
+================================
+
 fritz.box
 
 INVERT


### PR DESCRIPTION
Style in silent blogs gets overriden and takes no effect:
[fix transparent image background in darkmode
](https://github.com/fritx/silent/commit/22ae7e04b42691f0a8c4888ce01ec81a01a12e16)
Preview Link: https://blog.fritx.me/?2015/01/fs-auth

Before fix:
<img width=400 src=https://github.com/darkreader/darkreader/assets/6647633/70e06a74-f780-4e34-a83b-b682233f40ac>

After fix:
<img width=400 src=https://github.com/darkreader/darkreader/assets/6647633/d6cca410-c358-4ef2-aede-59623e974f67>
