### PR TITLE
fix arch-wiki background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -221,7 +221,6 @@ body {
     height: fit-content;
 }
 
-
 ================================
 
 *.babbel.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -217,6 +217,10 @@ CSS
 .vector-sticky-pinned-container::after {
     background: inherit;
 }
+body {
+    height: fit-content;
+}
+
 
 ================================
 


### PR DESCRIPTION
fixes the background on the archwiki when scrolling (below the initial screen size and non wide)