### PR TITLE
Fix for dsausa.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8016,6 +8016,7 @@ dsausa.org
 
 INVERT
 .navbar-toggler-icon
+.swiper-container-horizontal .swiper-pagination-bullet
 
 ================================
 


### PR DESCRIPTION
Fixes carousel buttons on home page.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/7679f255-74fa-4633-a3f1-ea0763ae7010)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/8f5d9eb3-2b65-458c-884e-a0cf74ac2e0a)