### PR TITLE
Fix for *.docs.kubernetes.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -189,6 +189,15 @@ CSS
 
 ================================
 
+*.docs.kubernetes.io
+
+CSS
+.highlight pre code > span[style*="text-decoration: underline"] {
+    text-decoration: none !important;
+}
+
+================================
+
 *.galaxus.de
 
 INVERT


### PR DESCRIPTION
fix for *.docs.kubernetes.io (#13716)
* 🐛 fix underscores on leading whitespace ---------
Co-authored-by: Patryk Łachan <patryk.lachan@gmail.com>
* added more details to selector

This time ordered correctly in list.