### PR TITLE
Update dynamic-theme-fixes.config to fix logo on *.abc.net.au

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -102,10 +102,11 @@ IGNORE INLINE STYLE
 
 *.abc.net.au
 
-CSS
-[data-component="ABCLogo"].path {
-    fill: "";
-}
+INVERT
+[data-component="ABCNewsLogo"] *
+
+IGNORE INLINE STYLE
+[data-component="ABCLogo"] *
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -100,6 +100,15 @@ IGNORE INLINE STYLE
 
 ================================
 
+*.abc.net.au
+
+CSS
+[data-component="ABCLogo"].path {
+    fill: "";
+}
+
+================================
+
 *.americanexpress.com
 
 CSS


### PR DESCRIPTION
Update dynamic-theme-fixes.config to fix logo on *.abc.net.au, by removing existing svg path fill to make darkreader inversion work.