### PR TITLE
feat(darkreader#13250): Allow matchMedia function to be undefined

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -38,14 +38,14 @@ export function disable(): void {
     isDarkReaderEnabled = false;
 }
 
-const darkScheme = matchMedia('(prefers-color-scheme: dark)');
+const darkScheme = typeof(matchMedia) === "function" ? matchMedia('(prefers-color-scheme: dark)') : undefined;
 let store = {
     themeOptions: null as Partial<Theme> | null,
     fixes: null as DynamicThemeFix | null,
 };
 
 function handleColorScheme(): void {
-    if (darkScheme.matches) {
+    if (darkScheme?.matches) {
         enable(store.themeOptions, store.fixes);
     } else {
         disable();
@@ -57,15 +57,15 @@ export function auto(themeOptions: Partial<Theme> | false = {}, fixes: DynamicTh
         store = {themeOptions, fixes};
         handleColorScheme();
         if (isMatchMediaChangeEventListenerSupported) {
-            darkScheme.addEventListener('change', handleColorScheme);
+            darkScheme?.addEventListener('change', handleColorScheme);
         } else {
-            darkScheme.addListener(handleColorScheme);
+            darkScheme?.addListener(handleColorScheme);
         }
     } else {
         if (isMatchMediaChangeEventListenerSupported) {
-            darkScheme.removeEventListener('change', handleColorScheme);
+            darkScheme?.removeEventListener('change', handleColorScheme);
         } else {
-            darkScheme.removeListener(handleColorScheme);
+            darkScheme?.removeListener(handleColorScheme);
         }
         disable();
     }


### PR DESCRIPTION
Enables Jest tests to run without errors when using the darkreader API.