### PR TITLE
add shockbs.is-a.dev to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -989,6 +989,7 @@ shatteredpixel.com
 sheet.host
 shellshock.io
 sherlock-project.github.io
+shockbs.is-a.dev
 showtimeanytime.com
 shpposter.club
 shrirambalaji.dev


### PR DESCRIPTION
hi! dark reader is causing my site shockbs.is-a.dev not functioning properly hence i would like to add it to dark-sites.config
my site met the requirements:

-  everything dark by default, ignoring system colour scheme
- no redirects
- yes completed and will not change

thanks!