### PR TITLE
Fix for nomadgoods.com logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19028,6 +19028,13 @@ CSS
 
 ================================
 
+nomadgoods.com
+
+INVERT
+header a[href="/"] > svg
+
+================================
+
 nonograms.org
 
 CSS


### PR DESCRIPTION
Inverts the logo as it's not inverted for some reason after page load.

![msedge_Main_2024-07-28_22-32-04](https://github.com/user-attachments/assets/ade47258-7265-4a6e-b41f-9185acf47014)

after: 

![msedge_Main_2024-07-28_22-32-48](https://github.com/user-attachments/assets/f33b1bac-131e-487f-8800-a231e20fced9)
