### PR TITLE
Updated fix for audible

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2369,10 +2369,29 @@ span[aria-label="Jira Software"] *
 
 ================================
 
-audible.com
+audible.com/webplayer
+audible.de
 
 INVERT
 #adbl-cloud-player-controls
+.hero-img > img
+
+CSS
+.adbl-page > #center-0 {
+    background-color: #0e0d0c !important;
+}
+.adblCloudPlayerContainer {
+    height: 99999vh !important;
+}
+.adblCloudPlayerContainer .bc-range-progress,
+.bc-range input[type="range"]::-moz-range-thumb,
+.bc-range input[type="range"]::-webkit-slider-thumb {
+    background-color: #f7991c !important;
+}
+.bc-range input[type="range"]::-moz-range-track,
+.bc-range input[type="range"]::-webkit-slider-runnable-track {
+    background: rgba(255,255,255,.5) !important;
+}
 
 ================================
 


### PR DESCRIPTION
1. Added `audible.de`
2. Inverted huge light images on the german site
3. The inversion of the player controls results in a fixed background color
4. Fixed progress bar being invisible

---------------

Without fix:

![image](https://github.com/darkreader/darkreader/assets/5329652/d0c00c9b-6376-4e5d-8188-1dd59e5005a6)

Current fix:

![image](https://github.com/darkreader/darkreader/assets/5329652/88d90961-888c-47f4-9543-8ecd1410ee3d)

New fix:

![image](https://github.com/darkreader/darkreader/assets/5329652/d60d0b3a-31fb-4b82-8736-89d21da014d1)
