### PR TITLE
Unify Wikimedia Foundation websites fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28136,6 +28136,8 @@ INVERT
 
 ================================
 
+wikimedia.de
+*.wikimedia.de
 wikimediastatus.net
 *.wikimediastatus.net
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28013,10 +28013,14 @@ wikivoyage.org
 *.wikivoyage.org
 
 INVERT
+#main_menu > li:not(.lang_btn) > img.logo_img ~ i
 #p-logo-text
+.article_btn .drop_down li a > i
 .bookend
+.central-featured-logo-text
 .central-textlogo
 .central-textlogo__image
+.feedback_btn .drop_down li a > i
 .locmap .pl
 .locmap .pr
 .logo
@@ -28036,17 +28040,23 @@ INVERT
 .mwe-math-fallback-image-inline
 .nav-logo
 .svg-Wikimedia-logo_black
+.title_icon
 .toc-title-icon
 .tool.tool-button[src$="background-image:"]
 .wd-mp-headerimage
+.zh-glyph img
 body > .oo-ui-windowManager .vega .marks
 div.post-content.footer-content > h2 > img
 header .branding-box > a > span > img
+img.immediate:not(.ntmb)
+img.logo_img
 img[alt="Video Camera Icon.svg"]
 img[alt="audio speaker icon"]
 img[alt="logo Wikisource"]
 img[src*="Wiktionary-logo"]
 img[src="images/black.png"]
+li.menu-tooltip:not(.lang_btn)
+td.icon
 
 CSS
 .mwe-popups-discreet > img,
