### PR TITLE
Handle teams.microsoft.com domain in fallback.ts

### DIFF
--- a/src/inject/fallback.ts
+++ b/src/inject/fallback.ts
@@ -48,7 +48,7 @@ if (
 
 declare const __FIREFOX_MV2__: boolean;
 
-if (__FIREFOX_MV2__ && location.host === 'teams.live.com') {
+if (__FIREFOX_MV2__ && (location.host === 'teams.live.com' || location.host === 'teams.microsoft.com')) {
     // Microsoft Teams calls sheet.cssRules on extension styles and that
     // causes "Not allowed to access cross-origin stylesheet" in Firefox
     (() => {


### PR DESCRIPTION
The fix for https://github.com/darkreader/darkreader/issues/11994 committed in https://github.com/darkreader/darkreader/commit/1794aaf16a44968a7ad11f9ddd8f9586cfd936b7 works for https://teams.live.com,  but loading still fails when using the Office365 version hosted at https://teams.microsoft.com 

This change should fix it.