### PR TITLE
Fixed logo's for Future-brand sites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2523,7 +2523,7 @@ INVERT
 img[src*="avlab-logo"]
 img[alt*="logo"]
 .elementor-widget-wrap div div a.elementor-icon svg
-.elementor-social-icons-wrapper *
+.elementor-social-icons-wrapper
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2523,7 +2523,24 @@ INVERT
 img[src*="avlab-logo"]
 img[alt*="logo"]
 .elementor-widget-wrap div div a.elementor-icon svg
-.elementor-social-icons-wrapper
+.elementor-social-icons-wrapper *
+
+================================
+
+avnetwork.com
+
+INVERT
+#Group-3
+#Fill-4
+span.site-logo.subsite-logo svg g * *
+span.site-logo.subsite-logo svg path
+#slice-container-subBrandsBar > div > a > span > svg > g:nth-child(1)
+#slice-container-subBrandsBar > div > a > span > svg > path:nth-child(2)
+
+IGNORE INLINE STYLE
+.site-logo svg *
+path
+g
 
 ================================
 
@@ -5206,6 +5223,16 @@ body {
 
 ================================
 
+cinemablend.com
+
+INVERT
+body > nav > div.burgerbar > div > div.logo > a > span.site-logo > svg > g > path:nth-child(1)
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 circleci.com/docs
 
 CSS
@@ -5513,6 +5540,13 @@ svg.cnn-badge-icon
 svg.cnn-badge-icon > rect
 svg.politics-logo-icon
 svg.business-logo-icon
+
+================================
+
+coachweb.com
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -6277,6 +6311,17 @@ CSS
 
 ================================
 
+creativebloq.com
+
+INVERT
+#publisherDetails > div > a > span.site-logo > svg > path:nth-child(9)
+#auth-in-nav-header-svg-block > svg > path
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 creativecommons.org
 
 CSS
@@ -6413,6 +6458,14 @@ cybernews.com
 
 IGNORE INLINE STYLE
 svg *
+
+================================
+
+cyclingnews.com
+
+IGNORE INLINE STYLE
+path
+g
 
 ================================
 
@@ -7285,6 +7338,18 @@ CSS
 body.not-front {
     background-image: none;
 }
+
+================================
+
+digitalcameraworld.com
+
+INVERT
+.site-logo svg * *
+.site-logo svg path
+#auth-in-nav-header-svg-block > svg > path
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -10178,6 +10243,16 @@ body {
 
 ================================
 
+fourfourtwo.com
+
+INVERT
+.site-logo svg * * * *
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 frame.work
 
 INVERT
@@ -10489,6 +10564,13 @@ gamesindustry.biz
 
 INVERT
 .logo
+
+================================
+
+gamesradar.com
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -11296,10 +11378,34 @@ CSS
 
 ================================
 
+golfmonthly.com
+
+INVERT
+.logo__svg svg *
+span.icon-svg-wrapper svg path
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 goodreads.com
 
 INVERT
 .responsiveSiteFooter__socialLinkWrapper
+
+================================
+
+goodto.com
+
+INVERT
+.logo__svg svg *
+span.icon-svg-wrapper svg path
+a.icon.icon__circle.icon__envelope svg g
+.icon__home svg *
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -11662,6 +11768,18 @@ INVERT
 tr > td > img
 p.standard_price
 p.promo_price
+
+================================
+
+guitarplayer.com
+
+INVERT
+.site-logo svg defs
+#GP_Home5
+
+IGNORE INLINE STYLE
+path
+polygon
 
 ================================
 
@@ -12061,6 +12179,16 @@ span[role="presentation"] > .cm-variable-2 {
 
 ================================
 
+homesandgardens.com
+
+INVERT
+.logo__svg svg * *
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 hooktail.sub.jp
 hooktail.org
 
@@ -12363,6 +12491,17 @@ CSS
 
 ================================
 
+idealhome.co.uk
+
+INVERT
+.navigation__search span svg *
+.logo__svg svg *
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 identity.kde.org
 
 CSS
@@ -12590,6 +12729,37 @@ CSS
 .result-list__listing {
     background-color: transparent !important;
 }
+
+================================
+
+imore.com
+
+INVERT
+.search-icon svg *
+
+CSS
+.site-logo {
+    background: #fbe446;
+}
+#_Group_2 * {
+    fill: #1d1d1d;
+}
+.wrapper {
+    background: #ffd600;
+}
+.sub-menu {
+    background: #ffd600;
+}
+.primary-nav .nav-list .menu-item a {
+    color: black;
+}
+.primary-nav .nav-list .menu-item span {
+    color: black;
+}
+
+IGNORE INLINE STYLE
+path
+div.flexisites-social.buttons-social.masthead-item *
 
 ================================
 
@@ -15027,6 +15197,16 @@ div.icoShare.iconSprite
 
 ================================
 
+livescience.com
+
+INVERT
+.site-logo svg *
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 liveuamap.com
 
 INVERT
@@ -15188,6 +15368,25 @@ CSS
 .bracket-line.z-up::after {
     border-width: 2px 0 0 2px !important;
 }
+
+================================
+
+loudersound.com
+
+INVERT
+.site-logo svg path
+.site-logo svg polygon
+.supernav__lead a svg path
+.supernav__lead a svg polygon
+
+CSS
+.one-louder a span svg path {
+    filter: unset !important;
+}
+
+IGNORE INLINE STYLE
+path
+polygon
 
 ================================
 
@@ -16660,6 +16859,16 @@ path[fill-rule="evenodd"]
 
 ================================
 
+mixonline.com
+
+INVERT
+.header-logo a svg * *
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 mjtnet.com
 
 INVERT
@@ -16812,6 +17021,19 @@ CSS
 a[href$="twitter.com/money_pl"] path:first-of-type {
     --darkreader-inline-fill: transparent !important;
 }
+
+================================
+
+moneyweek.com
+
+INVERT
+.icon__home svg *
+.navigation__search span svg *
+.icon__arrow-down svg *
+.icon__arrow-up svg *
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -17487,6 +17709,20 @@ INVERT
 
 ================================
 
+myimperfectlife.com
+
+INVERT
+.logo__svg svg * *
+.icon__home svg *
+.navigation__search span svg *
+.icon__arrow-down svg *
+.icon__arrow-up svg *
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 mymenu.be
 
 INVERT
@@ -17925,6 +18161,23 @@ CSS
     background-color: var(--darkreader-neutral-text) !important;
     border-color: var(--darkreader-neutral-text) !important;
 }
+
+================================
+
+nexttv.com
+
+INVERT
+.site-logo svg *
+#Group-Copy-2
+
+CSS
+.menu-item.menu-item-none.menu-item-nav-sub-set {
+    border-left: 1px solid #fff !important;
+}
+
+IGNORE INLINE STYLE
+path
+g
 
 ================================
 
@@ -19565,6 +19818,16 @@ INVERT
 
 ================================
 
+petsradar.com
+
+INVERT
+#Logo-play
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 pgatour.com
 
 CSS
@@ -20943,6 +21206,16 @@ CSS
 #header_img_right {
     background-image: none !important;
 }
