### PR TITLE
fixes for app.circleci.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1719,6 +1719,13 @@ CSS
 
 ================================
 
+app.circleci.com
+
+INVERT
+div[role="button"] svg[viewbox="0 0 300 100"]
+
+================================
+
 app.codesignal.com
 
 CSS


### PR DESCRIPTION
CircleCI just did a redesign of their authenticated site, and their logo looks terrible in dark reader.

Light mode:
![20240613_21h27m48s_grim](https://github.com/darkreader/darkreader/assets/934490/33cb600b-cd8a-4cd8-a156-f02462100a93)

Dark reader current:
![20240613_21h28m16s_grim](https://github.com/darkreader/darkreader/assets/934490/79d04598-87c6-4f5a-b448-45d3742959fa)

Dark reader after my fix:
![20240613_21h28m33s_grim](https://github.com/darkreader/darkreader/assets/934490/34a5bc75-59ff-4c48-859b-274580587c76)

