### PR TITLE
Add kasmedia to dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -600,6 +600,7 @@ kadantiscam.netlify.app
 kaioken.dev
 kalence2.github.io
 kaoskrew.org
+kasmedia.com
 kazimagazine.com
 kbh.games
 kbhgames.com


### PR DESCRIPTION
KasMedia has an available built-in dark mode, this pull request is also influenced by the fact that dark reader is breaking framer-motion animated images on the website, causing a black box instead of the image (see featured article, which is the biggest image on top of the website, it breaks with dark reader being enabled.