### PR TITLE
[app.ynab.com] Fix checkboxes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2170,6 +2170,15 @@ textarea {
 
 ================================
 
+app.ynab.com
+
+CSS
+.ynab-checkbox-button-square {
+    color: transparent;
+}
+
+================================
+
 app.youneedabudget.com
 
 CSS


### PR DESCRIPTION
Make unchecked checkboxes appear unchecked, rather than checked. The checkboxes are SVG icons, and the checkmark is set to the light background color when the state is unchecked. Dark Reader turns the background dark, revealing the light checkmark. This change makes the checkmark transparent. In the checked state, the transparent color is still overridden by the existing styles, revealing the checkmark.

### Before

![CleanShot 2024-08-17 at 13 49 15@2x](https://github.com/user-attachments/assets/eb17f5de-8e24-48ba-a9fe-d204b2c3c24e)


### After
![CleanShot 2024-08-17 at 13 49 27@2x](https://github.com/user-attachments/assets/1fbbd1b9-c1a7-43e1-9cb0-184772d3dfaf)
