### PR TITLE
Fix for w3champions.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29122,6 +29122,16 @@ img[alt*="equation" i]
 
 ================================
 
+w3champions.com
+
+IGNORE IMAGE ANALYSIS
+.race-icon-HUMAN
+.race-icon-ORC
+.race-icon-NIGHT_ELF
+.race-icon-UNDEAD
+
+================================
+
 wacom.com
 
 INVERT


### PR DESCRIPTION
For example: https://w3champions.com/player/Harstem%2321371/matches, the icons in the table on this page were getting inverted to almost pure white which looks bad.