### PR TITLE
Fix for foli.fi

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10158,6 +10158,17 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+foli.fi
+
+INVERT
+a[title="Etusivu"] svg
+a[title="Home"] svg
+a[title="Huvudsida"] svg
+button svg
+nav g > g:nth-child(1)
+
+================================
+
 follow.it
 
 INVERT


### PR DESCRIPTION
Invert logo and some icons

Before:
![image](https://github.com/user-attachments/assets/840014f0-a501-448f-9d37-f65b65f82576)

After:
![Screenshot from 2024-07-22 10-03-40](https://github.com/user-attachments/assets/694a1c3e-c49d-4b3d-bdbe-6c10acc0d2ab)
