### PR TITLE
add riflesniper.art + subdomain to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -514,6 +514,7 @@ grim.ac
 groovy.bot
 gtaforums.com
 guessr.tv
+gundamcocks.riflesniper.art
 gunshipmusic.com
 gusted.xyz
 hachyderm.io
@@ -929,6 +930,7 @@ reveddit.com
 review.lineageos.org
 rhwiki.net
 richup.io
+riflesniper.art
 ripped.guide
 ritsuka.moe
 rl6mans.com


### PR DESCRIPTION
i find that even with the dark lock put in the head, the sites still show up as white and unformatted for a split second before the css kicks in when i have darkreader turned on. hoping that adding my sites to the global list will help people avoid any possible trouble by turning it off automatically, since i try to be mindful of people who are photophobic/epileptic.