### PR TITLE
Add itch.io/embed-upload/ to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -594,6 +594,7 @@ intothetrenches.1917.movie
 iskdeusingqt6.org
 isthereanydeal.com
 isxander.dev
+itch.io/embed-upload/
 itrade.gg
 itsmeow.cat
 jackdaniels.com


### PR DESCRIPTION
`itch.io/embed-upload/` is a common subpage used by games that can be played in the browser via the website. Adding it to the list so Dark Reader doesn't interfere with those games and potentially reduce performance by trying to inject dark themes.

It's games, so Dark Reader should not touch them.