### PR TITLE
Add hqapps.org to always dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -520,6 +520,7 @@ hkamran.com
 hostedtalk.net
 hotstar.com
 hpdevone.com
+hqapps.org
 hrmspms.sicorax.mu
 hub.warframestat.us
 humblebundle.com/$


### PR DESCRIPTION
I added my own website which is dark mode only to the "always dark" list.