### PR TITLE
Remove flathub.org from dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -417,7 +417,6 @@ filterblade.xyz
 filterlists.com
 fireship.io
 fishshell.com
-flathub.org
 fleepy.tv
 flipperhub.com
 florr.io


### PR DESCRIPTION
Not dark-by-default if light theme is requested via `prefers-color-scheme`.