### PR TITLE
fix for strava.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26444,6 +26444,7 @@ text.label
 .leaflet-control-zoom-in
 .leaflet-control-zoom-out
 img.mr-sm
+.follow-action .selection.gear::after
 
 CSS
 .base-chart .grid-line,
@@ -26509,6 +26510,7 @@ div[style='background-image: url("https://web-assets.strava.com/assets/react-18/
 IGNORE IMAGE ANALYSIS
 .app-icon.icon-fb
 .app-icon.icon-rowing
+.follow-action .selection.gear::after
 
 ================================
 


### PR DESCRIPTION
Fix for black gear icon in firefox.
Making fix working fine in Firefox and Chromium based browsers using IGNORE IMAGE ANALYSIS.