### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28673,12 +28673,22 @@ section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand textu
 section[data-component="paralympic-medal-table"] img[alt="Multi-coloured sand texture"]
 
 CSS
-div[data-component="footer"] .dcr-1fespkx {
+div[data-component="footer"] .dcr-1fespkx,
+div[data-gu-name="body"] .dcr-1h6vumd,
+div[data-gu-name="body"] .dcr-1ita6aw,
+div[data-gu-name="body"] .dcr-1uvzqjj {
     background: rgb(255, 229, 0) !important;
     color: rgb(18, 18, 18) !important;
 }
 div[data-component="footer"] .dcr-jgzukx {
     color: rgb(255, 229, 0) !important;
+}
+div[data-gu-name="body"] .dcr-1uubej7,
+div[data-gu-name="body"] .dcr-h1iukq:hover > input {
+    border: 2px solid rgb(255, 229, 0) !important;
+}
+div[data-gu-name="body"] .dcr-vxrady {
+    border-top-color: rgb(255, 229, 0) !important;
 }
 div[data-link-name="most popular"] .dcr-9rsbaa {
     background-color: var(--age-warning-background) !important;


### PR DESCRIPTION
Improves visibility of support appeal on some article pages by using site-specific colors.

Before:
![1](https://github.com/user-attachments/assets/bbcbb231-6a6c-4fd9-b416-8341906c3df4)
![2](https://github.com/user-attachments/assets/67bfe608-e1fd-4107-9d8f-52a33d19adb0)

After:
![3](https://github.com/user-attachments/assets/51d7148e-ce6e-47cb-85d2-fb8977f9506e)
![4](https://github.com/user-attachments/assets/1b0a05fc-2d44-4d45-be53-df7492f3ef82)