### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29085,12 +29085,24 @@ div[data-gu-name="body"] .dcr-1uvzqjj {
 div[data-component="footer"] .dcr-jgzukx {
     color: rgb(255, 229, 0) !important;
 }
+div[data-component="youtube-atom"] .dcr-1n5sax3 {
+    background: linear-gradient( 180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 25% ) !important;
+}
+div[data-component="youtube-atom"] .play-icon {
+    background-color: rgba(18, 18, 18, 0.6) !important;
+}
 div[data-gu-name="body"] .dcr-1uubej7,
 div[data-gu-name="body"] .dcr-h1iukq:hover > input {
     border: 2px solid rgb(255, 229, 0) !important;
 }
 div[data-gu-name="body"] .dcr-vxrady {
     border-top-color: rgb(255, 229, 0) !important;
+}
+div[data-gu-name="media"] .dcr-ctvcrj,
+div[data-gu-name="standfirst"] .dcr-rruuos,
+main .dcr-1q3os16,
+main .dcr-pdifrs {
+    background-color: var(--star-rating-background) !important;
 }
 div[data-link-name="most popular"] .dcr-9rsbaa {
     background-color: var(--age-warning-background) !important;
@@ -29105,6 +29117,10 @@ header[data-component="header"] .dcr-1nulcij {
 }
 header[data-component="header"] .dcr-b3mn8w {
     background-color: var(--masthead-veggie-burger-background) !important;
+}
+main .dcr-1o2pyn8 {
+    background-color: var(--pill-background) !important;
+    color: var(--pill-text) !important;
 }
 section[data-component="documentaries"] p {
     border-top: 1px solid #ffffff50 !important;
@@ -29131,36 +29147,28 @@ section[data-component="olympic-medal-table"] circle[r="6.6"],
 section[data-component="paralympic-medal-table"] circle[r="6.6"] {
     fill: var(--darkreader-bg--section-background) !important;
 }
-section[data-component="video"] button[data-link-name="video-container-next"],
-section[data-component="video"] button[data-link-name="video-container-prev"] {
+section[data-component="video"] .dcr-18aqf5q[data-link-name="video-container-prev"],
+section[data-component="video"] .dcr-pbtc9t[data-link-name="video-container-next"] {
     background-color: var(--carousel-arrow-background) !important;
 }
-section[data-component="video"] button[data-link-name="video-container-next"]:hover,
-section[data-component="video"] button[data-link-name="video-container-prev"]:hover {
+section[data-component="video"] .dcr-18aqf5q[data-link-name="video-container-prev"]:hover,
+section[data-component="video"] .dcr-pbtc9t[data-link-name="video-container-next"]:hover {
     background-color: var(--carousel-arrow-background-hover) !important;
 }
-section[data-component="video"] button[data-link-name="video-container-next"]:hover svg,
-section[data-component="video"] button[data-link-name="video-container-prev"]:hover svg {
+section[data-component="video"] .dcr-18aqf5q[data-link-name="video-container-prev"] svg,
+section[data-component="video"] .dcr-1bvoox2[data-link-name="video-container-prev"] svg,
+section[data-component="video"] .dcr-1nrzsks[data-link-name="video-container-next"] svg,
+section[data-component="video"] .dcr-pbtc9t[data-link-name="video-container-next"] svg {
     fill: var(--carousel-arrow) !important;
 }
-section[data-component="video"] .dcr-192a2s8 {
-    background-color: rgba(0, 0, 0, 0.7) !important;
+section[data-component="video"] .dcr-1tzmmc7::before {
+    border-top: 1px solid var(--card-border-top) !important;
 }
-section[data-component="video"] .dcr-1n5sax3 {
-    background: linear-gradient( 180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.7) 25% ) !important;
-}
-section[data-component="video"] .dcr-1rvgcvp,
-section[data-component="video"] .dcr-kcvdg {
-    background-color: #707070 !important;
-}
-section[data-component="video"] .dcr-6r6u10 {
+section[data-component="video"] .dcr-6r6u10[data-link-name^="carousel-small-nav-dot-"] {
     background-color: var(--carousel-dot) !important;
 }
-section[data-component="video"] .dcr-zxdpfk {
+section[data-component="video"] .dcr-zxdpfk[data-link-name^="carousel-small-nav-dot-"] {
     background-color: var(--carousel-active-dot) !important;
-}
-section[data-component="video"] .play-icon {
-    background-color: rgba(18, 18, 18, 0.6) !important;
 }
 svg[stroke="var(--article-border)"],
 svg[stroke="var(--straight-lines)"] {
@@ -29168,7 +29176,7 @@ svg[stroke="var(--straight-lines)"] {
 }
 
 IGNORE INLINE STYLE
-div[data-component="youtube-atom"] path[fill="#FFFFFF"]
+div[data-component="youtube-atom"] .play-icon path[fill="#FFFFFF"]
 header[data-component="header"] .dcr-b3mn8w svg path
 nav[data-component="nav2"] a[data-link-name="nav3 : logo"] svg path
 section[data-component="contact-the-guardian"] *


### PR DESCRIPTION
- Fixes graphics on "Video" section on home page by using site-specific colors (supercedes fixes in #12786).
- Improves visibility of star ratings on "Reviews" page and article pages by using site-specific colors.
- Clarify several rules to allow for easier identification and sorting.

Before:
![1](https://github.com/user-attachments/assets/fd8ae03b-1fc1-43c3-a15a-1030a71a8590)
![2](https://github.com/user-attachments/assets/e36b6092-0fb4-4cb7-a0e4-52352c6b480f)
![3](https://github.com/user-attachments/assets/b07e9411-7b49-436b-bb9c-d494fa9fd429)

After:
![4](https://github.com/user-attachments/assets/f065201d-4bfd-459b-8cc1-2998986d60c4)
![5](https://github.com/user-attachments/assets/29eb498a-7684-4696-9e2f-9ec6d000fbd2)
![6](https://github.com/user-attachments/assets/7cf6a626-bbcf-470b-a55c-3207f2e8f1ee)