### PR TITLE
Uninvert unsplash logo

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30647,9 +30647,6 @@ textarea {
 
 unsplash.com
 
-INVERT
-svg[aria-labelledby="unsplash-home"]
-
 CSS
 li > a[aria-current="page"] {
     box-shadow: ${rgb(25,25,25)} 0px -2px inset;


### PR DESCRIPTION
Ok, follow up to my old pr #12188 for some reason it's now looking like this?
![image](https://github.com/user-attachments/assets/8d709150-e237-4cf1-8afa-090c555cafba)

And removing the invert line will fixes this
![image](https://github.com/user-attachments/assets/755f7694-c733-4fdd-ba75-7305e1e7a780)

I don't even know svg can revert on its own without the `prefers-color-scheme` media query.

