### PR TITLE
Fix for booking.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22730,6 +22730,13 @@ INVERT
 
 ================================
 
+secure.booking.com
+
+INVERT
+.security-popup_close
+
+================================
+
 secure.fanboy.co.nz
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3931,12 +3931,15 @@ IGNORE IMAGE ANALYSIS
 ================================
 
 booking.com
+*.booking.com
 
 INVERT
+span[data-testid="header-logo"]
 .bui-calendar__control
 .-iconset-close
 .-iconset-navarrow_left
 .-iconset-navarrow_right
+.security-popup_close
 .sort_more_options__button
 .mb-ico
 .-iconset-review_great
@@ -22727,13 +22730,6 @@ INVERT
 #lp_invite
 #manageNonAllyAccountsFrame .third-party-iframe
 #billPayFrame
-
-================================
-
-secure.booking.com
-
-INVERT
-.security-popup_close
 
 ================================
 


### PR DESCRIPTION
Invert message security popup's close button

Before:
![Screenshot from 2024-06-04 18-25-49](https://github.com/darkreader/darkreader/assets/1006477/ccd8c826-a75a-4536-ada8-0b712d68c734)

After:
![Screenshot from 2024-06-04 18-25-54](https://github.com/darkreader/darkreader/assets/1006477/f8cd431a-0060-4194-8ae8-50223e99d3c2)
