### PR TITLE
(Another) Fix for canvas.edu textareas

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4670,7 +4670,7 @@ INVERT
 .ic-DashboardCard__action-badge
 
 CSS
-[class*="-textArea"],
+textarea[class*="-textArea"],
 [class*="numberInput_input"] {
     background-color: var(--darkreader-neutral-background) !important;
 }


### PR DESCRIPTION
Found some overlapping rules for canvas.edu textareas, changed the rule to only apply to `textarea` elements of a given class. Again fixes/improves #12354.