### PR TITLE
Ddd svg diagrams for httpwg.org and rfc-editor.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12475,6 +12475,15 @@ article > article {
 
 ================================
 
+httpwg.org
+
+CSS
+svg.diagram text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 huawei.com
 
 INVERT
@@ -22179,6 +22188,15 @@ revolver.news
 INVERT
 h2.title
 h3.category
+
+================================
+
+rfc-editor.org
+
+CSS
+svg.diagram text {
+    fill: var(--darkreader-neutral-text) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Fixes SVG diagrams for RFCs on httpwg.org and rfc-editor.org.

See [RFC 9113](https://httpwg.org/specs/rfc9113.html#StreamStates) for an example.

Before:

![image](https://github.com/darkreader/darkreader/assets/468153/145ba4bd-dc68-4a62-872f-ecdf10d3f3bc)

After:

![image](https://github.com/darkreader/darkreader/assets/468153/368a42de-43fd-469f-b23e-3f7971c694c8)
