### PR TITLE
Fix for weather.gov

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27895,6 +27895,18 @@ CSS
 
 ================================
 
+weather.gov
+forecast.weather.gov
+
+INVERT
+.header-content > .header-doc
+.header-content > .header-nws
+#page-header > #header-doc
+#page-header > #header-noaa
+#page-header > #header-nws
+
+================================
+
 web.archive.org
 
 INVERT


### PR DESCRIPTION
Fixes logos on home page and forecast pages.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/2111adca-4ab4-4d2c-b1da-5bdfd0bd8883)
![2](https://github.com/darkreader/darkreader/assets/6563728/28892cdf-8369-4d23-9955-48cdaca3c15a)

After:
![3](https://github.com/darkreader/darkreader/assets/6563728/3a102f20-814e-48d6-96ce-d6e10a3d4e1e)
![4](https://github.com/darkreader/darkreader/assets/6563728/dea1f09c-30bc-411b-9b47-fde592bdc640)