### PR TITLE
chat.deepseek.com fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5981,6 +5981,15 @@ CSS
 
 ================================
 
+chat.deepseek.com
+
+CSS
+:root {
+    --darkreader-background-ffffff: #6e6d6b;
+}
+
+================================
+
 chat.google.com
 
 CSS


### PR DESCRIPTION
Deepseek is unreadable in light mode. Made a change to make it readable but I am not sure how to specify changes to only light mode.