### PR TITLE
vectra.pl contrast fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28938,6 +28938,27 @@ CSS
 
 ================================
 
+vectra.pl
+
+INVERT
+.bottom-menu-icons div img
+.footer-container_info--contact a img
+.ga-offer-data img
+.html-widget-wrapper a img
+.imgContainer img
+.logo
+.menu-container-level-one a img
+.offerBox_links div img
+.pionowe-menu img
+.singleRegulationLink img
+.widgetGroup div div div img
+a.homepage img
+span.separator img
+span.swiper-pagination-bullet
+.TvContainerClick img
+
+================================
+
 vendors.paddle.com
 
 INVERT


### PR DESCRIPTION
https://www.vectra.pl/
Contrast icons on site. 
![20241109-1731138340](https://github.com/user-attachments/assets/8f7c5437-2327-4206-aae2-814622349f02)
