### PR TITLE
Add import/order rule for future consistency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -156,6 +156,14 @@ config.overrides.push({
                 from: './src/ui/',
             }],
         }],
+        'import/order': ['warn', {
+            'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+            'newlines-between': 'always',
+            'alphabetize': {
+                'order': 'asc',
+                'caseInsensitive': true,
+            },
+        }],
     },
 
     overrides: [


### PR DESCRIPTION
## Overview

Hello reviewer,

I am a computer science student, and I've been using Dark Reader with great satisfaction. Thank you for the wonderful project!

I’d like to propose a small improvement related to the consistency of import statement alignment. While reviewing the codebase, I noticed there was no existing ESLint rule for sorting import statements.

To address this, I’ve added relevant rules to ensure better alignment of imports moving forward. Please note that I only added the rules and have not applied them to the code yet, in case the volume of changes might feel overwhelming.

Thank you for your consideration!

<br/>
<hr/>
<br/>

## Detail

### Rule Configuration

```js
'import/order': ['warn', {
    'groups': ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
    'newlines-between': 'always',
    'alphabetize': {
        'order': 'asc',
        'caseInsensitive': true,
    },
}],
```

<br/>

1. `groups`: This option defines the different categories of imports and their order in the import statements. The order specified is:

- `builtin`: Core Node.js modules such as `fs`, `path`, etc.
- `external`: Third-party libraries installed externally (library installed via npm or yarn).
- `internal`: Internal imports within the project, which could include modules that are not part of external dependencies but are specific to the project.
- `parent`: Parent directory imports, e.g., imports from `../`
- `sibling`: Sibling directory imports, e.g., imports from `./`
- `index`: Imports from the `index` file in a directory.

<br/>

2. `newlines-between`: This option enforces a newline between different import groups, making the code more readable and organized. The rule is set to `'always'`, meaning a blank line will be added between each group of imports (e.g., between external and internal imports).

<br/>

3. `alphabetize`: This option enforces alphabetical ordering of imports within each group, which is helpful for quickly locating imports. The configuration specifies:

- `order: 'asc'`: This ensures imports are sorted in ascending order.
- `caseInsensitive`: true: This makes the sorting case-insensitive.

<br/>
<br/>

Thank you for your consideration of this small but useful improvement!

Let me know if you have any feedback or suggestions.