### PR TITLE
fix wikipedia vector theme icon inversion

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17662,9 +17662,14 @@ img[src*="uc_lc"][src*=".svg"]
 img[src*="Greek_letter"][src*="sans.svg"]
 img[src*="Psi2.svg"]
 li.menu-tooltip:not(.lang_btn)
-td.icon
-#vector-main-menu-dropdown
+#vector-main-menu-dropdown .vector-icon
 #vector-page-tools-dropdown-label::after
+.vector-user-links-main .vector-icon
+#vector-user-links-dropdown .vector-icon
+#vector-user-links-dropdown .vector-icon:after
+#vector-user-links-dropdown-label::after
+.vector-menu-content .vector-icon
+td.icon
 .minerva-icon
 .mw-mmv-icon
 .cdx-button__icon
@@ -17685,6 +17690,8 @@ img[src*="Fallout_logo.svg"]
 img[src*="PlayStation_4_logo_and_wordmark.svg"]
 img[src*="PlayStation_logo_and_wordmark.svg"]
 img[src*="Xbox_logo_%282019%29.svg"]
+#p-twinkle-dropdown-label::after
+#p-lang-btn-label::after
 
 CSS
 :root {


### PR DESCRIPTION
For DR dynamic theme this change fixes inversion for various icons in the 2022 Wikipedia vector theme. These changes have been tested in Light/Dark mode in Firefox and Chrome.

One line adds an inversion fix for a third-party plugin icon.