### PR TITLE
Add gaijin.net and steamhunters.com to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -444,6 +444,7 @@ fusengine.github.io/apaxy-v2
 galacticabot.vercel.app
 game.chronodivide.com
 gamebanana.com
+gaijin.net
 gamejolt.com
 gamersnexus.net
 gamescoper.com
@@ -1014,6 +1015,7 @@ status.pandadev.net
 steamcharts.com
 steamcommunity.com
 steamdb.info
+steamhunters.com
 steamstat.us
 steamtimeidler.com
 stillu.cc

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -441,10 +441,10 @@ frozensand.com
 funnyjunk.com
 furt.app
 fusengine.github.io/apaxy-v2
+gaijin.net
 galacticabot.vercel.app
 game.chronodivide.com
 gamebanana.com
-gaijin.net
 gamejolt.com
 gamersnexus.net
 gamescoper.com


### PR DESCRIPTION
- `*.gaijin.net` is on the list, but `gaijin.net` itself is not (and it's always dark), so I have added it to the list too.
- `steamhunters.com` is always dark.