### PR TITLE
Update dark-sites.config (adding glyphtones.is-a.dev)

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -510,6 +510,7 @@ gitmoji.kaki87.net
 glow.phoesion.com
 glowing-bear.org
 glslsandbox.com
+glyphtones.is-a.dev
 go4liftoff.com
 gog.com/forum
 gogalaxy.com


### PR DESCRIPTION
I would like to add this site i made, which is in dark mode already.

[https://github.com/Firu115/nothing_glyphtones](https://github.com/Firu115/nothing_glyphtones)