### PR TITLE
config/dynamic: fix cal-heatmap on pagure hosts

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25020,6 +25020,14 @@ INVERT
 
 ================================
 
+src.fedoraproject.org
+pagure.io
+
+IGNORE INLINE STYLE
+#cal-heatmap svg rect
+
+================================
+
 ssllabs.com
 
 INVERT


### PR DESCRIPTION
TODO: should this be a generic rule?

Before:

![Before](https://github.com/user-attachments/assets/d9638bef-2e85-4b1c-a4da-244a1403f67b)

After:

![After](https://github.com/user-attachments/assets/c55c3890-946d-45b3-b585-0937952fb8c6)


Signed-off-by: Zephyr Lykos <git@mochaa.ws>
