### PR TITLE
Fix for passport.jd.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19568,6 +19568,15 @@ CSS
 
 ================================
 
+passport.jd.com
+
+CSS
+.qrcode-img {
+    background: white !important;
+}
+
+================================
+
 passport.yandex.*
 
 CSS


### PR DESCRIPTION
Make the padding of the qr code white, or their official client won't recognize the qr code.