### PR TITLE
Update dynamic-theme-fixes.config for medium.com fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6,6 +6,7 @@ INVERT
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
 span[data-href^="https://www.hcaptcha.com/"] > #icon
 img.Wirisformula
+a[data-testid="headerMediumLogo"]>svg
 
 CSS
 .vimvixen-hint {
@@ -17849,7 +17850,6 @@ medium.com
 INVERT
 .svgIcon
 .svgIcon-use
-a[data-testid="headerMediumLogo"]>svg
 a[href="/"]>svg
 div[role="separator"]
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17849,6 +17849,8 @@ medium.com
 INVERT
 .svgIcon
 .svgIcon-use
+a[data-testid="headerMediumLogo"]>svg
+a[href="/"]>svg
 div[role="separator"]
 
 ================================


### PR DESCRIPTION
This fixes the medium.com logo in the nav bar being unreadable by switching it to a contrasting color.

`a[href="/"]>svg` - Fixes the logo on the homepage
`a[data-testid="headerMediumLogo"]` - Fixes the logo on all other pages