### PR TITLE
Fix for ss64.com/pass, "Main password" field

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25385,6 +25385,19 @@ IGNORE INLINE STYLE
 
 ================================
 
+ss64.com/pass
+
+CSS
+.mainpw {
+    background-color: #ffffff;
+    color: #202223;
+}
+
+IGNORE INLINE STYLE
+.mainpw
+
+================================
+
 ssllabs.com
 
 INVERT


### PR DESCRIPTION
![Untitled-1 (1)](https://github.com/user-attachments/assets/8ed87759-555b-4b1c-9e25-364986c4639a)
