### PR TITLE
Add `_execute_browser_action` to Firefox manifest

### DIFF
--- a/tasks/bundle-manifest.js
+++ b/tasks/bundle-manifest.js
@@ -14,7 +14,9 @@ async function patchManifest(platform, debug, watch, test) {
     }
     if (platform === PLATFORM.CHROMIUM_MV3) {
         patched.browser_action = undefined;
-    }
+    } else if (platform === PLATFORM.FIREFOX_MV2) {
+        patched.commands._execute_browser_action = { }
+    } 
     if (debug) {
         patched.version = '1';
         patched.description = `Debug build, platform: ${platform}, watch: ${watch ? 'yes' : 'no'}.`;


### PR DESCRIPTION
Unlike in Chromium, Firefox extensions don't get a shortcut to trigger the `icon click` action by default. Specifying this command makes it also available on Firefox.