### PR TITLE
Fix for nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20453,6 +20453,7 @@ CSS
 nytimes.com
 
 INVERT
+button[aria-label="Listen to article"] path[stroke="#DFDFDF"]
 #site_header_wrapper a[aria-label="Wirecutter"]
 div[data-testid="masthead-desktop-logo"] > a > svg
 div#live-country-map.live-country-map-embed
@@ -20464,6 +20465,10 @@ div#live-us-map.live-us-map-embed
 #xwd-board
 
 CSS
+button[aria-label="Listen to article"] path[d="M22 38L37 28L22 18V38Z"],
+button[aria-label="Save article for reading later..."] .saved-stroke {
+    fill: var(--darkreader-neutral-text) !important;
+}
 .css-oylsik,
 .css-nhjhh0 svg,
 .css-18z7m18 svg,


### PR DESCRIPTION
Fixes play and save buttons on most article pages.

Before:
![1](https://github.com/user-attachments/assets/24909e9d-dd47-4c9b-8d64-9d872baf20c3)
![2](https://github.com/user-attachments/assets/409a8a1f-cdac-42a5-a21c-2016e74010c8)

After:
![3](https://github.com/user-attachments/assets/1da42acb-ab9d-4441-b151-e26a16a9f046)
![4](https://github.com/user-attachments/assets/077aa1c8-873a-4fbe-a258-d66f6a36b6c1)