### PR TITLE
Fix for GitHub.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11630,6 +11630,9 @@ span.commit-ref > a {
     background-color: rgb(28, 30, 31) !important;
     color: darkgrey !important;
 }
+.markdown-body a[href]:has(img) {
+    display: inline-flex;
+}
 .jfk-bubble,
 .octotree-sidebar,
 .cc-pr__logo,


### PR DESCRIPTION
Applies `display:inline-flex` to `<a href"..."><img>` sequences inside markdown bodies, this globally fixes an issue with annoying whitespaces between badges on GitHub.

See also:
https://stackoverflow.com/a/65645230
https://github.com/orhun/git-cliff/pull/809