### PR TITLE
fix(text-style): use case-insensitive CSS selectors

### DIFF
--- a/src/generators/text-style.ts
+++ b/src/generators/text-style.ts
@@ -10,9 +10,10 @@ const excludedSelectors = [
     '.fa', '.fab', '.fad', '.fal', '.far', '.fas', '.fass', '.fasr', '.fat',
 
     // Generic matches for icon/symbol fonts
-    '.icofont', '[style*="font-"]',
-    '[class*="icon"]', '[class*="Icon"]',
-    '[class*="symbol"]', '[class*="Symbol"]',
+    '.icofont',
+    '[style*="font-"]',
+    '[class*="icon"i]',
+    '[class*="symbol"i]',
 
     // Glyph Icons
     '.glyphicon',


### PR DESCRIPTION
See also
- https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
- https://caniuse.com/css-case-insensitive

This PR was previously submitted as #13312 and landed by @Myshor however @Gitoffthelawn has raised concerns about performance so we're asking for review by @alexanderby.