### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25287,7 +25287,8 @@ a[data-link-name$="logo"] svg
 a[href="https://www.theguardian.com/documentaries"] > svg
 .crossword__grid .crossword__cell-text
 .crossword__cell-number
-ol[data-link-name="Most viewed"] > li > a > span > svg
+section[data-link-name="deeply-read"] > ol > li > a > span > svg
+section[data-link-name="most-viewed"] > ol > li > a > span > svg
 
 CSS
 section[id="documentaries"] p {


### PR DESCRIPTION
- Updates fix in #12365 for "Most viewed" section on home page.
- Fixes "Deeply read" section on home page.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/2cb1ebfe-7f52-4fb6-8526-be9bf321523f)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/818491ce-7900-4c79-ab31-8621b17b1345)