### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27324,6 +27324,9 @@ section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand textu
 section[data-component="paralympic-medal-table"] img[alt="Multi-coloured sand texture"]
 
 CSS
+header[data-component="header"] a[data-link-name="header : logo"] svg {
+    fill: var(--darkreader-text--masthead-nav-link-text) !important;
+}
 section[data-component="documentaries"] p {
     border-top: 1px solid #ffffff50 !important;
 }
@@ -27386,8 +27389,8 @@ svg[stroke="var(--straight-lines)"] {
 }
 
 IGNORE INLINE STYLE
-a[data-link-name="nav3 : logo"] svg
 div[data-component="youtube-atom"] path[fill="#FFFFFF"]
+nav[data-component="nav2"] a[data-link-name="nav3 : logo"] svg path
 section[data-component="contact-the-guardian"] *
 section[data-component="documentaries"] path[fill="#121212"]
 section[data-component="headlines"] path


### PR DESCRIPTION
- Fixes logo on most pages.
- Updates fix in #13072 for logo on crossword pages.
- Clarifies fixes to allow for easier identification and sorting.