### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3475,6 +3475,9 @@ CSS
 html {
     height: inherit !important;
 }
+.main_father {
+    background-color: black !important;
+}
 
 ================================
 


### PR DESCRIPTION
在csdn网站上浏览博客时，在黑暗模式时会有大片的白色背景出现，添加这几行代码让整个页面看起来更契合黑暗模式。