### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22561,20 +22561,21 @@ INVERT
 
 ================================
 
-safeweb.norton.com
-
-INVERT
-.logo img
-
-================================
-
 safetysign.com
 
 CSS
 div[id*="RollUp-Aluminum-smalltext-preview"],
-div[id*="RollUp-Aluminum-largetext-preview"] {
+div[id*="RollUp-Aluminum-largetext-preview"],
+#_HillGradeCustom-hillgradetext-preview {
     color: rgb(0, 0, 0) !important;
 }
+
+================================
+
+safeweb.norton.com
+
+INVERT
+.logo img
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22568,6 +22568,16 @@ INVERT
 
 ================================
 
+safetysign.com
+
+CSS
+div[id*="RollUp-Aluminum-smalltext-preview"],
+div[id*="RollUp-Aluminum-largetext-preview"] {
+    color: rgb(0, 0, 0) !important;
+}
+
+================================
+
 saladelcembalo.org
 
 INVERT


### PR DESCRIPTION
Fix for sign preview text on https://www.safetysign.com/products/18654/orange-roll-up-sign (along with other colors: pink, yellow/green, white, and yellow)