### PR TITLE
Fix erroneous INVERT of .graphie-label for Khan Academy

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14896,13 +14896,6 @@ CSS
 
 ================================
 
-khanacademy.org
-
-INVERT
-.graphie-label
-
-================================
-
 khronos.org
 
 INVERT


### PR DESCRIPTION
The `.graphie-label` text is black by default, the `INVERT` makes it stay black on dark mode, rendering it unreadable.

I've removed this from the file and it seems to fix it.

Tested on Chrome Version 128.0.6613.119 (Official Build) (64-bit).

### Before
![image](https://github.com/user-attachments/assets/b8c032d7-e35a-40ae-9bc1-7b1bfa22a21e)
![image](https://github.com/user-attachments/assets/3ed0acb6-2d29-4d53-8965-60f73449de10)

### After
![image](https://github.com/user-attachments/assets/386bc968-88c0-45d3-81da-96e5ef8eb83c)
![image](https://github.com/user-attachments/assets/29cc2810-1f9b-40a7-923c-823078656587)
