### PR TITLE
dynamic fixes: Fix make.com on/off button

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15748,6 +15748,7 @@ IGNORE INLINE STYLE
 
 ================================
 
+make.com
 *.make.com
 
 CSS


### PR DESCRIPTION
Makes toggle buttons to activate scenarios much clearer (important to know which is which!), and more similar to the light mode formatting.

Before:
<img width="1108" alt="Screenshot 2024-05-03 at 01 59 44" src="https://github.com/darkreader/darkreader/assets/4953590/89d10f11-4dcd-4135-846e-f669ed6722b3">

After:
<img width="1108" alt="Screenshot 2024-05-03 at 01 59 03" src="https://github.com/darkreader/darkreader/assets/4953590/982a4a23-46f6-4f80-8edf-69780cbdaab1">

Light mode for comparison:
<img width="1108" alt="Screenshot 2024-05-03 at 02 00 54" src="https://github.com/darkreader/darkreader/assets/4953590/77404bd9-3924-452b-aef4-3f6f6f6320f5">