### PR TITLE
fix for t.bilibili.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28037,8 +28037,11 @@ CSS
 #limit-mask-wall::before {
     background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, var(--darkreader-bg--bg1) 100%) !important;
 }
-.button::before {
-    background-color: transparent !important;
+:root {
+    --bg1: var(--darkreader-neutral-background) !important;
+    --darkreader-bg--_container-color: transparent !important;
+    --darkreader-text--_label-text-color: var(--darkreader-text--text3) !important;
+    --graph_bg_thick: var(--darkreader-border--graph_bg_thick) !important;
 }
 
 ================================


### PR DESCRIPTION
Fix for t.bilibili.com
This PR is a fix for issue #13901, and the changes are inspired by PR #13978, raised by @rintrint. I just make some minor changes.

- Change `--darkreader-bg--_container-color` to `transparent`
- Updates the color of `--darkreader-text--_label-text-color` to use existing variable `--darkreader-text--text3`

### Before:
![PixPin_2025-03-02_16-20-28](https://github.com/user-attachments/assets/4260656e-1dd2-4b13-9951-dc22a9985659)
### After:
![PixPin_2025-03-02_16-19-02](https://github.com/user-attachments/assets/1ba43c82-e8c8-4f12-a00a-b5649ad04d0e)
