### PR TITLE
fix: dynamic mode on `emojipedia.org`

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8820,9 +8820,7 @@ body {
 emojipedia.org
 
 CSS
-div.sticky,
-main,
-aside {
+main {
     background-color: ${#e9e9e9} !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8817,6 +8817,17 @@ body {
 
 ================================
 
+emojipedia.org
+
+CSS
+div.sticky,
+main,
+aside {
+    background-color: ${#e9e9e9} !important;
+}
+
+================================
+
 endeavouros.com
 
 INVERT


### PR DESCRIPTION
The site has a regular dark mode but overriding with dynamic mode breaks the site and adds a mismatched segment.
Just changing based on `main` seems to be the best option the other stuff causes extra issues, this ones rly weird.

This also fixes the pop-up which in default dark mode is a white flash bang.