### PR TITLE
fix #12799 - check before spread for tree shake in Angular

### DIFF
--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -33,7 +33,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean, enableCustomElement
     function overrideProperty<T, P extends keyof T>(cls: {prototype: T}, prop: P, overrides: Record<string, OverrideFactory<T, P>>) {
         const proto = cls.prototype;
         const oldDescriptor = Object.getOwnPropertyDescriptor(proto, prop)!;
-        const newDescriptor: PropertyDescriptor = {...oldDescriptor};
+        const newDescriptor: PropertyDescriptor = oldDescriptor ? {...oldDescriptor} : {};
         Object.keys(overrides).forEach((key: keyof PropertyDescriptor) => {
             const factory = overrides[key];
             newDescriptor[key] = factory(oldDescriptor[key]);


### PR DESCRIPTION
Tree-shaken ES6 typescript compiler when oldDescriptor didn't exist resulted in __spreadChanges undefined error #12799 , albeit nonblocking. 

Added a ternary check before using the spread operator, and `npm run test` came back clean.