### PR TITLE
Dynamic theme fixes for AP News

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1973,6 +1973,8 @@ INVERT
 .hamburger-box
 .sticky-part > div svg
 .LeftRail > div svg
+.Banner
+.Banner-link
 
 ================================
 


### PR DESCRIPTION
These fixes are for the breaking news banner.