### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29610,9 +29610,9 @@ section[data-component="paralympic-medal-table"] img[alt="Multi-coloured sand te
 
 CSS
 div[data-component="footer"] .dcr-1fespkx,
-div[data-gu-name="body"] .dcr-1h6vumd,
-div[data-gu-name="body"] .dcr-1ita6aw,
-div[data-gu-name="body"] .dcr-1uvzqjj {
+gu-island[name="SlotBodyEnd"] div[data-testid="epic=buttons"] > div > a,
+gu-island[name="SlotBodyEnd"] div[id="slot-body-end"] p > strong > span,
+gu-island[name="SlotBodyEnd"] fieldset#P0-0 > div > div > div > div {
     background: rgb(255, 229, 0) !important;
     color: rgb(18, 18, 18) !important;
 }
@@ -29625,13 +29625,6 @@ div[data-component="youtube-atom"] .dcr-1n5sax3 {
 div[data-component="youtube-atom"] .play-icon {
     background-color: rgba(18, 18, 18, 0.6) !important;
 }
-div[data-gu-name="body"] .dcr-1uubej7,
-div[data-gu-name="body"] .dcr-h1iukq:hover > input {
-    border: 2px solid rgb(255, 229, 0) !important;
-}
-div[data-gu-name="body"] .dcr-vxrady {
-    border-top-color: rgb(255, 229, 0) !important;
-}
 div[data-gu-name="media"] .dcr-ctvcrj,
 div[data-gu-name="standfirst"] .dcr-rruuos,
 main .dcr-1q3os16,
@@ -29641,6 +29634,22 @@ main .dcr-pdifrs {
 div[data-link-name="most popular"] .dcr-9rsbaa {
     background-color: var(--age-warning-background) !important;
     color: var(--age-warning-text) !important;
+}
+gu-island[name="SlotBodyEnd"] div[id="slot-body-end"] div > section {
+    border-top-color: rgb(255, 229, 0) !important;
+}
+gu-island[name="SlotBodyEnd"] label > div:hover > input[type="radio"],
+gu-island[name="SlotBodyEnd"] label.dcr-1iljw00 > div > input[type="radio"] {
+    border: 2px solid rgb(255, 229, 0) !important;
+}
+gu-island[name="StickyBottomBanner"] div > div > div > div > div.dcr-1xq78ib {
+    background-color: var(--darkreader-neutral-text) !important;
+}
+gu-island[name="StickyBottomBanner"] div > svg {
+    --darkreader-inline-fill: var(--darkreader-neutral-text) !important;
+}
+gu-island[name="StickyBottomBanner"] div.dcr-bxrjkt > div {
+    background-color: ${rgb(5, 41, 98)} !important;
 }
 header[data-component="header"] a[data-link-name="header : logo"] svg {
     fill: var(--darkreader-text--masthead-nav-link-text) !important;


### PR DESCRIPTION
- Fixes graphics on sticky bottom banner on most pages.
- Updates fixes in #13979 for support appeal on some article pages.
  - Improves fixes by relying less on generated class names.

Before:
![1](https://github.com/user-attachments/assets/69d04f9d-48b2-460f-a6a4-e276fd666885)

After:
![2](https://github.com/user-attachments/assets/c6fe9fe6-06b9-4b9d-b75f-c41bc227ec21)