### PR TITLE
Fix spoiler styles on neoseeker.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18995,6 +18995,20 @@ div[class^="newsSingleBar"] > div[class^="newsSingleBarHeaderWidescreen-category
 
 ================================
 
+neoseeker.com
+
+CSS
+.hidden_text {
+    background-color: var(--darkreader-neutral-text) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.hidden_text.shown {
+    background-color: transparent !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 neowin.net
 
 INVERT


### PR DESCRIPTION
Neoseeker guides have spoiler text that is broken with Dark Reader due to it coloring the text and unhovered background color differently. This leads to the spoiler still being shown.

Example guide: https://www.neoseeker.com/the-legend-of-heroes-trails-through-daybreak/Prologue

### Before:
![image](https://github.com/user-attachments/assets/6a7c0f76-42a3-4c11-9dca-69f66afbb5bc)

### After - Dark:
![image](https://github.com/user-attachments/assets/12819042-4528-44ac-af69-f329d5c5e69a)

### After - Light:
![image](https://github.com/user-attachments/assets/b0bb65b9-fe3d-4719-9bc4-22fd6b727553)

