### PR TITLE
Fix for temu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24643,6 +24643,15 @@ body,
 
 ================================
 
+temu.com
+
+CSS
+._2Fkk_bmp {
+    background-color: ${#fff0} !important;
+}
+
+================================
+
 tenforums.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24647,7 +24647,7 @@ temu.com
 
 CSS
 ._2Fkk_bmp {
-    background-color: ${#fff0} !important;
+    background-color: transparent !important;
 }
 
 ================================


### PR DESCRIPTION
Background of certain divs were white.

Before:
![Screenshot 2024-04-12 at 02-25-16 Waterproof Mattress Protector Quilted (without Pillow Core) - Temu](https://github.com/darkreader/darkreader/assets/9978161/312972fc-9ee2-41c4-ad0e-a44c32382a6b)

After:
![Screenshot 2024-04-12 at 02-26-09 Waterproof Mattress Protector Quilted (without Pillow Core) - Temu](https://github.com/darkreader/darkreader/assets/9978161/ec7d0397-929d-4ed5-974f-45e8a0595b8a)
