### PR TITLE
Invert Audible header navigation logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2797,6 +2797,13 @@ span[aria-label="Jira Software"] *
 
 ================================
 
+audible.com
+
+INVERT
+.navigation-header-logo
+
+================================
+
 audible.com/webplayer
 audible.de
 


### PR DESCRIPTION
Inverts the header logo (dark grey text over a transparent background) on Audible.com.