### PR TITLE
remove mozilla.social from global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -689,7 +689,6 @@ motion-canvas.github.io
 motioncanvas.io
 motz.xyz
 mouse-sensitivity.com
-mozilla.social
 mrdemoapple.uk
 mrms.cz
 mrquantumoff.dev


### PR DESCRIPTION
This site was added in #12125, but mozilla.social doesn't have a dark theme by default, nor does it respect a preferred color scheme. It's running mastodon, so this is very strange (compare mastodon.social, which does respect my preferred color scheme) but this site is bright by default with current darkreader on Firefox for Android and Firefox for Linux.

I find it strange that sites such as mastodon.social are in the global dark list, because the contribution guidelines state that sites may only be added if they are *unconditionally* dark by default, regardless of the preferred color scheme. This is in contrast with mastodon, which respects the browser's preferred color scheme (generally; i have no idea why mozilla.social doesn't). It therefore does not meet the criteria for global dark list inclusion.