### PR TITLE
Added fix for bright.uvic.ca to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4882,6 +4882,18 @@ INVERT
 
 ================================
 
+bright.uvic.ca
+
+CSS
+.d2l-card-container {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.d2l-branding-navigation-background-color {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 brilliant.org
 
 INVERT


### PR DESCRIPTION
Darkens white navigation containers & makes top navigation bar match color scheme.