+
+================================
+
+realhomes.com
+
+INVERT
+.logo__svg svg *
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -24374,6 +24647,17 @@ INVERT
 
 ================================
 
+t3.com
+
+INVERT
+.subscribe-text span *
+.locale-selector__icon--chevron-down
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 tableau.com
 
 INVERT
@@ -24619,6 +24903,13 @@ techpowerup.com
 
 INVERT
 .page-header__logo
+
+================================
+
+techradar.com
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -25084,6 +25375,19 @@ INVERT
 .c-global-header__logo
 .c-tab-bar__logo
 .c-footer__logo-link
+
+================================
+
+theweek.com
+
+INVERT
+.navigation__search span svg *
+#auth-in-nav-header-svg-block svg *
+.icon__arrow-down svg *
+.icon__arrow-up svg *
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -25738,6 +26042,16 @@ tvrain.ru
 
 INVERT
 .menu3__logo
+
+================================
+
+tvtechnology.com
+
+INVERT
+#svg_3
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -27419,6 +27733,13 @@ INVERT
 
 ================================
 
+whathifi.com
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 whatruns.com
 
 INVERT
@@ -27461,6 +27782,18 @@ path[fill="#FFFFFF"]
 
 ================================
 
+whattowatch.com
+
+CSS
+a.icon.icon-circle.icon-twitter {
+    border: 1px solid #ffffff4f;
+}
+
+IGNORE INLINE STYLE
+path
+
+================================
+
 whitemad.pl
 
 INVERT
