### PR TITLE
Add remaining Tracker Network domains

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -15,6 +15,8 @@
 *.starbreeze.com
 *.suyu.dev
 *.tickettool.xyz
+*.tracker.gg
+*.tracker.network
 0bin.net
 0x00sec.org
 12bytes.org
@@ -123,6 +125,7 @@ baldursgate3.game
 banfeed.com
 based.cooking
 battle.net
+battlefieldtracker.com
 battlelog.battlefield.com/bf4
 bbc.co.uk/iplayer
 bdeditor.dev
@@ -529,6 +532,7 @@ hackthebox.com
 hackthebox.eu
 hackthissite.org
 hacktoberfest-projects.vercel.app
+halotracker.com
 halowaypoint.com
 hang.fm
 hardforum.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1110,6 +1110,7 @@ themes.vscode.one
 themetphilly.com
 thespacedevs.com
 thetatoken.org
+thetrackernetwork.com
 thispersondoesnotexist.com
 tickettool.xyz
 tilde.club


### PR DESCRIPTION
Many of our sites are already on the list (e.g. `tracker.gg`, `destinytracker.com`, `fortnitetracker.com`, etc.), but some of them are still missing (e.g. `apex.tracker.gg`, `r6.tracker.network`, and others).

`tracker.network` does not function on its own, it's just a redirect to `tracker.gg`, which is why only the wildcard is added as a catch-all.