### PR TITLE
fix for *.docs.kubernetes.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -252,6 +252,15 @@ CSS
 
 ================================
 
+*.docs.kubernetes.io
+
+CSS
+.highlight pre code > span {
+    text-decoration: none !important;
+}
+
+================================
+
 *.maricopa.edu
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -255,7 +255,7 @@ CSS
 *.docs.kubernetes.io
 
 CSS
-.highlight pre code > span {
+.highlight pre code > span[style*="text-decoration: underline"] {
     text-decoration: none !important;
 }
 


### PR DESCRIPTION
I'm not sure if this is the right way to fix the random underscores that I'm seeing.

<img width="490" alt="image" src="https://github.com/user-attachments/assets/5ea2f563-fc0d-4f56-998e-9024eea30d07" />
