### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26447,6 +26447,21 @@ CSS
 section[data-component="documentaries"] p {
     border-top: 1px solid #ffffff50 !important;
 }
+section[data-component="contact-the-guardian"] a {
+    color: #121212 !important;
+}
+section[data-component="contact-the-guardian"] .btn {
+    background-color: #fff !important;
+}
+section[data-component="contact-the-guardian"] .securedrop {
+    background-color: #ffe500 !important;
+}
+section[data-component="contact-the-guardian"] .securedrop__main > .eyes > .eye > .outside > svg > path {
+    stroke: rgba(230,207,0,.5) !important;
+}
+section[data-component="olympic-medal-table"] circle[r="6.6"] {
+    fill: var(--darkreader-bg--section-background) !important;
+}
 section[data-component="video"] button[data-link-name="video-container-next"],
 section[data-component="video"] button[data-link-name="video-container-prev"] {
     background-color: var(--carousel-arrow-background) !important;
@@ -26482,14 +26497,12 @@ svg[stroke="var(--article-border)"],
 svg[stroke="var(--straight-lines)"] {
     stroke: var(--darkreader-border--article-border) !important;
 }
-section[data-component="olympic-medal-table"] th > svg > circle[r="6.6"] {
-    fill: var(--darkreader-bg--section-background) !important;
-}
 
 IGNORE INLINE STYLE
 a[data-link-name="nav3 : logo"] svg
-section[id="documentaries"] path[fill="#121212"]
-section[id="video"] path[fill="#FFFFFF"]
+section[data-component="contact-the-guardian"] *
+section[data-component="documentaries"] path[fill="#121212"]
+section[data-component="video"] path[fill="#FFFFFF"]
 
 ================================
 


### PR DESCRIPTION
- Fixes "Tip us off" section on home page.
- Simplified fix in #13029.
- Tweaks a few `IGNORE INLINE STYLE` fixes to allow for easier sorting.

Before:
![1](https://github.com/user-attachments/assets/d69dd1a6-64f5-48b0-b263-5872826132c6)

After:
![2](https://github.com/user-attachments/assets/871bcafc-50f2-492f-a0da-f4bef1ec77ba)