### PR TITLE
Fix for Marquette.edu

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18065,6 +18065,18 @@ INVERT
 .svg-icon-block
 
 ================================
+marquette.edu
+
+CSS
+.h1 {
+    background-image: linear-gradient(
+        to right,
+        var(--darkreader-background-0098ca, #8fcdff) 20%,
+        var(--darkreader-background-003366, #8fcdff) 40%,
+        var(--darkreader-background-003366, #8fcdff) 100%
+    ) !important;
+}
+================================
 
 mastarti.com
 streamguard.cc


### PR DESCRIPTION
Dark reader on Marquette made it difficult to read some text due to the gradient. Made a change to gradient color to match font style.