### PR TITLE
Fix for author page backgrounds on bahaiteachings.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3336,6 +3336,9 @@ CSS
 .input-search {
     color: var(--darkreader-neutral-text) !important;
 }
+.author-page-bg {
+    background: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Part of the background was light. This fix darkens the entire background.