### PR TITLE
Fix for news and mobile tabs

### DIFF
--- a/src/ui/popup/components/body.tsx
+++ b/src/ui/popup/components/body.tsx
@@ -101,15 +101,27 @@ function Body(props: BodyProps & {fonts: string[]} & {installation: {date: numbe
         if (state.newsOpen && unreadNews.length > 0) {
             props.actions.markNewsAsRead(unreadNews.map(({id}) => id));
         }
-        setState({newsOpen: !state.newsOpen, didNewsSlideIn: state.didNewsSlideIn || !state.newsOpen});
+    
+        setState({
+            newsOpen: !state.newsOpen,
+            didNewsSlideIn: state.didNewsSlideIn || !state.newsOpen,
+            mobileLinksOpen: false
+        });
     }
+    
 
     function toggleMobileLinks() {
-        setState({mobileLinksOpen: !state.mobileLinksOpen, didMobileLinksSlideIn: state.didMobileLinksSlideIn || !state.mobileLinksOpen});
+        setState({
+            mobileLinksOpen: !state.mobileLinksOpen,
+            didMobileLinksSlideIn: state.didMobileLinksSlideIn || !state.mobileLinksOpen,
+            newsOpen: false
+        });
+    
         if (state.mobileLinksOpen && props.data.uiHighlights.includes('mobile-links')) {
             disableMobileLinksSlideIn();
         }
     }
+    
 
     function disableMobileLinksSlideIn() {
         if (props.data.uiHighlights.includes('mobile-links')) {

--- a/src/ui/popup/components/body.tsx
+++ b/src/ui/popup/components/body.tsx
@@ -101,27 +101,27 @@ function Body(props: BodyProps & {fonts: string[]} & {installation: {date: numbe
         if (state.newsOpen && unreadNews.length > 0) {
             props.actions.markNewsAsRead(unreadNews.map(({id}) => id));
         }
-    
+
         setState({
             newsOpen: !state.newsOpen,
             didNewsSlideIn: state.didNewsSlideIn || !state.newsOpen,
-            mobileLinksOpen: false
+            mobileLinksOpen: false,
         });
     }
-    
+
 
     function toggleMobileLinks() {
         setState({
             mobileLinksOpen: !state.mobileLinksOpen,
             didMobileLinksSlideIn: state.didMobileLinksSlideIn || !state.mobileLinksOpen,
-            newsOpen: false
+            newsOpen: false,
         });
-    
+
         if (state.mobileLinksOpen && props.data.uiHighlights.includes('mobile-links')) {
             disableMobileLinksSlideIn();
         }
     }
-    
+
 
     function disableMobileLinksSlideIn() {
         if (props.data.uiHighlights.includes('mobile-links')) {


### PR DESCRIPTION
Pull request based on issue [#13972 ](https://github.com/darkreader/darkreader/issues/13972)

Changed the 'src/ui/popup/components/body.tsx' file. Added changes so that only one tab (news or mobile tab) can be open at a time to prevent any overlap. I ran 'npm run code-style' and 'npm test' and was successful on both tests.

![image](https://github.com/user-attachments/assets/7f77c6fd-56a1-400e-9757-aaec2359cb20)

![image](https://github.com/user-attachments/assets/05c82003-5de2-438b-ad9d-e6b72b1e8e7c)
