### PR TITLE
Fix bgcolor of <button> in cart on instacart.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15175,8 +15175,8 @@ svg text {
 instacart.com
 
 CSS
-.e-im51v0 {
-    background-color: unset !important;
+html[data-darkreader-scheme="dark"] button:not(:hover) {
+    color: gray;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15172,6 +15172,15 @@ svg text {
 
 ================================
 
+instacart.com
+
+CSS
+.e-im51v0 {
+    background-color: unset !important;
+}
+
+================================
+
 instagram.com
 
 INVERT


### PR DESCRIPTION
The text of `<button>` elements in the cart, mainly cart items and <kbd>✏ Add instructions</kbd>, has gray text on a white background and is not legible. This fix uses CSS to override the style.

The reason I don't just add an INVERT section is that the text color is correct, it's just the background that needs resetting to a darker color.