### PR TITLE
fix for docs.redhat.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8927,6 +8927,15 @@ body {
 
 ================================
 
+docs.redhat.com
+
+CSS
+.codeblock__wrapper {
+    background-color: ${white} !important;
+}
+
+================================
+
 docs.sentry.io
 
 INVERT


### PR DESCRIPTION
Code blocks background colors are inverted.

See for example: 
https://docs.redhat.com/en/documentation/red_hat_openstack_platform/8/html/command-line_interface_reference_guide/openstackclient_commands

Prior to fix:

![{410E769F-7C6B-4348-9348-29D051307BD0}](https://github.com/user-attachments/assets/9fe04832-d603-428f-92ff-a550998b2672)

After fix:

![{804181CE-4748-4527-95CD-CEA2BEEC73F7}](https://github.com/user-attachments/assets/cff56f64-cb31-42ae-a652-820c6dc54729)

