### PR TITLE
Fix for ecco website

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9978,6 +9978,51 @@ img[alt="Review and Preview problems below"]
 
 ================================
 
+*.ecco.com
+CSS
+.css-12h6y9z {
+    background-color: rgb(255,209,217);
+}
+.css-14tyazf {
+    background-color: rgb(123,89,74);
+}
+.css-1jf7q23 {
+    background-color: rgb(91,175,90);
+}
+.css-1oi4pdp {
+    background-color: rgb(45,103,191);
+}
+.css-1p7pd14 {
+    background-color: rgb(249,115,111);
+}
+.css-1vgt0zm {
+    background-color: rgb(0,0,0,0);
+    background-image: linear-gradient(90deg, rgb(111,111,111) 0%, rgba(205,205,205,1) 100%);
+}
+.css-1voj8v {
+    background-color: rgb(255,254,176);
+}
+.css-2kxf35 {
+    background-color: rgb(192,192,192);
+}
+.css-92qii5 {
+    background-color: rgb(209,209,209);
+}
+.css-cfipfa {
+    background-color: rgb(245,235,219);
+}
+.css-ltcco6 {
+    background-color: rgb(195,127,200);
+}
+.css-s57bzs {
+    background-color: rgb(255,215,0);
+}
+.css-xvzxk1 {
+    background-color: rgb(255,255,255);
+}
+
+================================
+
 economist.com
 
 INVERT


### PR DESCRIPTION
Fixes for the colors in the "color" filter when browsing products. I couldn't get `IGNORE INLINE STYLES` to work with the selector `button[role="menuitem"] div:empty`, so I manually replaced the classes with the colors originally on the website without Dark Reader.