### PR TITLE
Remove gerrit.wikimedia.org from global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -467,7 +467,6 @@ geektyper.com
 genshin-impact.fandom.com
 genshin.gg
 geocities.restorativland.org
-gerrit.wikimedia.org
 getaether.net
 getdweb.net
 gethalfmoon.com


### PR DESCRIPTION
This PR removes https://gerrit.wikimedia.org from the global dark list
Reason: https://gerrit.wikimedia.org/g/mediawiki/core/ is light-themed