### PR TITLE
Fix RSVP Checkmark Background in Google Calendar

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4694,6 +4694,7 @@ calendar.google.com
 INVERT
 div[style*="gm_add_black"]
 img[src$="google_gsuite"]
+.wRfGxb > svg > path:first-child
 
 CSS
 div[role="checkbox"] > div > div > div {


### PR DESCRIPTION
On [calendar.google.com](https://calendar.google.com), if you go the event details of an event, people that have RSVPed will have a small check or x next to their name. ATM, the background on this icon is white, making the icons hard to see. This PR inverts the background, making it easier to distinguish between the two.