### PR TITLE
Fix for *.debian.net

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6924,10 +6924,13 @@ INVERT
 
 debian.org
 *.debian.org
+*.debian.net
 
 INVERT
 .community img
+img[src*="openlogo-100.jpg"]
 img[src*="openlogo-50.png"]
+img[src*="openlogo-50.svg"]
 img[src*="openlogo-nd-75.png"]
 
 CSS


### PR DESCRIPTION
Similar rules apply.

Fixes sites like codesearch.debian.net and cloudfront.debian.net