### PR TITLE
fix for fallout.wiki

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9961,6 +9961,9 @@ CSS
 .user-anon #cosmos-banner {
     position: sticky !important;
 }
+.k-player .control-bar {
+    background: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Setting darkreader-neutral-background for player control bar