### PR TITLE
Add inverts for Wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17533,6 +17533,8 @@ img[src*="Plasma_coloured_logo.svg"]
 img[src*="Coreboot_full.svg"]
 img[src*="Libreboot_logo.svg"]
 img[src*="Meson_(software)_logo_2019.svg"]
+img[src*="Freebsd_logo.svg"]
+img[src*="DragonFly_BSD_Logo.svg"]
 
 CSS
 :root {


### PR DESCRIPTION
Fixes logos in infoboxes.

https://en.wikipedia.org/wiki/Coreboot
https://commons.wikimedia.org/wiki/File:Coreboot_full.svg

https://en.wikipedia.org/wiki/Libreboot
https://commons.wikimedia.org/wiki/File:Libreboot_logo.svg

https://en.wikipedia.org/wiki/Meson_(software)
https://commons.wikimedia.org/wiki/File:Meson_(software)_logo_2019.svg

https://en.wikipedia.org/wiki/FreeBSD
https://en.wikipedia.org/wiki/File:Freebsd_logo.svg

https://en.wikipedia.org/wiki/DragonFly_BSD
https://en.wikipedia.org/wiki/File:DragonFly_BSD_Logo.svg