### PR TITLE
Dynamic theme fixes for bahaiteachings.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3011,6 +3011,21 @@ a {
 
 ================================
 
+bahaiteachings.org
+
+INVERT
+blockquote::before
+blockquote::after
+blockquote.wp-block-quote::before
+blockquote.wp-block-quote::after
+.container-big::after
+.top-info__social__link
+.input-search
+.event-topics__search__block
+.footer__info__text::after
+
+================================
+
 bahnhof.net
 
 CSS


### PR DESCRIPTION
Inverts block quote quotation marks and various classes that are otherwise bright in dark mode.