### PR TITLE
Fix for typst.app (sidebar, dashboard, settings)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29372,6 +29372,23 @@ staging.typst.app
 INVERT
 img[src$=".svg"]:not([alt="Typst"])
 
+CSS
+svg {
+    filter: none !important;
+}
+[class*="_project_"] [class*="_page_"]:not([class*="_new_"])::after {
+    background: #fff4;
+}
+[class*="_themeSwatch_"][class*="_light_"],
+[class*="_themeSwatch_"][class*="_system_"]:not([class*="_systemSecond_"]) {
+    background: #eff0f3;
+    color: #19181f;
+}
+[class*="_themeSwatch_"][class*="_light_"] [class*="_tSheet_"],
+[class*="_themeSwatch_"][class*="_system_"]:not([class*="_systemSecond_"]) [class*="_tSheet_"] {
+    background: #fdfdfd;
+}
+
 ================================
 
 typst.app/universe


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/15acf7ab-b8e5-424d-8a6d-7a75a92c1524) ![image](https://github.com/user-attachments/assets/d491cdaf-cce4-4fa9-9829-26aa87f64378)

![image](https://github.com/user-attachments/assets/f574072f-a75b-413a-981b-a30a6e21ed5a)


After:

![image](https://github.com/user-attachments/assets/e5630d90-58a7-406c-8646-a6d8f6371de7) ![image](https://github.com/user-attachments/assets/56690869-6f59-4b27-883d-9a7b8a1192ac)

![image](https://github.com/user-attachments/assets/17a72bb5-0c43-4029-8b21-7baf9a8308f5)

I wasn't able to fix the blue gradient background for the theme switcher because some `null` "inline:1" style was being added no matter what. But if I add it manually inline, then it starts working.