### PR TITLE
Fix for 338canada.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -947,6 +947,15 @@ img[alt="Zespół 300Gospodarki"]
 
 ================================
 
+338canada.com
+
+CSS
+svg text:not([fill]) {
+    fill: var(--darkreader-neutral-text);
+}
+
+================================
+
 350.org
 map.350.org
 


### PR DESCRIPTION
The embedded svg graphs contain texts not affected by default darkreader dynamic theme. 

An example link is the [338 federal election page](https://338canada.com/federal.htm).

Before the fix:
![image](https://github.com/user-attachments/assets/92716b5c-2e4f-4a2e-8706-561fd82ba0cb)

After the fix:
![image](https://github.com/user-attachments/assets/00f642a7-2276-479f-b805-9d2a9024e71d)
