### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25779,11 +25779,11 @@ theguardian.com
 INVERT
 .inline-the-guardian-logo__svg
 a[data-link-name$="logo"] svg
+a[data-sponsor="guardian.org"]
 a[href="https://www.theguardian.com/documentaries"] > svg
 .crossword__grid .crossword__cell-text
 .crossword__cell-number
-section[data-link-name="deeply-read"] > ol > li > a > span > svg
-section[data-link-name="most-viewed"] > ol > li > a > span > svg
+div[data-link-name="most-popular"] > section > ol > li > a > span > svg
 
 CSS
 button[data-link-name="video-container-next"],
@@ -25819,6 +25819,10 @@ section[id="video"] .dcr-zxdpfk {
 }
 section[id="video"] .play-icon {
     background-color: rgba(18, 18, 18, 0.6) !important;
+}
+svg[stroke="var(--article-border)"],
+svg[stroke="var(--straight-lines)"] {
+    stroke: var(--darkreader-border--article-border) !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
- Fixes horizontal dividers on most article pages.
- Fixes logo on some article pages.
- Improves fix in #12759 with a more concise fix.

Before:
![1](https://github.com/darkreader/darkreader/assets/6563728/868d2a99-2572-4274-9571-084d1660001a)
![2](https://github.com/darkreader/darkreader/assets/6563728/acb21345-a91f-4a67-a882-ded8802c166d)

After:
![3](https://github.com/darkreader/darkreader/assets/6563728/25afe6d8-2be0-482f-a258-47374152002d)
![4](https://github.com/darkreader/darkreader/assets/6563728/7ec30e25-ed29-4d11-be56-7103f4293c11)