### PR TITLE
Update desmos.com site section in dynamic-theme-fixes.config file

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7452,12 +7452,6 @@ desmos.com
 INVERT
 .dcg-calculator-api-container .dcg-grapher-2d .dcg-graph-outer[role="img"]
 .dcg-calculator-api-container .dcg-grapher-3d
-.dcg-expression-top-bar
-.dcg-icon-plus
-.dcg-icon-undo
-.dcg-icon-redo
-.dcg-icon-settings
-.dcg-icon-hide
 
 CSS
 html[data-darkreader-scheme="dark"] .dcg-calculator-api-container :is(.dcg-graph-inner, .dcg-webgl-canvas) {
@@ -7468,6 +7462,9 @@ html[data-darkreader-scheme="dark"] .dcg-calculator-api-container :is(.dcg-graph
 }
 .dcg-calculator-api-container .dcg-grapher-3d .dcg-graph-outer {
     z-index: 1;
+}
+.dcg-expression-top-bar {
+    background: var(--darkreader-neutral-background) !important;
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7452,6 +7452,12 @@ desmos.com
 INVERT
 .dcg-calculator-api-container .dcg-grapher-2d .dcg-graph-outer[role="img"]
 .dcg-calculator-api-container .dcg-grapher-3d
+.dcg-expression-top-bar
+.dcg-icon-plus
+.dcg-icon-undo
+.dcg-icon-redo
+.dcg-icon-settings
+.dcg-icon-hide
 
 CSS
 html[data-darkreader-scheme="dark"] .dcg-calculator-api-container :is(.dcg-graph-inner, .dcg-webgl-canvas) {


### PR DESCRIPTION
# Before:
![ДО](https://github.com/user-attachments/assets/04582614-3e3d-4662-abfa-8539711d233c)
# After:
![ПОСЛЕ](https://github.com/user-attachments/assets/5e7eb3c2-fa2f-4cc2-bdae-971501c1c2da)
# What I did
I just added some elements to ```INVERT``` in dynamic theme config file at ```desmos.com``` section.
Maybe there is a more neat way to fix this but I chosen the fastest one because this white line annoyed me while I just wanted to use desmos