### PR TITLE
Fix for wiki

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17553,6 +17553,7 @@ img[src*="Libreboot_logo.svg"]
 img[src*="Meson_"][src*="_logo_2019.svg"]
 img[src*="Freebsd_logo.svg"]
 img[src*="DragonFly_BSD_Logo.svg"]
+img[src*="Fallout_logo.svg"]
 
 CSS
 :root {


### PR DESCRIPTION
Fixes logo in infobox.

https://en.wikipedia.org/wiki/Fallout_(franchise)
https://commons.wikimedia.org/wiki/File:Fallout_logo.svg