### PR TITLE
[Feature] Improve Font replacement

### DIFF
--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -4,7 +4,7 @@ export function createTextStyle(config: Theme): string {
     const lines: string[] = [];
     // Don't target pre elements as they are preformatted element's e.g. code blocks
     // Exclude font libraries to preserve icons
-    lines.push('*:not(pre, pre *, code, .far, .fa, .glyphicon, [class*="vjs-"], .fab, .fa-github, .fas, .material-icons, .icofont, .typcn, mu, [class*="mu-"], .glyphicon, .icon) {');
+    lines.push('*:not(pre, pre *, code, [aria-hidden="true"], .far, .fa, i[class*="fa-"] .glyphicon, [class*="vjs-"], .fab, .fas, .material-icons, .icofont, .typcn, mu, [class*="mu-"], .glyphicon, .icon) {');
 
     if (config.useFont && config.fontFamily) {
         // TODO: Validate...


### PR DESCRIPTION
In this draft PR, I plan to fix some global issues with font replacement.

Currently there are multiple issues with replacing the font globally:
- Icon fonts aren't exhaustively excluded, leading to replacement characters being commonly displayed
- Complex code viewers and editors break when using a non-monospaced font
In GitHub.com's editor for example, sometimes the code text will be using the replacement font but sometimes it won't.
Selecting text inside the editor with an active replacement font, will still have GitHub's font as the "selection" font and will result in an incorrect cursor position.

I want to implement the following:
- Improve detection of icon fonts (first progress https://github.com/darkreader/darkreader/commit/4bee8fa9ff2c329290209f4c412834a1d730ad89)
- Improve detection of monospaced fonts
- Introduce hot fixes for large/planet scale sites like GitHub (wip)

Currently this feature is implemented naively in `createTextStyle`.
I think it might be interesting to expand on this feature by:
- Detecting monospaced fonts
- Detecting emoji/icon fonts

This could be done possibly by either checking the name (e.g. is font family `ui-monospace`, `Consolas`, ...`), actually analyzing the font's glyphs programmatically or rendering it to see if it displays correctly. Fallback: Don't replace font.

This would allow to offer a much more granular control over font replacement, for example based on the standard CSS font-family aliases `ui-*`, `emoji`, `math`, etc.