### PR TITLE
Remove caddy.community from Global Dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -182,7 +182,6 @@ bultek.com.ua
 bungie.net
 bytebin.lucko.me
 c-saccoccio.fr
-caddy.community
 cadence.moe
 caesarshiba.com
 canalplus.com


### PR DESCRIPTION
This PR removes caddy.community from the Global Dark list as it does not fulfill the requirements to be present in the Global Dark list, specifically:

- The entire website, including all subpages, is dark by default, **regardless of the system's preferred color scheme.**

caddy.community was added in #12125 