### PR TITLE
Improvements for q.utoronto.ca

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22525,6 +22525,8 @@ INVERT
 .ic-sidebar-logo__image
 .instructure_file_link_holder > .file_download_btn
 a.external > span > img:first-child
+.equation_image
+span[data-testid="mathml-preview-element"] svg
 
 CSS
 :root {
@@ -22539,6 +22541,14 @@ CSS
 }
 .ic-DashboardCard {
     box-shadow: ${rgba(0, 0, 0, 0.3)} 0px 1px 5px !important;
+}
+textarea[data-testid="advanced-editor"] {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+math-field,
+fieldset span {
+    color: var(--darkreader-neutral-text) !important;
 }
 
 ================================


### PR DESCRIPTION
Unfortunately this is a private site, so I can't link to the changes directly, but I can take screenshots of before/after if requested.

A description of changes:

- Inverted generated LaTeX svg images so they have black backgrounds with white text
- Fixed Canvas equation editor (normal mode) having a black background with black text
  - Changed it to use darkreader's neutral text color variable
- Fixed Canvas equation editor (LaTeX mode) having a white background and black text
  - Changed it to use darkreader's neutral background and text color variable