### PR TITLE
Updates to *.globo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -311,6 +311,19 @@ body {
 
 *.globo.com
 
+INVERT
+.header__brand__link[href*=extra]
+.header__brand__link[href*=umsoplaneta] path[fill=black]
+.header__brand__link[href*=umsoplaneta] path[stroke=black]
+.header__brand__link[href*=marieclaire]
+.header__brand__link[href*=revistaquem]
+.header__brand__link[href*=gq]
+#logo-valor_100-anos
+.pages-footer img[src$="logo_edg.png"]
+.pages-footer img[src$="logo-Conde-Nast.png"]
+.pages-footer img[src$="logo_condenast.png"]
+.pages-footer img[src$="Rádio_wordmark.png"]
+
 CSS
 .bar-scrubber .bar-scrubber-icon,
 .bar-background .bar-fill-2 {
@@ -335,6 +348,10 @@ span.bstn-hl-summary {
 
 IGNORE INLINE STYLE
 .poster__play-wrapper *
+#Logo_Valor_Economico_Branco *
+
+IGNORE IMAGE ANALYSIS
+.barra-globocom .barra-itens li .barra-item-videos
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -323,6 +323,7 @@ INVERT
 .pages-footer img[src$="logo-Conde-Nast.png"]
 .pages-footer img[src$="logo_condenast.png"]
 .pages-footer img[src$="Rádio_wordmark.png"]
+.header__menu__icon_background_color
 
 CSS
 .bar-scrubber .bar-scrubber-icon,
@@ -344,6 +345,9 @@ span.bstn-hl-summary {
 }
 .bstn-hl.with-photo::before {
     background-image: var(--bstn-hl-cover) !important;
+}
+.footer__logo__wrapper {
+    background: var(--darkreader-bg--custom-footer-background) !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
fixes globoplay at topbar:

IGNORE IMAGE ANALYSIS
.barra-globocom .barra-itens li .barra-item-videos
![Screenshot_20250219_133621](https://github.com/user-attachments/assets/51229295-bbe2-4e5a-9b13-7fe4ad7332c9)

![Screenshot_20250219_155412](https://github.com/user-attachments/assets/30ddadb5-7e0e-413d-911b-d24e9d2c4082)

Top logos:
.header__brand__link[href*=extra]
.header__brand__link[href*=umsoplaneta] path[fill=black]
.header__brand__link[href*=umsoplaneta] path[stroke=black]
.header__brand__link[href*=marieclaire]
.header__brand__link[href*=revistaquem]
.header__brand__link[href*=gq]

refers to:
https://extra.globo.com.br
https://umsoplaneta.globo.com
https://revistamarieclaire.globo.com
https://revistaquem.globo.com
https://gq.globo.com

#logo-valor_100-anos
refers to the logo of 
https://valor.globo.com


footer logos:
.pages-footer img[src$="logo_edg.png"]
.pages-footer img[src$="logo-Conde-Nast.png"]
.pages-footer img[src$="logo_condenast.png"]
.pages-footer img[src$="Rádio_wordmark.png"]

![Screenshot_20250219_140503](https://github.com/user-attachments/assets/0a211044-c1a7-467d-a0dc-ade72757e9a4)

There are two versions of the CondeNast logo in all of their websites.


IGNORE INLINE STYLE
#Logo_Valor_Economico_Branco *
![Screenshot_20250219_141326](https://github.com/user-attachments/assets/dc5b259e-ee8b-476c-97f4-6b8943e810a0)

![Screenshot_20250219_155603](https://github.com/user-attachments/assets/df207f4a-738f-4325-8577-8bd1e094acc4)

refers to the logo at the top of https://pipelinevalor.globo.com




I verified all of their websites at https://www.globo.com/todos-os-sites/