### PR TITLE
Fixes for zerohedge.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -35274,7 +35274,7 @@ zerohedge.com
 *.zerohedge.com
 
 INVERT
-* header > * img
+header img
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -35270,6 +35270,14 @@ INVERT
 
 ================================
 
+zerohedge.com
+*.zerohedge.com
+
+INVERT
+* header > * img
+
+================================
+
 zerossl.com
 
 INVERT


### PR DESCRIPTION
Inverts images in the header.

Before:
![zerohedge_before](https://github.com/user-attachments/assets/7fb4932b-f0d2-488e-a43f-32200aa65605)

After:
![zerohedge_after](https://github.com/user-attachments/assets/ddedf7d7-128b-4233-afac-b08d7c62140b)
