### PR TITLE
Fix for drop-down lists on Apple's old feedback pages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2294,6 +2294,11 @@ INVERT
 .controls-progress-indicator
 .rf-ccard-content-info
 
+CSS
+option {
+    background: var(--darkreader-neutral-background) !important;
+}
+
 ================================
 
 apple.com/leadership/


### PR DESCRIPTION
Drop-down lists on Apple's old feedback pages (such as https://www.apple.com/feedback/icloud.html and https://www.apple.com/feedback/keynote-for-icloud.html) appear solid white in dark mode. This fix forces all <option> elements (revealed by clicking the <select> element) to have a dark background, allowing these lists to be readable in dark mode.