### PR TITLE
Update index.tsx, in order to update Site List tab labels for better usability

### DIFF
--- a/src/ui/popup/components/site-list-settings/index.tsx
+++ b/src/ui/popup/components/site-list-settings/index.tsx
@@ -17,8 +17,8 @@ export default function SiteListSettings({data, actions, isFocused}: SiteListSet
             <Toggle
                 class="site-list-settings__toggle"
                 checked={!data.settings.enabledByDefault}
-                labelOn={getLocalMessage('invert_listed_only')}
-                labelOff={getLocalMessage('not_invert_listed')}
+                labelOn={getLocalMessage('Sites to Keep in Dark Mode')}
+                labelOff={getLocalMessage('Sites to Keep in Light Mode')}
                 onChange={(value) => actions.changeSettings({enabledByDefault: !value})}
             />
             <TextList


### PR DESCRIPTION
Updated Site List tab labels to be more intuitive, as discussed in issue #13044. This PR changes the current labels in the Site List tab from "Invert Listed Only" and "Not Invert Listed" to "Sites to Keep in Dark Mode" and "Sites to Keep in Light Mode" to improve clarity for all users.
