### PR TITLE
myaccount.google.com icon fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19149,7 +19149,7 @@ header,
 myaccount.google.com
 
 INVERT
-c-wiz ul img
+.iKN8Oe
 
 ================================
 


### PR DESCRIPTION
SITE https://myaccount.google.com
![20241103-1730654132](https://github.com/user-attachments/assets/cc9bb340-deea-4cf3-9101-40f04df83eb9)

I  know it is ugly, but works. 