### PR TITLE
Update subdomains of docusign.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7978,6 +7978,8 @@ img[src="assets/Uploads/dlp/images/logo-libreoffice.png"]
 ================================
 
 docusign.com
+apps.docusign.com
+account.docusign.com
 
 INVERT
 a[data-context="nav-main-logo"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7978,8 +7978,7 @@ img[src="assets/Uploads/dlp/images/logo-libreoffice.png"]
 ================================
 
 docusign.com
-apps.docusign.com
-account.docusign.com
+*.docusign.com
 
 INVERT
 a[data-context="nav-main-logo"]


### PR DESCRIPTION
Wildcard subdomain was removed when merging https://github.com/darkreader/darkreader/pull/12706 which broke the inner pages. Let's add them back.

I'm not sure if you prefer a wildcard again or specific ones, so I chose the latter this time.