### PR TITLE
Remove quarantined domains pref from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ Step 2: change Firefox's settings.
 A warning page may appear. Click `Accept the Risk and Continue` to proceed.
 - Search for and set `extensions.webextensions.restrictedDomains` to an empty value.
 - Create `extensions.webextensions.addons-restricted-domains@mozilla.com.disabled` with `boolean` as type and set its value to `true`.
-- Set `extensions.quarantinedDomains.enabled` to `false`.
 - Set `privacy.resistFingerprinting.block_mozAddonManager` to `true`.
 - Restart Firefox.
 


### PR DESCRIPTION
It is a security feature and should not be changed by common users.

https://support.mozilla.org/en-US/kb/quarantined-domains