### PR TITLE
Fix for septa.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22473,8 +22473,13 @@ div[aria-label$="stars"]
 septa.org
 
 INVERT
+.checked > label > div > .switch-marker
 .clear-btn
+.leaflet-control-attribution
+.leaflet-popup
 .listbox-row[role="presentation"] > svg-icon
+.map-container
+.map-zoom-controls > button > i
 .search-icon
 
 CSS
@@ -22486,6 +22491,14 @@ CSS
 .bus,
 .circle {
     border: 2px solid var(--darkreader-neutral-text) !important;
+}
+.leaflet-routes-pane > svg > g > path {
+    stroke: #000 !important;
+}
+.leaflet-stops-pane > svg > g > path,
+.trip-icon-container > svg > path {
+    fill: #fff !important;
+    stroke: #000 !important;
 }
 
 ================================


### PR DESCRIPTION
Fixes map widget on bus schedule page.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/b16d5b57-3d8a-4a6c-815a-e90ef14868bf)
![2](https://github.com/darkreader/darkreader/assets/6563728/a228d18f-84a4-4673-983f-5954c37c8408)
![3](https://github.com/darkreader/darkreader/assets/6563728/c1ae8e92-5d07-4c54-b661-953f328cb1be)

After:
![4](https://github.com/darkreader/darkreader/assets/6563728/5d2aa479-2ec6-4aca-aa86-77e8556f3173)
![5](https://github.com/darkreader/darkreader/assets/6563728/d7a54946-f791-4cfb-8dac-87e9f5d0d2be)
![6](https://github.com/darkreader/darkreader/assets/6563728/e1d288a8-c9db-4e41-b126-4d2dfd6ade94)