### PR TITLE
Apple Support Community nav bar CSS

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7942,6 +7942,15 @@ INVERT
 
 ================================
 
+discussions.apple.com
+
+CSS
+#globalnav {
+    --globalnav-background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 disk.yandex.*
 docviewer.yandex.*
 


### PR DESCRIPTION
Fixes the dynamic dark theme for the top navigation bar in Apple Support Community (discussions.apple.com)