### PR TITLE
fix washingtonpost.com mobile logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30872,6 +30872,7 @@ INVERT
 .hp-masthead
 .switch
 .switch::after
+nav svg[label$='logo']
 
 CSS
 .flex * {


### PR DESCRIPTION
Invert washingtonpost mobile logo
nav svg[label$='logo']

The desktop logo is already inverted using .hp-masthead

![Screenshot_20250217_030017](https://github.com/user-attachments/assets/0f7a3314-77a3-4698-aecb-2607686072dc)

In mobile, when scrolling down, there is already a small "wp" logo that is already inverted. It contains the label="The Washington Post logo mark"

![Screenshot_20250217_030239](https://github.com/user-attachments/assets/dcf2ca14-93c6-42d1-89ec-d8649bc6130a)

When we scroll all the way to the top, there is the fullname logo, that is dark on dark, it is not currently inverted. It contains the label="The Washington Post logo". I can't select by the class because it is a generated class that could be changed suddenly. (class="wpds-c-izfXWU wpds-c-izfXWU-bBzYgm-cv")

if I select label*='logo', I break the already inverted small "wp" logo. So I have to select only the fullname logo. So I use label$='logo' to select only when it's ends with logo, and not "mark". I also included the "nav" to prevent unintended inverters in the page or articles.