### PR TITLE
Remove invert from dynamic-theme-fixes.config for *.instructure.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -340,9 +340,6 @@ IGNORE INLINE STYLE
 
 *.instructure.com
 
-INVERT
-.tox-edit-area
-
 CSS
 .css-vrgbjj-textArea {
     background: var(--darkreader-neutral-background) !important;


### PR DESCRIPTION
Removed an Invert that caused textareas to have a white background.