### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11845,6 +11845,20 @@ genius.com
 
 INVERT
 .texmath
+.krOZTj
+
+CSS
+.header-primary,
+.dhlnLG {
+    background-color: rgb(255, 255, 100);
+}
+.header-action,
+.iiLMJr {
+    color: rgb(121, 115, 103);
+}
+
+IGNORE IMAGE ANALYSIS
+.header-primary .logo_link
 
 ================================
 
@@ -20629,7 +20643,13 @@ div#live-us-map.live-us-map-embed
 .svelte-1v1dl99
 .vmap-layer-container > g > text
 .vmap-zoom-buttons
-#xwd-board
+.pz-nav__logo
+#js-logo-nav > svg > rect
+#js-nav-burger
+.letter-boxed .hub-game-card__illustration
+.pz-moment__icon.letter-boxed
+.xwd__cell text
+[class^="progressIconContent puzzleProgress"]:not(progressIconContent puzzleProgress0)
 
 CSS
 button[aria-label="Listen to article"] path[d="M22 38L37 28L22 18V38Z"],
@@ -20671,19 +20691,30 @@ a[data-testid] > svg {
     fill: ${goldenrod} !important;
 }
 #xwd-board rect[class^="xwd__cell--cell"] {
-    fill: ${darkgrey} !important;
+    fill: #595963 !important;
 }
 #xwd-board rect[class^="xwd__cell--highlighted"] {
-    fill: ${lightgrey} !important;
+    fill: #483F80 !important;
 }
 #xwd-board rect[class^="xwd__cell--selected"] {
-    fill: ${white} !important;
+    fill: #4679AA !important;
 }
 #xwd-board rect[class^="xwd__cell--related"] {
     fill: ${khaki} !important;
 }
 #xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
-    fill: ${blue} !important;
+    fill: ${white} !important;
+    opacity: 50% !important;
+}
+.xwd__cell--block {
+    fill: #171717 !important;
+}
+#xwd-board rect,
+#xwd-board path {
+    stroke: #171717 !important;
+}
+#js-logo-nav > svg > rect {
+    fill: #000 !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
genius.com 
- Header: Color, logo and signup link fix nytimes.com
- Games hub: NYT Games logo, hamburger menu and progress icons fix
- Letter Boxed: Game icon fix
- The Crossword: Replaced some variable colors for cells with hex colors to match the color scheme to the android app in dark mode