### PR TITLE
Add dumpspace.spuckwaffel.com to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -346,6 +346,7 @@ dualshockers.com
 duckychannel.com.tw
 duelingnexus.com
 dumpert.nl
+dumpspace.spuckwaffel.com
 dumpus.app
 dungeon-lords.de
 dustinbrett.com


### PR DESCRIPTION
Add dumpspace.spuckwaffel.com to global dark list