### PR TITLE
Update dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -12,10 +12,10 @@
 12bytes.org
 1337x.*/$
 13willow.com
-23.social
 1lighty.github.io/BetterDiscordStuff
 1maginary.online
 1nf.me
+23.social
 2600.com
 2bqueue.info
 3072.vercel.app
@@ -83,8 +83,8 @@ aqtiongame.com
 archive.ragtag.moe
 archon.gg
 arcturusmc.xyz
-ardov.me
 ard.social
+ardov.me
 ari.lt
 arialfx.com
 arkenfox.github.io/TZP/
@@ -165,6 +165,7 @@ bocchilorenzo.github.io
 bogleech.com
 bondoer.fr
 bonfirenetworks.org
+bonn.social
 bootstrap.academy
 bot.noob.bio
 botboy.snaz.in
@@ -180,7 +181,6 @@ brodierobertson.xyz
 browserslist.vercel.app
 brunotome.dev
 bsodium.fr
-bonn.social
 bugmenot.com
 buildbot.orphis.net
 bultek.com.ua
@@ -370,9 +370,9 @@ e-z.host
 easypastes.tk
 ecosia.org
 ecys.xyz
+edi.social
 edit-csv.net
 editor.method.ac
-edi.social
 elderscrolls.fandom.com
 eleaks.to
 elitedangerous.com
@@ -753,8 +753,8 @@ mrdemoapple.uk
 mrms.cz
 mrquantumoff.dev
 mrtipson.github.io/otz-builds/
-mstdn.social
 ms-paint-i.de
+mstdn.social
 mtv.com
 mulv.tycrek.dev
 musedash.moe
@@ -1168,8 +1168,8 @@ ultrajs.dev
 undergroundcellar.com
 underlords.com
 undertale.com
-universeodon.com
 universe.eveonline.com
+universeodon.com
 unlimiter.github.io/pika
 urbanlinker.com
 userdiag.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -12,6 +12,7 @@
 12bytes.org
 1337x.*/$
 13willow.com
+23.social
 1lighty.github.io/BetterDiscordStuff
 1maginary.online
 1nf.me
@@ -55,6 +56,7 @@ an3x.org
 andrew-larson.dev
 andrewleguay.com
 andrewthedev.com
+androiddev.social
 animepahe.com
 animixplay.to
 animk.info
@@ -82,6 +84,7 @@ archive.ragtag.moe
 archon.gg
 arcturusmc.xyz
 ardov.me
+ard.social
 ari.lt
 arialfx.com
 arkenfox.github.io/TZP/
@@ -132,6 +135,7 @@ betterttv.com
 bg3.wiki
 bherila.net
 bidet.gg
+bildung.social
 bin.disroot.org
 bin.veracry.pt
 birdie0.github.io
@@ -176,6 +180,7 @@ brodierobertson.xyz
 browserslist.vercel.app
 brunotome.dev
 bsodium.fr
+bonn.social
 bugmenot.com
 buildbot.orphis.net
 bultek.com.ua
@@ -197,6 +202,7 @@ cc.com
 cdkeys.com
 cdn.minlor.net
 cdnnow.pro
+chaos.social
 chat-gpt.org
 chat.openai.com
 chat.ryzom.com
@@ -250,6 +256,7 @@ cswarzone.com
 ctf.hackthebox.com
 ctt.cx
 cuibonobo.com
+curia.social-network.europa.eu
 curiositystream.com
 cxsecurity.com
 cybercodeonline.com
@@ -294,6 +301,7 @@ desktop.github.com
 desoroxxx.github.io/Portfolio/
 destiny.gg
 destinytracker.com
+det.social
 devanbuggay.com
 devart.withgoogle.com
 developer.valvesoftware.com
@@ -364,6 +372,7 @@ ecosia.org
 ecys.xyz
 edit-csv.net
 editor.method.ac
+edi.social
 elderscrolls.fandom.com
 eleaks.to
 elitedangerous.com
@@ -374,6 +383,7 @@ emeraldchat.com/app
 emkc.org
 emoji.supply/kitchen/
 emuparadise.me
+energiewende.social
 enig.ma.tum.de
 enigame.de
 enlightenment.org
@@ -428,6 +438,7 @@ flavibot.xyz
 fleepy.tv
 flipperhub.com
 florr.io
+floss.social
 fluxpoint.dev
 fmovies.to
 food-le.co
@@ -442,6 +453,7 @@ forumplayer.dev
 forums.bhvr.com/dead-by-daylight/
 forums.eveonline.com
 forums.launchbox-app.com
+fosstodon.org
 fox.com
 fpn.firefox.com
 fragment.com
@@ -452,8 +464,10 @@ freecodecamp.org/learn/
 freeipa.org
 freesearch.club
 freespeechextremist.com
+front-end.sociall
 frozensand.com
 funnyjunk.com
+furry.engineer
 furt.app
 fusengine.github.io/apaxy-v2
 gaijin.net
@@ -502,7 +516,7 @@ gog.com/forum
 gogalaxy.com
 goodfirstissue.dev
 goosegame.io
-grapheneos.org
+grafana.social
 graydon2.dreamwidth.org
 grayjay.app
 grc.arikado.ru
@@ -571,9 +585,11 @@ imgur.com
 impb.in
 imperialb.in
 imxnoobx.com
+indieweb.social
 indiexpo.net
 infinitezoom.net
 infocon.org
+infosec.exchange
 inker.app
 inker.co
 intactphone.com
@@ -610,6 +626,7 @@ justwatch.com
 kadantiscam.netlify.app
 kaioken.dev
 kalence2.github.io
+kanoa.de
 kaoskrew.org
 kazimagazine.com
 kbh.games
@@ -691,8 +708,8 @@ m.daum.net
 m2v.ru
 macbb.org
 madiator.com
-mail.tutanota.com
 mango.pdf.zone
+mapstodon.space
 marte.dev
 marvil.co
 maskbox.app
@@ -736,6 +753,7 @@ mrdemoapple.uk
 mrms.cz
 mrquantumoff.dev
 mrtipson.github.io/otz-builds/
+mstdn.social
 ms-paint-i.de
 mtv.com
 mulv.tycrek.dev
@@ -796,6 +814,7 @@ nixos-and-flakes.thiscute.world
 nohello.fr
 nomanssky.com
 noob.bio
+norden.social
 northward.info
 nostr.com
 nostv.pt
@@ -1026,6 +1045,9 @@ smithed.dev
 smithed.net
 snazzah.com
 snowsta.mp
+social.bund.de
+social.saarland
+social.tchncs.de
 somafm.com
 spacestationgaming.com
 spacex.com
@@ -1133,6 +1155,7 @@ tukui.org
 tusharsadhwani.dev
 tvnz.co.nz
 tvplus.com.tr
+twiukraine.com
 twnft.vercel.app
 tycrek.com
 tygo-van-den-hurk.com
@@ -1145,6 +1168,7 @@ ultrajs.dev
 undergroundcellar.com
 underlords.com
 undertale.com
+universeodon.com
 universe.eveonline.com
 unlimiter.github.io/pika
 urbanlinker.com
@@ -1167,6 +1191,7 @@ vivek9patel.github.io
 vixeny.dev
 vleer.app
 vogons.org
+volksverpetzer.social
 volta.net
 vrv.co
 vscode.dev


### PR DESCRIPTION
Added several Mastodon servers with dark themes. Removed Graphene's and Tuta's websites because they're not dark by default.