### PR TITLE
fix for some buttons in arch wiki

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -212,7 +212,7 @@ INVERT
 img[src*="icons/"]
 img[src="/svg/calendar.svg"]
 .cdx-search-input .cdx-text-input__icon.cdx-text-input__start-icon
-.cdx-button--icon-only
+.cdx-button--icon-only .vector-icon
 
 CSS
 .vector-sticky-pinned-container::after {


### PR DESCRIPTION
mainly affects hamburger menus, expand/ collapse buttons and the button bar in the top right

(this fix also applies to other media wiki sites (like community.kde.org), but I have only applied it to the arch wiki for now) 