### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26226,59 +26226,58 @@ div.main_content {
 theguardian.com
 
 INVERT
-.inline-the-guardian-logo__svg
-a[data-link-name$="logo"] svg
 a[data-sponsor="guardian.org"]
-a[href="https://www.theguardian.com/documentaries"] > svg
-.crossword__grid .crossword__cell-text
-.crossword__cell-number
+div[data-link-name="Crosswords"] .crossword__cell-number
+div[data-link-name="Crosswords"] .crossword__cell-text
 div[data-link-name="most-popular"] > section > ol > li > a > span > svg
-img[alt="Multi-coloured sand texture"]
+section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
+section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand texture"]
 
 CSS
-button[data-link-name="video-container-next"],
-button[data-link-name="video-container-prev"] {
-    background-color: var(--carousel-arrow-background) !important;
-}
-button[data-link-name="video-container-next"]:hover,
-button[data-link-name="video-container-prev"]:hover {
-    background-color: var(--carousel-arrow-background-hover) !important;
-}
-button[data-link-name="video-container-next"]:hover svg,
-button[data-link-name="video-container-prev"]:hover svg {
-    fill: var(--carousel-arrow) !important;
-}
-section[id="documentaries"] p {
+section[data-component="documentaries"] p {
     border-top: 1px solid #ffffff50 !important;
 }
-section[id="video"] .dcr-192a2s8 {
+section[data-component="video"] button[data-link-name="video-container-next"],
+section[data-component="video"] button[data-link-name="video-container-prev"] {
+    background-color: var(--carousel-arrow-background) !important;
+}
+section[data-component="video"] button[data-link-name="video-container-next"]:hover,
+section[data-component="video"] button[data-link-name="video-container-prev"]:hover {
+    background-color: var(--carousel-arrow-background-hover) !important;
+}
+section[data-component="video"] button[data-link-name="video-container-next"]:hover svg,
+section[data-component="video"] button[data-link-name="video-container-prev"]:hover svg {
+    fill: var(--carousel-arrow) !important;
+}
+section[data-component="video"] .dcr-192a2s8 {
     background-color: rgba(0, 0, 0, 0.7) !important;
 }
-section[id="video"] .dcr-1n5sax3 {
+section[data-component="video"] .dcr-1n5sax3 {
     background: linear-gradient( 180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 25% ) !important;
 }
-section[id="video"] .dcr-1rvgcvp,
-section[id="video"] .dcr-kcvdg {
+section[data-component="video"] .dcr-1rvgcvp,
+section[data-component="video"] .dcr-kcvdg {
     background-color: #707070 !important;
 }
-section[id="video"] .dcr-6r6u10 {
+section[data-component="video"] .dcr-6r6u10 {
     background-color: var(--carousel-dot) !important;
 }
-section[id="video"] .dcr-zxdpfk {
+section[data-component="video"] .dcr-zxdpfk {
     background-color: var(--carousel-active-dot) !important;
 }
-section[id="video"] .play-icon {
+section[data-component="video"] .play-icon {
     background-color: rgba(18, 18, 18, 0.6) !important;
 }
 svg[stroke="var(--article-border)"],
 svg[stroke="var(--straight-lines)"] {
     stroke: var(--darkreader-border--article-border) !important;
 }
-th[abbr$=" medals"] > svg > circle[r="6.6"] {
+section[data-component="olympic-medal-table"] th > svg > circle[r="6.6"] {
     fill: var(--darkreader-bg--section-background) !important;
 }
 
 IGNORE INLINE STYLE
+a[data-link-name="nav3 : logo"] svg
 section[id="documentaries"] path[fill="#121212"]
 section[id="video"] path[fill="#FFFFFF"]
 


### PR DESCRIPTION
- Fixes logo on crossword pages.
- Merges `INVERT` fixes in #699 and #3557 into one `IGNORE INLINE STYLE` fix.
- Clarify several rules to allow for easier identification and sorting.

Before:
![1](https://github.com/user-attachments/assets/30bad7da-c3e8-4c3c-91dd-3b9028ffa46c)

After:
![2](https://github.com/user-attachments/assets/0621d433-9f35-4976-b510-196ac02e31b3)