### PR TITLE
Fix Codeforces.com Navbar

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6142,6 +6142,7 @@ CSS
 .cfpp-navbar-item > a {
     color: var(--darkreader-neutral-text) !important;
 }
+
 IGNORE INLINE STYLE
 #userActivityGraph rect
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6139,7 +6139,9 @@ CSS
 #footer img[alt="TON"] {
     border-radius: 50%;
 }
-
+.cfpp-navbar-item > a {
+    color: var(--darkreader-neutral-text) !important;
+}
 IGNORE INLINE STYLE
 #userActivityGraph rect
 


### PR DESCRIPTION
fix the color of the nav bar elements. It was not visible before because it was black on a dark background.

Navbar before fix:
<img width="602" alt="before" src="https://github.com/user-attachments/assets/27db2eb9-fe7a-4a25-805d-b1e06fc3300f">

Navbar after fix:
<img width="608" alt="after" src="https://github.com/user-attachments/assets/6441b78b-a301-46dc-b1ee-cfc807e05624">