### PR TITLE
Fix bright side nav on Salesforce Lightning

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1554,6 +1554,15 @@ html {
 
 ================================
 
+lightning.force.com
+*.lightning.force.com
+
+INVERT
+div.verticalNavContainer
+.verticalNavHeader::before
+
+================================
+
 linerad.io
 
 INVERT


### PR DESCRIPTION
## Before:
![Screenshot 2025-05-04 at 00 35 51](https://github.com/user-attachments/assets/99a0217a-e50f-4f07-b4e8-55a1a5c03bb6)

## After:
![Screenshot 2025-05-04 at 00 34 52](https://github.com/user-attachments/assets/82e45a47-f590-470d-b195-0c91595fe5e2)

Thanks to @Myshor for guidance on Filter+ behavior.