### PR TITLE
Fix homedepot.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13285,6 +13285,15 @@ span[role="presentation"] > .cm-variable-2 {
 
 ================================
 
+homedepot.com
+
+CSS
+span[role="progressbar"] > .sui-bg-inverse {
+    background-color: ${#f70} !important;
+}
+
+================================
+
 hooktail.sub.jp
 hooktail.org
 


### PR DESCRIPTION
Fixes invisible customer review bars.
  
Site example:  
https://www.homedepot.com/p/Crescent-48-oz-Fiberglass-Drilling-Hammer-CHFDRL48/321709101   (click on `Customer Reviews`)