### PR TITLE
Add detector hint for `dashboardicons.com`

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -204,6 +204,16 @@ MATCH
 
 ================================
 
+dashboardicons.com
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
+
 dcard.tw
 
 NO DARK THEME


### PR DESCRIPTION
Adding as proposed in #14228