### PR TITLE
Fix for icons in ConnectWise PSA/Manage

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17303,6 +17303,15 @@ span[class*="nk-icon_id_business-feedback-task"] > svg > g > path
 
 ================================
 
+na.myconnectwise.net
+
+CSS
+.cwsvg {
+    fill: white;
+}
+
+================================
+
 nagatabi-p.jimdofree.com
 
 INVERT


### PR DESCRIPTION
SVG icons on top menu were dark on dark background. This makes them match the text.