### PR TITLE
Fix for new.mta.info

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18126,6 +18126,13 @@ a.menu__canvas--toggle
 
 ================================
 
+new.mta.info
+
+IGNORE INLINE STYLE
+a[title="MTA"] > svg > path
+
+================================
+
 newegg.com
 
 CSS


### PR DESCRIPTION
Fixes logo on most pages.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/80e0c01c-1d51-4fdd-8561-833f8437972f)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/413d35d7-1a15-437c-910d-b8ecf3d9cc5b)