### PR TITLE
Fixed split button borders and 'Add Photo' button background on IMDB.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13921,6 +13921,12 @@ main {
 .ipc-tabs--display-chip .ipc-tab--active:hover {
     background: ${rgb(245,197,24)} !important;
 }
+.ipc-split-button {
+    border: solid 2px currentcolor !important;
+}
+section[cel_widget_id="StaticFeature_Photos"] button {
+    background: none !important;
+}
 
 ================================
 


### PR DESCRIPTION
Before:

<img width="830" alt="image" src="https://github.com/user-attachments/assets/ad6409fa-e0e4-4622-af8a-9a7be446a3ec">

After:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/bd9183aa-7559-4a3b-a540-d3f4dbd4df6f">
