### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28143,6 +28143,7 @@ theguardian.com
 
 INVERT
 a[data-sponsor="guardian.org"]
+a[data-sponsor="open society foundations"]
 div[data-link-name="Crosswords"] .crossword__cell-number
 div[data-link-name="Crosswords"] .crossword__cell-text
 div[data-link-name="most popular"] > section > ol > li > a > span > svg
@@ -28153,8 +28154,22 @@ section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand textu
 section[data-component="paralympic-medal-table"] img[alt="Multi-coloured sand texture"]
 
 CSS
+div[data-component="footer"] .dcr-1fespkx {
+    background: rgb(255, 229, 0) !important;
+    color: rgb(18, 18, 18) !important;
+}
+div[data-component="footer"] .dcr-jgzukx {
+    color: rgb(255, 229, 0) !important;
+}
 header[data-component="header"] a[data-link-name="header : logo"] svg {
     fill: var(--darkreader-text--masthead-nav-link-text) !important;
+}
+header[data-component="header"] .dcr-1nulcij {
+    background: rgb(255, 229, 0) !important;
+    color: rgb(5, 41, 98) !important;
+}
+header[data-component="header"] .dcr-b3mn8w {
+    background-color: var(--masthead-veggie-burger-background) !important;
 }
 section[data-component="documentaries"] p {
     border-top: 1px solid #ffffff50 !important;
@@ -28219,6 +28234,7 @@ svg[stroke="var(--straight-lines)"] {
 
 IGNORE INLINE STYLE
 div[data-component="youtube-atom"] path[fill="#FFFFFF"]
+header[data-component="header"] .dcr-b3mn8w svg path
 nav[data-component="nav2"] a[data-link-name="nav3 : logo"] svg path
 section[data-component="contact-the-guardian"] *
 section[data-component="documentaries"] path[fill="#121212"]


### PR DESCRIPTION
- Improves visibility of header and footer by using site-specific colors.
- Fixes logo on some article pages.

Before:
![1](https://github.com/user-attachments/assets/9c2c26c2-d855-4a20-9e71-511f33774ae5)
![2](https://github.com/user-attachments/assets/2aed7f5f-b03d-4de2-b4c3-052edab36114)

After:
![3](https://github.com/user-attachments/assets/16899486-e755-4f8c-ba0d-131f0f3f4fbd)
![4](https://github.com/user-attachments/assets/50be247d-34cd-4452-8f3a-89ecafdb0645)