### PR TITLE
Revert "Update detector-hints for github.com"

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -278,7 +278,6 @@ html
 
 MATCH
 [data-color-mode="dark"]
-[data-color-mode="auto"]
 
 ================================
 


### PR DESCRIPTION
Reverts darkreader/darkreader#11995

Works fine if Dark mode is set in system/browser but not if light.