### PR TITLE
Wikipedia: add fix for J. R. R. Tolkien page

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17416,6 +17416,7 @@ img[src*="AMD_Radeon_logo_2019.png"]
 img[src*="AMD_Radeon_RX_6000_series_wordmark.png"]
 img[src*="AMD_Radeon_RX_7000_Series_Logo.png"]
 img[src*="Creative_Assembly_logo.png"]
+img[src*="JRR_Tolkien_signature_-_from_Commons.svg"]
 
 CSS
 :root {


### PR DESCRIPTION
Fixes signature color in infobox.
https://en.wikipedia.org/wiki/J._R._R._Tolkien