### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14736,6 +14736,15 @@ span.inline-block.rounded-full.bg-white {
 
 ================================
 
+jojowiki.com
+
+CSS
+.mw-body {
+    background-image: none !important;
+}
+
+================================
+
 joplinapp.org
 
 CSS


### PR DESCRIPTION
Added fix for jojowiki.com.
- Removed the background image as the inverted image added by the extension makes it difficult to read the text.