### PR TITLE
unipoll.uni-obuda.hu textarea fix & removed telex.hu because it's default dark mode is based on prefers-color-scheme

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1160,7 +1160,6 @@ teddit.zaggy.nl
 telescope.org
 teleseer.com
 televizeseznam.cz
-telex.hu
 term.ooo
 terminal.sexy
 terminalroot.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28598,6 +28598,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+unipoll.uni-obuda.hu
+
+CSS
+textarea {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 unsplash.com
 
 INVERT


### PR DESCRIPTION
[telex.hu](https://telex.hu/) was added by me in February, but [as I learned a few minutes ago](https://github.com/darkreader/darkreader/pull/13506#discussion_r1844963437), it does not qualify to the `dark-sites.config` list: https://github.com/darkreader/darkreader/pull/12290

<hr>

For [unipoll.uni-obuda.hu](https://unipoll.uni-obuda.hu/) screenshots, I had to censor some of the parts because of privacy.

Dark Reader turned off:
![Screenshot 2024-11-16 at 11-19-47 unipoll](https://github.com/user-attachments/assets/144738f9-6af9-445c-b4d6-084f99308aab)

Dark Reader turned on, without fix:
![Screenshot 2024-11-16 at 11-25-47 unipoll](https://github.com/user-attachments/assets/6ef0d28e-2b76-49d0-8c43-891e94b589fc)

Dark Reader turned on, with fix:
![Screenshot 2024-11-16 at 11-12-40 unipoll](https://github.com/user-attachments/assets/387a28ba-b7da-4d02-ab79-0f1ad6c8f18a)