### PR TITLE
add detector for telex.hu

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -559,6 +559,16 @@ NO DARK THEME
 
 ================================
 
+telex.hu
+
+TARGET
+html
+
+MATCH
+.dark-mode
+
+================================
+
 thefederalist.com
 
 NO DARK THEME


### PR DESCRIPTION
Added detector for telex.hu after removing site from dark-sites.config in https://github.com/darkreader/darkreader/pull/13520