### PR TITLE
Fixed menu button on IKEA homepage.

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13765,6 +13765,9 @@ body,
 
 ikea.*
 
+INVERT
+.menu-btn
+
 CSS
 .range-revamp-ratings-bar__star--empty path,
 .range-revamp-ratings-bar__star--half path:first-child {


### PR DESCRIPTION
Before:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/bba1cb04-10c1-4e3c-8935-7ed7ff0700b3" />

After:
<img width="553" alt="image" src="https://github.com/user-attachments/assets/60fb6daf-7b3a-4679-803a-5daa05943309" />

It also applies to the close button when the menu is open.