### PR TITLE
Add react.dev and reactnative.dev to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -983,6 +983,8 @@ ray.so
 razeenf.ca
 razer.com
 razorsecure.com
+react.dev
+reactnative.dev
 redacted.ch
 redasm.io
 redbox.com


### PR DESCRIPTION
Both https://react.dev and https://reactnative.dev are dark mode by default. Adding them to the `dark-sites.config` per [contribution guidelines](https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#adding-a-website-that-is-already-dark)