### PR TITLE
Fix for zillow.com Mortgage Calculator

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32761,6 +32761,15 @@ div.mt5
 
 ================================
 
+zillow.com
+
+CSS
+#breakdown-panel .pie-chart svg g text {
+    fill: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 zippyshare.com
 
 INVERT


### PR DESCRIPTION
This fixes the "Your Payment" text in the center of the Mortgage Calculator's pie chart.

<hr>

## Before:
![image](https://github.com/user-attachments/assets/777040b5-7369-487d-ac10-f08fec5a882f)

## After:
![image](https://github.com/user-attachments/assets/972b8d6f-95ad-41c5-9af8-07878333cc60)
