### PR TITLE
Fix dark reader *permanently* modifying text color in google sheets

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8011,6 +8011,9 @@ input.docs-title-input {
     fill: var(--darkreader-selection-background) !important;
 }
 
+IGNORE INLINE STYLE
+.cell-input > span
+
 ================================
 
 docs.google.com/picker


### PR DESCRIPTION
Resolves: https://github.com/darkreader/darkreader/issues/10922

Dark Reader was permanently modifying text color of edited cells in google sheets (as in when editing a cell with Dark Reader enabled, it would change the color and stay changed even when refreshing or revisiting the sheet)
This pr fixes that behaviour.

For some reason, if I were to add a `docs.google.com/spreadsheets` url to dynamic theme editor it would break the invert filter (outlined in my issue), so I was forced to put the fix under `docs.google.com` which isn't ideal, but I don't think it will be a problem? If it is, a more specific selector could be used like `body:has(.classSpecificToSheets) .cell-input > span` or something, but that seems a bit janky to me.

If there's a better way to do this or any other way it can be improved, please let me know.