### PR TITLE
Fix for septa.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22379,6 +22379,26 @@ div[aria-label$="stars"]
 
 ================================
 
+septa.org
+
+INVERT
+.clear-btn
+.listbox-row[role="presentation"] > svg-icon
+.search-icon
+
+CSS
+.bg-black,
+.is-frequent {
+    background-color: var(--darkreader-neutral-text) !important;
+    color: var(--darkreader-neutral-background) !important;
+}
+.bus,
+.circle {
+    border: 2px solid var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 server.pro
 
 INVERT


### PR DESCRIPTION
Fixes "Find a Route" graphics on home page.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/0b78c306-3cf4-41d1-8ff9-e5bece548b4e)
![2](https://github.com/darkreader/darkreader/assets/6563728/624e1d0b-86b6-4046-8683-2b31e0bcd4be)

After:
![3](https://github.com/darkreader/darkreader/assets/6563728/657a0c46-ff75-461a-9f3e-76a60a0080fc)
![4](https://github.com/darkreader/darkreader/assets/6563728/bdc33fbd-614a-4fee-8cbe-a8881abe1af1)