### PR TITLE
Add dynamic theme fix for `elitepvpers.com`

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8721,7 +8721,7 @@ td[id="navstart"],
 td[id="userbarbg"],
 td[id="navbg"],
 td[id="navstart"] {
-    background-color: #35383A;
+    background-color: color-mix(in srgb, var(--darkreader-neutral-text) 10%, var(--darkreader-neutral-background) 90%) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8684,6 +8684,50 @@ INVERT
 
 ================================
 
+elitepvpers.com
+
+CSS
+body,
+td[id="userbarbg"],
+.alt1,
+.alt1Active,
+.alt2,
+.alt2Active,
+.panel,
+.panelsurround,
+.thead,
+.vBulletin_editor,
+.fieldset,
+.ticker,
+#contentshadowwhite,
+td[id="navbg"],
+td[id="navstart"],
+.cwalt {
+    background-image: none !important;
+}
+.alt1,
+.alt1Active,
+.alt2,
+.alt2Active,
+.panel,
+.panelsurround,
+.thead,
+.vBulletin_editor,
+.fieldset {
+    border-color: var(--darkreader-neutral-background) !important;
+}
+.ticker,
+#contentshadowwhite {
+    border-color: var(--darkreader-neutral-background) !important;
+}
+td[id="userbarbg"],
+td[id="navbg"],
+td[id="navstart"] {
+    background-color: #35383A;
+}
+
+================================
+
 elle.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8713,9 +8713,7 @@ td[id="navstart"],
 .panelsurround,
 .thead,
 .vBulletin_editor,
-.fieldset {
-    border-color: var(--darkreader-neutral-background) !important;
-}
+.fieldset,
 .ticker,
 #contentshadowwhite {
     border-color: var(--darkreader-neutral-background) !important;


### PR DESCRIPTION
This commit adds fixes for the dynamic theme on elitepvpers.com.

<details><summary>Screenshots: No patch applied</summary>
<p>

![image](https://github.com/darkreader/darkreader/assets/6305520/ff3cda90-f417-4afa-92a4-e1d0b4e24d7a)
*(thread view)*

![image](https://github.com/darkreader/darkreader/assets/6305520/71bcd5d7-5b3c-448d-8c8b-1871b822236e)
*(forum view)*

![image](https://github.com/darkreader/darkreader/assets/6305520/ba462bc6-bf31-4574-9b73-2ea21f9c2c9f)
*(quick reply)*

</p>
</details> 

<details><summary>Screenshots: Patch applied</summary>
<p>

![image](https://github.com/darkreader/darkreader/assets/6305520/374297bb-3a54-46ca-ac32-421b89b714bd)
*(thread view)*

![image](https://github.com/darkreader/darkreader/assets/6305520/c420af35-14d1-4604-bc1a-9dbbfe301f67)
*(forum view)*

![image](https://github.com/darkreader/darkreader/assets/6305520/40cf69fa-c93a-4206-9482-05ebc182c320)
*(quick reply)*

</p>
</details> 


As you can see, by default the site behaves badly under "Dynamic" mode due to heavy abuse of background images. Loading the website also causes a lot of screen flashes.

This patch addresses only the most annoying issues of the site (background images leaking into content views, flashbangs while loading the page, etc.)