### PR TITLE
More fixes for BrickLink

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5016,6 +5016,8 @@ a[href*="/myCollection/main.page"]
 
 IGNORE INLINE STYLE
 td[align="RIGHT"]+td[bgcolor]
+.pciColorTabListItem
+tr td+td[bgcolor]
 
 ================================
 


### PR DESCRIPTION
Prevents inversion of brick colors.
Example pages:
`.pciColorTabListItem` https://www.bricklink.com/v2/catalog/catalogitem.page?P=3755&C=1#T=C&C=1
`tr td+td[bgcolor]` https://www.bricklink.com/catalogItemIn.asp?P=3755&in=S