### PR TITLE
Fix for www.baidu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30431,6 +30431,8 @@ INVERT
 .pass-qrcode-download .qrcode-hover .qrcode-download-link
 #s_side_wrapper .qrcode-tooltip .Qrcode-status-con img
 .entry_5uuDY .aladdin_5ycBj:hover>.code_44Mq0
+.favor-icon_44cdR
+.btn-icon_BvyPS
 
 CSS
 .cos-pc,
@@ -30661,7 +30663,8 @@ a:hover,
 .c-link,
 .c-color-gray,
 .op_translation_selfrom,
-.op_translation_selto) {
+.op_translation_selto,
+.jz-container-new-first_1rxT2 .cos-link) {
     color: #8ab4f8;
 }
 a em,
@@ -30891,7 +30894,11 @@ a:hover,
 ._selected_9e3yq_14,
 ._selectItem_9e3yq_23:not(._disabled_9e3yq_19):hover,
 ._selectItem_9e3yq_23:not(._disabled_9e3yq_19):active,
-.calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 tbody .current_88rTP div:hover {
+.calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 tbody .current_88rTP div:hover,
+.button-wrapper_1q1Ke.button-theme_6xA8r,
+.favor_5gsCb,
+.btn-list-untop_21NFc .btn_5IdT0,
+.basics-wenda-zuci-link_4aky8 {
     background-color: ${#d6d6d6} !important;
 }
 ._tabs-nav_1n2to_4,
@@ -30929,7 +30936,6 @@ a:hover,
 .rank-list_1Oklt:hover,
 .c-song-item_66iAf:hover,
 #guaranteePopper.guarantee-pc .popover-content .actions .btn,
-.button-wrapper_1q1Ke.button-theme_6xA8r,
 .c-select-selection,
 .c-checkbox-inner,
 .c-radio-inner,
@@ -30999,7 +31005,8 @@ a:hover,
 .default_1TgiU,
 .default_1TgiU:hover,
 .disable_xmIc6,
-.disable_xmIc6:hover) {
+.disable_xmIc6:hover),
+.btn-list-untop_21NFc .btn-primary_5ig3T {
     background-color: ${#c1c1cf} !important;
     color: #8ab4f8 !important;
 }
@@ -31174,7 +31181,14 @@ a.pass-reglink,
 .s-skin-layer .s-random-open .c-checkbox-inner-i,
 .s-skin-layer .s-skin-set.is-hover,
 .s-skin-layer .skin-img-item-choose,
-.item-name_1FYv8:hover {
+.item-name_1FYv8:hover,
+.con a,
+.button-wrapper_1q1Ke.theme-color_2tBiV:not(.cos-pc .button-wrapper_1q1Ke:hover),
+.wenda-general_72WpQ .fold-switch_6VL6i .cos-fold-switch-text,
+.wenda-general_72WpQ .fold-switch_6VL6i .cos-fold-switch-icon,
+.btn-list-untop_21NFc .btn-primary_5ig3T .btn-text_1fn6W,
+.pc_5ioRQ .btn_5IdT0 .btn-text_1fn6W:hover,
+.desc_4FVyG .text_46Zo1 {
     color: #8ab4f8 !important;
 }
 .cos-pc .box_5nmMD:not(.selected_3I0vG):hover {
@@ -31256,7 +31270,8 @@ a.pass-reglink,
 .card_layout_11HoJ,
 .s-skin-layer,
 .select_3ZzKD .select-wrapper_17vIt .scroll-wrap_2W76t .scroll-roll_1Rqwi,
-.visible-pull_1n9XQ {
+.visible-pull_1n9XQ,
+.cos-tag-outline {
     background-color: ${#eaeae6} !important;
 }
 .wrapper_new #s_tab .s-tab-item:hover::before,
@@ -31305,8 +31320,12 @@ a.pass-reglink,
 .content-game_KJ6bU:hover,
 .new-pmd .c-link:hover,
 .cos-pc .paragraph_Z0a6a:hover,
-.it-name-data_6AlPV:hover {
+.it-name-data_6AlPV:hover,
+.pc_5ioRQ .desc_4FVyG .text_46Zo1:hover {
     color: #9ac4ff !important;
+}
+.pc-container_1YASq a:visited {
+    color: rgb(139 132 255) !important;
 }
 .boiling-all_29kBD .boiling-wrapper_fhywn .boiling-contain_3r2Lv .row-left_1OGNu .boiling-right_3Etl4 .boiling-btn_29fbf:hover {
     background-color: ${#c1c1cf} !important;
@@ -31451,6 +31470,32 @@ a.pass-reglink,
 .c-select-dropdown-list.c-select-scroll {
     overflow: auto !important;
     scrollbar-color: ${#aaaaaa} ${#cfcfe9} !important;
+}
+.cos-pc .line_jFrxr,
+.line_31LBD {
+    background: linear-gradient(to bottom, transparent 0, transparent 50%, rgb(0 255 222 / 20%) 31%, rgb(0 255 222 / 20%) 86%, transparent 87%, transparent 100%) !important;
+}
+.key-words-content_4oMQn,
+.key-words-content_5nQXr {
+    background: rgba(100, 199, 156, .08) !important;
+}
+.scroll-wrapper-pc_1KMqB .scroll-wrapper-con-pc_36qnN .item-wrapper-pc_79JU8,
+.scroll-wrapper-pc_7wThY .scroll-wrapper-con-pc_Dw6p7 .item-wrapper-pc_2j8aa {
+    position: relative;
+    z-index: 1;
+}
+.scroll-wrapper-pc_1KMqB .scroll-wrapper-con-pc_36qnN .item-wrapper-pc_79JU8::before,
+.scroll-wrapper-pc_7wThY .scroll-wrapper-con-pc_Dw6p7 .item-wrapper-pc_2j8aa::before {
+    background: url(https://psstatic.cdn.bcebos.com/video/edu/pinyin-4line_1657870444000.png);
+    background-size: 100% 100%;
+    bottom: 0;
+    content: "";
+    filter: brightness(800%);
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: -1;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30418,6 +30418,19 @@ INVERT
 .exam-tab_1oog6 .exam-title_32Y60 .exam-tit-img_1pVD5
 .pc-code-img_11zj5
 .privacy-img
+.single-card-wrapper_1X9WS .title-icon_2sYhE
+.mall-slogan-pc-logo_7Hhbl
+.video_loading img
+.demo-question_227j3 .image-icon_713sS
+.history-bac_2hVN5 .bac-img_1K0z5
+.siderbar-wrapper_Nk4dE .bjh-logo_21oog img
+.Qrcode-status-error .Qrcode-status-icon
+.tang-pass-pop-login .tang-pass-login-phoenix .phoenix-btn-item
+.boiling-all_29kBD .bg-wrapper_2Yb28
+.boiling-all_29kBD .boiling-wrapper_fhywn .boiling-contain_3r2Lv .row-right_1eYkS .qrcode-wrapper_2XUfj .qrcode-img_28IRS
+.pass-qrcode-download .qrcode-hover .qrcode-download-link
+#s_side_wrapper .qrcode-tooltip .Qrcode-status-con img
+.entry_5uuDY .aladdin_5ycBj:hover>.code_44Mq0
 
 CSS
 .cos-pc,
@@ -30428,6 +30441,7 @@ CSS
     --darkreader-bg--cos-color-bg-page: ${#eaeae6} !important;
     --darkreader-bg--cos-color-bg-primary-light: ${#c1c1cf} !important;
     --darkreader-bg--cos-color-bg-raised: ${#c1c1cf} !important;
+    --darkreader-bg--cos-color-border-minor: #ffffff0c !important;
     --darkreader-bg--cosd-color-bg-primary: #a99af2 !important;
     --darkreader-border--cosd-color-text-primary: #a99af2 !important;
     --darkreader-selection-background: #8ab4f8 !important;
@@ -30442,12 +30456,34 @@ CSS
 #head_wrapper #s_lg_img,
 #head_wrapper.s-ps-islite #s_lg_img,
 .index-logo-src,
-index-logo-srcnew {
+.index-logo-srcnew,
+.s_lg_img_gold_showre,
+.index-logo-peak,
+.logo > *,
+#result_logo > * {
     display: none !important;
 }
-.s-p-top .index-logo-aging-tools,
-.index-logo-peak {
+.s-p-top .index-logo-aging-tools {
     display: inline !important;
+}
+.result_logo,
+#result_logo {
+    background-image: url(https://www.baidu.com/img/flexible/logo/pc/peak-result.png) !important;
+    background-size: cover !important;
+    height: 33px !important;
+    width: 101px !important;
+}
+.logo {
+    background-image: url(https://www.baidu.com/img/flexible/logo/pc/peak-result.png) !important;
+    background-size: 100% 100% !important;
+    height: 32px !important;
+    width: 101px !important;
+}
+p.pass-form-logo {
+    background-image: url(https://www.baidu.com/img/flexible/logo/pc/peak-result.png) !important;
+    background-size: auto 100% !important;
+    height: 30px !important;
+    width: 94px !important;
 }
 #head_wrapper .s_btn,
 .wrapper_new .s_btn_wr .s_btn,
@@ -30459,11 +30495,6 @@ index-logo-srcnew {
 .wrapper_new .s_ipt_wr {
     border-color: rgb(97 97 97);
 }
-p.pass-form-logo {
-    background-image: url(https://www.baidu.com/img/PCfb_5bf082d29588c07f842ccde3f97243ea.png);
-    height: 44.9px;
-    margin-left: 20px;
-}
 .login-type-tab .switch-item.activ::after,
 .wrapper_new #s_tab .cur-tab::after,
 .s-ctner-menus .s-menu-item-underline,
@@ -30472,15 +30503,20 @@ p.pass-form-logo {
 .nav_3xYGl .tab-li_1-F1N.is-active_2p-0t::after,
 .s-skin-layer .choose-page-btn .skin-page-number-btn,
 .s-skin-layer .nav-underline,
-.definition-item_1CSUm .percentage_5pEV9 .jindu_43UUC .jindu-light_2Z1VG {
+.definition-item_1CSUm .percentage_5pEV9 .jindu_43UUC .jindu-light_2Z1VG,
+.s_tab_1z9nv .cur-tab_ReMW2::after,
+#s_tab .cur-tab::after,
+.content-tab-wrapper_mOcNS .active_2hwRT::after,
+.tabs-item-act_2_kZO::after,
+.prize-wrapper_TK3KC .prize-tab-wrapper_1o39d .active_rs7B4::after,
+.tang-pass-footerBarPhoenixSplit {
     background-color: #8ab4f8 !important;
 }
 .tang-pass-pop-login-color-blue .pass-button:hover,
 .page_2muyV strong,
-.c-btn:hover,
+.c-btn:hover:not(.ask-doctor-card .ask-doctor-btn[data-a-1075df6b]:hover),
 .page_2muyV a:hover .page-item_M4MDr,
 #page .n:hover,
-.new-pmd .c-text-blue，
 .btn-primary_2s82F:hover:not([disabled]),
 .ask_4pvUb,
 .wrapper_new #u .lb,
@@ -30508,21 +30544,53 @@ p.pass-form-logo {
 .soutu-env-new .soutu-layer .upload-wrap,
 .avator-wrap_L2zSM .consulting-btn_dYXy1:hover,
 .c-btn-primary,
-.offical-tag_1tgnd {
+.offical-tag_1tgnd,
+.fm .s_btn_wr .s_btn,
+.wrapper_new #page strong,
+.wrapper_new #page a:hover,
+.wrapper_new #page a:hover .pc,
+.wrapper_new #page .n:hover,
+.card_ZQsT- .year-tag_3Iqeg,
+.container_7Xe_0 .error_14OKd .retry-btn_2ZJcf:hover,
+.tab-wrapper_3YYym .tab-item-act_3-7WG,
+.content-game-select_31woR,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21:hover,
+.site-container_3QJpT .site-item-link_2He-Y .site-item-img_3NN3N .normal-site-img_3ID7V,
+.calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 tbody .is-select_3jw86,
+.btn_39Gv2 {
     background-color: #8ab4f8 !important;
     color: #000000 !important;
+}
+.btn {
+    background-color: #8ab4f8;
+    color: #000000;
 }
 .wrapper_new .iptfocus.s_ipt_wr,
 .item__tbGV .dot_30fkr,
 #head_wrapper #kw:focus,
-.wrapper_new .iptfocus.s_ipt_wr,
 .publisher_TpAsB.border_NWmBE:hover,
 ._operative_shkz3_56,
 .wrapper_new .peak-down #u .s-top-img-wrapper,
 .wrapper_new.wrapper_s .soutu-env-new .soutu-layer .soutu-url-wrap,
 .wrapper_new.wrapper_s .soutu-env-new .soutu-layer #soutu-url-kw,
 .s-top-right .s-top-username .s-top-img-wrapper,
-.wrapper_new #u .s-top-img-wrapper {
+.wrapper_new #u .s-top-img-wrapper,
+#bg s_ipt_wr new-pmd quickdelete-wrap iptfocus new-ipt-focus,
+#s_kw_wrap:focus,
+.s_ipt_wr.iptfocus,
+.tang-pass-pop-login-color-blue .pass-text-input-focus,
+.soutu-env-new .soutu-layer #soutu-url-kw,
+#head_wrapper #form #kw.new-ipt-focus,
+.wrapper_new #form .s_ipt_wr.new-ipt-focus,
+.site-container_3QJpT .add-site-btn_QCc9N:hover,
+.site-container_3QJpT .add-cate-site-btn_1U_oz:hover,
+#s_side_wrapper .aging-entry:hover .aging-entry-inner,
+.s-skin-hasbg #head_wrapper #form #kw,
+.s-skin-hasbg #head_wrapper #form #kw:focus,
+.s-skin-hasbg #head_wrapper #form .bdsug-new,
+.wrapper_new #form .bdsug-new,
+#head_wrapper #form .bdsug-new {
     border-color: #8ab4f8 !important;
 }
 .a-se-st-single-video-zhanzhang-capsule,
@@ -30532,28 +30600,134 @@ p.pass-form-logo {
 .new-pmd .c-gap-right-small,
 .cos-color-border-primary-light,
 .baozhang-r-tip .opui-honourCard4 .opui-honourCard4-title,
-.new-tag_4ozgi .pc-tag_2Nde8 {
+.new-tag_4ozgi .pc-tag_2Nde8,
+.rx-tag_2MW39:not(.bg-red-tag_4pdwo),
+.history-bac_2hVN5 .title_1y9Sg .label_3eMwB,
+.tag-container-label1_EX6wq {
     border-color: #8ab4f888 !important;
-}
-.wrapper_new #form .bdsug-new,
-#head_wrapper #form .bdsug-new {
-    border-bottom-color: #8ab4f8 !important;
-    border-left-color: #8ab4f8 !important;
-    border-right-color: #8ab4f8 !important;
 }
 .tang-pass-pop-login-color-blue .pass-button {
     background-color: ${#dadad4} !important;
     color: #ffffff !important;
 }
-a {
+a,
+a:link:not(.c-color-t,
+.s-top-userset-menu a,
+.opr-toplist1-update_39A0r .toplist-refresh-btn_2ky31,
+.fold-btn-text_3r8hd,
+.help-container_3VJQo a,
+.c-tool-first-wrapper .tip-item,
+.s_tab_1z9nv .s-tab-item_1CwH-,
+.sam_newgrid .opr-recommends-merge-more-btn-new,
+a:hover,
+.c-group-title a,
+.sub-title_5pGrK,
+.abstracts-normal-color_3gipx,
+.attribute-item_3r4Kz,
+.attribute-item_3r4Kz:hover,
+.attribute-item_3r4Kz:visited,
+.photo-albums_7okj5,
+._group-title_avy0e_34,
+.footer_BI2Zk a,
+.brand-logo_6Lv5s .link-wrap_4meQq,
+.more-wrap_1ixZo .more-link_PaaxA,
+.new-pmd .c-color-text,
+.nami-source_BbZ19,
+.daoliu-con_3mmBo .down_4ZF7G,
+.bjh-container_2msbY .bjh-board_qxYkZ .multi-video_3S8vD a,
+.buttonGroup_vNXg1 .buttonItem_854F1,
+.footer-container_7jDHJ,
+.pc-app-privacy_1RxtI,
+.pc-app-permission_3TPDd,
+.tag-item_UHf7p,
+.mainContent_1dOGV a,
+.sc-header_5wgf6 .title-container_xznnZ .main-title_1PL7w a,
+.cos-color-text,
+.cosd-citation-title,
+.history-bac_2hVN5 .title_1y9Sg,
+.view-bac_PurEx a,
+.footer-wrapper_6l5jm .footer-list_I6v5H .text_uvMqv,
+.new-pmd .c-color-gray,
+.hot-item_1473U .item-mid_vrw25,
+.card_1FDsA .card-title_3mXrq .more-text_3Oa53,
+.new-pmd .c-gray,
+.link_54c0D,
+.abstract_PABIy,
+.selected-search-box a,
+.selected-search-box a:hover,
+.selected-search-box a:visited,
+.cu-color-text,
+.new-pmd .c-tools-tip-con .c-tip-menu li a,
+.c-link,
+.c-color-gray,
+.op_translation_selfrom,
+.op_translation_selto) {
     color: #8ab4f8;
 }
 a em,
 em {
     color: rgb(255 98 98);
 }
-a:hover {
+a:hover,
+.c-link:hover {
     color: #9ac4ff;
+}
+a:visited:not(.c-color-t,
+.c-color-gray2,
+.s-top-userset-menu a,
+.help-container_3VJQo a,
+.s_tab_1z9nv .s-tab-item_1CwH-,
+.more-wrap_1ixZo .more-link_PaaxA,
+.opr-toplist1-update_39A0r .toplist-refresh-btn_2ky31,
+.fold-btn-text_3r8hd,
+.c-tool-first-wrapper .tip-item,
+.sam_newgrid .opr-recommends-merge-more-btn-new,
+a:hover,
+.sub-title_5pGrK,
+.abstracts-normal-color_3gipx,
+.attribute-item_3r4Kz,
+.attribute-item_3r4Kz:hover,
+.attribute-item_3r4Kz:visited,
+.photo-albums_7okj5,
+._group-title_avy0e_34,
+.footer_BI2Zk a,
+.brand-logo_6Lv5s .link-wrap_4meQq,
+.new-pmd .c-color-text,
+.nami-source_BbZ19,
+.daoliu-con_3mmBo .down_4ZF7G,
+.bjh-container_2msbY .bjh-board_qxYkZ .multi-video_3S8vD a,
+.buttonGroup_vNXg1 .buttonItem_854F1,
+.footer-container_7jDHJ,
+.pc-app-privacy_1RxtI,
+.pc-app-permission_3TPDd,
+.tag-item_UHf7p,
+.mainContent_1dOGV a,
+.sc-header_5wgf6 .title-container_xznnZ .main-title_1PL7w a,
+.cos-color-text,
+.cosd-citation-title, .con a,
+.s_link a,
+.history-bac_2hVN5 .title_1y9Sg,
+.view-bac_PurEx a,
+.footer-wrapper_6l5jm .footer-list_I6v5H .text_uvMqv,
+.new-pmd .c-color-gray,
+.hot-item_1473U .item-mid_vrw25,
+.card_1FDsA .card-title_3mXrq .more-text_3Oa53,
+.new-pmd .c-gray,
+.link_54c0D,
+.abstract_PABIy,
+.selected-search-box a,
+.selected-search-box a:hover,
+.selected-search-box a:visited,
+.cu-color-text,
+.new-pmd .c-tools-tip-con .c-tip-menu li a,
+.c-link,
+.c-color-gray,
+.op_translation_selfrom,
+.op_translation_selto) {
+    color: rgb(139 132 255);
+}
+.opr-toplist1-link_2Ag1v a:visited {
+    color: rgb(139 132 255) !important;
 }
 .opr-toplist1-link_2Ag1v a:hover {
     color: #8ab4f8 !important;
@@ -30561,14 +30735,16 @@ a:hover {
 .btn-primary_2s82F {
     background-image: none !important;
 }
-.tag-selected_lD4sS,
-.tag-common_8ztfL:not(.tag-selected_lD4sS):hover {
-    background-color: ${#cfcfe9} !important;
-    color: #8ab4f8 !important;
-}
-.ask_4pvUb {
+.ask_4pvUb,
+.agent-wrapper_3RqY7 .avatar_6Jvb5 .badge_6RJyd {
     background-color: #a99af2 !important;
     color: #000000 !important;
+}
+.agent-wrapper_3RqY7 .content_45TiT .name-wrapper_5dALN .icon_77xV3 {
+    background-color: #a99af233 !important;
+}
+.agent-wrapper_3RqY7 .avatar_6Jvb5 .badge_6RJyd {
+    background-color: #a99af2 !important;
 }
 .cos-pc .item-word_2Fvt9:hover,
 ._ai-ask-back_1hre3_1 ._ai-ask-back-category_1hre3_36 ._category_1hre3_50 ._active_1hre3_110,
@@ -30577,7 +30753,18 @@ a:hover {
 .cos-pc .btn-group_4wwGy:hover .exp-icon_1SF8P,
 .cos-pc .btn-group_4wwGy:hover .exp-text_4wc20,
 .pcStyle_Tm3GW .copy_4xoef:hover,
-.pcStyle_Tm3GW .textbox_2W0Tw:hover {
+.pcStyle_Tm3GW .textbox_2W0Tw:hover,
+.cos-pc .btn-group_7iOL0:hover .exp-text_3hco9,
+.cos-pc .btn-group_7iOL0:hover .exp-icon_7qajy,
+.cos-pc .copy_3vr62:hover,
+.cos-pc .dqa-code-pre .code-copy:hover,
+.title-wrapper_105vc .source_1or0t .source-tag_vStce,
+.title-wrapper_105vc .source_1or0t .right-icon_1pMIZ,
+.cos-pc .btn-group_7iOL0:hover .num_5f3uX,
+.input-right_IAgUq,
+.agent-wrapper_3RqY7 .content_45TiT .name-wrapper_5dALN .icon_77xV3,
+.suffix_5evkO,
+.button_4dj2L {
     color: #a99af2 !important;
 }
 .cu-border._content-border_zc167_4,
@@ -30594,8 +30781,12 @@ a:hover {
 .re-box-shadow_1FfgR,
 .zuowen-content_2nnxI,
 .aladdin_5FSBd,
-.cos-pc .songs-content_5ZWPu {
-    background-color: ${#eaeae6};
+.cos-pc .songs-content_5ZWPu,
+.single-card-wrapper_1X9WS,
+.content-info_2LiPq,
+.content-info_1ifVG,
+.cu-border {
+    background-color: ${#eaeae6} !important;
     border: solid, 0px !important;
     border-radius: 16px !important;
 }
@@ -30620,6 +30811,12 @@ a:hover {
     background-color: #ffffff0c !important;
     border: #FFFFFF22, solid, 1px !important;
 }
+.cosd-markdown .marklang code {
+    border: #FFFFFF22, solid, 1px;
+}
+.cosd-markdown .marklang pre code {
+    border: #1b1b1d, solid, 1px !important;
+}
 .fold_1udxT,
 .more_49t85,
 .cover-container_1Nem2,
@@ -30636,8 +30833,11 @@ a:hover {
 }
 .indicator-track_7H9n0,
 ._sc-divider-horizontal_1rtxp_1::after,
-.new-pmd button.c-btn,
-.pc-down-pc_1SaAU .pc-down-btn_3ndGY {
+.pc-down-pc_1SaAU .pc-down-btn_3ndGY,
+.cosd-citation-citationId,
+.cos-pc .line_WF20X,
+.pinyin-switch-close_2Xjt5:not(.pinyin-switch-open_5fHRG),
+.s-skin-layer .skin-page-number-btn {
     background-color: ${#b0b0bf} !important;
 }
 .bg_2LxZD,
@@ -30653,24 +30853,46 @@ a:hover {
 .calc-oprate_24c8k .base-calc_27A59 .calc-key-number_1fqx4,
 .head-container_1ASW4 .head-right_2OyG6 .find-lrc-btn_ayH7_,
 .inpt_disable_3UETE,
-.custdom_input_25IQU,
-.time_pop_1-CDl .input_from_1ITZ-,
-.inpt_disable_16KeJ,
 .exam-tab_1oog6 .select-item_5zPMB,
 .tab-wi_2Rp7j,
 .pc-query-content-wrapper_9xudv .pc-query-content-box_5dDvI .operate-box_7cLzn .audio-box_2QevP,
 .sc-city-header-tab-active,
 ._ai-ask-back_1hre3_1 ._ai-ask-back-category_1hre3_36 ._category-item_1hre3_74:hover,
-#guaranteePopper.guarantee-pc .popover-content .actions .btn:hover {
+#guaranteePopper.guarantee-pc .popover-content .actions .btn:hover,
+.answer-wrapper_3nXRG .other-answer-wrapper_1Z6rh .answer-item_2wxfu:hover,
+.answer-wrapper_3nXRG .other-answer-wrapper_1Z6rh .answer-item_2wxfu:visited,
+.answer-wrapper_3nXRG .first-answer_6i7Cn:hover,
+.answer-wrapper_3nXRG .first-answer_6i7Cn:visited,
+.item_3WKCf:hover,
+.inpt_disable_16KeJ,
+.s-top-left-new .s-top-more .s-top-more-content > a:hover,
+.s-top-left-new .s-top-more .s-top-tomore:hover,
+.img-peak-theme_6g2TY,
+.site-container_3QJpT .edit-site-item-mask_2lfL5,
+.item-pull_5yvpV:hover {
     background-color: ${#c1c1cf} !important;
 }
-.content_27h2V,
+.c-btn,
+.new-pmd .c-btn {
+    background-color: ${#cfcfcf};
+}
 .rs-link_2DE3Q,
 .item_3WKCf,
 .wrap_f1met,
-._select-entry_9e3yq_48,
-.header-btn_68kgy {
-    background-color: ${#d4d4df} !important;
+.item-word_2Fvt9,
+.ask-doctor-card .ask-doctor-btn[data-a-1075df6b],
+.time_pop_1-CDl .input_from_1ITZ-,
+.custdom_input_25IQU,
+.s-mod-setweather .setweather-content .everyday-mod .everyday-item:hover,
+.pane-pc_X8r4v .filter_3Zkta .tag-item_5AXDP.active_7mrTJ,
+.new-pmd .c-gap-right-large:not(.btn_UbC6G),
+.site-container_3QJpT .cate-title_3gMAm,
+.s-skin-layer .subnav-tag,
+._selected_9e3yq_14,
+._selectItem_9e3yq_23:not(._disabled_9e3yq_19):hover,
+._selectItem_9e3yq_23:not(._disabled_9e3yq_19):active,
+.calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 tbody .current_88rTP div:hover {
+    background-color: ${#d6d6d6} !important;
 }
 ._tabs-nav_1n2to_4,
 .sc-button.sc-sublink,
@@ -30690,7 +30912,6 @@ a:hover {
 .op-ly_ticket_train-tabs-nav,
 .develop_3ZJsP,
 .item_2q0df,
-.new-pmd .c-gap-bottom-middle,
 .custom-bar_XvJUN .nav-box_3tac9,
 .content-list_6tfRu .scard-item_6vzi9 .scard-audio-copy_4I4tP,
 .tags_2yHYj,
@@ -30707,16 +30928,40 @@ a:hover {
 .race-item_1u-Bl:hover,
 .rank-list_1Oklt:hover,
 .c-song-item_66iAf:hover,
-.new-pmd .c-gap-right-large,
 #guaranteePopper.guarantee-pc .popover-content .actions .btn,
-.button-wrapper_1q1Ke.button-theme_6xA8r {
+.button-wrapper_1q1Ke.button-theme_6xA8r,
+.c-select-selection,
+.c-checkbox-inner,
+.c-radio-inner,
+.tab-wrapper_3YYym .tab-item_2YaJJ:not(.tab-wrapper_3YYym .tab-item-act_3-7WG),
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1:not(._pagination_1e5eg_1 ._pagination-button_1e5eg_1._ellipsis_1e5eg_26,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21:hover),
+.advanced-setting .adv-q-input,
+.advanced-setting .adv-input-prepend,
+.c-input,
+.c-select-dropdown,
+.page-btn_1XR1p:not(.page-btn_1XR1p:hover,
+.active-page-item_wYYY-,
+.active-page-item_wYYY-:hover,
+.default_1TgiU,
+.default_1TgiU:hover),
+.disable_xmIc6:hover,
+.selected-search-box,
+.basics-wenda-zuci-link_7DDoJ,
+.episode_2QuKF .episode-btn_7KChm,
+.select_2ORf2,
+.select_2ORf2 .select-wrapper_4oPMb,
+.pass-qrcode-download .qrcode-hover,
+.pass-qrcode-download a,
+.s-skin-layer .defined-state-chooseimg,
+.calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 thead {
     background-color: ${#cfcfe9} !important;
 }
 .button_sx9Ei:hover {
     background-color: ${#b7b7bf} !important;
     color: #8ab4f8 !important;
 }
-.item_3WKCf:hover,
 .rs-link_2DE3Q:hover,
 .single-card-more_2npN-:hover,
 .btn_1N-yB,
@@ -30732,9 +30977,29 @@ a:hover {
 .button_sx9Ei,
 .sc-city-content-city-item-text:hover,
 .sc-city-header-search-word:hover,
-.sc-button,
-.sc-button-new,
-.tag-item_UHf7p:hover {
+.sc-button:not(.filter-btns_7wR3o .btns-group_4du0r .confirm-btn_6Scxq,
+.filter-btns_7wR3o .btns-group_4du0r .reset-btn_6Epss),
+.sc-button-new:not(.filter-btns_7wR3o .btns-group_4du0r .confirm-btn_6Scxq,
+.filter-btns_7wR3o .btns-group_4du0r .reset-btn_6Epss),
+.tag-item_UHf7p:hover,
+.tag-selected_lD4sS,
+.tag-common_8ztfL:not(.tag-selected_lD4sS):hover,
+.siderbar-wrapper_Nk4dE .sider-tabs_1l2UI .active_JwncH,
+.siderbar-wrapper_Nk4dE .sider-tabs_1l2UI li:hover,
+.siderbar-wrapper_Nk4dE .sider-tabs_1l2UI .active_JwncH i,
+.siderbar-wrapper_Nk4dE .sider-tabs_1l2UI li:hover i,
+.container_7Xe_0 .error_14OKd .retry-btn_2ZJcf,
+.container_7Xe_0 .no-document_15k7O .retry-btn_2ZJcf,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1:hover:not(._pagination_1e5eg_1 ._pagination-button_1e5eg_1._ellipsis_1e5eg_26,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21:hover ._pagination_1e5eg_1 ._pagination-button_1e5eg_1._disabled_1e5eg_33,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._disabled_1e5eg_33:hover),
+.page-btn_1XR1p:hover:not(.active-page-item_wYYY-,
+.active-page-item_wYYY-:hover,
+.default_1TgiU,
+.default_1TgiU:hover,
+.disable_xmIc6,
+.disable_xmIc6:hover) {
     background-color: ${#c1c1cf} !important;
     color: #8ab4f8 !important;
 }
@@ -30823,16 +31088,102 @@ a:hover {
 .new-pmd .c-tools-tip-con .c-tip-menu li a:hover,
 .baozhang-r-tip .opui-honourCard4 .opui-honourCard4-title,
 .baozhang-r-tip .honourCard4-more-info,
-.button_sx9Ei .content_7L4g2 {
+.button_sx9Ei .content_7L4g2,
+.rx-tag_2MW39:not(.bg-red-tag_4pdwo),
+.col-pc-more_5Wycx:hover .col-pc-more-btn_31pmf,
+.col-pc-more_5Wycx:hover ix,
+.cos-pc .text_1aZG9:hover,
+.cos-pc .more_4Wd1Y:hover,
+.sam_newgrid .opr-recommends-merge-more-btn-new:hover,
+.left_1Ro_O:hover:not(.touch_2GI_H),
+.right_3yC9L:hover:not(.touch_2GI_H),
+.new-pmd .c-color-link,
+._link_avy0e_24:hover,
+.s-top-left-new .s-top-more .s-top-more-content > a:hover .s-top-more-title,
+.s-top-left-new .s-top-more .s-top-tomore:hover a,
+.c-select-item:hover,
+.c-select-item-selected,
+.s_link a:hover,
+.header-wrapper_3YLmb .right-part_3w_5k .user-info_2B40k .header-pop_1OIG6 li a:hover,
+.select_2ORf2 .select-wrapper_4oPMb .select-board_3hZnS .select-scroll_1i6yj .select-color_1BJFZ,
+.select_2ORf2 .select-wrapper_4oPMb .select-board_3hZnS .select-scroll_1i6yj .select-item_1qIVt:hover,
+.item-act_1hyaM,
+.totop-wrapper_775JV .active_3542p,
+.tang-pass-pop-login p.Qrcode-refresh-btn,
+a.pass-reglink,
+.tang-pass-footerBar,
+.collection-item-pic__BRw0:hover .collection-item-title_1pQWu,
+.collection-item-pic__BRw0 .collection-item-right_2jTSh .collection-item-delete_15m9r:hover,
+.delete-btn_fJqgw:hover,
+.history-box_2McBx ul li:hover .history-item-query_3_6c_,
+.history-box_2McBx ul .history-item-delete_YFEM9:hover,
+.wrapper_new #form .bdsug-new > div span:hover,
+.wrapper_new #form .bdsug-new > div a:hover,
+.pane-pc_X8r4v .filter_3Zkta .tag-item_5AXDP.active_7mrTJ,
+.pane-pc_X8r4v .filter_3Zkta .tag-item_5AXDP:hover,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1:not(._pagination_1e5eg_1 ._pagination-button_1e5eg_1._ellipsis_1e5eg_26,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21:hover,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._disabled_1e5eg_33,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._disabled_1e5eg_33:hover),
+.pfpanelclose:hover,
+._tabs-nav-item_1n2to_30:hover:not(.tabs-nav-item_2hbp8:hover,
+.tabs-nav-item_3zziJ:hover),
+.zi-pc_64Vcz a:hover,
+.history-bac_2hVN5 .title_1y9Sg .label_3eMwB,
+._tabs-nav-selected_1n2to_52:not(.tabs-nav-selected_1QSZ2),
+#container.sam_newgrid .pc-quick-intro_2iPvm h3:hover .hover-style,
+.detail-pc-btn_5uGSV:hover i,
+.select_3ZzKD .select-wrapper_17vIt .select-board_2vss_ .select-scroll_3h0Ij .select-item_2EG2g:hover,
+.page-btn_1XR1p:not(.active-page-item_wYYY-,
+.active-page-item_wYYY-:hover,
+.default_1TgiU,
+.default_1TgiU:hover,
+.disable_xmIc6,
+.disable_xmIc6:hover),
+.tag-container-label1_EX6wq,
+.cos-pc .paragraph_Z0a6a,
+.selected-search-box i,
+._more_w7nnv_23:hover ._icon_w7nnv_8,
+._more_w7nnv_23:hover,
+.cos-pc .root_6w3tK .text-title_23l9x span,
+.label_5Uerq,
+.header-container_Hgukk .left_ht6px:hover .hover-blue_29VAT,
+.wrapper_new #form .bdsug-new .bdsug-store-del:hover,
+.tang-pass-pop-login .pass-item-timer,
+.tang-pass-pop-login .pass-item-time-timing,
+.pass-fgtpwd.pass-link:hover,
+.tang-pass-login a,
+.card_layout_11HoJ .edit-btn_1qNOn:hover .icon_33ay3,
+.card_layout_11HoJ .to-top_3Y2JS:hover .icon_33ay3,
+.card_layout_11HoJ .edit-btn_1qNOn:hover .icon-text_2ceWr,
+.card_layout_11HoJ .to-top_3Y2JS:hover .icon-text_2ceWr,
+.desktop-opt:hover,
+.desktop-opt:hover i,
+.trigger-cate-btn_3qrtQ:hover,
+.site-container_3QJpT .add-site-btn_QCc9N:hover i,
+.site-container_3QJpT .add-cate-site-btn_1U_oz:hover i,
+.site-container_3QJpT .site-item-link_2He-Y:hover .site-item-label_3WxsF > span,
+.site-container_3QJpT .edit-site-item-mask_2lfL5 .update_e2t9z,
+.card_layout_11HoJ .complete_1ch1v,
+.s-skin-layer .s-skin-subnav li.cur .subnav-tag,
+.s-skin-layer .subnav-tag:hover,
+.s-skin-layer .s-skin-up:hover,
+.s-skin-layer .page-next:hover,
+.s-skin-layer .page-pre:hover,
+.s-skin-layer .s-random-open .c-checkbox-inner-i,
+.s-skin-layer .s-skin-set.is-hover,
+.s-skin-layer .skin-img-item-choose,
+.item-name_1FYv8:hover {
     color: #8ab4f8 !important;
 }
-.cos-pc .box_5nmMD:hover {
+.cos-pc .box_5nmMD:not(.selected_3I0vG):hover {
     background-color: #BBBBFF22 !important;
 }
 .selected_3I0vG {
     background-color: #2f54ef !important;
 }
-.festival_8Y6ks,
+.festival_8Y6ks:not(.selected_3I0vG),
 .button_sx9Ei:hover {
     background-color: rgb(255 100 100 / 8%) !important;
 }
@@ -30848,7 +31199,6 @@ a:hover {
 }
 .text-area-box_4e4nT .text-area_5EkLk,
 .op-ly_ticket_train-tabs-nav-li.op-ly_ticket_train-tabs-nav-selected,
-.tabs-content_3ZTqE,
 .see-more-wrap_gKBWt .see-more-content_2Bljh,
 .op-map_flight-tabs-nav-li.op-map_flight-tabs-nav-selected,
 .desc-common_3sbkZ,
@@ -30867,37 +31217,65 @@ a:hover {
 .soutu-env-new .soutu-layer .soutu-error,
 .soutu-env-new .soutu-layer .soutu-waiting,
 .soutu-env-new .soutu-layer .soutu-drop-tip,
-.pop_over_svvNd,
-.pop_over_AuuUs,
 .file_type_16eh4 .file_li_2nywH,
-.pop_over_ppVmY,
 .time_pop_1-CDl .dis_able_A9pol,
 .time_pop_1-CDl .time_li_3_ArK,
 #wrapper.wrapper_new .bdpfmenu,
 #wrapper.wrapper_new .usermenu,
 .wrapper_new #u .bdpfmenu a,
 .wrapper_new #u .usermenu a,
-.c-tip-con,
 #content_left .search-source-wrap .search-source-content:hover .search-source-popup,
 #guaranteePopper.guarantee-pc .popover-content .popover-inner,
 .sc-city-selector-content,
 .sc-city-content-content-wrapper,
 .sc-city-content-nav-row,
 .item-selected_3Em1g .left-circle_77jIg,
-.item-selected_3Em1g .right-circle_1eiAS {
+.item-selected_3Em1g .right-circle_1eiAS,
+.tag-common_8ztfL:not(.tag-selected_lD4sS),
+.content_27h2V,
+.header-btn_68kgy,
+._select-entry_9e3yq_48,
+.purchase-tabs_3OCnx,
+.empty_3vOkw,
+.siderbar-wrapper_Nk4dE,
+.recommend-wrapper_M-eYq,
+.content-tab-wrapper_mOcNS,
+.container_7Xe_0,
+.collection-container_GPTiB,
+.history-container_24HQf,
+.prize-wrapper_TK3KC .prize-tab-wrapper_1o39d,
+.container_lwfjL .no-content_3I5k1,
+.new-pmd .c-tabs-content,
+.bdlayer,
+.popup-box_22-gb,
+.open-content-info .tip-hover-panel .rest_info_tip,
+.tang-pass-pop-login div.tang-body,
+.tang-pass-pop-login .pass-text-input,
+.tang-pass-pop-login .pass-item-timer,
+.tang-pass-pop-login .pass-item-time-timing,
+.card_layout_11HoJ,
+.s-skin-layer,
+.select_3ZzKD .select-wrapper_17vIt .scroll-wrap_2W76t .scroll-roll_1Rqwi,
+.visible-pull_1n9XQ {
     background-color: ${#eaeae6} !important;
 }
-.wrapper_new #s_tab .s-tab-item:hover::before {
+.wrapper_new #s_tab .s-tab-item:hover::before,
+.wrapper_new #s_tab .cur-tab::before,
+.s_tab_1z9nv .s-tab-item_1CwH-:hover::before,
+.s_tab_1z9nv .cur-tab_ReMW2::before {
     color: rgb(224 224 224) !important;
 }
-.wrapper_new #s_tab .s-tab-item::before {
+.wrapper_new #s_tab .s-tab-item::before,
+.s_tab_1z9nv .s-tab-item_1CwH-::before {
     color: rgb(178 178 178) !important;
 }
 .demo-question_227j3 .demo-list_7oJi2 .ai-bgprops_2FVDG {
     background-color: rgb(127 114 253 / 9%) !important;
 }
-.sc-button,
-.sc-button-new {
+.sc-button:not(.filter-btns_7wR3o .btns-group_4du0r .confirm-btn_6Scxq,
+.filter-btns_7wR3o .btns-group_4du0r .reset-btn_6Epss),
+.sc-button-new:not(.filter-btns_7wR3o .btns-group_4du0r .confirm-btn_6Scxq,
+.filter-btns_7wR3o .btns-group_4du0r .reset-btn_6Epss) {
     background-image: none !important;
 }
 .head-name-sign_3sFI- {
@@ -30917,11 +31295,17 @@ a:hover {
 .wrapper_new #form .bdsug-new ul li:hover b,
 .sc-search-link:hover,
 .sc-search-link:hover .suffix,
-.page-btn_1XR1p:hover,
 ._search-link_ajims_1:hover,
 .cos-pc .sc-fold-switch-text:hover,
 #container.sam_newgrid .c-showurl-hover,
-.detail-btn_2Ar6f:hover .arrow-icon_49DBU {
+.detail-btn_2Ar6f:hover .arrow-icon_49DBU,
+.item_3WKCf:hover,
+.new-pmd .c-color-link:hover,
+.item_2881O:hover,
+.content-game_KJ6bU:hover,
+.new-pmd .c-link:hover,
+.cos-pc .paragraph_Z0a6a:hover,
+.it-name-data_6AlPV:hover {
     color: #9ac4ff !important;
 }
 .boiling-all_29kBD .boiling-wrapper_fhywn .boiling-contain_3r2Lv .row-left_1OGNu .boiling-right_3Etl4 .boiling-btn_29fbf:hover {
@@ -30940,7 +31324,9 @@ a:hover {
 }
 #container.sam_newgrid .result .c-tools .c-icon,
 #container.sam_newgrid .result-op .c-tools .c-icon,
-#content_left .search-source-wrap .iconfont {
+#content_left .search-source-wrap .iconfont,
+.disable_xmIc6,
+.disable_xmIc6:hover {
     color: #ffffff40 !important;
 }
 ._feedback-icon_pbmk1_13 {
@@ -30966,6 +31352,105 @@ a:hover {
 }
 .sc-city-content-nav-row {
     margin-right: 0px !important;
+}
+.marklang .code-wrapper .code-right {
+    overflow: auto !important;
+}
+.bg-red-tag_4pdwo,
+.coupon-tag_6ZqRA,
+.text-box-red_26L9j,
+.text-box-red_4TVDd,
+.pink_2_yGo {
+    border-color: #ff695988 !important;
+}
+.right-tab_1kBns,
+.load_5MoX5.more_7CTQB {
+    background-image: linear-gradient(to right, ${#eaeae600}, ${#eaeae6} 50%) !important;
+}
+.left-tab_2tBTY,
+.load_5MoX5.back_5gkUM {
+    background-image: linear-gradient(to left, ${#eaeae600}, ${#eaeae6} 50%) !important;
+}
+.c-checkbox-inner,
+.c-radio-inner,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._disabled_1e5eg_33,
+._pagination_1e5eg_1 ._pagination-button_1e5eg_1._disabled_1e5eg_33:hover {
+    color: #ffffff44 !important;
+}
+.new-pmd .c-btn-primary,
+.new-pmd .c-btn-primary:visited {
+    color: #000000 !important;
+}
+.bdlayer-shadow {
+    opacity: .3 !important;
+}
+.btn {
+    border-bottom-color: #8ab4f8;
+}
+.filter-btns_7wR3o .btns-group_4du0r .reset-btn_6Epss {
+    background-color: rgb(143 255 206 / 10%) !important;
+}
+.time_1ugkL .time-box_23JAo .time-text_1S5fz {
+    background-color: #ffffff !important;
+}
+.right-wz-link-dot_1o6OB,
+.pinyin-switch-circle_4tweF {
+    background-color: #dddddd !important;
+}
+.time_1ugkL .time-box_23JAo,
+.wrapper_3MEnd .content_4kScn .time-zone-wrapper_mcQ1R .time-zone_dtfkE .time-zone-item_6Qz1E {
+    background-color: rgba(255, 255, 255, .1) !important;
+}
+.index-map_52TxD {
+    position: relative;
+    z-index: 1;
+}
+.index-map_52TxD::before {
+    background: url(https://gips0.baidu.com/it/u=2799332568,1627663323&fm=3028&app=3028&f=PNG&fmt=auto&q=87&size=f1680_600);
+    background-size: cover;
+    bottom: 0;
+    content: "";
+    filter: invert(100%) hue-rotate(180deg) brightness(200%) contrast(70%);
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: -1;
+}
+.index-map-container_1ps33 .index-map_52TxD .index-item_7wfaw .line_5fjd2 {
+    border-color: #777777 !important;
+}
+.compose-left-container .Qrcode-status-animation {
+    filter: invert(100%) hue-rotate(180deg) brightness(130%) contrast(70%);
+}
+.s-skin-layer .preview-nobg .preview-pageUI {
+    background-position: 0 0 !important;
+}
+._popup_65wrg_1,
+.calendar-all_2gjkC .calendar-wrapper_jX1uN,
+.pop_over_svvNd,
+.pop_over_AuuUs,
+.pop_over_ppVmY,
+.c-tip-con,
+.select_3ZzKD .select-wrapper_17vIt,
+.visible_5Jf4D {
+    background-color: ${#eaeae6} !important;
+    box-shadow: rgb(0 0 0 / 40%) 0px 0px 8px !important;
+}
+.cos-pc .filters-container_49Lmt,
+.cos-pc .filter-btns_7wR3o {
+    background-color: ${#eaeae6} !important;
+    box-shadow: rgb(0 0 0 / 20%) 0px 0px 4px !important;
+}
+._select-list_9e3yq_82,
+.sc-city-content-scroll-bar,
+.visible-pull_1n9XQ {
+    overflow: auto !important;
+    scrollbar-color: ${#909090} ${#eaeae6} !important;
+}
+.c-select-dropdown-list.c-select-scroll {
+    overflow: auto !important;
+    scrollbar-color: ${#aaaaaa} ${#cfcfe9} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30433,6 +30433,8 @@ INVERT
 .entry_5uuDY .aladdin_5ycBj:hover>.code_44Mq0
 .favor-icon_44cdR
 .btn-icon_BvyPS
+.footer_1R38X .opt-ctn_3QzcM .center_2QbMy.active_jFT8S .icon-center_5WIG2
+.model_img_3ThAm
 
 CSS
 .cos-pc,
@@ -30449,6 +30451,7 @@ CSS
     --darkreader-selection-background: #8ab4f8 !important;
     --darkreader-text--cos-brand-dqa-0: #a99af2 !important;
     --darkreader-text--cos-brand-search-0: #9ac4ff !important;
+    --darkreader-text--cos-color-text: rgb(210 215 223);
     --darkreader-text--cos-color-text-link: #8ab4f8 !important;
     --darkreader-text--cos-color-text-primary: #8ab4f8 !important;
     --darkreader-text--cos-dqa-color: #a99af2 !important;
@@ -30496,12 +30499,12 @@ p.pass-form-logo {
 #head_wrapper #kw,
 .wrapper_new .s_ipt_wr,
 .s_ipt_wr {
-    border-color: rgb(100 100 108) !important;
+    border-color: rgb(97 100 108) !important;
 }
 #head_wrapper #kw:hover,
 .wrapper_new .s_ipt_wr:hover,
 .s_ipt_wr:hover {
-    border-color: rgb(120 120 130) !important;
+    border-color: rgb(116 120 129) !important;
 }
 .login-type-tab .switch-item.activ::after,
 .wrapper_new #s_tab .cur-tab::after,
@@ -30517,7 +30520,8 @@ p.pass-form-logo {
 .content-tab-wrapper_mOcNS .active_2hwRT::after,
 .tabs-item-act_2_kZO::after,
 .prize-wrapper_TK3KC .prize-tab-wrapper_1o39d .active_rs7B4::after,
-.tang-pass-footerBarPhoenixSplit {
+.tang-pass-footerBarPhoenixSplit,
+.single_size_wrapper_ZyQTi .choosen_1J7-j {
     background-color: #8ab4f8 !important;
 }
 .tang-pass-pop-login-color-blue .pass-button:hover,
@@ -30566,7 +30570,9 @@ p.pass-form-logo {
 ._pagination_1e5eg_1 ._pagination-button_1e5eg_1._current_1e5eg_21:hover,
 .site-container_3QJpT .site-item-link_2He-Y .site-item-img_3NN3N .normal-site-img_3ID7V,
 .calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 tbody .is-select_3jw86,
-.btn_39Gv2 {
+.btn_39Gv2,
+.x-interact-publish .send,
+.no_content_1hR4o .left_content_1VYIl .add_btn_2VRdZ {
     background-color: #8ab4f8 !important;
     color: #000000 !important;
 }
@@ -30598,7 +30604,10 @@ p.pass-form-logo {
 .s-skin-hasbg #head_wrapper #form #kw:focus,
 .s-skin-hasbg #head_wrapper #form .bdsug-new,
 .wrapper_new #form .bdsug-new,
-#head_wrapper #form .bdsug-new {
+#head_wrapper #form .bdsug-new,
+.single_size_wrapper_ZyQTi:hover .model_card_22b0U,
+.single_size_wrapper_ZyQTi .choosen_1J7-j,
+.stock-container_3De4x .add-stock-btn_p_ZRr:hover {
     border-color: #8ab4f8 !important;
 }
 .a-se-st-single-video-zhanzhang-capsule,
@@ -30611,7 +30620,8 @@ p.pass-form-logo {
 .new-tag_4ozgi .pc-tag_2Nde8,
 .rx-tag_2MW39:not(.bg-red-tag_4pdwo),
 .history-bac_2hVN5 .title_1y9Sg .label_3eMwB,
-.tag-container-label1_EX6wq {
+.tag-container-label1_EX6wq,
+.follow_37dNC {
     border-color: #8ab4f888 !important;
 }
 .tang-pass-pop-login-color-blue .pass-button {
@@ -30671,7 +30681,7 @@ a:hover,
 .op_translation_selfrom,
 .op_translation_selto,
 .jz-container-new-first_1rxT2 .cos-link) {
-    color: #8ab4f8;
+    color: ${#295397};
 }
 a em,
 em {
@@ -30679,7 +30689,7 @@ em {
 }
 a:hover,
 .c-link:hover {
-    color: #9ac4ff;
+    color: ${#1a447f};
 }
 a:visited:not(.c-color-t,
 .c-color-gray2,
@@ -30733,13 +30743,13 @@ a:hover,
 .c-color-gray,
 .op_translation_selfrom,
 .op_translation_selto) {
-    color: rgb(139 132 255);
+    color: ${#6d66e1};
 }
 .opr-toplist1-link_2Ag1v a:visited {
-    color: rgb(139 132 255) !important;
+    color: ${#6d66e1} !important;
 }
 .opr-toplist1-link_2Ag1v a:hover {
-    color: #8ab4f8 !important;
+    color: ${#295397} !important;
 }
 .btn-primary_2s82F {
     background-image: none !important;
@@ -30967,7 +30977,9 @@ a:hover,
 .pass-qrcode-download .qrcode-hover,
 .pass-qrcode-download a,
 .s-skin-layer .defined-state-chooseimg,
-.calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 thead {
+.calendar-all_2gjkC .calendar-wrapper_jX1uN .calendar-table_Za720 thead,
+.pop_content_1Zr5R,
+.new-pmd .c-recommend .recommend-line-one .recommend-item-a {
     background-color: ${#cfcfe9} !important;
 }
 .button_sx9Ei:hover {
@@ -31012,9 +31024,10 @@ a:hover,
 .default_1TgiU:hover,
 .disable_xmIc6,
 .disable_xmIc6:hover),
-.btn-list-untop_21NFc .btn-primary_5ig3T {
+.btn-list-untop_21NFc .btn-primary_5ig3T,
+.active_item_W5MnX {
     background-color: ${#c1c1cf} !important;
-    color: #8ab4f8 !important;
+    color: ${#295397} !important;
 }
 .nvl-bookstore-wrap_3AHiL .bookinfo_1k-rc .read-btn_2j2Ar:hover,
 .zk-header_39T7V .line_26Rhs,
@@ -31194,8 +31207,14 @@ a.pass-reglink,
 .wenda-general_72WpQ .fold-switch_6VL6i .cos-fold-switch-icon,
 .btn-list-untop_21NFc .btn-primary_5ig3T .btn-text_1fn6W,
 .pc_5ioRQ .btn_5IdT0 .btn-text_1fn6W:hover,
-.desc_4FVyG .text_46Zo1 {
-    color: #8ab4f8 !important;
+.desc_4FVyG .text_46Zo1,
+.follow_37dNC,
+.footer_1R38X .opt-ctn_3QzcM .center_2QbMy.active_jFT8S,
+.close_icon_3MF9_:hover,
+.stock-refresh_2dpHf .refresh-btn_1g4z9:hover .update-icon_1_Rks,
+.stock-refresh_2dpHf .refresh-btn_1g4z9:hover .icon-text_1aCCU,
+.no_content_1hR4o .left_content_1VYIl .super_title_3UL8W {
+    color: ${#295397} !important;
 }
 .cos-pc .box_5nmMD:not(.selected_3I0vG):hover {
     background-color: #BBBBFF22 !important;
@@ -31277,18 +31296,9 @@ a.pass-reglink,
 .s-skin-layer,
 .select_3ZzKD .select-wrapper_17vIt .scroll-wrap_2W76t .scroll-roll_1Rqwi,
 .visible-pull_1n9XQ,
-.cos-tag-outline {
+.cos-tag-outline,
+.no_content_1hR4o {
     background-color: ${#eaeae6} !important;
-}
-.wrapper_new #s_tab .s-tab-item:hover::before,
-.wrapper_new #s_tab .cur-tab::before,
-.s_tab_1z9nv .s-tab-item_1CwH-:hover::before,
-.s_tab_1z9nv .cur-tab_ReMW2::before {
-    color: rgb(224 224 224) !important;
-}
-.wrapper_new #s_tab .s-tab-item::before,
-.s_tab_1z9nv .s-tab-item_1CwH-::before {
-    color: rgb(178 178 178) !important;
 }
 .demo-question_227j3 .demo-list_7oJi2 .ai-bgprops_2FVDG {
     background-color: rgb(127 114 253 / 9%) !important;
@@ -31328,7 +31338,7 @@ a.pass-reglink,
 .cos-pc .paragraph_Z0a6a:hover,
 .it-name-data_6AlPV:hover,
 .pc_5ioRQ .desc_4FVyG .text_46Zo1:hover {
-    color: #9ac4ff !important;
+    color: ${#1a447f} !important;
 }
 .pc-container_1YASq a:visited {
     color: rgb(139 132 255) !important;
@@ -31403,7 +31413,9 @@ a.pass-reglink,
     color: #ffffff44 !important;
 }
 .new-pmd .c-btn-primary,
-.new-pmd .c-btn-primary:visited {
+.new-pmd .c-btn-primary:visited,
+.no_content_1hR4o .left_content_1VYIl .add_btn_2VRdZ .add_text_MJd2y,
+.no_content_1hR4o .left_content_1VYIl .add_btn_2VRdZ .add_icon_2xZiE {
     color: #000000 !important;
 }
 .bdlayer-shadow {
@@ -31458,7 +31470,8 @@ a.pass-reglink,
 .pop_over_ppVmY,
 .c-tip-con,
 .select_3ZzKD .select-wrapper_17vIt,
-.visible_5Jf4D {
+.visible_5Jf4D,
+.x-interact-emoj-panel-wrapper {
     background-color: ${#eaeae6} !important;
     box-shadow: rgb(0 0 0 / 40%) 0px 0px 8px !important;
 }
@@ -31469,7 +31482,8 @@ a.pass-reglink,
 }
 ._select-list_9e3yq_82,
 .sc-city-content-scroll-bar,
-.visible-pull_1n9XQ {
+.visible-pull_1n9XQ,
+.x-interact-emoj-panel {
     overflow: auto !important;
     scrollbar-color: ${#909090} ${#eaeae6} !important;
 }
@@ -31496,12 +31510,116 @@ a.pass-reglink,
     background-size: 100% 100%;
     bottom: 0;
     content: "";
-    filter: brightness(800%);
+    filter: brightness(200%);
     left: 0;
     position: absolute;
     right: 0;
     top: 0;
     z-index: -1;
+}
+.s_tab_1z9nv .s-tab-csaitab_2k1Nv,
+.s_tab_1z9nv .s-tab-csaitab_2k1Nv:hover {
+    background: none !important;
+    position: relative;
+    z-index: 1;
+}
+.s_tab_1z9nv .s-tab-csaitab-peak_mSBr2 {
+    height: 0 !important;
+}
+.s_tab_1z9nv .s-tab-csaitab_2k1Nv::before {
+    background: url(https://psstatic.cdn.bcebos.com/basics/chat/AI_1721378175000.svg) !important;
+    background-position: left, center top 6px !important;
+    background-repeat: no-repeat !important;
+    background-size: 14px 14px !important;
+    bottom: 0;
+    content: "";
+    cursor: pointer;
+    filter: brightness(89%);
+    height: 28px;
+    left: 0;
+    padding-left: 18px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: -1;
+}
+.s_tab_1z9nv .s-tab-csaitab_2k1Nv:hover::before {
+    filter: brightness(115%) !important;
+}
+.new-pmd.c-container,
+.title_6OfO5,
+.cu-color-text,
+.new-pmd .c-color-text,
+.render-item_GS8wb .group-content_3jCZd .group-sub-abs_N-I8P,
+.s-top-userset-menu a,
+.c-color-text,
+.advanced-setting .adv-input-prepend,
+.c-btn,
+.c-btn:visited,
+#container.sam_newgrid .c-container ._head-title_zc167_142 ._link_zc167_146,
+#container.sam_newgrid .c-container ._head-title_zc167_142 ._link_zc167_146:hover,
+#container.sam_newgrid .c-container ._head-title_zc167_142 ._link_zc167_146:active,
+#container.sam_newgrid .c-container ._head-title_zc167_142 ._link_zc167_146.c-showurl-hover {
+    color: ${#242931} !important;
+}
+.hint_PIwZX,
+.new-pmd .c-color-gray2,
+.new-pmd .c-color-gray,
+.options_2Vntk,
+.tip-gen_2nWF0,
+._text_pbmk1_40,
+._text1_pbmk1_41,
+._text2_pbmk1_42,
+.help-container_3VJQo a,
+.button_1I6J3,
+.cu-color-info,
+.new-pmd .c-index-single:not(.new-pmd .c-color-red,
+.new-pmd .c-index-single-hot,
+.new-pmd .c-index-single-hot1,
+.new-pmd .c-index-single-hot2,
+.new-pmd .c-index-single-hot3),
+#content_left .search-source-wrap .search-source-title,
+.wrapper_new #form .bdsug-new ul li span,
+.interact__skny,
+.c-color-gray2,
+.soutu-env-new .soutu-layer .soutu-drop-tip,
+.attr-container_22wB9,
+.fold-btn-text_3r8hd {
+    color: ${#52565e} !important;
+}
+[data-darkreader-inline-color],
+.con span {
+    color: ${#52565e};
+}
+.wrap_f1met,
+.c-group-title a,
+.c-select,
+.wrapper_new #s_tab .s-tab-item:hover::before,
+.wrapper_new #s_tab .cur-tab::before,
+.s_tab_1z9nv .s-tab-item_1CwH-:hover::before,
+.s_tab_1z9nv .cur-tab_ReMW2::before,
+.wrapper_new #s_tab .s-tab-item:hover,
+.pfpanel-bd,
+.pftab .pftab_hd .cur,
+.new-pmd .cr-title,
+.item-word_2Fvt9,
+.s_tab_1z9nv .s-tab-item_1CwH-:hover,
+.wrapper_new #u > a {
+    color: ${#151a22} !important;
+}
+.c-color-t,
+.new-pmd .c-color-t {
+    color: ${#151a22};
+}
+.wrapper_new #s_tab .s-tab-item::before,
+.s_tab_1z9nv .s-tab-item_1CwH-::before,
+.pftab .pftab_hd {
+    color: ${#595d64} !important;
+}
+.wrapper_new #s_tab a,
+#bottom_layer .text-color,
+.s_tab_1z9nv a {
+    color: ${#333841} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30494,8 +30494,14 @@ p.pass-form-logo {
     color: #000000;
 }
 #head_wrapper #kw,
-.wrapper_new .s_ipt_wr {
-    border-color: rgb(97 97 97);
+.wrapper_new .s_ipt_wr,
+.s_ipt_wr {
+    border-color: rgb(100 100 108) !important;
+}
+#head_wrapper #kw:hover,
+.wrapper_new .s_ipt_wr:hover,
+.s_ipt_wr:hover {
+    border-color: rgb(120 120 130) !important;
 }
 .login-type-tab .switch-item.activ::after,
 .wrapper_new #s_tab .cur-tab::after,


### PR DESCRIPTION
**Update log:** 
- **New:** 
  - Compatible with [Baidu News Search](https://www.baidu.com/s?rtt=1&bsst=1&cl=2&tn=news&ie=utf-8&word=example), [Video Search](https://www.baidu.com/sf/vsearch?pd=video&wd=example), and [Note Search](https://www.baidu.com/s?pd=note&rpf=pc&word=example) pages. 
  - Adapt to [Baidu Product Collection page](https://www.baidu.com/more/) and [Personal Center page](https://www.baidu.com/my/index). 
  - Adapt the ["Today in History" page](https://www.baidu.com/s?wd=%E5%8E%86%E5%8F%B2%E4%B8%8A%E7%9A%84%E4%BB%8A%E5%A4%A9). 
  - Adapt to the [movie](https://www.baidu.com/s?ie=utf-8&f=8&rsv_bp=1&tn=baidu&wd=%E7%94%B5%E5%BD%B1) and [game](https://www.baidu.com/s?ie=utf-8&f=8&rsv_bp=1&tn=baidu&wd=%E6%89%8B%E6%B8%B8) cards(card components) on the search results page. 
  - Adapt to the homepage skin. 
  - Adapt to the numerous secondary menus on the homepage, as well as the "News" and "Favorites" pages. 
- **Fix:** 
  - Fixed style errors in encyclopedia cards, event cards, essay cards, calendar cards, weather cards, time cards, AI assistant cards, translation cards, ancient poetry cards, ancient text cards, Chinese character cards, famous quote cards, information cards, stock cards, lottery cards, map cards, travel cards, express delivery cards, Baidu Health cards, product cards, and their secondary menus on the search results page.
  - Fixed style errors in the homepage, including advanced search, skin settings, search settings, weather card, image search, and their secondary menus. 
  - Fix the style errors on the user login page. 
  - Fix the style errors on the Baidu Hot Search page. 
  - Fixed the style error of the search box when redirecting from the homepage to the search results page. 
  - Fixed the `:hover` style errors of history and search prediction below the search box. 
  - Fix other known issues. 