### PR TITLE
Add white boarder around amazon barcode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1913,6 +1913,9 @@ span.milestone-bar_background {
 .abn-desktop-footer-app-qr > img {
     background-color: white !important;
 }
+#pickupInformation-container img {
+    border: 20px solid white !important;
+}
 
 IGNORE INLINE STYLE
 .s-color-swatch-inner-circle-fill


### PR DESCRIPTION
This add a white border around the barcode for lockers on amazon. Before the black background would interfere with scanning and I'd have to disable the extension to be able to scan.
Before:
![image](https://github.com/user-attachments/assets/0dfc0409-eb08-4792-87b0-ba29ca3e215f)
After:
![image](https://github.com/user-attachments/assets/7f9c1e84-a80a-4447-a57d-bf7b86f51896)
