### PR TITLE
fixes for last.fm

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15984,6 +15984,9 @@ IGNORE IMAGE ANALYSIS
 .tag-label--average-daily-scrobbles::before
 .report-headline-border
 .header .header-background::before
+.chartlist-play-button::before
+.stationlink-list .stationlink::before
+.featured-item-art .image-overlay-playlink-link::before
 
 ================================
 


### PR DESCRIPTION
Added IGNORE IMAGE ANALYSIS to PLAY buttons as they was blobed in chromium based browsers and not blobed in Firefox.