### PR TITLE
Added a site syntax fix for https://cpulator.01xz.net/ in dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6288,11 +6288,15 @@ cpulator.01xz.net
 
 INVERT
 .terminal-cursor
+.cm-s-neat span.cm-tag
 
 CSS
 div.dev_uart_term .terminal-cursor {
     background: var(--darkreader-neutral-background) !important;
     color: var(--darkreader-neutral-text) !important;
+}
+.cm-s-neat span.cm-tag {
+    color: #006000;
 }
 
 ================================


### PR DESCRIPTION
Changed the code syntax so that it looks the same with both dark reader on and off