### PR TITLE
Add codebuff.com to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -228,6 +228,7 @@ cnc-comm.com
 cncnet.org
 co.wukko.me
 cobalt.tools
+codebuff.com
 codeium.com
 codepen.io
 coder.com


### PR DESCRIPTION
# Codebuff.com: 
Site already supports dark mode, and currently Dark Reader is causing certain information like Pricing to fail to display

## Before 

<img width="1715" alt="Screenshot 2025-02-09 at 4 03 53 PM" src="https://github.com/user-attachments/assets/cfcf74c6-9a48-4fa4-8926-5cf087cd4bac" />

## After

<img width="1676" alt="Screenshot 2025-02-09 at 4 03 59 PM" src="https://github.com/user-attachments/assets/b0511ac0-5e32-4265-8180-c92c05b0efd3" />
