### PR TITLE
Fix for inquirer.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15025,6 +15025,21 @@ CSS
 
 ================================
 
+inquirer.com
+
+CSS
+.footer-share-bar-container > a > svg,
+.search-bar > .relative button svg {
+    fill: var(--darkreader-neutral-text) !important;
+}
+.hamburger-inner,
+.hamburger-inner::after,
+.hamburger-inner::before {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 insomniac.com
 
 INVERT


### PR DESCRIPTION
Fixes icons on home page.

Before:
![1](https://github.com/user-attachments/assets/8215e00a-64e3-4b71-b692-1decb9296636)
![2](https://github.com/user-attachments/assets/9e4f23cd-8488-485f-bd2d-0f5f6bc8f255)

After:
![3](https://github.com/user-attachments/assets/dda481b4-b367-4590-8abd-36c0d02d36d6)
![4](https://github.com/user-attachments/assets/8ee3fcba-8287-4eca-8210-a447849f5b0a)