### PR TITLE
Invert Stockbit's site logos and stock charts

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26050,9 +26050,12 @@ INVERT
 stockbit.com
 
 INVERT
-#landing-logo img
-.footer-logo img
 .konvajs-content canvas
+a[href$="chartbit"] canvas
+footer + section img
+footer img
+img[alt*="chart"]
+img[src$="stockbit.svg"]
 
 CSS
 .highlight {


### PR DESCRIPTION
This pull request inverts company logos and stock charts (requires an account) shown on Stockbit's site.
This pull request readdresses the work previously underlined in https://github.com/darkreader/darkreader/pull/11245 and prior related pull requests.