### PR TITLE
Add satisfactory-factories.app to dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1033,6 +1033,7 @@ saliven.com
 sammcheese.net
 sandervanderburg.blogspot.com
 sapph.xyz
+satisfactory-factories.app
 sauce420.github.io
 sauce420.gitlab.io
 save.tf


### PR DESCRIPTION
This website is inheritantly dark mode, so would appriciate this is whitelisted. Thanks!