### PR TITLE
fix for *.garmin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11455,6 +11455,7 @@ INVERT
 .gh__logo
 .map-controls.player .pause span
 .recharts-dot
+.highcharts-plot-line-label
 
 CSS
 .recharts-wrapper text {


### PR DESCRIPTION
Added invert for average line label text in charts as it was black and almost invisible.