### PR TITLE
Fix for staging.typst.app{,/universe}

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28000,7 +28000,43 @@ img[src$=".svg"]:not([alt="Typst"])
 
 ================================
 
+staging.typst.app
+
+INVERT
+img[src$=".svg"]:not([alt="Typst"])
+
+================================
+
 typst.app/universe
+
+INVERT
+img[src$=".svg"]:not([alt="Typst"])
+#results li
+#results .title
+#results .description
+#results .template-thumbnail
+#template-thumbnail
+#banner
+#banner .title
+#banner .description
+#banner .featured-label
+#banner .featured-label .icon
+.carousel
+.carousel .top-text
+.carousel .title
+.carousel .bottom-text
+#categories ul li a
+
+CSS
+#results li a,
+#banner {
+    border: 1px solid !important;
+    border-color: lightgray !important;
+}
+
+================================
+
+staging.typst.app/universe
 
 INVERT
 img[src$=".svg"]:not([alt="Typst"])

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27993,6 +27993,7 @@ CSS
 
 ================================
 
+staging.typst.app
 typst.app
 
 INVERT
@@ -28000,43 +28001,8 @@ img[src$=".svg"]:not([alt="Typst"])
 
 ================================
 
-staging.typst.app
-
-INVERT
-img[src$=".svg"]:not([alt="Typst"])
-
-================================
-
-typst.app/universe
-
-INVERT
-img[src$=".svg"]:not([alt="Typst"])
-#results li
-#results .title
-#results .description
-#results .template-thumbnail
-#template-thumbnail
-#banner
-#banner .title
-#banner .description
-#banner .featured-label
-#banner .featured-label .icon
-.carousel
-.carousel .top-text
-.carousel .title
-.carousel .bottom-text
-#categories ul li a
-
-CSS
-#results li a,
-#banner {
-    border: 1px solid !important;
-    border-color: lightgray !important;
-}
-
-================================
-
 staging.typst.app/universe
+typst.app/universe
 
 INVERT
 img[src$=".svg"]:not([alt="Typst"])

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27993,16 +27993,16 @@ CSS
 
 ================================
 
-staging.typst.app
 typst.app
+staging.typst.app
 
 INVERT
 img[src$=".svg"]:not([alt="Typst"])
 
 ================================
 
-staging.typst.app/universe
 typst.app/universe
+staging.typst.app/universe
 
 INVERT
 img[src$=".svg"]:not([alt="Typst"])


### PR DESCRIPTION
During the testing phase (before each new release) a lot of people in the Typst community are using staging.typst.app instead of typst.app to find bugs etc.

I don't know if there is a regex syntax to do `(staging.)?typst.app`, so I created 2 secondary entries.
