### PR TITLE
Fix Discogs.com logo and bullet points

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -149,6 +149,18 @@ CSS
 
 ================================
 
+*.discogs.com
+
+CSS
+[class*="logo"] {
+    filter: invert(100%) hue-rotate(180deg) !important;
+}
+.swiper-pagination-bullet {
+    background: var(--swiper-pagination-bullet-inactive-color, #FFFFFF) !important;
+}
+
+================================
+
 *.globo.com
 
 CSS


### PR DESCRIPTION
Invert the logo's hue so it is distinguishable from the background and set bullet points' background color to white.