### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3475,7 +3475,9 @@ CSS
 html {
     height: inherit !important;
 }
-
+.main_father {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 ================================
 
 blog.documentfoundation.org

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3478,6 +3478,7 @@ html {
 .main_father {
     background-color: var(--darkreader-neutral-background) !important;
 }
+
 ================================
 
 blog.documentfoundation.org


### PR DESCRIPTION
在csdn网站浏览时，打开黑暗模式时，会有大片的白色背景出现，添加这几行代码使其更契合黑暗模式。