### PR TITLE
Fix for mubi.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17645,6 +17645,29 @@ INVERT
 
 ================================
 
+mubi.com
+
+INVERT
+.css-jd0r3a.e1kjxayp2
+.css-k7pew6.ef3qs2t4 img
+
+CSS
+.css-ztue73 {
+    filter: brightness(1) !important;
+}
+.css-1fdxz4i.e1f1mjpr0 path,
+.css-1fdxz4i.e1f1mjpr0 rect,
+.css-1fdxz4i.e1f1mjpr0 circle {
+    fill: #FFFFFF !important;
+}
+.css-ker29f.ed6irnx8 {
+    filter: invert(1) hue-rotate(180deg) !important;
+}
+
+IGNORE INLINE STYLE
+.star
+
+================================
 mullvad.net
 
 CSS


### PR DESCRIPTION
Fixes the 'Now showing' movie banner, mubi logo, notification icon and partially fixes movie critics's star rating (partially filled stars still show as empty).