### PR TITLE
add subdomain to zybooks.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33455,6 +33455,7 @@ INVERT
 ================================
 
 zybooks.com
+learn.zybooks.com
 
 CSS
 .image-content-resource img,


### PR DESCRIPTION
Adds the subdomain that zybooks hosts its library on (learn.zybooks.com). This allows the fix for transparent images to be applied where it was needed.

The results of this fix are likely paywalled.