### PR TITLE
Fix for account.booking.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -689,6 +689,13 @@ INVERT
 
 ================================
 
+account.booking.com
+
+INVERT
+span[data-testid="header-logo"]
+
+================================
+
 account.live.com
 
 INVERT


### PR DESCRIPTION
Invert logo

Before:
![Screenshot from 2024-06-04 18-48-36](https://github.com/darkreader/darkreader/assets/1006477/71301c86-de3d-4675-90b5-0c020afe1693)

After:
![Screenshot from 2024-06-04 18-49-17](https://github.com/darkreader/darkreader/assets/1006477/5163a1f7-9b35-4e9e-8f32-31adaa220362)
