### PR TITLE
Proliferate Town of Salem changes to clones

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26974,6 +26974,8 @@ INVERT
 ================================
 
 town-of-salem.fandom.com
+breezewiki.com/town-of-salem/
+bw.artemislena.eu/town-of-salem/
 
 IGNORE INLINE STYLE
 span[style^="text-shadow"]


### PR DESCRIPTION
See https://breezewiki.com/ for more details about the URLs.

bw.artemislena.eu is a fork/mirror of BreezeWiki.
Same fix from Fandom also applies to the forks.

Adding the URLs after the main URL so "town-of-salem" still remains as the first in the site order.