### PR TITLE
Update dynamic-theme-fixes.config: Fixed digikey logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7307,6 +7307,15 @@ body.not-front {
 
 ================================
 
+digikey.*
+
+CSS
+.flymenu .header__top .logo-wrapper .header__logo {
+    background-image: url("/-/media/Images/Header/logo_dk.png");
+}
+
+================================
+
 digitalextremes.zendesk.com
 
 INVERT


### PR DESCRIPTION
Added digikey.* to config.
Now using default website logo, as auto-generated one looks washed out.