### PR TITLE
Invert 2700chess' live ratings table

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -612,11 +612,8 @@ body {
 2700chess.com
 
 INVERT
-.cg-wrap piece.queen.black
-.cg-wrap piece.bishop.black
-.cg-wrap piece.rook.black
-.cg-wrap piece.knight.black
-.cg-wrap piece.pawn.black
+#live-ratings-table td *:not(.flag):last-child
+cg-board piece.black:not(.king)
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -613,7 +613,7 @@ body {
 
 INVERT
 #live-ratings-table td *:not(.flag):last-child
-cg-board piece.black:not(.king)
+cg-board piece.black
 
 ================================
 


### PR DESCRIPTION
This pull request inverts the table that displays chess live ratings on the main page for better readability.
This pull request also simplifies existing selectors.