### PR TITLE
fix issue label coloring on github.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12903,10 +12903,11 @@ img.network-tree {
 .user-has-reacted {
     background-color: rgba(17, 88, 199, 0.2) !important;
 }
-.hx_IssueLabel {
-    background: rgb(var(--label-r),var(--label-g),var(--label-b)) !important;
-    border-color: hsla(var(--label-h),calc(var(--label-s)*1%),calc((var(--label-l) - 25)*1%),var(--border-alpha)) !important;
-    color: hsl(0,0%,calc(var(--lightness-switch)*100%)) !important;
+.hx_IssueLabel,
+.TokenBase__StyledTokenBase-sc-47c3884c-0 {
+    background: rgba(var(--label-r),var(--label-g),var(--label-b),var(--background-alpha)) !important;
+    border-color: hsla(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) + var(--lighten-by)) * 1%),var(--border-alpha)) !important;
+    color: hsl(var(--label-h),calc(var(--label-s) * 1%),calc((var(--label-l) + var(--lighten-by)) * 1%)) !important;
 }
 .header-search-input {
     border: 0 !important;


### PR DESCRIPTION
fixes #14024 and keeps the transparency of the label

GitHub seems to have removed the "IssueLabel" selectors from the labels on the issues page.
While "TokenBase__StyledTokenBase-sc-47c3884c-0" seems temporary, judging from the Wayback-Machine it seems to have been consistent since the change.

Additionally this commit updates the properties to the ones currently in use by GitHub, making them not look out of place with dark reader om.