### PR TITLE
Update for specific site

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21070,7 +21070,14 @@ realmicentral.com
 INVERT
 img[itemprop="logo"]
 div.fly-but-wrap.left.relative > span
+================================
 
+recupere.azurewebsites.net
+
+CSS
+.svg-inline--fa {
+    filter: invert(0%) !important;
+}
 ================================
 
 redbubble.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21070,6 +21070,7 @@ realmicentral.com
 INVERT
 img[itemprop="logo"]
 div.fly-but-wrap.left.relative > span
+
 ================================
 
 recupere.azurewebsites.net
@@ -21078,6 +21079,7 @@ CSS
 .svg-inline--fa {
     filter: invert(0%) !important;
 }
+
 ================================
 
 redbubble.com


### PR DESCRIPTION
SVG icons were turning dark instead of remaining white, for better visibility, for both light and dark themes.

As seen here: 
![image](https://github.com/darkreader/darkreader/assets/18279534/1a96870b-9648-4142-bb60-f81cfdc09b7e)                             ![image](https://github.com/darkreader/darkreader/assets/18279534/50de6563-d14a-444d-9eb8-2811968f728c)
