### PR TITLE
fix for ipko.pl

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14093,7 +14093,7 @@ INVERT
 ipko.pl
 
 INVERT
-a[href="#"]
+a[href="#"]:has(span)
 
 CSS
 ._1IGN3 {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14093,7 +14093,7 @@ INVERT
 ipko.pl
 
 INVERT
-._1vyn4
+a[href="#"]
 
 CSS
 ._1IGN3 {


### PR DESCRIPTION
Changed selector for main ipko logo as it is always used inside a[href="#"] and has span in it