### PR TITLE
app.getport.io fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1714,6 +1714,19 @@ svg text.time_cursor {
 
 ================================
 
+app.getport.io
+
+CSS
+.ring-solid-gray-200 {
+    --tw-ring-color: var(--darkreader-selection-text) !important;
+    --tw-ring-opacity: 1;
+}
+.ring-1 {
+    box-shadow: var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow, 0 0 --darkreader-selection-text) !important;
+}
+
+================================
+
 app.grammarly.com
 
 CSS


### PR DESCRIPTION
This updates the dynamic CSS for port's portal once you have logged in.
https://app.getport.io

Before:
![image](https://github.com/darkreader/darkreader/assets/44812862/f173f118-4a4b-4a48-9bfa-b2f55018026f)

After:
![image](https://github.com/darkreader/darkreader/assets/44812862/0540a460-9e8b-4d5a-a112-9e8edce42e56)

Fixes issue with outside ring on nodes so they can be seen better against the background.