### PR TITLE
Update dynamic-theme-fixes.config for musicmakers.ru

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17465,6 +17465,13 @@ body:not(.dark-mode) .dt-search-box__icon
 
 ================================
 
+musicmakers.ru
+
+INVERT
+#menubtn > *
+
+================================
+
 musictheory.net
 
 INVERT


### PR DESCRIPTION
Left menu navbar's centre button had near-zero contrast - small fix using INVERT for icon