### PR TITLE
Add ChatGPT to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -174,6 +174,7 @@ cdkeys.com
 cdn.minlor.net
 cdnnow.pro
 chat-gpt.org
+chat.openai.com
 chat.ryzom.com
 chat.vote
 cheat.sh


### PR DESCRIPTION
ChatGPT by default is in dark mode. I'm don't think it even has a light mode. So I added it to the global dark list.

This would close #12606.