### PR TITLE
Fixed AllRecipes.com hamburger menu/close icons.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1527,6 +1527,9 @@ INVERT
 .icon-share-favorite
 .rating-bar-wrapper
 img[src="/img/profile.png"]
+.mntl-header__close-icon
+.mntl-header__menu-icon
+.mntl-header__nav-panel-close-icon
 
 ================================
 


### PR DESCRIPTION
Before:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/d759e1a1-18f8-4fdb-b06d-5fac2d52b7e9">

After:

<img width="547" alt="image" src="https://github.com/user-attachments/assets/b417aea6-b88b-4ab4-9d50-c8b21fca6462">

https://www.allrecipes.com/