### PR TITLE
Add filegarden.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -411,6 +411,7 @@ fanpage.fm
 fastro.dev
 fedidb.org
 femto.dev
+filegarden.com
 filmmakermode.com
 filterblade.xyz
 filterlists.com


### PR DESCRIPTION
This adds [File Garden](https://filegarden.com/) to the global dark list, as it's already a fully dark-themed website (regardless of preferred color scheme), and Dark Reader just reduces the contrast and makes lines harder to see for example.