### PR TITLE
Dynamic resizing for GH PR file view sidebar

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11210,6 +11210,10 @@ article div[style^="background: linear-gradient"] {
 .ͼ5 .cm-panel.cm-search > button {
     background-color: var(--darkreader-neutral-background) !important;
 }
+div[data-target="diff-layout.sidebarContainer"] {
+    min-width: var(--Layout-sidebar-width);
+    resize: horizontal;
+}
 
 IGNORE INLINE STYLE
 a[href^="https://apps.apple.com/app/"] g


### PR DESCRIPTION
This change enables dynamic resizing of the file list sidebar in the GitHub PR file view tab. It will only allow the user to resize the div to the minimum horizontal size that GH calculates, so it shouldn't be a major change to the UI.

https://github.com/darkreader/darkreader/assets/86027207/dc092ebd-42df-44af-adaa-5896e21db075

The resize adjustment corner is at the bottom of the sidebar, so if it fills the window vertically, it will be on the bottom, otherwise it will be at the lowest part of the text, as seen above.

I'm not sure this is something that's dark-theme related enough to merit merging, but seeing as GH has no built-in feature for this and I don't use a scripting extension, this was the quickest way to fix this for me, so I thought I would propose it here.