### PR TITLE
Fix for kamigame.jp 's main article column

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13381,6 +13381,16 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+kamigame.jp
+
+CSS
+article,
+.article {
+    background-image: none !important;
+}
+
+================================
+
 kaos-community-packages.github.io
 
 INVERT


### PR DESCRIPTION
The main/central article column of kamigame.jp for its various subwikis aren't getting darkened. [E.g.](https://kamigame.jp/bluearchive/index.html):
![image](https://github.com/darkreader/darkreader/assets/116596352/85b9c053-6d10-4c9c-af87-06f5f5e86093)

The background of each subwiki is a mostly white background with faint game-themed detailing ([e.g.](https://kamigame.jp/img/bluearchive/bluearchive_bg.png)); is that what's confusing the dynamic theming analysis?

I propose removing the background image:
![image](https://github.com/darkreader/darkreader/assets/116596352/235bef88-326c-47a3-989e-0658ad675a82)

I tried inverting the element and re-inverting its children, but that looks worse in my opinion:
![image](https://github.com/darkreader/darkreader/assets/116596352/b477421a-dbe1-435c-8c0e-352e2781ef86)

---

There's two selectors because it seems like they rewrote their article system at some point, and so newer games like my above example have an element:
![image](https://github.com/darkreader/darkreader/assets/116596352/73fb1a6b-eb5f-4c18-9f39-272d1a37cd39)
that's formatted differently than the equivalent element for a subwiki for an older game like FGO:
![image](https://github.com/darkreader/darkreader/assets/116596352/a1ad0b17-c61e-49c1-8875-9912ebb353ea)
