### PR TITLE
Fix for GitHub.com (monospace font)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11008,7 +11008,7 @@ CSS
 [aria-labelledby*="codemirror"] *,
 [class*="blob-code"] *,
 code > a[class="Link--secondary"],
-section[aria-labelledby] > div > div *,
+section[aria-labelledby*="file-name-id"] > div > div *,
 span.commit-ref > a > *,
 span.commit-ref > a {
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace !important;


### PR DESCRIPTION
Fixes an issue with the monospace font incorrectly being applied on GitHub's "Release" page by further restricting the CSS selector.