### PR TITLE
Fix for app.element.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2133,63 +2133,63 @@ svg text.time_cursor {
 app.element.io
 
 CSS
-.mx_NotificationBadge,
-.mx_ReplyPreview_header_cancel,
-.mx_RoomTile_menuButton::before,
-.mx_IconizedContextMenu_icon::before,
-.mx_RoomTile_notificationsButton::before,
-.mx_RoomTile_notificationsButton_show::before {
+.cpd-theme-dark .mx_NotificationBadge,
+.cpd-theme-dark .mx_ReplyPreview_header_cancel,
+.cpd-theme-dark .mx_RoomTile_menuButton::before,
+.cpd-theme-dark .mx_IconizedContextMenu_icon::before,
+.cpd-theme-dark .mx_RoomTile_notificationsButton::before,
+.cpd-theme-dark .mx_RoomTile_notificationsButton_show::before {
     background: var(--cpd-color-icon-primary) !important;
 }
-.mx_MessageContextMenu_iconRedact::before {
+.cpd-theme-dark .mx_MessageContextMenu_iconRedact::before {
     background: var(--cpd-color-icon-critical-primary) !important;
 }
-.mx_AccessibleButton.mx_NotificationBadge {
+.cpd-theme-dark .mx_AccessibleButton.mx_NotificationBadge {
     background-clip: padding-box !important;
     border: 3px solid rgba(38, 39, 43, 0.82) !important;
 }
-.mx_EventTile[data-layout="group"].mx_EventTile_selected > .mx_EventTile_line {
+.cpd-theme-dark .mx_EventTile[data-layout="group"].mx_EventTile_selected > .mx_EventTile_line {
     background-color: var(--cpd-color-bg-subtle-secondary);
     box-shadow: rgb(235, 238, 242) 54px 0px 0px -50px inset;
 }
-.mx_ReplyChain {
+.cpd-theme-dark .mx_ReplyChain {
     border-left: 2px solid var(--username-color);
 }
-.mx_UserMenu,
-.mx_RoomHeader,
-.mx_TimelineSeparator > hr,
-.mx_LeftPanel_filterContainer {
+.cpd-theme-dark .mx_UserMenu,
+.cpd-theme-dark .mx_RoomHeader,
+.cpd-theme-dark .mx_TimelineSeparator > hr,
+.cpd-theme-dark .mx_LeftPanel_filterContainer {
     border-bottom: 1px solid var(--cpd-color-gray-400) !important;
 }
-.mx_RoomSublist_resizeBox:hover .mx_RoomSublist_resizerHandle,
-.mx_SpaceButton_icon::before {
+.cpd-theme-dark .mx_RoomSublist_resizeBox:hover .mx_RoomSublist_resizerHandle,
+.cpd-theme-dark .mx_SpaceButton_icon::before {
     background-color: var(--cpd-color-text-primary) !important;
 }
-.mx_RoomSearch,
-.mx_RoomTile:hover,
-.mx_SpaceButton_icon,
-.mx_LeftPanel_exploreButton,
-.mx_RoomListHeader_plusButton,
-.mx_RoomTile.mx_RoomTile_selected {
+.cpd-theme-dark .mx_RoomSearch,
+.cpd-theme-dark .mx_RoomTile:hover,
+.cpd-theme-dark .mx_SpaceButton_icon,
+.cpd-theme-dark .mx_LeftPanel_exploreButton,
+.cpd-theme-dark .mx_RoomListHeader_plusButton,
+.cpd-theme-dark .mx_RoomTile.mx_RoomTile_selected {
     background-color: var(--cpd-color-alpha-gray-300) !important;
 }
-.mx_SpaceButton_icon::before {
+.cpd-theme-dark .mx_SpaceButton_icon::before {
     background-color: var(--cpd-color-text-secondary) !important;
 }
-.mx_SpaceButton.mx_SpaceButton_active.mx_SpaceButton_narrow
-.mx_SpaceButton_selectionWrapper {
+.cpd-theme-dark .mx_SpaceButton.mx_SpaceButton_active.mx_SpaceButton_narrow
+.cpd-theme-dark .mx_SpaceButton_selectionWrapper {
     border: 3px solid var(--cpd-color-icon-primary) !important;
 }
-.mx_IconizedContextMenu .mx_IconizedContextMenu_optionList:nth-child(n+2) {
+.cpd-theme-dark .mx_IconizedContextMenu .mx_IconizedContextMenu_optionList:nth-child(n+2) {
     border-top: var(--cpd-border-width-1) solid var(--cpd-color-gray-400);
 }
-.mx_ContextualMenu {
+.cpd-theme-dark .mx_ContextualMenu {
     border: var(--cpd-border-width-1) solid var(--cpd-color-border-interactive-secondary);
 }
-.mx_Verified {
+.cpd-theme-dark .mx_Verified {
     color: var(--cpd-color-icon-success-primary);
 }
-.mx_RightPanel {
+.cpd-theme-dark .mx_RightPanel {
     border-left: 1px solid var(--cpd-color-gray-400);
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2130,6 +2130,71 @@ svg text.time_cursor {
 
 ================================
 
+app.element.io
+
+CSS
+.mx_NotificationBadge,
+.mx_ReplyPreview_header_cancel,
+.mx_RoomTile_menuButton::before,
+.mx_IconizedContextMenu_icon::before,
+.mx_RoomTile_notificationsButton::before,
+.mx_RoomTile_notificationsButton_show::before {
+    background: var(--cpd-color-icon-primary) !important;
+}
+.mx_MessageContextMenu_iconRedact::before {
+    background: var(--cpd-color-icon-critical-primary) !important;
+}
+.mx_AccessibleButton.mx_NotificationBadge {
+    background-clip: padding-box !important;
+    border: 3px solid rgba(38, 39, 43, 0.82) !important;
+}
+.mx_EventTile[data-layout="group"].mx_EventTile_selected > .mx_EventTile_line {
+    background-color: var(--cpd-color-bg-subtle-secondary);
+    box-shadow: rgb(235, 238, 242) 54px 0px 0px -50px inset;
+}
+.mx_ReplyChain {
+    border-left: 2px solid var(--username-color);
+}
+.mx_UserMenu,
+.mx_RoomHeader,
+.mx_TimelineSeparator > hr,
+.mx_LeftPanel_filterContainer {
+    border-bottom: 1px solid var(--cpd-color-gray-400) !important;
+}
+.mx_RoomSublist_resizeBox:hover .mx_RoomSublist_resizerHandle,
+.mx_SpaceButton_icon::before {
+    background-color: var(--cpd-color-text-primary) !important;
+}
+.mx_RoomSearch,
+.mx_RoomTile:hover,
+.mx_SpaceButton_icon,
+.mx_LeftPanel_exploreButton,
+.mx_RoomListHeader_plusButton,
+.mx_RoomTile.mx_RoomTile_selected {
+    background-color: var(--cpd-color-alpha-gray-300) !important;
+}
+.mx_SpaceButton_icon::before {
+    background-color: var(--cpd-color-text-secondary) !important;
+}
+.mx_SpaceButton.mx_SpaceButton_active.mx_SpaceButton_narrow
+.mx_SpaceButton_selectionWrapper {
+    border: 3px solid var(--cpd-color-icon-primary) !important;
+}
+.mx_IconizedContextMenu .mx_IconizedContextMenu_optionList:nth-child(n+2) {
+    border-top: var(--cpd-border-width-1) solid var(--cpd-color-gray-400);
+}
+.mx_ContextualMenu {
+    border: var(--cpd-border-width-1) solid var(--cpd-color-border-interactive-secondary);
+}
+.mx_Verified {
+    color: var(--cpd-color-icon-success-primary);
+}
+.mx_RightPanel {
+    border-left: 1px solid var(--cpd-color-gray-400);
+}
+
+================================
+
 app.estuda.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2169,8 +2169,7 @@ CSS
 .cpd-theme-dark .mx_LeftPanel_filterContainer {
     border-bottom: 1px solid var(--cpd-color-gray-400) !important;
 }
-.cpd-theme-dark .mx_RoomSublist_resizeBox:hover .mx_RoomSublist_resizerHandle,
-.cpd-theme-dark .mx_SpaceButton_icon::before {
+.cpd-theme-dark .mx_RoomSublist_resizeBox:hover .mx_RoomSublist_resizerHandle {
     background-color: var(--cpd-color-text-primary) !important;
 }
 .cpd-theme-dark .mx_RoomSearch,
@@ -2184,8 +2183,7 @@ CSS
 .cpd-theme-dark .mx_SpaceButton_icon::before {
     background-color: var(--cpd-color-text-secondary) !important;
 }
-.cpd-theme-dark .mx_SpaceButton.mx_SpaceButton_active.mx_SpaceButton_narrow
-.cpd-theme-dark .mx_SpaceButton_selectionWrapper {
+.cpd-theme-dark .mx_SpaceButton.mx_SpaceButton_active.mx_SpaceButton_narrow .mx_SpaceButton_selectionWrapper {
     border: 3px solid var(--cpd-color-icon-primary) !important;
 }
 .cpd-theme-dark .mx_IconizedContextMenu .mx_IconizedContextMenu_optionList:nth-child(n+2) {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2132,6 +2132,14 @@ svg text.time_cursor {
 
 app.element.io
 
+INVERT
+.cpd-theme-light .mx_NotificationBadge
+.cpd-theme-light .mx_ReplyPreview_header_cancel
+.cpd-theme-light .mx_RoomTile_menuButton::before
+.cpd-theme-light .mx_IconizedContextMenu_icon::before
+.cpd-theme-light .mx_RoomTile_notificationsButton::before
+.cpd-theme-light .mx_RoomTile_notificationsButton_show::before
+
 CSS
 .cpd-theme-dark .mx_NotificationBadge,
 .cpd-theme-dark .mx_ReplyPreview_header_cancel,


### PR DESCRIPTION
I tried using `IGNORE INLINE STYLE` and `INVERT` at the start, but it doesn't seem to work.

After:

![screenshot_2024-12-26_18-30-16](https://github.com/user-attachments/assets/579d052f-8e19-4f46-acc3-cf47018d004c)

![screenshot_2024-12-26_18-34-59](https://github.com/user-attachments/assets/e8c7bf2c-219c-4abe-9d9e-4b2bb51003d2)

![image](https://github.com/user-attachments/assets/e49347c0-0307-4c72-b243-c207723475c8)

Before:

![screenshot_2024-12-26_18-39-23](https://github.com/user-attachments/assets/3cd7fd01-3a55-4c30-b7ad-f651ec111a4a)

![image](https://github.com/user-attachments/assets/5d2110a3-68e8-4b5c-b663-0b9143bf559c)
