### PR TITLE
Fix Filter(+) selection color on kickstarter.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1390,7 +1390,7 @@ kickstarter.com
 
 CSS
 ::selection, ::-moz-selection {
-    background-color: var(--ck-ksr-dark-green) !important;
+    background-color: #06E584 !important;
 }
 
 ================================


### PR DESCRIPTION
The auto-generated highlight background color in Filter/Filter+ mode is essentially unnoticable due to Kickstarter setting their own that doesn't play nicely with the addon. This fix just switches it from their light green brand color to their dark green brand color.