### PR TITLE
Add runevm.io to dark-site.config file

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -947,6 +947,7 @@ rtbyte.xyz
 rtech.support
 ruben-p.com
 runechanger.stirante.com
+runevm.io
 runicgames.com
 rusherhack.org
 rust.facepunch.com


### PR DESCRIPTION
Hello, I am adding the site runevm.io to the list of default sites already in black.