### PR TITLE
Added a fix for the myorca site

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17416,6 +17416,15 @@ IGNORE INLINE STYLE
 
 ================================
 
+myorca.*
+
+INVERT
+h1
+strong
+.b
+
+================================
+
 myunidays.com
 
 INVERT


### PR DESCRIPTION
Fixed some icons/headers on the "myorca.com*" site that were not visible.

Before:
![image](https://github.com/darkreader/darkreader/assets/157659446/df2f34fa-3791-4add-88ab-9610fe948cd6)
![image](https://github.com/darkreader/darkreader/assets/157659446/5957a5db-2303-418b-967e-aae71600cd47)

After:
![image](https://github.com/darkreader/darkreader/assets/157659446/e19fcda7-8d2a-403f-82ce-b6ff12f3eb7f)
![image](https://github.com/darkreader/darkreader/assets/157659446/5bf87c2f-679a-420f-a4cb-8ee5c5864cdc)
