### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26086,6 +26086,7 @@ a[href="https://www.theguardian.com/documentaries"] > svg
 .crossword__grid .crossword__cell-text
 .crossword__cell-number
 div[data-link-name="most-popular"] > section > ol > li > a > span > svg
+img[alt="Multi-coloured sand texture"]
 
 CSS
 button[data-link-name="video-container-next"],
@@ -26125,6 +26126,9 @@ section[id="video"] .play-icon {
 svg[stroke="var(--article-border)"],
 svg[stroke="var(--straight-lines)"] {
     stroke: var(--darkreader-border--article-border) !important;
+}
+th[abbr$=" medals"] > svg > circle[r="6.6"] {
+    fill: var(--darkreader-bg--section-background) !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
Fixes "Olympic medal table" section on home page.

Before (dark mode):
![1](https://github.com/user-attachments/assets/a30e2011-f054-46bf-9f77-e5eda194e4fc)
Before (light mode):
![2](https://github.com/user-attachments/assets/28d7a292-8c2a-41fb-9a67-67d04722c817)

After (dark mode):
![3](https://github.com/user-attachments/assets/f4d001f9-9913-4127-baf6-4c9903bf1ef8)
After (light mode):
![4](https://github.com/user-attachments/assets/1545ce4a-2a3d-46dd-afaf-cf0a5e1fb356)