### PR TITLE
Fixes for pcgamer.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19480,9 +19480,6 @@ CSS
 img {
     mix-blend-mode: normal !important;
 }
-a {
-    color: revert-layer !important;
-}
 
 IGNORE INLINE STYLE
 path

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19480,6 +19480,12 @@ CSS
 img {
     mix-blend-mode: normal !important;
 }
+a {
+    color: revert-layer !important;
+}
+
+IGNORE INLINE STYLE
+path
 
 ================================
 


### PR DESCRIPTION
Fixed text readability by reverting to default colours, and fixed site logo by adding `path` (element used in the sites svg logo) to ignore inline styling.

Before:

![pcgamer-before](https://github.com/darkreader/darkreader/assets/31993698/0ee28dde-8722-4d63-8c86-a9e66229f73f)

After:

![pcgamer-after](https://github.com/darkreader/darkreader/assets/31993698/cc994fd2-a3da-4d4f-8530-c5b8a0da89c7)