### PR TITLE
Fix for subdomains on ConnectWise ScreenConnect app

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21909,6 +21909,7 @@ g[data-argument-type="colour"] > path
 
 ================================
 
+creenconnect.com
 *.screenconnect.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21909,7 +21909,7 @@ g[data-argument-type="colour"] > path
 
 ================================
 
-screenconnect.com
+*.screenconnect.com
 
 CSS
 .OuterPanel .MainPanel .MasterPanel .MasterListContainer ul li.HasChildren > div > p {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21909,7 +21909,7 @@ g[data-argument-type="colour"] > path
 
 ================================
 
-creenconnect.com
+screenconnect.com
 *.screenconnect.com
 
 CSS


### PR DESCRIPTION
The CSS was correct but it never triggered because the site is accessed via yourcompany.screenconnect.com

I don't know if this is the proper way to do this, but I added *. and it started working immediately.