### PR TITLE
Fix search bar on mail.google.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1559,7 +1559,7 @@ CSS
 mail.google.com
 
 CSS
-.gb_re {
+form#aso_search_form_anchor td > div > input {
     background: none !important;
     filter: none !important;
 }


### PR DESCRIPTION
Looks like the class, `.gb_re`, changed, causing the text to become unreadable again:
<img width="778" alt="Screenshot 2024-06-20 at 11 23 24" src="https://github.com/darkreader/darkreader/assets/17463710/c2f569ed-fc55-41b6-9fb6-9c25e8f3a1d5">

Rather than chasing these ephemeral classes, we can have a somewhat more structural selector, which will hopefully not change quite as often. This seems to have the intended effect:
<img width="770" alt="Screenshot 2024-06-20 at 11 23 50" src="https://github.com/darkreader/darkreader/assets/17463710/534a5b9a-3a05-4d4c-801a-6c4eaa80cd54">

