### PR TITLE
Fix figures on neuralnetworksanddeeplearning.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18436,6 +18436,18 @@ a.menu__canvas--toggle
 
 ================================
 
+neuralnetworksanddeeplearning.com
+
+INVERT
+img[src$=".png"]
+img[src^="images/KSH"]
+img[src^="images/bump_function"]
+img[src^="images/high_weight_function"]
+canvas
+video
+
+================================
+
 new.mta.info
 
 CSS


### PR DESCRIPTION
Hi there! 👋 

Here are some changes to fix the readability of several figures and also make it more consistent reading experience.

The site has a mix of graphs and photos so I decided to select the graphs by name so that the photos wouldn't inverted. I believe this is the [repo](https://github.com/mnielsen/nnadl_site) for the site, the last commit was 5 years ago. So I believe this should be a reasonable approach.

Lemme know if this going too far and I'll update the PR to be more conservative.

---

Before
![Screenshot 2024-06-29 at 00 37 51](https://github.com/darkreader/darkreader/assets/3779513/5fc791b2-85a6-4356-af58-51c3e739d2b0)

After
![Screenshot 2024-06-29 at 00 37 57](https://github.com/darkreader/darkreader/assets/3779513/3be74f46-0a3a-43a6-8b4e-f2f708364af7)

---

Before
![Screenshot 2024-06-29 at 00 43 10](https://github.com/darkreader/darkreader/assets/3779513/d8dde7f0-659d-46ae-9788-066f186b0c9a)

After
![Screenshot 2024-06-29 at 00 43 36](https://github.com/darkreader/darkreader/assets/3779513/9233f9c8-b83d-4721-b416-8e32a2908740)

---

Before
![Screenshot 2024-06-29 at 00 48 54](https://github.com/darkreader/darkreader/assets/3779513/cb62bbed-4503-4468-8d6e-ad84a617fd9e)

After
![Screenshot 2024-06-29 at 00 49 08](https://github.com/darkreader/darkreader/assets/3779513/7ef694ac-8d70-47b6-8872-4435fba208c6)