### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10093,9 +10093,11 @@ IGNORE INLINE STYLE
 ================================
 
 fivethirtyeight.com
+*.fivethirtyeight.com
 
 INVERT
 .logo
+.abclogo
 .site-logo
 #searchform
 .header-espn-link


### PR DESCRIPTION
The logos on the projects.fivethirtyeight.com page were not inverting properly. They currently display as black on a dark background. 

I updated the config file to include *.fivethirtyeight.com in order to invert these elements.

In addition, the ABC News logo at the top right has its own class ("abclogo") and this had to be added to the INVERT list in order for it to appear inverted.

Before:
![fivethirtyeight_bef](https://github.com/user-attachments/assets/ba19395a-c43a-4d97-bb96-0d6744cc3db2)

After:
![fivethirtyeight_after](https://github.com/user-attachments/assets/3d26ac06-acbe-451a-8490-47da75d5836b)
