### PR TITLE
Update dynamic-theme-fixes.config for 3 websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16341,6 +16341,7 @@ CSS
 .noUi-target {
     border-color: #8c8273 !important;
 }
+
 ================================
 
 leagueoflegends.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12007,6 +12007,15 @@ img,
 
 ================================
 
+generatorbible.com
+
+CSS
+.noUi-handle,.noUi-target{
+    border-color:#8c8273!important
+}
+
+================================
+
 genius.com
 
 INVERT
@@ -16322,6 +16331,14 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 
+================================
+
+leafblowerguide.com
+
+CSS
+.noUi-handle,.noUi-target{
+    border-color:#8c8273!important
+}
 ================================
 
 leagueoflegends.com
@@ -22955,6 +22972,15 @@ pressgazette.co.uk
 
 INVERT
 .site-logo
+
+================================
+
+pressurewasherdb.com
+
+CSS
+.noUi-handle,.noUi-target{
+    border-color:#8c8273!important
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12010,8 +12010,9 @@ img,
 generatorbible.com
 
 CSS
-.noUi-handle,.noUi-target{
-    border-color:#8c8273!important
+.noUi-handle,
+.noUi-target {
+    border-color: #8c8273 !important;
 }
 
 ================================
@@ -16336,8 +16337,9 @@ CSS
 leafblowerguide.com
 
 CSS
-.noUi-handle,.noUi-target{
-    border-color:#8c8273!important
+.noUi-handle,
+.noUi-target {
+    border-color: #8c8273 !important;
 }
 ================================
 
@@ -22978,8 +22980,9 @@ INVERT
 pressurewasherdb.com
 
 CSS
-.noUi-handle,.noUi-target{
-    border-color:#8c8273!important
+.noUi-handle,
+.noUi-target {
+    border-color: #8c8273 !important;
 }
 
 ================================


### PR DESCRIPTION
The slider handles used with filters on pages such as https://generatorbible.com/generators/ are not visible enough in dark mode. This css fix makes their border color match the color of checkboxes