### PR TITLE
Fix for studip.uni-hannover.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28293,7 +28293,7 @@ studip.uni-hannover.de
 
 CSS
 #content-wrapper {
-    background: var(--darkreader-neutral-background);
+    background: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
The Website was updated, which broke the fix from #14083.