### PR TITLE
fixes for app.circleci.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1723,7 +1723,7 @@ CSS
 app.circleci.com
 
 INVERT
-div[role="button"] svg[viewbox="0 0 300 100"]
+div[role="button"] svg[viewBox="0 0 300 100"]
 
 ================================
 


### PR DESCRIPTION
In #12849, I guess I got some capitalization wrong, which works in chromium browsers, but not Firefox. This correct casing works in both types of browsers.
