### PR TITLE
fix: update dynamic theme fixes for GitHub.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11005,9 +11005,11 @@ CSS
 img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
 }
+.commit-ref,
+span.commit-ref > a,
+span.commit-ref > a > *,
 code > a[class="Link--secondary"],
 .pr-1 > code > a,
-span[class="css-truncate-target"],
 .text-mono *,
 .CodeMirror pre > span,
 .CodeMirror-linenumber,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11005,6 +11005,8 @@ CSS
 img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
 }
+.pr-1 *,
+span[class="css-truncate-target"],
 .text-mono *,
 .CodeMirror pre > span,
 .CodeMirror-linenumber,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11005,7 +11005,8 @@ CSS
 img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
 }
-.pr-1 *,
+code > a[class="Link--secondary"],
+.pr-1 > code > a,
 span[class="css-truncate-target"],
 .text-mono *,
 .CodeMirror pre > span,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11005,11 +11005,14 @@ CSS
 img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
 }
+.text-mono *,
 .blob-code-inner,
 .blob-code-inner > *,
 .CodeMirror pre > span,
-.CodeMirror-linenumber {
-    font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace !important;
+.CodeMirror-linenumber,
+section[aria-labelledby] *,
+[aria-labelledby*="codemirror"] * {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;
 }
 #commit-activity-detail > svg {
     fill: ${black} !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10949,6 +10949,19 @@ INVERT
 .mx-lg-auto.col-lg-7.col-12
 
 CSS
+.commit-ref,
+span.commit-ref > a,
+span.commit-ref > a > *,
+code > a[class="Link--secondary"],
+.pr-1 > code > a,
+.text-mono *,
+.CodeMirror pre > span,
+.CodeMirror-linenumber,
+[class*="blob-code"] *,
+[aria-labelledby*="codemirror"] *,
+section[aria-labelledby] * {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;
+}
 .markdown-body code,
 .markdown-title code {
     background-color: ${rgba(27, 31, 35, 0.1)} !important;
@@ -11004,19 +11017,6 @@ CSS
 #network canvas,
 img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
-}
-.commit-ref,
-span.commit-ref > a,
-span.commit-ref > a > *,
-code > a[class="Link--secondary"],
-.pr-1 > code > a,
-.text-mono *,
-.CodeMirror pre > span,
-.CodeMirror-linenumber,
-[class*="blob-code"] *,
-[aria-labelledby*="codemirror"] *,
-section[aria-labelledby] * {
-    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;
 }
 #commit-activity-detail > svg {
     fill: ${black} !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11006,12 +11006,11 @@ img.network-tree {
     filter: invert(94.4%) hue-rotate(180deg) contrast(90%) !important;
 }
 .text-mono *,
-.blob-code-inner,
-.blob-code-inner > *,
 .CodeMirror pre > span,
 .CodeMirror-linenumber,
-section[aria-labelledby] *,
-[aria-labelledby*="codemirror"] * {
+[class*="blob-code"] *,
+[aria-labelledby*="codemirror"] *,
+section[aria-labelledby] * {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;
 }
 #commit-activity-detail > svg {


### PR DESCRIPTION
This commit addresses various issues caused by dynamic font replacement on GitHub.com.

### Editor view
![image](https://github.com/darkreader/darkreader/assets/6305520/73c1186a-295e-4874-b875-9542ebbd9b71)
---
![image](https://github.com/darkreader/darkreader/assets/6305520/1aa9dce3-c367-4af3-942e-f45452b6b50f)

### PR view
![image](https://github.com/darkreader/darkreader/assets/6305520/418d4b25-cde3-4a92-aa4e-7451db37476d)
---
![image](https://github.com/darkreader/darkreader/assets/6305520/6041956a-a067-46c7-9e5c-d0210d145112)