### PR TITLE
Fix chatgpt.com (formerly chat.openai.com)

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -345,10 +345,9 @@ NO INVERT
 
 ================================
 
-chat.openai.com
+chatgpt.com
 
 INVERT
-.overflow-hidden:has(textarea)
 pre .dark
 
 ================================


### PR DESCRIPTION
`chat.openai.com` now redirects to `chatgpt.com` and the [text input area fix](https://github.com/darkreader/darkreader/commit/fee87cf7a1bc09fa0319ea293e5606c92b384c68) is no longer necessary.