### PR TITLE
Add "Deltahub.io". Create CSS background-img rule.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7556,6 +7556,15 @@ CSS
 
 ================================
 
+deltahub.io
+
+CSS
+img {
+    background-image: linear-gradient(rgba(255, 255, 255, 1), rgba(0, 0, 0, 1));
+}
+
+================================
+
 dennisbareis.com
 
 CSS


### PR DESCRIPTION
Create CSS background-img rule regarding scrolling images on the x axis below image carousel. Update background color in dark mode. 

![Screenshot 2024-12-11 at 14 50 24](https://github.com/user-attachments/assets/672c79d2-8c8a-4ad9-b3ac-676d9239173d)
