### PR TITLE
Change restricted pages option text

### DIFF
--- a/src/ui/options/advanced/enable-for-protected-pages.tsx
+++ b/src/ui/options/advanced/enable-for-protected-pages.tsx
@@ -13,8 +13,8 @@ export function EnableForProtectedPages(props: ViewProps): Malevic.Child {
             onChange={onEnableForProtectedPages}
             label={'Enable on restricted pages'}
             description={props.data.settings.enableForProtectedPages ?
-                'You should enable it in browser flags too' :
-                'Disabled for web store and other pages'}
+                'See the README file on GitHub for details' :
+                'Disabled for the Web Store and other pages'}
         />
     );
 }


### PR DESCRIPTION
Change text to let users know about the README.

Is there any way to add a hyperlink to this text? Would be nice.

Also, shouldn't this option be hidden for non-Firefox users? As far as I know, Chromium-based browsers do not allow any extension on restricted pages, and there's no easy way to disable this protection.