### PR TITLE
fix for bilibili.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32952,11 +32952,13 @@ CSS
 .qrcode {
     background: white !important;
 }
-.button::before {
-    background-color: var(--_container-color) !important;
-}
 body {
     background: var(--darkreader-neutral-background) !important;
+}
+:root {
+    --bg1: var(--darkreader-neutral-background) !important;
+    --darkreader-bg--_container-color: rgba(0, 0, 0, 0) !important;
+    --graph_bg_thick: var(--darkreader-border--graph_bg_thick) !important;
 }
 
 ================================


### PR DESCRIPTION
Fix bili-text-button element in dark mode

Previously fixed in #12937 by me, but the issue has resurfaced after recent site updates. 
This PR:
- Removes the previous fix that no longer works
- Adds a new solution using CSS custom properties
- Sets `--darkreader-bg--_container-color: rgba(0, 0, 0, 0)` to make button text visible
- Updates other related variables to maintain consistent dark theme appearance

Tested on bilibili.com with latest site version as of 20250301.

# Before：
<img width="653" alt="Snipaste_2025-03-01_20-35-18" src="https://github.com/user-attachments/assets/710a7650-6cd5-401a-854e-7b88f7cedfd2" />

# After：
<img width="661" alt="Snipaste_2025-03-01_20-36-05" src="https://github.com/user-attachments/assets/3a611633-7576-400d-aae1-47029ccfb52c" />