### PR TITLE
fix: Improve cursor visibility for console.cloud.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6866,8 +6866,8 @@ input[type=text] {
 .monaco-editor .cursor,
 .monaco-editor .cursor-block,
 .monaco-editor .cursor-line {
-    background-color: #ffffff !important;
-    border-color: #ffffff !important;
+    background-color: ${#000000} !important;
+    border-color: ${#000000} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6863,6 +6863,12 @@ input[type=text] {
 .bq-results-table-header-cell {
     background: var(--darkreader-neutral-background) !important;
 }
+.monaco-editor .cursor,
+.monaco-editor .cursor-block,
+.monaco-editor .cursor-line {
+    background-color: #ffffff !important;
+    border-color: #ffffff !important;
+}
 
 ================================
 


### PR DESCRIPTION
# Description
Dear Dark Reader Maintainers, This PR fixes the cursor visibility issue in `console.cloud.google.com` when Dark Reader is enabled. Previously, the text cursor was difficult to see due to its dark color against dark backgrounds, especially in query editors.

# Changes
Added site-specific CSS rules for console.cloud.google.com to make the Monaco Editor cursor white:
```css
.monaco-editor .cursor,
.monaco-editor .cursor-block,
.monaco-editor .cursor-line {
    background-color: #ffffff !important;
    border-color: #ffffff !important;
}
```

# Before/After
I attached a screen capture for ease of checking out.


https://github.com/user-attachments/assets/ba9827f8-b5ae-42af-b6b3-b1acf2016b0b



Before: Text cursor is dark and barely visible in dark mode
After: Text cursor is white and clearly visible against dark backgrounds
This change specifically improves the user experience when editing queries in Google Cloud Console's query editor.

# Testing
Tested in Google Cloud Console (console.cloud.google.com)
Verified that the change only affects console.cloud.google.com