### PR TITLE
Update: add/remove various dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -13,6 +13,7 @@
 *.quad9.net
 *.rustclash.com
 *.sapph.xyz
+*.starbreeze.com
 *.suyu.dev
 *.tickettool.xyz
 0bin.net
@@ -1096,6 +1097,7 @@ spoticord.com
 spyware.neocities.org
 srrdb.com
 star-made.org
+starbreeze.com
 starlink.com
 starmadedock.net
 statbot.net


### PR DESCRIPTION
Notes:

- `*.cncnet.org`: https://cncnet.org/, https://forums.cncnet.org/, https://ladder.cncnet.org/
- `*.curseforge.com`: https://www.curseforge.com/, https://authors.curseforge.com/, https://studios.curseforge.com/
- `*.paydaythegame.com`: https://www.paydaythegame.com/, https://fbi.paydaythegame.com/, https://store.paydaythegame.com/
- `*.pleasefix.gg`: https://pleasefix.gg/, https://fix.pleasefix.gg/projects/PLEASEFIX
- `*.quad9.net`: https://quad9.net/, https://on.quad9.net/, https://docs.quad9.net/
- `*.sapph.xyz`: https://sapph.xyz/, https://docs.sapph.xyz/
- `*.starbreeze.com`: https://www.starbreeze.com/, https://nebula.starbreeze.com/, https://nebula.starbreeze.com/support, https://corporate.starbreeze.com/
- `*.suyu.dev`: https://suyu.dev/, https://git.suyu.dev/
- `*.tickettool.xyz`: https://tickettool.xyz/, https://docs.tickettool.xyz/
-------------------------------
- https://gamedle.wtf/: causes notable issues
- https://zolika1351.pages.dev/: not dark-by-default