### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28609,8 +28609,6 @@ a[data-sponsor="guardian.org"]
 a[data-sponsor="open society foundations"]
 div[data-link-name="Crosswords"] .crossword__cell-number
 div[data-link-name="Crosswords"] .crossword__cell-text
-div[data-link-name="most popular"] > section > ol > li > a > span > svg
-div[data-link-name="most-popular"] > section > ol > li > a > span > svg
 section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
 section[data-component="headlines"] .dcr-d4xwbm > svg
 section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand texture"]
@@ -28623,6 +28621,10 @@ div[data-component="footer"] .dcr-1fespkx {
 }
 div[data-component="footer"] .dcr-jgzukx {
     color: rgb(255, 229, 0) !important;
+}
+div[data-link-name="most popular"] .dcr-9rsbaa {
+    background-color: var(--age-warning-background) !important;
+    color: var(--age-warning-text) !important;
 }
 header[data-component="header"] a[data-link-name="header : logo"] svg {
     fill: var(--darkreader-text--masthead-nav-link-text) !important;


### PR DESCRIPTION
- Fixes "Most viewed" section on home page and article pages.
- Deletes outdated fixes (introduced in #12759 and #13422) for "Most viewed" section on home page and article pages.
- Improves visibility of age warnings on "Most viewed" section on article pages.
  - Note that these age warnings apparently don't appear on "Most viewed" section on home page.

Before (dark scheme):
![1](https://github.com/user-attachments/assets/fa39339b-b32a-4def-8972-d9980e08924e)
Before (light scheme):
![2](https://github.com/user-attachments/assets/e7988537-ac0e-468d-8c73-77a7527e5b18)

After (dark scheme):
![3](https://github.com/user-attachments/assets/a48c16fd-61ef-4467-aa85-3e23568c6f49)
After (light scheme):
![4](https://github.com/user-attachments/assets/ff46118e-7a7b-4126-8ce8-66d15a989c19)