### PR TITLE
Dynamic theme fixes for Amazon icons

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1616,6 +1616,8 @@ img[src*="smile-logo"]
 .a-icon-close
 .a-icon-extender-expand
 .a-icon-popover
+.a-icon-section-collapse
+.a-icon-section-expand
 .a-link-nav-icon
 .currencyINR
 .ssf-share-trigger


### PR DESCRIPTION
Added .a-icon-section-collapse and .a-icon-section-expand to the list of CSS classes to invert