### PR TITLE
Added fixes for Coupang

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6814,6 +6814,23 @@ img[src$="MCCP-wordmark-denim.png"]
 
 ================================
 
+coupang.com
+mc.coupang.com
+
+INVERT
+img[src="https://static.coupangcdn.com/image/coupang/common/pc_header_img_sprite_new_gnb.svg#person"]
+img[src="https://static.coupangcdn.com/image/coupang/common/pc_header_img_sprite_new_gnb.svg#cart"]
+.main-section h2
+#categoryBestMenu > .category-anchor
+.category-best-title-ad-product
+
+CSS
+.select--category--button {
+    filter: invert() contrast(0.8);
+}
+
+================================
+
 courses.fit.cvut.cz
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6818,16 +6818,12 @@ coupang.com
 mc.coupang.com
 
 INVERT
+.select--category--button
 img[src="https://static.coupangcdn.com/image/coupang/common/pc_header_img_sprite_new_gnb.svg#person"]
 img[src="https://static.coupangcdn.com/image/coupang/common/pc_header_img_sprite_new_gnb.svg#cart"]
 .main-section h2
 #categoryBestMenu > .category-anchor
 .category-best-title-ad-product
-
-CSS
-.select--category--button {
-    filter: invert() contrast(0.8);
-}
 
 ================================
 


### PR DESCRIPTION
https://coupang.com/ - South Korean shopping website, like Amazon. The `mc` subdomain is short for "My Coupang" - essentially all of the logged-in user stuff.

- <img width="1039" alt="image" src="https://github.com/user-attachments/assets/4357cf0b-97ad-48ca-a4ac-231154f27914" />
- <img width="1032" alt="image" src="https://github.com/user-attachments/assets/cb5d83dd-7f3a-4a32-a668-04b94788a714" />


-----------

https://www.coupang.com/#todayDiscoveryUnit

- <img width="497" alt="image" src="https://github.com/user-attachments/assets/a7ebce46-5839-4dee-9258-d58ede164ff6" />
- <img width="624" alt="image" src="https://github.com/user-attachments/assets/e2331da9-c06f-42b4-8803-b52813b705a1" />

------------

https://www.coupang.com/#categoryBestUnit

- <img width="575" alt="image" src="https://github.com/user-attachments/assets/83c65219-48c5-404f-801a-e91d636506e7" />
- <img width="563" alt="image" src="https://github.com/user-attachments/assets/8752881f-95f8-4cfd-9768-2e9630fbae38" />


