### PR TITLE
Add musedash.moe to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -692,6 +692,7 @@ mrquantumoff.dev
 ms-paint-i.de
 mtv.com
 mulv.tycrek.dev
+musedash.moe
 music.com
 music.youtube.com
 muttwizard.com


### PR DESCRIPTION
This website has a dark theme by default, so I added it to the list.

Furthermore, having Dark Reader enabled breaks the site (the leaderboards don't ever load). I have not investigated the cause of the issue, but it may be worth to take a look at, since it may also be breaking other sites. I opened a ticket for it.