### PR TITLE
Remove mastodon.social/online from Global Dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -698,8 +698,6 @@ marvil.co
 maskbox.app
 masseffect.fandom.com
 mastercomfig.com
-mastodon.online
-mastodon.social
 mastofeed.com
 maximepinot.com
 md.quad.codes


### PR DESCRIPTION
This PR removes mastodon.social and mastodon.online from the Global Dark list as they do not fulfill the requirements to be present in the Global Dark list, specifically:

- The entire website, including all subpages, is dark by default, **regardless of the system's preferred color scheme.**
 
This reverts PR #7840