### PR TITLE
Update dynamic-theme-fixes.config for Google Voice

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27167,6 +27167,15 @@ img[alt="serwisy tvp"]
 
 ================================
 
+voice.google.com
+
+CSS
+.gb_sd.gb_ld {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 voltalbania.org
 voltbelgium.org
 voltdanmark.org


### PR DESCRIPTION
The header on Google Voice was no longer being affected. It now gets `darkreader-neutral-background` applied.