### PR TITLE
Fix for zhihu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31336,6 +31336,9 @@ div.css-vurnku button {
 div.css-vurnku button svg {
     fill: ${darkblue} !important;
 }
+div.Popover-content .Menu {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
This patch is a fix for zhihu.com's messagebox banner.

Before:
![image](https://github.com/user-attachments/assets/43803e9b-be27-4bc8-84cb-4052bbb9ee44)

After:
![image](https://github.com/user-attachments/assets/a2771b15-ec35-4a11-9b30-755a4371f058)
