### PR TITLE
Add club.steam250.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -230,6 +230,7 @@ cl00e9ment.gitlab.io/kingdom-blazon-generator/
 clashofstats.com
 cleo.li
 cloud.minlor.net
+club.steam250.com
 cnc-comm.com
 cncnet.org
 co.wukko.me


### PR DESCRIPTION
Normally it redirects to steam250.com but when you open below links it won't redirect:
- https://club.steam250.com/app/3164500
- https://club.steam250.com/ranking/custom/AA
- https://club.steam250.com/ranking/trending-now