### PR TITLE
Fix objshadow.pages.dev (and mirrors)

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1230,3 +1230,7 @@ zt64.github.io
 ztdp.ca
 zunivers.zerator.com
 zyrenth.dev
+objshadow.pages.dev
+objshadow.tun.webredirect.org
+shadow.tun.webredirect.org
+shadowobj.eu.org


### PR DESCRIPTION
This is my personal blog website: `objshadow.pages.dev`
(`objshadow.tun.webredirect.org`, `shadow.tun.webredirect.org`, `shadowobj.eu.org` are mirrors for this website)
I've already designed dark theme for my website,
and Dark Reader **CANNOT** detect the dark theme,
Even if I added `color-scheme="dark"` to the <html> tag.
Besides, Dark Reader makes the dark theme of my website (especially the colors) looks strange,
so I hope that Dark Reader can be disabled on my website.

Best wishes,
Object Shadow

Screenshots:

1. Dark Reader Enabled
![image](https://github.com/user-attachments/assets/64e8ac29-686a-48cf-961f-1d89e638ad86)

2. Dark Reader Disabled
![image](https://github.com/user-attachments/assets/f3a17b87-ded2-4146-b7e4-e9572b683618)
