### PR TITLE
Update dynamic-theme-fixes.config for gamepress.gg

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10669,7 +10669,7 @@ INVERT
 
 ================================
 
-gamepress.gg
+fgo.gamepress.gg
 
 CSS
 .TLW-tier-charname {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9729,6 +9729,18 @@ INVERT
 
 ================================
 
+fgo.gamepress.gg
+
+CSS
+.TLW-tier-charname {
+    color: ${black} !important;
+}
+#content-inner {
+    background-image: none !important;
+}
+
+================================
+
 fibermap.it
 
 INVERT
@@ -10666,18 +10678,6 @@ gameinformer.com
 
 INVERT
 .site-logo
-
-================================
-
-fgo.gamepress.gg
-
-CSS
-.TLW-tier-charname {
-    color: ${black} !important;
-}
-#content-inner {
-    background-image: none !important;
-}
 
 ================================
 


### PR DESCRIPTION
URL needs to be changed due to site migration. According to https://gamepress.gg/ , there are 3 games in the "Original URL" section. pogo redirects to V2, ak does not have this CSS problem, only fgo does.