### PR TITLE
Fix for new.mta.info

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18160,8 +18160,30 @@ a.menu__canvas--toggle
 
 new.mta.info
 
+CSS
+.services-container > .ss-header > #service-status-widget > .active > a:link {
+    background-color: #f2a900 !important;
+    color: #002d72 !important;
+}
+.services-container > .ss-header > #service-status-widget > .active > a:link::before {
+    color: #002d72 !important;
+}
+.ss-header {
+    border-bottom: 3px solid #f2a900 !important;
+}
+
 IGNORE INLINE STYLE
 a[title="MTA"] > svg > path
+
+IGNORE IMAGE ANALYSIS
+.block-service-status-block .line-1
+.block-service-status-block .line-2
+.block-service-status-block .line-3
+.block-service-status-block .line-7
+.block-service-status-block .line-A
+.block-service-status-block .line-C
+.block-service-status-block .line-E
+.block-service-status-block .line-SI
 
 ================================
 


### PR DESCRIPTION
Fixes "Service Status" widget on home page.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/374da5aa-5fb6-4ffc-991f-e6108f5c628c)

After:
![2](https://github.com/darkreader/darkreader/assets/6563728/531e1ae7-ce48-4b0c-8559-d4c74ad41600)