### PR TITLE
fix for garmin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11997,6 +11997,7 @@ INVERT
 .map-controls.player .pause span
 .recharts-dot
 .highcharts-plot-line-label
+svg[class*="MapZoom"] path
 
 CSS
 .recharts-wrapper text {


### PR DESCRIPTION
Fix for black ZoomIn and ZoomOut buttons on the map.
![obraz](https://github.com/user-attachments/assets/5d2f2bd3-8b02-4445-aa2d-ed4916229308)
