### PR TITLE
`envs.net` isn't entirely a `dark-site`

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -380,7 +380,6 @@ enlightenment.org
 enlisted.net
 enterprise.hackthebox.com
 entity.works
-envs.net
 epack.herokuapp.com
 epack.js.org
 epicgames.com/id


### PR DESCRIPTION
Some URLs may point to arbitrary HTML+CSS, which may not support dark-theme