### PR TITLE
Add nano-editor.org to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -730,6 +730,7 @@ n7hq.masseffect.com
 nameslol.com
 nanhu.ca
 nanobun.tv
+nano-editor.org
 nationsglory.com
 nationsglory.es
 nationsglory.fr


### PR DESCRIPTION
https://www.nano-editor.org/ is already dark and meets the criteria.