### PR TITLE
Fix for fandom.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9398,6 +9398,7 @@ div.drm-container svg g
 fandom.com
 
 INVERT
+.mobile-global-navigation__logo
 .wds-global-navigation__logo-fandom
 a[href^="https://auth.fandom.com/auth/redirect?redirect="][data-test="back-button"]
 


### PR DESCRIPTION
Fixes logo on mobile view.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/aa246338-c5ee-4d91-9b48-b3bfa22305bb)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/8fd458a7-dd4d-428d-88cb-685c99009e0c)