### PR TITLE
feat: add `abhiyan.me` in `dark-sites.config`

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -34,6 +34,7 @@
 9anime.pl
 9anime.to
 aagaming.me
+abhiyan.me
 abletonbot.me
 about.benjithatbluefox.eu
 absolucy.moe


### PR DESCRIPTION
The site [abhiyan.me](https://abhiyan.me) is dark by default. So, I'm adding the site to the dark-sites.config