### PR TITLE
Fix tailscale.com docs (dynamic)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28862,6 +28862,16 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+tailscale.com/kb/
+
+CSS
+main aside .sticky > .absolute.from-white {
+    --tw-gradient-from: var(--darkreader-neutral-background) var(--tw-gradient-from-position) !important;
+    --tw-gradient-to: rgb(from var(--darkreader-neutral-background) r g b / 0) var(--tw-gradient-from-position) !important;
+}
+
+================================
+
 tailwindcss.com
 
 CSS


### PR DESCRIPTION
Uses [relative color syntax](https://caniuse.com/css-relative-colors) to have the fading gradient match the background color

| Current | Fixed |
|---|---|
| <img width="407" alt="image" src="https://github.com/user-attachments/assets/975bc77e-317b-4eb8-b76b-159b8dfc8172" /> | <img width="386" alt="image" src="https://github.com/user-attachments/assets/2569edc4-328e-4024-a276-8e85bfd62dc5" /> |

```css
tailscale.com/kb/

CSS
main aside .sticky > .absolute.from-white {
    --tw-gradient-from: var(--darkreader-neutral-background) var(--tw-gradient-from-position) !important;
    --tw-gradient-to: rgb(from var(--darkreader-neutral-background) r g b / 0) var(--tw-gradient-from-position) !important;
}
```