### PR TITLE
Fix for wiki fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17556,7 +17556,7 @@ img[src*="DragonFly_BSD_Logo.svg"]
 img[src*="Fallout_logo.svg"]
 img[src*="PlayStation_4_logo_and_wordmark.svg"]
 img[src*="PlayStation_logo_and_wordmark.svg"]
-img[src*="Xbox_logo_(2019).svg"]
+img[src*="Xbox_logo_"][src*="2019"][src*=".svg"]
 
 CSS
 :root {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17556,7 +17556,7 @@ img[src*="DragonFly_BSD_Logo.svg"]
 img[src*="Fallout_logo.svg"]
 img[src*="PlayStation_4_logo_and_wordmark.svg"]
 img[src*="PlayStation_logo_and_wordmark.svg"]
-img[src*="Xbox_logo_"][src*="2019"][src*=".svg"]
+img[src*="Xbox_logo_%282019%29.svg"]
 
 CSS
 :root {


### PR DESCRIPTION
(Continuation of https://github.com/darkreader/darkreader/pull/13426)

Fixes the fix of invert for Xbox logo (parentheses don't work properly).

@Myshor You said we should avoid using 3 look-ups ("[src]"), but in this case not using three may result in some other random image being inverted I believe. It's fine to use 3 this time then?

https://en.wikipedia.org/wiki/Xbox
https://commons.wikimedia.org/wiki/File:Xbox_logo_(2019).svg