### PR TITLE
Remove unnecessary entries from dynamic theme fixes [icon fonts]

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -86,24 +86,12 @@ svg line.messageLine1 {
 div.mermaid .actor {
     fill: var(--darkreader-neutral-background) !important;
 }
-.google-material-icons {
-    font-family: 'Google Material Icons' !important;
-}
-.google-symbols {
-    font-family: 'Google Symbols Subset', 'Google Symbols' !important;
-}
-.material-icons-extended {
-    font-family: 'Material Icons Extended' !important;
-}
 mitid-authenticators-code-app > .code-app-container {
     background-color: white !important;
     padding-top: 1rem;
 }
 iframe#unpaywall[src$="unpaywall.html"] {
     color-scheme: light !important;
-}
-.oui-icon {
-    font-family: 'Oui Icons' !important;
 }
 
 IGNORE INLINE STYLE

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -12,9 +12,7 @@ const excludedSelectors = [
     // Generic matches for icon/symbol fonts
     '.icofont', '[style*="font-"]',
     '[class*="icon"]', '[class*="Icon"]',
-    '[class*="icons"]', '[class*="Icons"]',
     '[class*="symbol"]', '[class*="Symbol"]',
-    '[class*="symbols"]', '[class*="Symbols"]',
 
     // Glyph Icons
     '.glyphicon',

--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -12,7 +12,9 @@ const excludedSelectors = [
     // Generic matches for icon/symbol fonts
     '.icofont', '[style*="font-"]',
     '[class*="icon"]', '[class*="Icon"]',
+    '[class*="icons"]', '[class*="Icons"]',
     '[class*="symbol"]', '[class*="Symbol"]',
+    '[class*="symbols"]', '[class*="Symbols"]',
 
     // Glyph Icons
     '.glyphicon',


### PR DESCRIPTION
This PR aims to remove now unnecessary entries from the dynamic theme fixes.
These are no longer necessary as now `*icon*` and `*symbol*` are not being overridden by dynamic theme replacement.

_Naturally we don't need the plural variants cause it's already 💯_ 