### PR TITLE
Fix button not showing after update to v4.9.87

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28964,6 +28964,9 @@ CSS
 .qrcode {
     background: white !important;
 }
+.button::before {
+    background-color: var(--_container-color) !important;
+}
 
 ================================
 


### PR DESCRIPTION
before<img width="281" alt="Snipaste_2024-07-05_17-55-30" src="https://github.com/darkreader/darkreader/assets/152774318/c912781f-4f32-4b96-8f34-bdf2f767ea79">
after<img width="252" alt="Snipaste_2024-07-05_17-55-46" src="https://github.com/darkreader/darkreader/assets/152774318/fe21e919-701a-432b-99c0-85d8763ffa49">

I use `!important` to change the affected CSS back to the website's original style.
I'm not sure if this is the correct approach, as this was broken by the recent update.
If other websites have the same issue, then these kinds of small patches might not be appropriate.