### PR TITLE
fix for zonatmo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28809,13 +28809,6 @@ INVERT
 
 ================================
 
-visortmo.com
-
-IGNORE IMAGE ANALYSIS
-*
-
-================================
-
 vitaexpress.ru
 
 INVERT
@@ -32771,6 +32764,13 @@ znanium.com
 
 INVERT
 .bookreadimgs
+
+================================
+
+zonatmo.com
+
+IGNORE IMAGE ANALYSIS
+*
 
 ================================
 


### PR DESCRIPTION
#12825 site has changed its url
visortmo.com redirects to zonatmo.com