### PR TITLE
fix for strava.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26964,6 +26964,7 @@ text.label
 .leaflet-control-zoom-out
 .follow-action .selection.gear::after
 img[src*="gift"]:not(a.btn-primary img)
+ul.options span
 
 CSS
 .base-chart .grid-line,


### PR DESCRIPTION
Invert for icons under (+) menu.
![obraz](https://github.com/user-attachments/assets/8e97f76d-dbf6-4d80-bac4-f9955df09997)
