### PR TITLE
Update dynamic-theme-fixes.config for YouTube (youtube.com)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32972,6 +32972,32 @@ a.yt-simple-endpoint.yt-formatted-string:hover {
 .page-header-banner-image {
     background-image: var(--yt-channel-banner) !important;
 }
+yt-formatted-string[has-link-only_]:not([force-default-style]) a.yt-simple-endpoint.yt-formatted-string {
+    color: #d2d0cc !important;
+}
+.yt-spec-button-shape-next--mono.yt-spec-button-shape-next--filled {
+    background-color: #121416 !important;
+    color: #d2d0cc !important;
+}
+.yt-spec-button-shape-next--mono.yt-spec-button-shape-next--tonal {
+    background-color: #121416 !important;
+}
+yt-chip-cloud-chip-renderer[chip-style="STYLE_DEFAULT"].iron-selected {
+    background-color: #121416 !important;
+    color: #d2d0cc !important;
+}
+#metadata-line.ytd-video-meta-block span.ytd-video-meta-block {
+    color: #d2d0cc !important;
+}
+#description.ytd-watch-metadata {
+    background-color: #121416 !important;
+}
+tp-yt-paper-menu-button {
+    background-color: transparent !important;
+}
+#paid-comment-background.ytd-comment-view-model {
+    background-color: transparent !important;
+}
 
 IGNORE INLINE STYLE
 yt-live-chat-ticker-paid-message-item-renderer *


### PR DESCRIPTION
-Fixed some text color in light mode such as channel name or secondary section 'yt-related-chip-cloud-renderer' "STYLE_DEFAULT" color

-Fixed Join button colors in both dark and light mode

-Fixed Subscribe button and other buttons as like, dislike, share... colors in both dark and light mode

-Fixed Sort button background colors in both dark and light mode

-Fixed all comments background colors in both dark and light mode

-Some additional small color fix