### PR TITLE
Fix for itch.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15279,6 +15279,7 @@ itch.io
 
 INVERT
 .header_widget .mobile_nav_btn
+img[src="https://static.itch.io/images/logo-black-new.svg"]
 
 CSS
 .index_page .app_banner .outline_button,


### PR DESCRIPTION
Fixes logo color in the top-left corner (adds invert).

Before
![image](https://github.com/user-attachments/assets/1b8a4a3f-dee9-46e4-853a-c82f419bd9e8)

After
![image](https://github.com/user-attachments/assets/725ef229-32fa-4127-a79f-31c401b70736)
