### PR TITLE
 Fixed fritz.box navigation Menu colors in dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11009,6 +11009,12 @@ div.formular input[type="radio"],
 div.formular input[type="checkbox"] {
     background-color: transparent !important;
 }
+#navigationMenu {
+    background: linear-gradient(#1b1e1f 30%, rgba(255, 255, 255, 0)) center top,linear-gradient(rgba(255, 255, 255, 0), #1b1e1f 70%) center bottom,linear-gradient(var(--charcoal-gray-30), transparent) center top,linear-gradient(transparent, #1b1e1f) center bottom !important;
+    background-attachment: local,local,scroll,scroll !important;
+    background-repeat: no-repeat !important;
+    background-size: 100% 1.2rem,100% 1.2rem,100% .5rem,100% .5rem !important;
+}
 
 ================================
 


### PR DESCRIPTION
Fixed white Gradients on the navigation Menu on the fritz.box website (local dns to 192.168.178.1 for controlling the AVM fritz box; only accessible with a fritz box router).