### PR TITLE
fix: Garmin Coach Plans

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10923,6 +10923,18 @@ span[class*="Gc5ChallengesCard_progressBar"] div[class*="ProgressBar_bar__"],
 span[class*="DayView_progressBar"] div[class*="ProgressBar_bar__"] {
     background: ${black} !important;
 }
+.find-plan-filters button {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.plan-section-label {
+    color: var(--darkreader-neutral-text) !important;
+}
+.plan-info,
+.plan-specs {
+    background-color: var(--darkreader-neutral-background) !important;
+    border-color: transparent !important;
+    color: var(--darkreader-neutral-text) !important;
+}
 
 ================================
 


### PR DESCRIPTION
This PR fixes Garmin Coach Plans glitches (search filters, section headings, plan cards) in Garmin Connect dashboard.

Before (dark mode):

![Screenshot 2024-07-29 104830](https://github.com/user-attachments/assets/49c385a1-5ddc-4c62-87ab-f54979ea6035)

Before (light mode):

![Screenshot 2024-07-29 113044](https://github.com/user-attachments/assets/347646be-ff6d-4369-9c6e-e02e4ec17300)

After (dark mode):

![Screenshot 2024-07-29 104925](https://github.com/user-attachments/assets/a5201016-0f81-4479-8d5f-3829a328b358)

After (light mode):

![Screenshot 2024-07-29 111527](https://github.com/user-attachments/assets/ac5b0cc1-3225-406c-bf25-77581f2da4c1)

