### PR TITLE
Revert patch for fritx.me to fix unexpected image filter

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10908,16 +10908,6 @@ body {
 
 ================================
 
-fritx.me
-*.fritx.me
-*.*.fritx.me
-fritx.github.io
-
-INVERT
-.main-page img
-
-================================
-
 fritz.box
 
 INVERT


### PR DESCRIPTION
Reverts previous PR: https://github.com/darkreader/darkreader/pull/12466 , which I have fixed on my own side.

And fixes all the unexpected image filter.

![image](https://github.com/user-attachments/assets/7477fae4-aede-4b5b-bddd-29b18f3cc623)

-- https://blog.fritx.me/?aboutme
