### PR TITLE
rmf24.pl fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21393,6 +21393,20 @@ CSS
 
 ================================
 
+rmf24.pl
+
+INVERT
+.mainContent3-left iframe
+.belkaNew
+
+CSS
+#twojezdrowieCont .page3,
+#regionySection {
+    background-image: none !important;
+}
+
+================================
+
 roblox.com
 
 CSS


### PR DESCRIPTION
SITE https://www.rmf24.pl/
Fixes:
- remove bg img from sections Health, Provinces
-  hard workaround  invert dynamic CSS image section (the current broadcast has its own css tag and hardly disable background image). 
- invert top right radio player  box iframe 

![20240404-1712256026](https://github.com/darkreader/darkreader/assets/9846948/b33650d8-8a74-4e2b-9e2d-6887f551829f)
![20240404-1712256018](https://github.com/darkreader/darkreader/assets/9846948/33c05bb4-a38a-4dad-815d-8980a412d078)
![20240404-1712256009](https://github.com/darkreader/darkreader/assets/9846948/cac5964e-e1a3-469c-911b-b7fff7fab141)

