### PR TITLE
Add dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,6 +1,4 @@
 *.comfig.app
-*.counter-strike.net
-*.dota2.com
 *.iaas.store
 *.iaasdev.ru
 *.mastercomfig.com
@@ -269,6 +267,7 @@ dblstatistics.com
 dbzer0.com
 dd-wrt.com
 ddpe.androz2091.fr
+deadbydaylight.com
 deadbydaylight.fandom.com
 deepswap.ai
 deepweblinks.net

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,5 +1,10 @@
+*.comfig.app
+*.counter-strike.net
+*.dota2.com
 *.iaas.store
 *.iaasdev.ru
+*.mastercomfig.com
+*.newgrounds.com
 0bin.net
 0x00sec.org
 12bytes.org
@@ -140,7 +145,6 @@ blink.sh
 blizzard.com
 blocks.pandadev.net
 blog.aractus.com
-blog.counter-strike.net
 blog.ja-ke.tech
 blog.pixelexperience.org
 blox.link
@@ -212,6 +216,7 @@ codestackr.com
 codewars.com
 colean.cc
 colordesigner.io
+comfig.app
 comicextra.com
 community.eveonline.com
 connect-4.xyz
@@ -219,6 +224,7 @@ console.firebase.google.com
 cookieplmonster.github.io
 coolmathgames.com
 coriolis.io
+counter-strike.net
 countermail.com
 cp.minetro.com
 cracked.to
@@ -316,6 +322,7 @@ doesitarm.com
 dominion.games
 donk.link
 doodstream.com
+dota2.com
 dota2.ru
 dotabuff.com
 dotapicker.com
@@ -778,6 +785,7 @@ open.spotify.com
 opendota.com
 openemu.org
 openrazer.github.io
+openrgb.org
 orama-interactive.itch.io/pixelorama
 orteil.dashnet.org/cookieclicker
 osu.ppy.sh
@@ -921,6 +929,7 @@ sauce420.gitlab.io
 sb.ltn.fi
 schildi.chat
 science-news.co
+scottgames.com
 screfy.com
 scriptkit.com
 seaofthieves.fandom.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -421,6 +421,7 @@ forum.lastos.org
 forum.tribler.org
 forum.xda-developers.com
 forumplayer.dev
+forums.bhvr.com/dead-by-daylight/
 forums.eveonline.com
 forums.launchbox-app.com
 fox.com
@@ -701,6 +702,7 @@ mouse-sensitivity.com
 mrdemoapple.uk
 mrms.cz
 mrquantumoff.dev
+mrtipson.github.io/otz-builds/
 ms-paint-i.de
 mtv.com
 mulv.tycrek.dev
@@ -790,6 +792,8 @@ orama-interactive.itch.io/pixelorama
 orteil.dashnet.org/cookieclicker
 osu.ppy.sh
 osumatrix.me
+otz-addon-tierlist.pages.dev
+otz-opinions.pages.dev
 otzdarva.com
 ovagames.com
 overcoder.dev

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -143,6 +143,7 @@ blink.sh
 blizzard.com
 blocks.pandadev.net
 blog.aractus.com
+blog.counter-strike.net
 blog.ja-ke.tech
 blog.pixelexperience.org
 blox.link


### PR DESCRIPTION
- comfig.app = same as mastercomfig.com, should not be touched by Dark Reader
  - take a look at https://mastercomfig.com/, https://comfig.app/, https://docs.mastercomfig.com/, https://docs.comfig.app/, https://mastercomfig.com/app/, https://comfig.app/app/
- counter-strike.net = always dark, including blog.counter-strike.net (the latter is already in the global dark list)
- deadbydaylight.com = was removed in the past (https://github.com/darkreader/darkreader/issues/10390) due to how Dark Reader used to handle URLs: it interprted `deadbydaylight.com` as (`deadbydaylight.com` + `*.deadbydaylight.com`), but today it doesn't do that anymore and it's safe to re-add it back
- newgrounds: main site (https://www.newgrounds.com/) is already in the list, but this doesn't cover subpages (`https://username.newgrounds.com/`); example https://jamestdg.newgrounds.com/ (and also, it seems that user can customize their profiles, and Dark Reader doesn't play nice with it)
- every other site not mentioned: it's always dark