### PR TITLE
Adjust Quad9 sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -10,7 +10,6 @@
 *.newgrounds.com
 *.paydaythegame.com
 *.pleasefix.gg
-*.quad9.net
 *.rustclash.com
 *.sapph.xyz
 *.starbreeze.com
@@ -359,6 +358,7 @@ djflame.tech
 dlive.tv
 docs.adonisjs.com
 docs.gofiber.io
+docs.quad9.net
 dodi-repacks.site
 doesitarm.com
 dominion.games
@@ -857,6 +857,7 @@ okayeg.com
 oldfag.org
 omcar.pl
 omgwtfnzbs.me
+on.quad9.net
 onionplay.co
 onlyformats.netlify.app
 onlyfors.com


### PR DESCRIPTION
Remove `*.quad9.net` from the dark sites list because https://status.quad9.net/smap/ is not dark.
Add other sites to the coverage.

See also: https://github.com/darkreader/darkreader/issues/13418.