### PR TITLE
Update en-US.config, in order to update Site List tab labels for better usability

### DIFF
--- a/src/_locales/en-US.config
+++ b/src/_locales/en-US.config
@@ -95,10 +95,10 @@ Apply settings to current website only
 Site list
 
 @invert_listed_only
-Invert listed only
+Sites to Keep in Dark Mode
 
 @not_invert_listed
-Not invert listed
+Sites to Keep in Light Mode
 
 @add_site_to_list
 Add site to list


### PR DESCRIPTION
Updated Site List tab labels to be more intuitive, as discussed in issue #13044. This PR changes the current labels in the Site List tab from "Invert Listed Only" and "Not Invert Listed" to "Sites to Keep in Dark Mode" and "Sites to Keep in Light Mode" to improve clarity for all users.