### PR TITLE
Fix cnrtl.fr syntagma highlighting

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -140,6 +140,15 @@ INVERT
 
 ================================
 
+*.cnrtl.fr
+
+CSS
+.tlf_csyntagme {
+    background-color: rgb(22, 89, 0) !important;
+}
+
+================================
+
 *.crm*.dynamics.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -143,8 +143,14 @@ INVERT
 *.cnrtl.fr
 
 CSS
+.tlf_cdefinition {
+    background-color: ${rgb(255, 255, 0)} !important;
+}
+.tlf_cdomaine {
+    background-color: ${rgb(255, 176, 96)} !important;
+}
 .tlf_csyntagme {
-    background-color: rgb(22, 89, 0) !important;
+    background-color: ${rgb(192, 255, 192)} !important;
 }
 
 ================================


### PR DESCRIPTION
The original color, rgb(192, 255, 192), for syntagma highlighting makes the text illegible