### PR TITLE
fix for last.fm

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16361,7 +16361,6 @@ IGNORE INLINE STYLE
 .page-loading-logo-container *
 .highcharts-series-group *
 .highcharts-legend *:not(text)
-.highcharts-background
 
 IGNORE IMAGE ANALYSIS
 .masthead-logo-loading


### PR DESCRIPTION
Removed .highcharts-background from IGNORE INLINE STYLE it was fixing gray background in reports but makes white background on artist page listening charts.