### PR TITLE
Image fix for Ableton dynamic theme

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -813,6 +813,11 @@ INVERT
 .main-footer__basics__logo
 .main-footer__secondary__signature__logo
 
+CSS
+.body-text--manual figure img {
+    background-color: #DCDAD8 !important;
+}
+
 ================================
 
 about.gitlab.com


### PR DESCRIPTION
Some graphics in Ableton's knowledge base are line diagrams with transparency, and thus aren't visible against a dark background. I opted to just add a white background since it'd only (visibly) affect images with transparency (I'd have preferred to simply invert only these images, but there wasn't a selector with enough specificity). The hex code `#DCDAD8` exactly matches the white background from the default Light scheme. I tried using the preferred dynamic variables, but nothing would work for _both_ Light & Dark schemes (a workaround is technically possible, but it requires diverting somewhat from the code style, so hardcoded color it is).

(relevant page, for reference: https://www.ableton.com/en/live-manual/11/midi-fact-sheet/#midi-fact-sheet)