### PR TITLE
fresha.com logo fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11280,6 +11280,13 @@ body {
 
 ================================
 
+fresha.com
+
+INVERT
+a[aria-label="Fresha"]
+
+================================
+
 fritz.box
 
 INVERT


### PR DESCRIPTION
Sample https://www.fresha.com/pl/a/propodis-malopolskie-centrum-zdrowej-stopy-krakow-wielopole-17-or2a3ln4

![20241016-1729093802](https://github.com/user-attachments/assets/7f3b7eb4-a133-468c-bff7-85d013181003)

