### PR TITLE
Fix for Wikipedia

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18405,6 +18405,7 @@ img[src*="Sun_cross.svg"]
 img[src*="Maru_juji.svg"]
 img[src*="Thule-Gesellschaft.svg"]
 img[src*="BlackSun.svg"]
+img[src*="KG54_Totenkopf.svg"]
 
 CSS
 :root {


### PR DESCRIPTION
Fixes 

The "standalone" version of the WW II Luftwaffe KG 54 wing's dead's head unit insignia

in

https://en.wikipedia.org/wiki/Totenkopf