### PR TITLE
Fix the company logo icon for https://www.elastic.co/

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -702,6 +702,13 @@ INVERT
 
 ================================
 
+elastic.co
+
+INVERT
+path[fill="#000"]
+
+================================
+
 electronics-tutorials.ws
 
 REMOVE BG

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -707,6 +707,11 @@ elastic.co
 INVERT
 path[fill="#000"]
 
+CSS
+#navigation_container[fixed][data-component-theme="color"] [class*="Index_navigation_header"] > a svg path:last-child {
+    fill: gray !important;
+}
+
 ================================
 
 electronics-tutorials.ws


### PR DESCRIPTION
Fixes the company logo icon for https://www.elastic.co/
The selector used might be catching other SVG graphics also on the same domain with fill="#000" but that should work just fine for us.