### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27700,6 +27700,9 @@ INVERT
 .mwe-math-fallback-image-inline
 .mwe-math-fallback-image-display
 
+IGNORE IMAGE ANALYSIS
+.site_logo
+
 ================================
 
 vbulletin.com


### PR DESCRIPTION
Ignore image analysis of site logo on https://www.vasp.at/forum/index.php to prevent unwanted inversion
![vasp-darkreader](https://github.com/user-attachments/assets/146e2554-2f38-445e-9156-24c3278a3e34)
