### PR TITLE
Add Valve-related sites to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -515,6 +515,7 @@ hackthebox.com
 hackthebox.eu
 hackthissite.org
 hacktoberfest-projects.vercel.app
+half-life.com/*/halflife25
 halowaypoint.com
 hardforum.com
 hardstuck.gg
@@ -633,6 +634,7 @@ kulbachny.com
 kwejk.pl
 kyleggiero.me
 kyun.host
+l4d.com
 labs.hackthebox.com
 lagom.nl/lcd-test
 lainchan.org
@@ -1080,6 +1082,7 @@ theme-park.dev
 themes.vscode.one
 thespacedevs.com
 thetatoken.org
+thinkwithportals.com
 thiscatdoesnotexist.com
 thispersondoesnotexist.com
 tilde.club


### PR DESCRIPTION
- `half-life.com` looks fine with Dark Reader, but the special subpage `half-life.com/*/halflife25` has some problems with Dark Reader ON, and it can be disabled specifically for that page.
  - `*` here is for language (`/en/`, `/fr/` etc.).
- `l4d.com` is already dark.
- `thinkwithportals.com` is already dark, except for the background, but enabling Dark Reader there defeats the site purpose's of resembling the in-game levels.