### PR TITLE
Fix embedded image FDIC-Insured text visibility on AmericanExpress.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -201,6 +201,10 @@ select[aria-labelledby="bankAccount-label"] > option {
     background-color: var(--darkreader-neutral-background) !important;
 }
 
+img[alt*="FDIC-Insured"] {
+    filter: invert(1) hue-rotate(180deg) brightness(0.75) contrast(1.7) !important;
+}
+
 ================================
 
 *.archlinux.org

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -196,13 +196,12 @@ IGNORE INLINE STYLE
 
 *.americanexpress.com
 
+INVERT
+img[alt*="FDIC-Insured"]
+
 CSS
 select[aria-labelledby="bankAccount-label"] > option {
     background-color: var(--darkreader-neutral-background) !important;
-}
-
-img[alt*="FDIC-Insured"] {
-    filter: invert(1) hue-rotate(180deg) brightness(0.75) contrast(1.7) !important;
 }
 
 ================================


### PR DESCRIPTION
-Ensure the FDIC-Insured text remains visible in Dark Mode
-Targets embedded image while keeping other elements unchanged and matching color with the rest of the page.