### PR TITLE
nvst.ly => nvstly.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -771,7 +771,7 @@ notebooks.quantumstat.com
 notiger.xyz
 nowplayi.ng
 nulledbb.com
-nvst.ly
+nvstly.com
 nyaa.si
 obsidian.md
 oculus.com/experiences/quest/


### PR DESCRIPTION
Changes the old https://nvst.ly domain to new https://nvstly.com