### PR TITLE
fix for betterbird.eu

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3735,6 +3735,28 @@ CSS
 
 ================================
 
+betterbird.eu
+
+CSS
+#content {
+    background: transparent;
+}
+#content::before {
+    background-image: url("/betterbird-bg.svg");
+    background-repeat: no-repeat;
+    background-size: contain;
+    content: "";
+    display: block;
+    height: 870px;
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 50%, rgba(0, 0, 0, 1) 100%);
+    opacity: 7%;
+    position: absolute;
+    top: 170px;
+    width: 870px;
+}
+
+================================
+
 bettercap.org
 
 INVERT


### PR DESCRIPTION
The background logo makes some text unreadable. In the original theme it is barely visible, in fact only the bottom half is visible.

I tried to recreate the same look, because completely removing the logo is not really the same vibe. But one big issue is that on different pages the `top` is different, and I don't know how to make the CSS inheritance to add multiple overrides. So I stuck with the more or less usual `170px` (on the home page it actually supposed to be `735px`).

https://www.betterbird.eu/
https://www.betterbird.eu/faq/index.html
https://www.betterbird.eu/expert-tips/