### PR TITLE
Fix mediawiki equations on vasp.at

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26751,6 +26751,14 @@ CSS
 
 ================================
 
+vasp.at
+
+INVERT
+.mwe-math-fallback-image-inline
+.mwe-math-fallback-image-display
+
+================================
+
 vbulletin.com
 
 CSS


### PR DESCRIPTION
Like on other mediawiki pages, equations from math environments are not correctly inverted.