### PR TITLE
Add fixes for various Wikipedia pages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17479,6 +17479,8 @@ td.icon
 .mw-kartographer-attribution
 img[src*="GNUTLS-logo.svg"]
 img[src*="Zelda_2017.svg"]
+img[src*="Gnomelogo.svg"]
+img[src*="Plasma_coloured_logo.svg"]
 
 CSS
 :root {


### PR DESCRIPTION
Adds invert to logo. Fixes logo color in infobox.

https://en.wikipedia.org/wiki/GnuTLS
https://commons.wikimedia.org/wiki/File:GNUTLS-logo.svg

Edit: also added invert for Zelda infobox logo.

https://en.wikipedia.org/wiki/The_Legend_of_Zelda
https://commons.wikimedia.org/wiki/File:Zelda_2017.svg

Edit 2: also added invert for logos in infobox of GNOME and Plasma Desktop.

https://en.wikipedia.org/wiki/GNOME
https://commons.wikimedia.org/wiki/File:Gnomelogo.svg

https://en.wikipedia.org/wiki/KDE_Plasma
https://commons.wikimedia.org/wiki/File:Plasma_coloured_logo.svg