### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19038,6 +19038,19 @@ CSS
 
 ================================
 
+naeu.playblackdesert.com
+
+INVERT
+.top_news_detail_visual
+.top_news_detail_visual h2
+
+CSS
+.top_news_detail_visual {
+    background-image: url("https://s1.pearlcdn.com/NAEU/contents/img/portal/news/news_detail_visual_top.png") !important;
+}
+
+================================
+
 nagatabi-p.jimdofree.com
 
 INVERT


### PR DESCRIPTION
Restored the banner that's visible when reading an announcement, made sure it changes correctly in light and dark mode, same for the "Announcements" text.

Example: https://www.naeu.playblackdesert.com/en-US/News/Detail?groupContentNo=7532&countryType=en-US

default website without dark reader:
![original](https://github.com/user-attachments/assets/684a8f59-ad31-4a97-b7b2-cb8e294606f1)
dark reader with dynamic light theme:
![dynamic light](https://github.com/user-attachments/assets/5de3f3ec-0ca6-400e-b3f4-4edb59aa9acc)
dark reader with dynamic light theme after the changes:
![fixed](https://github.com/user-attachments/assets/ff56709d-7ffa-40f5-9e97-0567f803ec66)

Perhaps the banner is a bit too bright compared to the rest of the theme but dark definitely looks better with it.