### PR TITLE
Fix for typst.app/universe

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28017,6 +28017,7 @@ img[src$=".svg"]:not([alt="Typst"])
 .carousel .top-text
 .carousel .title
 .carousel .bottom-text
+#categories ul li a
 
 CSS
 #results li a,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27999,6 +27999,25 @@ img[src$=".svg"]:not([alt="Typst"])
 
 ================================
 
+typst.app/universe
+
+INVERT
+#results li .title .name
+#results li .description
+#results li .template-thumbnail
+#banner
+#banner .title
+#banner .description
+#banner .featured-label
+
+CSS
+#results li a,
+#banner {
+    filter: invert(95%) hue-rotate(180deg) contrast(90%) !important;
+}
+
+================================
+
 ubank.com.au
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28002,18 +28002,23 @@ img[src$=".svg"]:not([alt="Typst"])
 typst.app/universe
 
 INVERT
-#results li .title .name
-#results li .description
-#results li .template-thumbnail
+img[alt*="icon"]
+#results li
+#results .title
+#results .description
+#results .template-thumbnail
+#template-thumbnail
 #banner
 #banner .title
 #banner .description
 #banner .featured-label
+#banner .icon
 
 CSS
 #results li a,
 #banner {
-    filter: invert(95%) hue-rotate(180deg) contrast(90%) !important;
+    border: 1px solid !important;
+    border-color: lightgray !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28012,7 +28012,7 @@ img[alt*="icon"]
 #banner .title
 #banner .description
 #banner .featured-label
-#banner .icon
+#banner .featured-label .icon
 
 CSS
 #results li a,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28002,7 +28002,7 @@ img[src$=".svg"]:not([alt="Typst"])
 typst.app/universe
 
 INVERT
-img[alt*="icon"]
+img[src$=".svg"]:not([alt="Typst"])
 #results li
 #results .title
 #results .description
@@ -28013,6 +28013,10 @@ img[alt*="icon"]
 #banner .description
 #banner .featured-label
 #banner .featured-label .icon
+.carousel
+.carousel .top-text
+.carousel .title
+.carousel .bottom-text
 
 CSS
 #results li a,


### PR DESCRIPTION
The problem I faced is that `#results li`/`#banner` style inverts the style for all children, which is why I had to _additionally_ invert all of their key children.

Note that the default `filter: invert(100%) hue-rotate(180deg) contrast(90%) !important;` inversion style doesn't look good here, so I used `filter: invert(95%) hue-rotate(180deg) contrast(90%) !important;` instead.

I made a separate `/universe` entry because Typst Universe is a different/isolated website, so it insures that some other `#banner` etc. styles on other pages won't be affected. And the previous SVG fix is more of a global fix (applies to Universe and docs websites).

## Before

https://typst.app/universe/search:

![image](https://github.com/user-attachments/assets/9a5bfd65-4382-4cb5-aaaf-e00da82edd4f)
---

https://typst.app/universe/package/alchemist:

![image](https://github.com/user-attachments/assets/08ec0d3f-6a5a-49da-9503-34b591b57a37)
---

https://typst.app/universe/package/a2c-nums:

![image](https://github.com/user-attachments/assets/c9ca3774-78e8-4d9a-8a1e-f98a2ecd9c05)

## After

https://typst.app/universe/search:

![image](https://github.com/user-attachments/assets/d63b7feb-e288-4643-b857-6ab3ff625fd3)
---

https://typst.app/universe/package/alchemist:

![image](https://github.com/user-attachments/assets/ac7757bf-1a25-41c1-b031-bc9a1f1aecb0)
---

https://typst.app/universe/package/a2c-nums:

![image](https://github.com/user-attachments/assets/0075b920-7553-453a-9ecf-9d0d3af875ee)