@@ -28132,6 +28142,9 @@ div.locked-warning {
     background-color: ${#ffa9a9} !important;
     border-color: ${#ffa1a1} !important;
 }
+div.NavFrame div.NavHead {
+    background-image: none !important;
+}
 
 IGNORE INLINE STYLE
 #on_image_elements span
@@ -28143,38 +28156,6 @@ IGNORE IMAGE ANALYSIS
 .mf-icon-expand
 .mw-wiki-logo
 .toc-title-icon
-
-================================
-
-wikiwand.com
-
-INVERT
-.mwe-math-fallback-image-inline
-.mwe-math-fallback-image-display
-img.immediate:not(.ntmb)
-.title_icon
-img.logo_img
-td.icon
-li.menu-tooltip:not(.lang_btn)
-#main_menu > li:not(.lang_btn) > img.logo_img ~ i
-.article_btn .drop_down li a > i
-.feedback_btn .drop_down li a > i
-
-================================
-
-wiktionary.org
-
-INVERT
-.bookend
-.central-featured-logo-text
-.zh-glyph img
-img[alt="audio speaker icon"]
-.mw-logo-wordmark
-
-CSS
-div.NavFrame div.NavHead {
-    background-image: none !important;
-}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27959,6 +27959,8 @@ wikibooks.org
 *.wikibooks.org
 wikidata.org
 *.wikidata.org
+wikiless.org
+*.wikiless.org
 wikimedia.org
 *.wikimedia.org
 wikimediafoundation.org

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28011,6 +28011,8 @@ wikiversity.org
 *.wikiversity.org
 wikivoyage.org
 *.wikivoyage.org
+wikiwand.com
+*.wikiwand.com
 
 INVERT
 #main_menu > li:not(.lang_btn) > img.logo_img ~ i

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28005,10 +28005,17 @@ wikipedia.org
 *.wikipedia.org
 wikiquote.org
 *.wikiquote.org
+wikisource.org
+*.wikisource.org
+wikiversity.org
+*.wikiversity.org
+wikivoyage.org
+*.wikivoyage.org
 
 INVERT
 #p-logo-text
 .bookend
+.central-textlogo
 .central-textlogo__image
 .locmap .pl
 .locmap .pr
@@ -28035,7 +28042,9 @@ INVERT
 body > .oo-ui-windowManager .vega .marks
 div.post-content.footer-content > h2 > img
 header .branding-box > a > span > img
+img[alt="Video Camera Icon.svg"]
 img[alt="audio speaker icon"]
+img[alt="logo Wikisource"]
 img[src*="Wiktionary-logo"]
 img[src="images/black.png"]
 
@@ -28134,32 +28143,6 @@ IGNORE IMAGE ANALYSIS
 .mf-icon-expand
 .mw-wiki-logo
 .toc-title-icon
-
-================================
-
-wikisource.org
-wikiversity.org
-wikivoyage.org
-
-INVERT
-.mwe-math-fallback-image-inline
-.mwe-math-fallback-image-display
-.mw-wiki-logo
-.central-textlogo
-img[alt="logo Wikisource"]
-img[alt="Video Camera Icon.svg"]
-img[alt="audio speaker icon"]
-
-================================
-
-wikitech.wikimedia.org
-
-INVERT
-img[alt="audio speaker icon"]
-#p-logo-text
-
-IGNORE IMAGE ANALYSIS
-.mw.wiki-logo
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5874,21 +5874,6 @@ INVERT
 
 ================================
 
-commons.wikimedia.org
-
-INVERT
-.mwe-math-fallback-image-inline
-.mwe-math-fallback-image-display
-.mw-mmv-filepage-buttons .mw-mmv-view-expanded .mw-ui-icon::before
-.mw-mmv-filepage-buttons .mw-mmv-view-config .mw-ui-icon::before
-.licensetpl td[style^="width"]
-img[alt="audio speaker icon"]
-
-IGNORE IMAGE ANALYSIS
-.mw-wiki-logo
-
-================================
-
 commonvoice.mozilla.org
 
 INVERT
@@ -13062,13 +13047,6 @@ instructure.com
 INVERT
 .equation_image
 .Page-container
-
-================================
-
-integration.wikimedia.org
-
-INVERT
-img.graphite-graph
 
 ================================
 
@@ -27981,6 +27959,8 @@ wikibooks.org
 *.wikibooks.org
 wikidata.org
 *.wikidata.org
+wikimedia.org
+*.wikimedia.org
 wikimediafoundation.org
 *.wikimediafoundation.org
 wikinews.org
@@ -28007,6 +27987,7 @@ INVERT
 .central-textlogo
 .central-textlogo__image
 .feedback_btn .drop_down li a > i
+.licensetpl td[style^="width"]
 .locmap .pl
 .locmap .pr
 .logo
@@ -28021,6 +28002,8 @@ INVERT
 .mw-kartographer-mapDialog-map
 .mw-logo-tagline
 .mw-logo-wordmark
+.mw-mmv-filepage-buttons .mw-mmv-view-config .mw-ui-icon::before
+.mw-mmv-filepage-buttons .mw-mmv-view-expanded .mw-ui-icon::before
 .mw-wiki-logo
 .mwe-math-fallback-image-display
 .mwe-math-fallback-image-inline
@@ -28034,6 +28017,7 @@ INVERT
 body > .oo-ui-windowManager .vega .marks
 div.post-content.footer-content > h2 > img
 header .branding-box > a > span > img
+img.graphite-graph
 img.immediate:not(.ntmb)
 img.logo_img
 img[alt="Video Camera Icon.svg"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27977,34 +27977,6 @@ CSS
 
 ================================
 
-wikibooks.org
-*.wikibooks.org
-
-INVERT
-.mwe-math-fallback-image-inline
-.mwe-math-fallback-image-display
-.bookend
-img[alt="audio speaker icon"]
-
-IGNORE INLINE STYLE
-.infobox td
-
-================================
-
-wikidata.org
-*.wikidata.org
-
-INVERT
-.mwe-math-fallback-image-inline
-.mwe-math-fallback-image-display
-.wd-mp-headerimage
-img[alt="audio speaker icon"]
-
-IGNORE IMAGE ANALYSIS
-.mw-wiki-logo
-
-================================
-
 wikimapia.org
 
 INVERT
@@ -28012,88 +27984,60 @@ INVERT
 
 ================================
 
-wikimedia.de
+wikimediastatus.net
+*.wikimediastatus.net
 
 INVERT
 .logo
-
-================================
-
-wikimedia.org
-*.wikimedia.org
-
-INVERT
-img[src="images/black.png"]
-img[alt="audio speaker icon"]
-
-CSS
-div.mw-warning-with-logexcerpt,
-div.mw-lag-warn-high,
-div.mw-cascadeprotectedwarning,
-div#mw-protect-cascadeon,
-div.titleblacklist-warning,
-div.locked-warning {
-    background-color: ${#ffa9a9} !important;
-    border-color: ${#ffa1a1} !important;
-}
-
-================================
-
-wikimediafoundation.org
-
-INVERT
-.nav-logo
-
-================================
-
-wikimediastatus.net
-
-INVERT
 .logo-container
 
 ================================
 
+wikibooks.org
+*.wikibooks.org
+wikidata.org
+*.wikidata.org
+wikimediafoundation.org
+*.wikimediafoundation.org
 wikinews.org
-wikiquote.org
 *.wikinews.org
+wikipedia.org
+*.wikipedia.org
+wikiquote.org
 *.wikiquote.org
 
 INVERT
-.bookend
-img[alt="audio speaker icon"]
-
-================================
-
-wikipedia.org
-wikiless.org
-*.wikipedia.org
-
-INVERT
-.mwe-math-fallback-image-inline
-.mwe-math-fallback-image-display
-.mw-ext-score
-.mw-logo-wordmark
-.mw-logo-tagline
-.mw-wiki-logo
-.central-textlogo__image
-.svg-Wikimedia-logo_black
-header .branding-box > a > span > img
-.main-footer-menuToggle
-div.post-content.footer-content > h2 > img
-.mw-hiero-outer.mw-hiero-table
 #p-logo-text
-body > .oo-ui-windowManager .vega .marks
-.minerva-footer-logo img
-.music-symbol img
-.tool.tool-button[src$="background-image:"]
-.mw-kartographer-map
-.mw-kartographer-mapDialog-map
-img[alt="audio speaker icon"]
-img[src*="Wiktionary-logo"]
+.bookend
+.central-textlogo__image
 .locmap .pl
 .locmap .pr
+.logo
+.logo-container
+.main-footer-menuToggle
 .mf-icon-expand
+.minerva-footer-logo img
+.music-symbol img
+.mw-ext-score
+.mw-hiero-outer.mw-hiero-table
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.mw-logo-tagline
+.mw-logo-wordmark
+.mw-wiki-logo
+.mwe-math-fallback-image-display
+.mwe-math-fallback-image-inline
+.nav-logo
+.svg-Wikimedia-logo_black
 .toc-title-icon
+.tool.tool-button[src$="background-image:"]
+.wd-mp-headerimage
+body > .oo-ui-windowManager .vega .marks
+div.post-content.footer-content > h2 > img
+header .branding-box > a > span > img
+img[alt="audio speaker icon"]
+img[src*="Wiktionary-logo"]
+img[src="images/black.png"]
 
 CSS
 .mwe-popups-discreet > img,
@@ -28170,14 +28114,25 @@ button[class*=mw-mmv-]:not(.cdx-button),
 a[role="button"][class*=mw-mmv-] {
     background-color: white !important;
 }
+div.mw-warning-with-logexcerpt,
+div.mw-lag-warn-high,
+div.mw-cascadeprotectedwarning,
+div#mw-protect-cascadeon,
+div.titleblacklist-warning,
+div.locked-warning {
+    background-color: ${#ffa9a9} !important;
+    border-color: ${#ffa1a1} !important;
+}
 
 IGNORE INLINE STYLE
-.legend-color:not(table.wikitable .legend-color)
 #on_image_elements span
+.infobox td
+.legend-color:not(table.wikitable .legend-color)
 
 IGNORE IMAGE ANALYSIS
 .k-player .k-menu-bar li a
 .mf-icon-expand
+.mw-wiki-logo
 .toc-title-icon
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27977,22 +27977,6 @@ CSS
 
 ================================
 
-wikimapia.org
-
-INVERT
-#map
-
-================================
-
-wikimediastatus.net
-*.wikimediastatus.net
-
-INVERT
-.logo
-.logo-container
-
-================================
-
 wikibooks.org
 *.wikibooks.org
 wikidata.org
@@ -28158,6 +28142,22 @@ IGNORE IMAGE ANALYSIS
 .mf-icon-expand
 .mw-wiki-logo
 .toc-title-icon
+
+================================
+
+wikimapia.org
+
+INVERT
+#map
+
+================================
+
+wikimediastatus.net
+*.wikimediastatus.net
+
+INVERT
+.logo
+.logo-container
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2995,6 +2995,8 @@ wikibooks.org
 *.wikibooks.org
 wikidata.org
 *.wikidata.org
+wikiless.org
+*.wikiless.org
 wikimedia.org
 *.wikimedia.org
 wikimediafoundation.org

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -3003,6 +3003,12 @@ wikipedia.org
 *.wikipedia.org
 wikiquote.org
 *.wikiquote.org
+wikisource.org
+*.wikisource.org
+wikiversity.org
+*.wikiversity.org
+wikivoyage.org
+*.wikivoyage.org
 
 INVERT
 .mwe-popups-discreet > svg

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2995,6 +2995,8 @@ wikibooks.org
 *.wikibooks.org
 wikidata.org
 *.wikidata.org
+wikimedia.org
+*.wikimedia.org
 wikimediafoundation.org
 *.wikimediafoundation.org
 wikinews.org

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -3009,6 +3009,8 @@ wikiversity.org
 *.wikiversity.org
 wikivoyage.org
 *.wikivoyage.org
+wikiwand.com
+*.wikiwand.com
 
 INVERT
 .mwe-popups-discreet > svg

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2991,8 +2991,18 @@ CSS
 
 ================================
 
+wikibooks.org
+*.wikibooks.org
+wikidata.org
+*.wikidata.org
+wikimediafoundation.org
+*.wikimediafoundation.org
+wikinews.org
+*.wikinews.org
 wikipedia.org
 *.wikipedia.org
+wikiquote.org
+*.wikiquote.org
 
 INVERT
 .mwe-popups-discreet > svg


### PR DESCRIPTION
This pull request unifies all websites fixes for Wikimedia Foundation websites and related websites (Wikipedia, Wikimedia etc.).

All the following websites now share the same fixes, because they use the same layout (due to MediaWiki software):
```
wikibooks.org
*.wikibooks.org
wikidata.org
*.wikidata.org
wikimediafoundation.org
*.wikimediafoundation.org
wikinews.org
*.wikinews.org
wikipedia.org
*.wikipedia.org
wikiquote.org
*.wikiquote.org
wikisource.org
*.wikisource.org
wikiversity.org
*.wikiversity.org
wikivoyage.org
*.wikivoyage.org
wikiwand.com
*.wikiwand.com
```

For `wikimediastatus.net`, I choose to keep it separate and also added `*.wikimediastatus.net`, and also `.logo` to the `INVERT` section alongside `.logo-container` (based on the other fixes).

I sorted the lines alphabetically and removed duplicates.

The pull request is complete, but there's some duplicates in different sections that I'm not sure which one I should keep:

`dynamic-theme-fixes.config`
For all Wikimedia Foundation websites, the following are repeated in `INVERT` and `IGNORE IMAGE ANALYSIS`:
```
.mf-icon-expand
.mw-wiki-logo
.toc-title-icon
```

Which one should be prioritized? `INVERT` or `IGNORE IMAGE ANALYSIS`? Or can both exist at the same time with the same elements?

Thanks in advance for your attention.