### PR TITLE
[Feature] Support preconfiguration via Policy

### DIFF
--- a/src/background/utils/extension-api.ts
+++ b/src/background/utils/extension-api.ts
@@ -97,6 +97,19 @@ export async function readLocalStorage<T extends {[key: string]: any}>(defaults:
     });
 }
 
+export async function readManagedStorage<T extends {[key: string]: any}>(defaults: T): Promise<T> {
+    return new Promise<T>((resolve) => {
+        chrome.storage.managed.get(defaults, (managed: T) => {
+            if (chrome.runtime.lastError) {
+                console.error(chrome.runtime.lastError.message);
+                resolve(defaults);
+                return;
+            }
+            resolve(managed);
+        });
+    });
+}
+
 function prepareSyncStorage<T extends {[key: string]: any}>(values: T): {[key: string]: any} {
     for (const key in values) {
         const value = values[key];

--- a/src/managed-storage.json
+++ b/src/managed-storage.json
@@ -1,0 +1,297 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "schemeVersion": {
+      "type": "integer"
+    },
+    "enabled": {
+      "type": "boolean"
+    },
+    "fetchNews": {
+      "type": "boolean"
+    },
+    "theme": {
+      "$ref": "Theme"
+    },
+    "presets": {
+      "type": "array",
+      "items": {
+        "$ref": "ThemePreset"
+      }
+    },
+    "customThemes": {
+      "type": "array",
+      "items": {
+        "$ref": "CustomSiteConfig"
+      }
+    },
+    "enabledByDefault": {
+      "type": "boolean"
+    },
+    "enabledFor": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "disabledFor": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "changeBrowserTheme": {
+      "type": "boolean"
+    },
+    "syncSettings": {
+      "type": "boolean"
+    },
+    "syncSitesFixes": {
+      "type": "boolean"
+    },
+    "automation": {
+      "$ref": "Automation"
+    },
+    "time": {
+      "$ref": "TimeSettings"
+    },
+    "location": {
+      "$ref": "LocationSettings"
+    },
+    "previewNewDesign": {
+      "type": "boolean"
+    },
+    "enableForPDF": {
+      "type": "boolean"
+    },
+    "enableForProtectedPages": {
+      "type": "boolean"
+    },
+    "enableContextMenus": {
+      "type": "boolean"
+    },
+    "detectDarkTheme": {
+      "type": "boolean"
+    },
+    // Chrome's JSON schema format is weird and doesn't support `definitions` property and thus `#/definitions` references
+    // https://datatracker.ietf.org/doc/html/draft-zyp-json-schema-03
+    // This "property" mimics it
+    "definitions": {
+      "type": "object",
+      "properties": {
+        "Theme": {
+          "id": "Theme",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "$ref": "FilterMode"
+            },
+            "brightness": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 200
+            },
+            "contrast": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 200
+            },
+            "grayscale": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            },
+            "sepia": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 100
+            },
+            "useFont": {
+              "type": "boolean"
+            },
+            "fontFamily": {
+              "type": "string",
+              "minLength": 1
+            },
+            "textStroke": {
+              "type": "number"
+            },
+            "engine": {
+              "type": "string",
+              "enum": [
+                "cssFilter",
+                "svgFilter",
+                "staticTheme",
+                "dynamicTheme"
+              ]
+            },
+            "stylesheet": {
+              "type": "string"
+            },
+            "darkSchemeBackgroundColor": {
+              "$ref": "HexColor"
+            },
+            "darkSchemeTextColor": {
+              "$ref": "HexColor"
+            },
+            "lightSchemeBackgroundColor": {
+              "$ref": "HexColor"
+            },
+            "lightSchemeTextColor": {
+              "$ref": "HexColor"
+            },
+            "scrollbarColor": {
+              "$ref": "HexColorOrAuto"
+            },
+            "selectionColor": {
+              "$ref": "HexColorOrAuto"
+            },
+            "styleSystemControls": {
+              "type": "boolean"
+            },
+            "lightColorScheme": {
+              "type": "string",
+              "minLength": 1
+            },
+            "darkColorScheme": {
+              "type": "string",
+              "minLength": 1
+            },
+            "immediateModify": {
+              "type": "boolean"
+            }
+          }
+        },
+        "HexColor": {
+          "id": "HexColor",
+          "type": "string",
+          "pattern": "^[0-9a-f]{6}$"
+        },
+        "HexColorOrAuto": {
+          "id": "HexColorOrAuto",
+          "type": "string",
+          "pattern": "^([0-9a-f]{6}|auto)$"
+        },
+        "FilterMode": {
+          "id": "FilterMode",
+          "type": "integer",
+          "enum": [
+            0,
+            1
+          ]
+        },
+        "ThemePreset": {
+          "id": "ThemePreset",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "name": {
+              "type": "string",
+              "minLength": 1
+            },
+            "urls": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "theme": {
+              "$ref": "Theme"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "urls",
+            "theme"
+          ]
+        },
+        "CustomSiteConfig": {
+          "id": "CustomSiteConfig",
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "theme": {
+              "$ref": "Theme"
+            }
+          },
+          "required": [
+            "url",
+            "theme"
+          ]
+        },
+        "Automation": {
+          "id": "Automation",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "mode": {
+              "$ref": "AutomationMode"
+            },
+            "behavior": {
+              "type": "string",
+              "enum": [
+                "OnOff",
+                "Scheme"
+              ]
+            }
+          }
+        },
+        "AutomationMode": {
+          "id": "AutomationMode",
+          "type": "string",
+          "enum": [
+            "",
+            "time",
+            "system",
+            "location"
+          ]
+        },
+        "TimeSettings": {
+          "id": "TimeSettings",
+          "type": "object",
+          "properties": {
+            "activation": {
+              "$ref": "Time"
+            },
+            "deactivation": {
+              "$ref": "Time"
+            }
+          }
+        },
+        "Time": {
+          "id": "Time",
+          "type": "string",
+          "pattern": "^((0?[0-9])|(1[0-9])|(2[0-3])):([0-5][0-9])$"
+        },
+        "LocationSettings": {
+          "id": "LocationSettings",
+          "type": "object",
+          "properties": {
+            "latitude": {
+              "type": "number"
+            },
+            "longitude": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -46,6 +46,9 @@
     "optional_permissions": [
         "contextMenus"
     ],
+    "storage": {
+        "managed_schema": "managed-storage.json"
+    },
     "commands": {
         "toggle": {
             "suggested_key": {

--- a/tasks/bundle-manifest.js
+++ b/tasks/bundle-manifest.js
@@ -4,6 +4,7 @@ import {PLATFORM} from './platform.js';
 import * as reload from './reload.js';
 import {createTask} from './task.js';
 import {readJSON, writeJSON} from './utils.js';
+import {copyFile} from 'node:fs/promises';
 
 async function patchManifest(platform, debug, watch, test) {
     const manifest = await readJSON(absolutePath('src/manifest.json'));
@@ -38,6 +39,7 @@ async function manifests({platforms, debug, watch, test}) {
         const manifest = await patchManifest(platform, debug, watch, test);
         const destDir = getDestDir({debug, platform});
         await writeJSON(`${destDir}/manifest.json`, manifest);
+        await copyFile(absolutePath('src/managed-storage.json'), `${destDir}/managed-storage.json`);
     }
 }
 
@@ -45,7 +47,7 @@ const bundleManifestTask = createTask(
     'bundle-manifest',
     manifests,
 ).addWatcher(
-    ['src/manifest*.json'],
+    ['src/manifest*.json', 'managed-storage.json'],
     async (changedFiles, _, buildPlatforms) => {
         const chrome = changedFiles.some((file) => file.endsWith('manifest.json'));
         const platforms = {};


### PR DESCRIPTION
Solves #12619 .

This PR adds configuration via policy for [Chrome](https://developer.chrome.com/docs/extensions/reference/api/storage#property-managed) and [Firefox](https://extensionworkshop.com/documentation/enterprise/enterprise-development/) browsers.
I'd be glad if someone could confirm if it works on Safari, Edge, and Thunderbird, I can't test them.