### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10750,6 +10750,13 @@ strong
 
 ================================
 
+forums.stardock.com
+
+IGNORE IMAGE ANALYSIS
+.body .forum > .post .postcontainer .postinfo .menu .karma_badge
+
+================================
+
 forums.tomshardware.com
 
 INVERT


### PR DESCRIPTION
Stardock forum karma badge fix (avoids inverting the badge background)