@@ -27490,6 +27823,17 @@ whois.com
 
 INVERT
 img[src^="logo.gif"]
+
+================================
+
+whowhatwear.com
+
+INVERT
+.logo__svg svg * *
+.navigation__search span svg *
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -27936,6 +28280,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+windowscentral.com
+
+IGNORE INLINE STYLE
+path
+.site-logo svg *
+div.flexisites-social.buttons-social.masthead-item *
+
+================================
+
 windscribe.com
 
 CSS
@@ -27983,6 +28336,20 @@ wmar2news.com
 INVERT
 .PageLogo-image
 .wx-nav > img
+
+================================
+
+womanandhome.com
+
+INVERT
+.logo__svg svg *
+.icon__home svg *
+.navigation__search span svg *
+.icon__arrow-down svg *
+.icon__arrow-up svg *
+
+IGNORE INLINE STYLE
+path
 
 ================================
 
@@ -28855,6 +29222,16 @@ www.tinkoff.ru
 
 INVERT
 a[title="Tinkoff"]
+
+================================
+
+www.tomshardware.com
+
+INVERT
+#publisherDetails > a > span.site-logo > svg > g > path:nth-child(4)
+
+IGNORE INLINE STYLE
+path
 
 ================================
 


### PR DESCRIPTION
Fixes multiple SVG elements and related problems on Future-brand sites. Includes mostly changes to the site's logo's and some other icons. 

### Example before:

![before](https://github.com/darkreader/darkreader/assets/31993698/2c989e5a-9bff-4da3-8a81-362043e1bf81)

### Example after:

![after](https://github.com/darkreader/darkreader/assets/31993698/594d9496-1d70-4186-8678-5cd65dec7ab3)

### Notes

This is a continuation of my original fix https://github.com/darkreader/darkreader/pull/12613 for pcgamer.com. As other Future-branded sites raised in https://github.com/darkreader/darkreader/issues/12507 also needed fixing.

Additional fixes relating to CSS layers have already been merged https://github.com/darkreader/darkreader/commit/7bdf63ed3714f8cc00d19b1d742bba406b53cf2e.

## Site list:

- https://nexttv.com
- https://www.tomshardware.com (www required)
- https://techradar.com
- https://avnetwork.com
- https://cinemablend.com
- https://loudersound.com
- https://coachweb.com
- https://creativebloq.com
- https://tvtechnology.com
- https://cyclingnews.com
- https://digitalcameraworld.com
- https://fourfourtwo.com
- https://gamesradar.com
- https://golfmonthly.com
- https://goodto.com
- https://guitarplayer.com
- https://homesandgardens.com
- https://idealhome.co.uk
- https://livescience.com
- https://moneyweek.com
- https://myimperfectlife.com
- https://petsradar.com
- https://mixonline.com
- https://realhomes.com
- https://t3.com
- https://theweek.com
- https://whathifi.com
- https://whattowatch.com
- https://whowhatwear.com
- https://windowscentral.com
- https://imore.com
- https://womanandhome.com
