### PR TITLE
Adjust Dropdown Margin for Improved Visibility

### DIFF
--- a/src/ui/options/automation/automation.less
+++ b/src/ui/options/automation/automation.less
@@ -71,6 +71,7 @@
             cursor: pointer;
             height: @size-control-inner + 2 * @size-border;
             width: 100%;
+            margin-bottom: @size-control-inner;
     
             &__selected {
                 background-color: transparent;

--- a/src/ui/options/automation/automation.less
+++ b/src/ui/options/automation/automation.less
@@ -71,7 +71,7 @@
             cursor: pointer;
             height: @size-control-inner + 2 * @size-border;
             width: 100%;
-            margin-bottom: @size-control-inner;
+            margin-bottom: @size-control-inner + @size-border;
     
             &__selected {
                 background-color: transparent;


### PR DESCRIPTION
# Adjust Dropdown Margin for Improved Visibility

## Description

This pull request addresses an issue with the dropdown component where the options would not display correctly when the dropdown is clicked. To improve user experience, I have modified the margin of the dropdown to ensure that the options are fully visible.

## Change  made

- Altered the relevant CSS properties to improve visibility and usability.

## Screenshots

Here are the before and after screenshots demonstrating the changes:

**Before**

<img width="1435" alt="before" src="https://github.com/user-attachments/assets/edf5faeb-54bd-4875-91df-94f280d0988a">

**After**

<img width="1382" alt="after" src="https://github.com/user-attachments/assets/aed38431-3134-4af7-a030-11840ce82ab7">
