### PR TITLE
Fix www.mozilla.org (dynamic)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32495,6 +32495,7 @@ www.mozilla.org
 INVERT
 img.sidebar-icon
 h1.c-logo
+.c-navigation-logo-image
 .m24-c-navigation-logo-image
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32495,6 +32495,7 @@ www.mozilla.org
 INVERT
 img.sidebar-icon
 h1.c-logo
+.m24-c-navigation-logo-image
 
 CSS
 div.mzp-c-navigation-logo {


### PR DESCRIPTION
Logo in upper-left corner  
Example page: https://www.mozilla.org