### PR TITLE
Add circuits.vcn.com to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5257,6 +5257,22 @@ INVERT
 
 ================================
 
+circuits.vcn.com
+
+INVERT
+img
+
+CSS
+select {
+    background-color: #121212 !important;
+    color: #e6e3ea !important;
+}
+img {
+    background-color: #e6e3ea !important;
+}
+
+================================
+
 cisce.org
 
 INVERT


### PR DESCRIPTION
This makes images on a site that my company uses for work more readable in dark mode. It also makes selection boxes readable. Since this is a private access website, I understand if this won't be accepted, but I'm not sure how to make the changes automatically apply when I open up the site for the first time without having to go into dev tools and apply them there. Other users of the site at my company would appreciate this very much, since not everyone is technical enough to figure this out. Let me know if you want pictures of how this looks in dark mode and light mode, or if you need anything else.