### PR TITLE
Add eclipse.menu to Global List

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -368,9 +368,9 @@ dyinglight.wiki.gg
 dyno.gg
 e-z.bio
 e-z.host
+eclipse.menu
 ecosia.org
 ecys.xyz
-eclipse.menu
 edi.social
 edit-csv.net
 editor.method.ac

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -370,6 +370,7 @@ e-z.bio
 e-z.host
 ecosia.org
 ecys.xyz
+eclipse.menu
 edi.social
 edit-csv.net
 editor.method.ac


### PR DESCRIPTION
This website is only dark mode and it breaks with Dark Reader, so this pull request adds this website to the Global List.