### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33101,6 +33101,9 @@ tp-yt-paper-menu-button {
 #paid-comment-background.ytd-comment-view-model {
     background-color: transparent !important;
 }
+svg[id^="yt-ringo2"] :not([id^="youtube-paths"]) path:nth-child(1) {
+    fill: #ff0033 !important;
+}
 
 IGNORE INLINE STYLE
 yt-live-chat-ticker-paid-message-item-renderer *


### PR DESCRIPTION
-i dont know why but although youtube default logo red side hex color #ff0033, when dark reader in dark mode it converts into #ff1e68 ,and when dark reader in light mode it converts into #ff5880. I fixed it as default value. SS are below.

Before:
![logo](https://github.com/user-attachments/assets/bb7de840-6d56-4b36-a527-72be3a8ebbb0)

After:
![logoFixed](https://github.com/user-attachments/assets/fe1ac5b7-5188-4361-b9ee-57080608efcb)
