### PR TITLE
Add import settings warning

### DIFF
--- a/src/ui/options/advanced/import-settings.tsx
+++ b/src/ui/options/advanced/import-settings.tsx
@@ -29,6 +29,24 @@ export function ImportSettings(props: ViewProps): Malevic.Child {
         />
     ) : null;
 
+    function showWarningDialog() {
+        context.store.isWarningDialogVisible = true;
+        context.refresh();
+    }
+
+    function hideWarningDialog() {
+        context.store.isWarningDialogVisible = false;
+        context.refresh();
+    }
+
+    const warningDialog = context.store.isWarningDialogVisible ? (
+        <MessageBox
+            caption='Are you sure you want to import? Please export your current settings if you would like to restore them later.'
+            onOK={importSettings}
+            onCancel={hideWarningDialog}
+        />
+    ) : null;
+
     function importSettings() {
         openFile({extensions: ['json']}, (result: string) => {
             try {
@@ -53,11 +71,12 @@ export function ImportSettings(props: ViewProps): Malevic.Child {
         <ControlGroup>
             <ControlGroup.Control>
                 <Button
-                    onclick={importSettings}
+                    onclick={showWarningDialog}
                     class="advanced__import-settings-button"
                 >
                     Import Settings
                     {dialog}
+                    {warningDialog}
                 </Button>
             </ControlGroup.Control>
             <ControlGroup.Description>

--- a/src/ui/options/advanced/import-settings.tsx
+++ b/src/ui/options/advanced/import-settings.tsx
@@ -41,7 +41,7 @@ export function ImportSettings(props: ViewProps): Malevic.Child {
 
     const warningDialog = context.store.isWarningDialogVisible ? (
         <MessageBox
-            caption="Are you sure you want to import? Please export your current settings if you would like to restore them later."
+            caption="Warning! Your current settings will be overwritten. Click OK to proceed."
             onOK={importSettings}
             onCancel={hideWarningDialog}
         />

--- a/src/ui/options/advanced/import-settings.tsx
+++ b/src/ui/options/advanced/import-settings.tsx
@@ -41,7 +41,7 @@ export function ImportSettings(props: ViewProps): Malevic.Child {
 
     const warningDialog = context.store.isWarningDialogVisible ? (
         <MessageBox
-            caption='Are you sure you want to import? Please export your current settings if you would like to restore them later.'
+            caption="Are you sure you want to import? Please export your current settings if you would like to restore them later."
             onOK={importSettings}
             onCancel={hideWarningDialog}
         />


### PR DESCRIPTION
Pull request based on issue #13985.

Changed the 'src/ui/options/advanced/import-settings.tsx' file. Added functions modeled after similar functions from the 'reset all settings' feature to show users a warning confirmation before they select and open a settings file to import. Tried to be as non-intrusive as possible to existing code. Ran 'npm run code-style' and 'npm test' successfully.

![import-warning](https://github.com/user-attachments/assets/6080de9d-9042-4236-8755-008dc2e4fd46)
