### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27081,6 +27081,7 @@ INVERT
 a[data-sponsor="guardian.org"]
 div[data-link-name="Crosswords"] .crossword__cell-number
 div[data-link-name="Crosswords"] .crossword__cell-text
+div[data-link-name="most popular"] > section > ol > li > a > span > svg
 div[data-link-name="most-popular"] > section > ol > li > a > span > svg
 section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
 section[data-component="headlines"] .dcr-d4xwbm > svg
@@ -27105,6 +27106,9 @@ section[data-component="contact-the-guardian"] .securedrop__main > .eyes > .eye 
 }
 section[data-component="headlines"] .dcr-d4xwbm {
     background-color: var(--darkreader-neutral-text) !important;
+}
+section[data-component="headlines"] path[fill="#ddd"] {
+    fill: #BDBDBD !important;
 }
 section[data-component="olympic-medal-table"] circle[r="6.6"],
 section[data-component="paralympic-medal-table"] circle[r="6.6"] {


### PR DESCRIPTION
- Improves light scheme visibility of some weather widget graphics on home page.
- Fixes "Most viewed" section on article pages.

Before:
![1](https://github.com/user-attachments/assets/aa9c41d3-490e-4bef-b9fa-b1d892162f52)
![2](https://github.com/user-attachments/assets/e8b2f943-8488-4826-bef9-d0f089eeb265)

After:
![3](https://github.com/user-attachments/assets/fbc79d08-48fb-41dd-9604-301865ac6746)
![4](https://github.com/user-attachments/assets/24e4af6f-e2f8-4eae-a5e0-373aa91166f7)