### PR TITLE
Updated sciencedirect.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21688,6 +21688,12 @@ INVERT
 
 sciencedirect.com
 
+INVERT
+.article-textbox
+.article-textbox > span#tbcap1 > p
+.article-textbox > div
+.article-textbox a
+
 CSS
 body,
 .gh-nav .gh-nav-action,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21688,12 +21688,6 @@ INVERT
 
 sciencedirect.com
 
-INVERT
-.article-textbox
-.article-textbox > span#tbcap1 > p
-.article-textbox > div
-.article-textbox a
-
 CSS
 body,
 .gh-nav .gh-nav-action,
@@ -21735,6 +21729,13 @@ body,
 }
 #gh-overlay {
     background-color: rgba(20, 20, 20, .85) !important;
+}
+.article-textbox {
+    background-color: ${rgb(213, 211, 207)} !important;
+}
+.Article .topic-link {
+    color: ${rgb(46, 50, 52)} !important;
+    text-decoration-color: ${rgb(46, 50, 52)} !important;
 }
 
 ================================


### PR DESCRIPTION
Added a fix for when reading articles on sciencedirect.com

Before:
![before](https://github.com/darkreader/darkreader/assets/9437154/efea665d-7957-4549-adb1-8e858a64a28d)

After:
![after](https://github.com/darkreader/darkreader/assets/9437154/452b7213-ada0-4f43-a2b0-13c3f5797356)
