### PR TITLE
Fix TOC on the ArchLinux Wiki

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -116,6 +116,11 @@ INVERT
 img[src*="icons/"]
 img[src="/svg/calendar.svg"]
 
+CSS
+.vector-sticky-pinned-container::after {
+    background: inherit;
+}
+
 ================================
 
 *.bitrix24.ru


### PR DESCRIPTION
The TOC on the ArchLinux wiki has a gradient below it going from white to transparent transparent black and is therefore not visible. Setting it to inherit instead makes it fit in with the DarkReader changes.