### PR TITLE
Add detector hints for Wikipedia

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -694,6 +694,17 @@ NO DARK THEME
 
 ================================
 
+wikipedia.org
+
+TARGET
+html
+
+MATCH
+.skin-theme-clientpref-night
+.skin-theme-clientpref-os
+
+================================
+
 x.com
 
 TARGET

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -701,7 +701,6 @@ html
 
 MATCH
 .skin-theme-clientpref-night
-.skin-theme-clientpref-os
 
 ================================
 


### PR DESCRIPTION
Add detector hints for new Wikipedia theme [`Vector (2022)`](https://en.wikipedia.org/wiki/Special:Preferences#mw-prefsection-rendering). Also, add the second hint for cases when the user chooses the `Automatic` option, the same as for GitHub.