### PR TITLE
Remove libreboot.org from Dark Sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -645,7 +645,6 @@ lemm.ee
 lemmi.no
 lemmy.world
 lemmyverse.net
-libreboot.org
 lichess.org
 lightweightpdf.com
 limeshark.dev/editor


### PR DESCRIPTION
libreboot.org is no longer a dark website.