### PR TITLE
fix for translate.google.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28727,6 +28727,9 @@ CSS
 .trans-verified-button {
     background-size: cover;
 }
+canvas.ita-hwt-canvas {
+    cursor: url(https://icons.iconarchive.com/icons/paomedia/small-n-flat/16/pencil-icon.png) 0 16,auto !important;
+}
 
 IGNORE IMAGE ANALYSIS
 .ita-kd-img


### PR DESCRIPTION
Changed pencil cursor for hand write in canvas from default black to colorful and visible in both light and dark scheme.

Fixes #13744