### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26698,7 +26698,9 @@ div[data-link-name="Crosswords"] .crossword__cell-number
 div[data-link-name="Crosswords"] .crossword__cell-text
 div[data-link-name="most-popular"] > section > ol > li > a > span > svg
 section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
+section[data-component="headlines"] .dcr-d4xwbm > svg
 section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand texture"]
+section[data-component="paralympic-medal-table"] img[alt="Multi-coloured sand texture"]
 
 CSS
 section[data-component="documentaries"] p {
@@ -26716,7 +26718,11 @@ section[data-component="contact-the-guardian"] .securedrop {
 section[data-component="contact-the-guardian"] .securedrop__main > .eyes > .eye > .outside > svg > path {
     stroke: rgba(230,207,0,.5) !important;
 }
-section[data-component="olympic-medal-table"] circle[r="6.6"] {
+section[data-component="headlines"] .dcr-d4xwbm {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+section[data-component="olympic-medal-table"] circle[r="6.6"],
+section[data-component="paralympic-medal-table"] circle[r="6.6"] {
     fill: var(--darkreader-bg--section-background) !important;
 }
 section[data-component="video"] button[data-link-name="video-container-next"],
@@ -26759,6 +26765,7 @@ IGNORE INLINE STYLE
 a[data-link-name="nav3 : logo"] svg
 section[data-component="contact-the-guardian"] *
 section[data-component="documentaries"] path[fill="#121212"]
+section[data-component="headlines"] path
 section[data-component="video"] path[fill="#FFFFFF"]
 
 ================================


### PR DESCRIPTION
- Fixes weather widget on home page.
- Fixes "Paralympic medal table" section on home page.

Before:
![1](https://github.com/user-attachments/assets/e7a834de-af49-49f3-9202-e56940ba2f78)
![2](https://github.com/user-attachments/assets/3fe6b547-2dc5-4fa4-a9e1-91df9959aed9)

After:
![3](https://github.com/user-attachments/assets/4f678657-0eb0-495a-bb07-cb75d2ec424a)
![4](https://github.com/user-attachments/assets/c3bea808-fe1c-466b-9cac-64c365c59873)