### PR TITLE
Fix LaTeX code color in pir2.forumeiros.com and app.estuda.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30885,3 +30885,17 @@ CSS
 .zyimage {
     background-color: var(--darkreader-neutral-text) !important;
 }
+
+================================
+
+pir2.forumeiros.com
+
+INVERT
+img[src*="latex"]
+
+================================
+
+app.estuda.com
+
+INVERT
+img[src*="latex"]

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1810,6 +1810,13 @@ svg text.time_cursor {
 
 ================================
 
+app.estuda.com
+
+INVERT
+img[src*="latex"]
+
+================================
+
 app.getport.io
 
 CSS
@@ -20556,6 +20563,13 @@ INVERT
 
 ================================
 
+pir2.forumeiros.com
+
+INVERT
+img[src*="latex"]
+
+================================
+
 pirateship.com
 
 INVERT
@@ -30885,17 +30899,3 @@ CSS
 .zyimage {
     background-color: var(--darkreader-neutral-text) !important;
 }
-
-================================
-
-pir2.forumeiros.com
-
-INVERT
-img[src*="latex"]
-
-================================
-
-app.estuda.com
-
-INVERT
-img[src*="latex"]


### PR DESCRIPTION
The LaTeX images are being displayed in black color, and considering the dark background, it's very difficult to understand them. The proposed change aims to invert the color of these images to white, as to make them easy to read.

Examples of the change on these sites can be seen in:

https://pir2.forumeiros.com/t205435-probabilidade-banca-fgv#705383

https://app.estuda.com/questoes/?id=11473523