### PR TITLE
Fix oxfordlearnerdictionaries.com logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22579,6 +22579,7 @@ h5 {
 oxfordlearnersdictionaries.com
 
 INVERT
+.old_logo
 .logo-footer
 
 ================================


### PR DESCRIPTION
Despite the name "old_logo" it still used as the logo on the navbar
![image](https://github.com/user-attachments/assets/fba44af9-cbea-4dac-83f2-b968c4dc7291)
or am i wrong here?

Refs: 52666d4b05154fbb8513eaa5805f51c3dba84f30