### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1099,7 +1099,6 @@ totems.me
 tov.monster
 tracker.gg
 trblwlf.net
-trblwlf.tk
 trilon.io
 tripleaughtdesign.com
 trojansource.codes


### PR DESCRIPTION
trblwlf.tk is now dead. (replaced by .net)