### PR TITLE
Fix for 350.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -510,6 +510,25 @@ img[alt="Zespół 300Gospodarki"]
 
 ================================
 
+350.org
+map.350.org
+
+INVERT
+.dark\:bg-gray-700
+.dark\:bg-gray-700::after
+.dark\:text-gray-300
+.mapboxgl-canvas
+.mapboxgl-ctrl-compass > .mapboxgl-ctrl-icon
+.mapboxgl-ctrl-logo
+.mapboxgl-marker
+
+CSS
+mapbox-search-box > input {
+    --darkreader-bg--boxShadow: 0 0 10px 2px ${rgba(0, 0, 0, 0.05)}, 0 0 6px 1px ${rgba(0, 0, 0, 0.1)}, 0 0 0 1px ${rgba(0, 0, 0, 0.1)} !important;
+}
+
+================================
+
 37.com
 
 INVERT


### PR DESCRIPTION
Fixes map widget on "Get Involved" page.

Before (desktop view):
![1](https://github.com/darkreader/darkreader/assets/6563728/1d9131f4-b59f-4edc-8206-979c43692f14)

Before (mobile view):
![2](https://github.com/darkreader/darkreader/assets/6563728/297c3b5e-fea7-4b7b-9a94-5472017ae3b2)

After (desktop view):
![3](https://github.com/darkreader/darkreader/assets/6563728/fd0b36cb-6fc3-476b-8091-9ded90320066)

After (mobile view):
![4](https://github.com/darkreader/darkreader/assets/6563728/c39fb4a1-215e-4c92-afc0-6f78311c7f6c)