### PR TITLE
Consolidate Wikipedia etc. fixes with MediaWiki.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16394,14 +16394,209 @@ img[src*="wzory"]
 ================================
 
 mediawiki.org
+*.mediawiki.org
+wikibooks.org
+*.wikibooks.org
+wikidata.org
+*.wikidata.org
+wikiless.org
+*.wikiless.org
+wikimedia.org
+*.wikimedia.org
+wikimediafoundation.org
+*.wikimediafoundation.org
+wikinews.org
+*.wikinews.org
+wikipedia.org
+*.wikipedia.org
+wikiquote.org
+*.wikiquote.org
+wikisource.org
+*.wikisource.org
+wikiversity.org
+*.wikiversity.org
+wikivoyage.org
+*.wikivoyage.org
+wikiwand.com
+*.wikiwand.com
 
 INVERT
+#main_menu > li:not(.lang_btn) > img.logo_img ~ i
 #p-logo-text
+.article_btn .drop_down li a > i
+.bookend
+.cdx-text-input__icon.cdx-text-input__start-icon
+.central-featured-logo-text
+.central-textlogo__image
+.feedback_btn .drop_down li a > i
+.licensetpl td[style^="width"]
+.locmap .pl
+.locmap .pr
+.logo-container
+.logo:not(td)
+.main-footer-menuToggle
+.mf-icon-close-gray
+.mf-icon-expand
+.mf-icon-expand-invert
+.minerva-footer-logo img
+.music-symbol img
+.mw-ext-score
+.mw-hiero-outer.mw-hiero-table
+.mw-kartographer-map
+.mw-kartographer-mapDialog-map
+.mw-logo-tagline
 .mw-logo-wordmark
+.mw-mmv-filepage-buttons .mw-mmv-view-config .mw-ui-icon::before
+.mw-mmv-filepage-buttons .mw-mmv-view-expanded .mw-ui-icon::before
+.mw-ui-icon-wikimedia-expand
+.mw-wiki-logo
+.mwe-math-fallback-image-display
+.mwe-math-fallback-image-inline
+.nav-logo
+.svg-Wikimedia-logo_black
+.title_icon
+.toc-title-icon
+.tool.tool-button[src$="background-image:"]
+.wd-mp-headerimage
+.zh-glyph img
+body > .oo-ui-windowManager .vega .marks
+div.post-content.footer-content > h2 > img
+header .branding-box > a > span > img
+img.graphite-graph
+img.immediate:not(.ntmb)
+img.logo_img
+img[alt="Video Camera Icon.svg"]
 img[alt="audio speaker icon"]
