### PR TITLE
analyzeSVGAsImage: workaround for SVGs containing non-Latin1 characters.

### DIFF
--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -377,7 +377,7 @@ export function overrideInlineStyle(element: HTMLElement, theme: Theme, ignoreIn
             const analyzeSVGAsImage = () => {
                 let svgString = svg.outerHTML;
                 svgString = svgString.replaceAll('<style class="darkreader darkreader--sync" media="screen"></style>', '');
-                const dataURL = `data:image/svg+xml;base64,${btoa(svgString)}`;
+                const dataURL = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgString)))}`;
                 getImageDetails(dataURL).then((details) => {
                     if (
                         (details.isDark && details.isTransparent) ||


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/webappapis.html#atob The function btoa()/atob() does not support Unicode characters outside the range of Latin1. (0x00-0xFF)

So if any part of the svg contains Unicode characters outside that range, btoa will fail. This will cause analyzeSVGAsImage() to throw an exception:

<img width="940" alt="screenshot" src="https://github.com/darkreader/darkreader/assets/16161991/37ec9d53-6a1a-47d3-aa96-24cca156c79f">

To test:
```js
// this will throw exception
btoi(`<text x="20" y="35" class="small">中文测试 https://🌍.🏠/</text>`)
```

This pull request adds a workaround `btoa(unescape(encodeURIComponent(svgString)))`, which does:
1. Use `encodeURIComponent()` to escape Unicode characters to `%xx%xx%xx` form.
2. Use `unescape()` to decode those `%` escaped Unicode characters into it's individual component bytes (instead of treating them as a single Unicode character.)
3. feed that into `btoa()`

---

This workaround does produce correctly-encoded base64 data that works with SVG:

```html
<html>
  <head> <meta charset="UTF-8"> </head>
  <body>
    <p>svg element:</p>
    <div id="a"></div>
    <p>img element with "data:image/svg-xml,base64,..." as src:</p>
    <div id="b"></div>

    <script>
      svg=`
      <svg id="图形层1" fill="#000000" height="50px" width="800px" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
        <text x="20" y="35" class="small">中文测试 https://🌍.🏠/?abc=%20%FF&amp;</text>
      </svg>`
      document.getElementById("a").outerHTML = svg
      document.getElementById("b").outerHTML = `
      <img src="data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}">` // the workaround
    </script>
  </body>
</html>
```

<img width="471" alt="screenshot2" src="https://github.com/darkreader/darkreader/assets/16161991/2c8093e2-9bcd-4061-8c42-35fe97404b7c">

However, it does use a deprecated function "unescape()". A solution that does not use the "unescape()" function is described here: https://stackoverflow.com/a/52647441/7509248
```js
function b64EncodeUnicode(str) {
	return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g,
		function toSolidBytes(match, p1) {
			return String.fromCharCode('0x' + p1);
	}));
}
```
This does the same thing, but replaces the "unescape()" step with regex. I didn't benchmark them to see the performance difference though. I also don't imagine "unescape()" being removed from major browsers anytime soon.

Alternatively, we can use `base64-js`, which this project already depends on. But I also don't know about the performance and I wouldn't imagine a pure JS solution would be faster than browser builtins. 