### PR TITLE
Update dynamic-theme-fixes.config for `auth0.openai.com` (ChatGPT)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2510,6 +2510,13 @@ button[data-handler="authorise-github"] > img.icon.icon-default
 
 ================================
 
+auth0.openai.com/u/login
+
+INVERT
+._prompt-box-outer > div
+
+================================
+
 autodesk.com
 
 INVERT


### PR DESCRIPTION
Fixes the login page for ChatGPT.
To get to the faulty website it seems one has to go to [https://chatgpt.com/auth/login](https://chatgpt.com/auth/login), click `Login`, on the next site you can press `Continue` without inserting a email address, it then redirects to the faulty site [https://auth0.openai.com/u/login/identifier](https://auth0.openai.com/u/login/identifier) (or to [https://auth0.openai.com/u/login/password](https://auth0.openai.com/u/login/password) when you specified an email address). Without going this route it just says `Oops!, something went wrong`.

I only added `auth0.openai.com/u/login`, so it works on the `identifier` and `password` page.

Before:
![image](https://github.com/darkreader/darkreader/assets/991866/81db4ea1-1cf4-4f58-be66-be0081fd2b5a)

After:
![image](https://github.com/darkreader/darkreader/assets/991866/72849b69-c62c-4b1f-ac2b-a273824f2bbb)
