### PR TITLE
Invert code blocks on claude.ai

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -361,6 +361,13 @@ INVERT
 
 ================================
 
+claude.ai
+
+INVERT
+pre .code-block__code
+
+================================
+
 cloud-catcher.squiddev.cc
 
 INVERT


### PR DESCRIPTION
Code blocks are currently not inverted on claude.ai when using Filter and Filter+ modes. This fixes that.

Before:
![Screenshot 2024-05-28 at 16 20 01](https://github.com/darkreader/darkreader/assets/17463710/7dc5694a-7f8c-4b33-b942-04484d4e242b)

After:
![Screenshot 2024-05-28 at 16 19 42](https://github.com/darkreader/darkreader/assets/17463710/cb868fc9-9b39-4197-ac07-7415c69ddc9a)
