### PR TITLE
Add `_execute_browser_action`

### DIFF
--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,5 +1,8 @@
 {
     "browser_specific_settings": {
+        "commands": {
+            "_execute_browser_action": { }
+        },
         "gecko": {
             "id": "addon@darkreader.org",
             "strict_min_version": "78.0"


### PR DESCRIPTION
Unlike in Chromium, Firefox extensions don't get a shortcut to trigger the `icon click` action by default. Specifying this command makes it also available on Firefox.

I'm not quite sure how the manifests for the different browsers are merged, so please let me know if this key should be added in another file