+img[alt="logo Wikisource"]
+img[src*="Wiktionary-logo"]
+img[src="images/black.png"]
+li.menu-tooltip:not(.lang_btn)
+td.icon
+
+CSS
+:root {
+    --darkreader-border--border-color-base: ${#a2a9b1} !important;
+}
+.mwe-popups-discreet > img,
+div .thumbimage[src$=".png"],
+div .thumbimage img[src$=".png"],
+.image-carousel .image-loaded {
+    background-color: white;
+}
+.mw-mmv-image .svg,
+.fullImageLink [src*=".svg"],
+a[href$=".svg"]:hover > img,
+a[href*=".gif"]:hover > img {
+    background-blend-mode: color;
+    background-color: rgba(255, 255, 255, 0.75) !important;
+}
+.diff-addedline .diffchange {
+    background-color: ${lightblue} !important;
+}
+.diff-deletedline .diffchange {
+    background-color: ${#feeec8} !important;
+}
+@keyframes unseen-fadeout-to-unread {
+    from {
+        background-color: ${#dce8ff} !important;
+    }
+    to {
+        background-color: ${#ffffff} !important;
+    }
+}
+@keyframes unseen-fadeout-to-read {
+    from {
+        background-color: ${#dce8ff} !important;
+    }
+    to {
+        background-color: ${#eaecf0} !important;
+    }
+}
+.main-top {
+    background: none !important;
+}
+ol.references li:target,
+sup.reference:target {
+    background-color: ${lightblue} !important;
+}
+.control-bar {
+    background-color: var(--darkreader-neutral-background) !important;
+    background-image: none !important;
+}
+.k-player,
+body.mediawiki,
+#dialogEngineContainer #dialogEngineDialog {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.template-facttext {
+    background-color: ${#c8c6c3} !important;
+}
+#mw-page-base {
+    background-color: var(--darkreader-neutral-background);
+    background-image: linear-gradient(${rgb(231, 229, 228)} 50%, var(--darkreader-neutral-background) 100%) !important;
+}
+body.skin--responsive,
+#menus-cover-background {
+    background-image: linear-gradient(${rgb(231, 229, 228)} 50%, var(--darkreader-neutral-background) 100%) !important;
+}
+.vector-sticky-pinned-container::after {
+    background: linear-gradient(transparent, var(--darkreader-neutral-background)) !important;
+}
+[style*="background: rgb(221, 221, 255)"],
+[style*="background-color: rgb(221, 221, 255)"] {
+    background: ${rgb(221, 221, 255)} !important;
+}
+button[class*=mw-mmv-]:not(.cdx-button),
+.cdx-button:enabled .cdx-button__icon,
+a[role="button"][class*=mw-mmv-] {
+    background-color: white !important;
+}
+div.mw-warning-with-logexcerpt,
+div.mw-lag-warn-high,
+div.mw-cascadeprotectedwarning,
+div#mw-protect-cascadeon,
+div.titleblacklist-warning,
+div.locked-warning {
+    background-color: ${#ffa9a9} !important;
+    border-color: ${#ffa1a1} !important;
+}
+div.NavFrame div.NavHead {
+    background-image: none !important;
+}
+.infobox-subheader {
+    background-color: ${#ddd} !important;
+}
+.infobox-below {
+    background-color: ${#ccffcc} !important;
+}
+figure[typeof~="mw:File/Thumb"],
+figure[typeof~="mw:File/Thumb"] > figcaption,
+figure[typeof~="mw:File/Thumb"] > :not(figcaption) .mw-file-element,
+div.thumbinner,
+#filetoc,
+.mw_metadata td,
+div.flaggedrevs_short,
+.wbmi-entityview-captionsPanel,
+.page-actions-menu,
+.content .mw-image-border .mw-file-element,
+.mw-footer,
+.last-modified-bar,
+.minerva-footer-logo,
+.cdx-card,
+.cdx-thumbnail__placeholder {
+    border-color: var(--darkreader-border--border-color-base) !important;
+}
+
+IGNORE INLINE STYLE
+#on_image_elements span
+.infobox td
+.legend-color:not(table.wikitable .legend-color)
 
 IGNORE IMAGE ANALYSIS
-.mw.wiki-logo
+.k-player .k-menu-bar li a
+.mf-icon-expand
+.mw-wiki-logo
+.toc-title-icon
 
 ================================
 
@@ -28189,211 +28384,6 @@ CSS
 .b-main {
     background: var(--darkreader-neutral-background) !important;
 }
-
-================================
-
-wikibooks.org
-*.wikibooks.org
-wikidata.org
-*.wikidata.org
-wikiless.org
-*.wikiless.org
-wikimedia.org
-*.wikimedia.org
-wikimediafoundation.org
-*.wikimediafoundation.org
-wikinews.org
-*.wikinews.org
-wikipedia.org
-*.wikipedia.org
-wikiquote.org
-*.wikiquote.org
-wikisource.org
-*.wikisource.org
-wikiversity.org
-*.wikiversity.org
-wikivoyage.org
-*.wikivoyage.org
-wikiwand.com
-*.wikiwand.com
-
-INVERT
-#main_menu > li:not(.lang_btn) > img.logo_img ~ i
-#p-logo-text
-.article_btn .drop_down li a > i
-.bookend
-.cdx-text-input__icon.cdx-text-input__start-icon
-.central-featured-logo-text
-.central-textlogo__image
-.feedback_btn .drop_down li a > i
-.licensetpl td[style^="width"]
-.locmap .pl
-.locmap .pr
-.logo:not(td)
-.logo-container
-.main-footer-menuToggle
-.mf-icon-expand
-.minerva-footer-logo img
-.music-symbol img
-.mw-ext-score
-.mw-hiero-outer.mw-hiero-table
-.mw-kartographer-map
-.mw-kartographer-mapDialog-map
-.mw-logo-tagline
-.mw-logo-wordmark
-.mw-mmv-filepage-buttons .mw-mmv-view-config .mw-ui-icon::before
-.mw-mmv-filepage-buttons .mw-mmv-view-expanded .mw-ui-icon::before
-.mw-wiki-logo
-.mw-ui-icon-wikimedia-expand
-.mwe-math-fallback-image-display
-.mwe-math-fallback-image-inline
-.nav-logo
-.svg-Wikimedia-logo_black
-.title_icon
-.toc-title-icon
-.tool.tool-button[src$="background-image:"]
-.wd-mp-headerimage
-.zh-glyph img
-body > .oo-ui-windowManager .vega .marks
-div.post-content.footer-content > h2 > img
-header .branding-box > a > span > img
-img.graphite-graph
-img.immediate:not(.ntmb)
-img.logo_img
-img[alt="Video Camera Icon.svg"]
-img[alt="audio speaker icon"]
-img[alt="logo Wikisource"]
-img[src*="Wiktionary-logo"]
-img[src="images/black.png"]
-li.menu-tooltip:not(.lang_btn)
-td.icon
-.mf-icon-close-gray
-.mf-icon-expand-invert
-
-CSS
-:root {
-    --darkreader-border--border-color-base: ${#a2a9b1} !important;
-}
-.mwe-popups-discreet > img,
-div .thumbimage[src$=".png"],
-div .thumbimage img[src$=".png"],
-.image-carousel .image-loaded {
-    background-color: white;
-}
-.mw-mmv-image .svg,
-.fullImageLink [src*=".svg"],
-a[href$=".svg"]:hover > img,
-a[href*=".gif"]:hover > img {
-    background-blend-mode: color;
-    background-color: rgba(255, 255, 255, 0.75) !important;
-}
-.diff-addedline .diffchange {
-    background-color: ${lightblue} !important;
-}
-.diff-deletedline .diffchange {
-    background-color: ${#feeec8} !important;
-}
-@keyframes unseen-fadeout-to-unread {
-    from {
-        background-color: ${#dce8ff} !important;
-    }
-    to {
-        background-color: ${#ffffff} !important;
-    }
-}
-@keyframes unseen-fadeout-to-read {
-    from {
-        background-color: ${#dce8ff} !important;
-    }
-    to {
-        background-color: ${#eaecf0} !important;
-    }
-}
-.main-top {
-    background: none !important;
-}
-ol.references li:target,
-sup.reference:target {
-    background-color: ${lightblue} !important;
-}
-.control-bar {
-    background-color: var(--darkreader-neutral-background) !important;
-    background-image: none !important;
-}
-.k-player,
-body.mediawiki,
-#dialogEngineContainer #dialogEngineDialog {
-    background-color: var(--darkreader-neutral-background) !important;
-}
-.template-facttext {
-    background-color: ${#c8c6c3} !important;
-}
-#mw-page-base {
-    background-color: var(--darkreader-neutral-background);
-    background-image: linear-gradient(${rgb(231, 229, 228)} 50%, var(--darkreader-neutral-background) 100%) !important;
-}
-body.skin--responsive,
-#menus-cover-background {
-    background-image: linear-gradient(${rgb(231, 229, 228)} 50%, var(--darkreader-neutral-background) 100%) !important;
-}
-.vector-sticky-pinned-container::after {
-    background: linear-gradient(transparent, var(--darkreader-neutral-background)) !important;
-}
-[style*="background: rgb(221, 221, 255)"],
-[style*="background-color: rgb(221, 221, 255)"] {
-    background: ${rgb(221, 221, 255)} !important;
-}
-button[class*=mw-mmv-]:not(.cdx-button),
-.cdx-button:enabled .cdx-button__icon,
-a[role="button"][class*=mw-mmv-] {
-    background-color: white !important;
-}
-div.mw-warning-with-logexcerpt,
-div.mw-lag-warn-high,
-div.mw-cascadeprotectedwarning,
-div#mw-protect-cascadeon,
-div.titleblacklist-warning,
-div.locked-warning {
-    background-color: ${#ffa9a9} !important;
-    border-color: ${#ffa1a1} !important;
-}
-div.NavFrame div.NavHead {
-    background-image: none !important;
-}
-.infobox-subheader {
-    background-color: ${#ddd} !important;
-}
-.infobox-below {
-    background-color: ${#ccffcc} !important;
-}
-figure[typeof~="mw:File/Thumb"],
-figure[typeof~="mw:File/Thumb"] > figcaption,
-figure[typeof~="mw:File/Thumb"] > :not(figcaption) .mw-file-element,
-div.thumbinner,
-#filetoc,
-.mw_metadata td,
-div.flaggedrevs_short,
-.wbmi-entityview-captionsPanel,
-.page-actions-menu,
-.content .mw-image-border .mw-file-element,
-.mw-footer,
-.last-modified-bar,
-.minerva-footer-logo,
-.cdx-card,
-.cdx-thumbnail__placeholder {
-    border-color: var(--darkreader-border--border-color-base) !important;
-}
-
-IGNORE INLINE STYLE
-#on_image_elements span
-.infobox td
-.legend-color:not(table.wikitable .legend-color)
-
-IGNORE IMAGE ANALYSIS
-.k-player .k-menu-bar li a
-.mf-icon-expand
-.mw-wiki-logo
-.toc-title-icon
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1641,6 +1641,50 @@ NO INVERT
 
 ================================
 
+mediawiki.org
+*.mediawiki.org
+wikibooks.org
+*.wikibooks.org
+wikidata.org
+*.wikidata.org
+wikiless.org
+*.wikiless.org
+wikimedia.org
+*.wikimedia.org
+wikimediafoundation.org
+*.wikimediafoundation.org
+wikinews.org
+*.wikinews.org
+wikipedia.org
+*.wikipedia.org
+wikiquote.org
+*.wikiquote.org
+wikisource.org
+*.wikisource.org
+wikiversity.org
+*.wikiversity.org
+wikivoyage.org
+*.wikivoyage.org
+wikiwand.com
+*.wikiwand.com
+
+INVERT
+#Vorlage_Infobox_Chemikalie > tbody > tr:nth-child(2) > td > a
+.mw-ext-score
+.mw-mmv-overlay
+.mwe-popups-discreet > svg
+
+NO INVERT
+.mwe-math-fallback-image-display
+.mwe-math-fallback-image-inline
+.mwe-popups image
+img[alt^="Skeletal" i]
+img[alt^="Structural" i]
+img[src*="svg.png"]
+img[src^="https://wikimedia.org/api/rest_v1/media/math/render/svg"]
+
+================================
+
 meduza.io
 
 INVERT
@@ -2994,48 +3038,6 @@ CSS
 .qrcode {
     border: 8px solid black;
 }
-
-================================
-
-wikibooks.org
-*.wikibooks.org
-wikidata.org
-*.wikidata.org
-wikiless.org
-*.wikiless.org
-wikimedia.org
-*.wikimedia.org
-wikimediafoundation.org
-*.wikimediafoundation.org
-wikinews.org
-*.wikinews.org
-wikipedia.org
-*.wikipedia.org
-wikiquote.org
-*.wikiquote.org
-wikisource.org
-*.wikisource.org
-wikiversity.org
-*.wikiversity.org
-wikivoyage.org
-*.wikivoyage.org
-wikiwand.com
-*.wikiwand.com
-
-INVERT
-.mwe-popups-discreet > svg
-.mw-ext-score
-.mw-mmv-overlay
-#Vorlage_Infobox_Chemikalie > tbody > tr:nth-child(2) > td > a
-
-NO INVERT
-.mwe-math-fallback-image-inline
-.mwe-math-fallback-image-display
-.mwe-popups image
-img[src*="svg.png"]
-img[alt^="Skeletal" i]
-img[alt^="Structural" i]
-img[src^="https://wikimedia.org/api/rest_v1/media/math/render/svg"]
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1634,13 +1634,6 @@ CSS
 
 ================================
 
-medium.com
-
-NO INVERT
-.canvas-renderer
-
-================================
-
 mediawiki.org
 *.mediawiki.org
 wikibooks.org
@@ -1682,6 +1675,13 @@ img[alt^="Skeletal" i]
 img[alt^="Structural" i]
 img[src*="svg.png"]
 img[src^="https://wikimedia.org/api/rest_v1/media/math/render/svg"]
+
+================================
+
+medium.com
+
+NO INVERT
+.canvas-renderer
 
 ================================
 


### PR DESCRIPTION
This pull request:

- Consolidates all Wikimedia Foundation-related sites fixes with https://mediawiki.org/.
  - Current fixes for MediaWiki are the same as Wikimedia Foundation, and that's why it's feasible to merge.
- I also sorted the current fixes alphabetically (except for the CSS part).
- Due to alphabetical order, Wikimedia Foundation-related sites have been moved to be together with **M**ediaWiki.org.

See issue https://github.com/darkreader/darkreader/issues/12763 for more context.

This closes #12763.