### PR TITLE
Updated inversion-fixes.config (dark theme fix for hardwaretester.com)

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1117,6 +1117,25 @@ CSS
 
 ================================
 
+hardwaretester.com
+
+INVERT
+.css-18zdsro.en092cd1
+.css-1yi8w9s.ex43mx610
+.css-2n3ua2.ex43mx611
+.css-13i6n5b.en092cd9 div canvas
+.css-1jxoetp.eezel420 svg g text
+
+CSS
+.css-13i6n5b, .css-1gmvfms, .css-oi07q0 {
+    box-shadow: rgba(251, 229, 208, 0.1) 0px 2px 5px;
+}
+.css-oi07q0 {
+    box-shadow: rgba(255, 255, 255, 0.2) 0px 5px 10px;
+}
+
+================================
+
 homestuck.com
 
 INVERT


### PR DESCRIPTION
Updated inversion fixes for **hardwaretester.com** in **dark mode** to fix multiple incorrect color inversions in Filter and Filter+ modes, like the topbar being white, piano being inverted on MIDI tester, the drop shadow on all panels, and keeping the circularity error text white in dark mode.

Fix applies across all Gamepad, GPU, Mic, and MIDI Tester subpages when used in dark theme. Can verify that in light theme all changes appear the same as without the extension enabled; decided to keep the piano and microphone spectrum's appearance in light theme as unmodified, can be changed by others if desired.

![image](https://github.com/darkreader/darkreader/assets/35157665/33b231a1-843e-44e0-86da-7938ff354470)
![image](https://github.com/darkreader/darkreader/assets/35157665/4f3b04a9-09a3-4dd7-ac1d-c69b3cdfa657)
![image](https://github.com/darkreader/darkreader/assets/35157665/0c82d55a-bf19-4e16-8e2d-4b80980cc5eb)