### PR TITLE
Fix for *.tripadvisor.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26681,6 +26681,14 @@ img.partner-img
 
 ================================
 
+tripadvisor.com
+*.tripadvisor.com
+
+INVERT
+img[alt="Tripadvisor"]
+
+================================
+
 trojmiasto.pl
 
 INVERT


### PR DESCRIPTION
Invert logo.

Wildcard match needed for multilingual subdomains.

Before:
![image](https://github.com/user-attachments/assets/c0541118-5e1c-4362-8f85-e51d023d0599)

After:
![Screenshot from 2024-07-17 23-17-57](https://github.com/user-attachments/assets/d21ce55e-58a5-4dfe-8404-f8cb69e090ac)
