### PR TITLE
Fixed sidebar text color for docs.vyos.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7873,6 +7873,15 @@ CSS
 
 ================================
 
+docs.vyos.io
+
+CSS
+.wy-menu-vertical a {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 doctorswithoutborders.org
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7877,8 +7877,8 @@ docs.vyos.io
 
 CSS
 .wy-menu-vertical a {
-    color: var(--darkreader-neutral-text) !important;
     background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7878,6 +7878,7 @@ docs.vyos.io
 CSS
 .wy-menu-vertical a {
     color: var(--darkreader-neutral-text) !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
Currently the text color of the sidebar is to dark and therefore hard to read. This change sets the text color to the darkreader neutral text color.