### PR TITLE
Added acumatica.com to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -110,6 +110,18 @@ IGNORE INLINE STYLE
 
 ================================
 
+*.acumatica.com
+
+CSS
+.control-GridCheck:after {
+    background-color: var(--darkreader-bg--background-color) !important;
+}
+.control-GridUncheck:after {
+    background-color: var(--darkreader-bg--background-color) !important;
+}
+
+================================
+
 *.americanexpress.com
 
 CSS


### PR DESCRIPTION
Making checkbox background dark for `*.acumatica.com`. Without this, checkmarks would invert and their background would not, turning it white-on-white.