### PR TITLE
rm MSL from `dark-sites.config`

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -668,7 +668,6 @@ landchad.net
 larbs.xyz
 lazer.ppy.sh
 lbrynomics.com
-learn.microsoft.com
 lecantiche.com
 lemm.ee
 lemmi.no


### PR DESCRIPTION
Removes `learn.microsoft.com`

As per [the rules](https://github.com/darkreader/darkreader/blob/2caaef226ea3a3dea20e44526fa4e9032751e3f7/CONTRIBUTING.md#adding-a-website-that-is-already-dark), the domain is currently violating the 1st one, as it automatically adapts to the preferred `color-scheme`.

Also, [it's light by default](https://github.com/darkreader/darkreader/pull/12385#issuecomment-1985195562)