### PR TITLE
Fix for brucebase.wikidot.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4185,6 +4185,20 @@ body {
 
 ================================
 
+brucebase.wikidot.com
+
+CSS
+.yui-nav li em {
+    color: var(--darkreader-neutral-text) !important;
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.yui-nav .selected a em {
+    color: var(--darkreader-selection-text) !important;
+    background-color: var(--darkreader-selection-background) !important;
+}
+
+================================
+
 bsi.bund.de
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4189,12 +4189,12 @@ brucebase.wikidot.com
 
 CSS
 .yui-nav li em {
-    color: var(--darkreader-neutral-text) !important;
     background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
 }
 .yui-nav .selected a em {
-    color: var(--darkreader-selection-text) !important;
     background-color: var(--darkreader-selection-background) !important;
+    color: var(--darkreader-selection-text) !important;
 }
 
 ================================


### PR DESCRIPTION
Website: brucebase.wikidot.com

Issue
This site makes use of tabs on their pages. But they are not themed correctly in the dynamic theme. Normally, unselected is black text/white bg, and selected is white text/blue bg. Dynamic theme changes the "selected" text color, but the unselected tabs are not changed. Which means white text/white bg.

I made fixes to properly theme these tab elements, making sure to correct the text color on both unselected and selected tabs.

This works on both light and dark modes as well.