### PR TITLE
Wikipedia: add fix for Creative Assembçy

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17401,6 +17401,7 @@ img[src*="Stylized_eye.svg"]
 img[src*="AMD_Radeon_logo_2019.png"]
 img[src*="AMD_Radeon_RX_6000_series_wordmark.png"]
 img[src*="AMD_Radeon_RX_7000_Series_Logo.png"]
+img[src*="Creative_Assembly_logo.png"]
 
 CSS
 :root {


### PR DESCRIPTION
Fixes black logo in infobox https://en.wikipedia.org/wiki/Creative_Assembly