### PR TITLE
Add sites in the domain jothin.tech

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -31,6 +31,7 @@
 314n.org
 5cs.fail
 5stardata.info
+a-maze.jothin.tech
 aagaming.me
 abhiyan.me
 absolucy.moe
@@ -166,6 +167,7 @@ blocks.pandadev.net
 blog.aractus.com
 blog.counter-strike.net
 blog.ja-ke.tech
+blog.jothin.tech
 blog.pixelexperience.org
 blox.link
 blueagle.top
@@ -613,6 +615,7 @@ joeydrewstudios.com
 join-lemmy.org
 jonahsnider.com
 josephchataignon.github.io
+jothin.tech
 jqbx.fm
 jsben.ch
 jsitor.com
@@ -710,6 +713,7 @@ mastercomfig.com
 mastofeed.com
 max.com
 maximepinot.com
+mazes.jothin.tech
 md.quad.codes
 mechapower.eu
 mednafen.github.io
@@ -957,6 +961,7 @@ rusherhack.org
 rust.facepunch.com
 rust.nolt.io
 rythm.fm
+sa.jothin.tech
 sacred-legends.de
 sadh.life
 sadistic.pl

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -166,8 +166,6 @@ blizzard.com
 blocks.pandadev.net
 blog.aractus.com
 blog.counter-strike.net
-blog.ja-ke.tech
-blog.jothin.tech
 blog.pixelexperience.org
 blox.link
 blueagle.top


### PR DESCRIPTION
 - jothin.tech [`Sitemap`](https://jothin.tech/sitemap.txt)
 - a-maze.jothin.tech [`Sitemap`](https://a-maze.jothin.tech/sitemap.txt)
 - sa.jothin.tech [`Sitemap`](https://sa.jothin.tech/sitemap.txt)
 - mazes.jothin.tech `It's a single page app`
 - blog.jothin.tech [`Sitemap`](https://blog.jothin.tech/sitemap.xml)

The first 4 sites are dark mode only. The last site has a theme toggle but dark theme is the default.