### PR TITLE
Add fix for campus.datacamp.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6773,8 +6773,14 @@ video#vjs_video_3_html5_api.vjs-tech {
     color: var(--darkreader-neutral-text) !important;
     mix-blend-mode: normal !important;
 }
-.css-alxior code {
-    color: #f0f0f0 !important;
+.css-alxior code,
+pre {
+    color: ${#0f0f0f} !important;
+    mix-blend-mode: difference !important;
+}
+.css-1ebl8to code,
+pre {
+    color: ${#0f0f0f} !important;
     mix-blend-mode: difference !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6773,6 +6773,10 @@ video#vjs_video_3_html5_api.vjs-tech {
     color: var(--darkreader-neutral-text) !important;
     mix-blend-mode: normal !important;
 }
+.css-alxior code {
+    color: #f0f0f0 !important;
+    mix-blend-mode: difference !important;
+}
 
 ================================
 


### PR DESCRIPTION
When dark theme is enabled, the code tag is not readable. I fixed this for campus.datacamp.com 
Default
![Default](https://github.com/user-attachments/assets/3aa96330-83b3-4849-82a4-f02583d7612a)
Fixed
![Fixed](https://github.com/user-attachments/assets/ed25ae94-f433-49cf-89ba-b1ebe861d671)
