### PR TITLE
add alina.cx to the global dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -59,6 +59,7 @@ alecks.dev
 alexkaehler.com
 alfawal.dev
 aliciasykes.com
+alina.cx
 ambr.top
 ameliorated.info
 amog-os.github.io


### PR DESCRIPTION
This commit adds alina.cx to the global dark sites list so I don't have to tell every visitor to disable darkreader if they want to see proper non-generated dark theme.