### PR TITLE
Fix for nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20170,10 +20170,12 @@ nytimes.com
 
 INVERT
 #site_header_wrapper a[aria-label="Wirecutter"]
+div[data-testid="masthead-desktop-logo"] > a > svg
 div#live-country-map.live-country-map-embed
 div#live-us-map.live-us-map-embed
-g > text
+.needle-wrap > svg
 .svelte-1v1dl99
+.vmap-layer-container > g > text
 .vmap-zoom-buttons
 #xwd-board
 
@@ -20227,6 +20229,9 @@ a[data-testid] > svg {
 #xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
     fill: ${blue} !important;
 }
+
+IGNORE INLINE STYLE
+line[style="stroke: var(--tie); stroke: black;"]
 
 ================================
 


### PR DESCRIPTION
- Fixes logo on home page.
- Fixes graphics on "The Needle: Senate and House Forecast" (2022) page.
- Updates fix in #7554 for maps on "Tracking Omicron and Other Coronavirus Variants" (2022) page.

Before:
![1](https://github.com/user-attachments/assets/49ca417b-35c5-4182-a7e6-6499689ebaa0)
![2](https://github.com/user-attachments/assets/815233c0-535b-435f-9c69-e2be28316933)

After:
![3](https://github.com/user-attachments/assets/6d734bce-322c-45be-9b22-d5bbf8291dfd)
![4](https://github.com/user-attachments/assets/3bcd7724-ea8c-4618-a152-750a68fcec43)