### PR TITLE
Fix for Hackernews (news.ycombinator.com)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21332,6 +21332,9 @@ CSS
 #hnmain {
     background-color: var(--darkreader-neutral-background) !important;
 }
+#hnmain .toptext {
+    color: var(--darkreader-neutral-text) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Previously, "Ask HN" posts with body text were using a darker text color, making it difficult to read:

![image](https://github.com/user-attachments/assets/9ca98673-73b1-4379-a8fb-a213b0ac6920)

This just changes that div to use the neutral text color instead:

![image](https://github.com/user-attachments/assets/e676feec-81c7-4311-9bce-46c6af2d48c5)
