### PR TITLE
Add checkout.steampowered.com to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -211,6 +211,7 @@ chat.openai.com
 chat.ryzom.com
 chat.vote
 cheat.sh
+checkout.steampowered.com
 checkra.in
 chess.com
 chesstempo.com


### PR DESCRIPTION
It's dark-only, along with other steampowered.com domains.