### PR TITLE
fixes interpride.org, del dead domain rules

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14080,22 +14080,13 @@ div.fade
 
 ================================
 
-internetowa.tv
-
-INVERT
-img[src*="/img/"]
-
-CSS
-.star-on-png::before {
-    color: #FCAD03 !important;
-}
-
-================================
-
 interpride.org
 
 INVERT
-.logo .img-responsive
+.header__logo
+.search-open
+.logo-items picture
+.footer__logo
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14085,6 +14085,7 @@ interpride.org
 INVERT
 .header__logo
 .search-open
+.top-line::after
 .logo-items picture
 .footer__logo
 


### PR DESCRIPTION
1. DEL dead domain rules `internetowa.tv`
2. Fixes for https://www.interpride.org/


![20241028-1730140279](https://github.com/user-attachments/assets/14cc464b-3bdd-425d-9a1d-48e124c7021b)
![20241028-1730140294](https://github.com/user-attachments/assets/57ece6f7-39c1-4c7a-a3bc-0cc0cebf3596)
![20241028-1730140305](https://github.com/user-attachments/assets/43c18939-f329-4a07-b526-c2153c00a257)