### PR TITLE
Update dynamic-theme-fixes.config For Overleaf.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21243,6 +21243,7 @@ overleaf.com
 
 INVERT
 .canvasWrapper
+.canvasWrapper>canvas 
 
 ================================
 


### PR DESCRIPTION
Website: overleaf.com
config: Dynamic

Addition:
I added ".canvasWrapper>canvas" in INVERT so the pdf is more readable but still gets the luminosity and contrast effect because the black version of pdf is usually less readable (for math articles at least). 
I propose it more as an alternative than a permanent change but I can't create a pdf exception for a website.