### PR TITLE
Fix for wunderground.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31361,6 +31361,10 @@ select:focus {
 
 wunderground.com
 
+INVERT
+.map > .logo
+.map > .map-ui > lib-mini-map > .mapboxgl-map > div > .mapboxgl-canvas
+
 CSS
 .bar-on {
     fill: rgba(0, 0, 0, 0.4) !important;


### PR DESCRIPTION
Fixes map widget on "Weather Conditions" pages.

Before:
![1](https://github.com/user-attachments/assets/29e18f5c-4afb-40cc-ae8a-4d6d8870dd8b)

After:
![2](https://github.com/user-attachments/assets/ffc41104-2300-4b3c-b445-53b19a8d339c)