### PR TITLE
fixed gamepress.gg background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10562,6 +10562,9 @@ CSS
 .TLW-tier-charname {
     color: ${black} !important;
 }
+#content-inner {
+    background-image: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
Gamepress's background makes it hard to read in dark mode. It is better to remove it as removing it does not affect browsing experience and improves readability.

Before: 
![Screenshot 2024-05-08 at 02-03-58 Learning With Manga Collab - Walkthrough](https://github.com/darkreader/darkreader/assets/9978161/27063e2a-f866-4b88-a378-ddcb2c933bc7)

After: 
![Screenshot 2024-05-08 at 02-05-09 Learning With Manga Collab - Walkthrough](https://github.com/darkreader/darkreader/assets/9978161/54569b92-66d1-46df-bd4e-b433ae8743a7)
