### PR TITLE
Fix Desmos 3D canvas Z order

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6778,6 +6778,9 @@ html[data-darkreader-scheme="dark"] .dcg-calculator-api-container :is(.dcg-graph
 .dcg-calculator-api-container .dcg-container.dcg-inverted-colors {
     filter: hue-rotate(180deg) !important;
 }
+.dcg-calculator-api-container .dcg-grapher-3d .dcg-graph-outer {
+    z-index: 1;
+}
 
 IGNORE INLINE STYLE
 .dcg-calculator-api-container .dcg-colored-icon


### PR DESCRIPTION
Adding a filter to .dcg-webgl-canvas creates a stacking context that blocks the element that listens for mouse events on the graph. This restores the Z order on the sibling element.

https://www.desmos.com/3d