### PR TITLE
Fix for tripadvisor.com.tw

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26682,6 +26682,7 @@ img.partner-img
 ================================
 
 tripadvisor.com
+tripadvisor.com.tw
 *.tripadvisor.com
 
 INVERT


### PR DESCRIPTION
The same fix applies as the .com domain.