### PR TITLE
Add chess.wintrcat.uk to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -214,6 +214,7 @@ cheat.sh
 checkout.steampowered.com
 checkra.in
 chess.com
+chess.wintrcat.uk
 chesstempo.com
 chitownhousemusic.com
 chromatic-tuner.com


### PR DESCRIPTION
Already is in dark mode and dark reader breaks some graphics (e.g. eval bar graph on the left side of the chess board)

With Dark Reader:
![grafik](https://github.com/user-attachments/assets/40f2eb4f-bfd0-41d1-8786-050b047d87fa)

Without Dark Reader (expected result):
![grafik](https://github.com/user-attachments/assets/bf27bc77-5c7c-4991-bd76-55066669ec15)
