### PR TITLE
dynamic-theme-fixes.config :: copilot.microsoft.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6163,6 +6163,7 @@ copilot.microsoft.com
 
 INVERT
 button[is="cib-button"] svg-icon
+button[class$="icon-button"] svg-icon
 
 ================================
 


### PR DESCRIPTION
Inverted the buttons that pop on hover in the history panel.