### PR TITLE
Fix Lightning Settings Header

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1560,6 +1560,7 @@ lightning.force.com
 INVERT
 div.verticalNavContainer
 .verticalNavHeader::before
+.flexipageEditorHeader
 
 ================================
 


### PR DESCRIPTION
Salesforce Lighting settings header was showing up as bright cyan. Fix is shown:

<img width="564" alt="Screenshot 2025-05-15 at 22 15 43" src="https://github.com/user-attachments/assets/a4d7a95a-4c43-4f31-ae43-0a66ad31c2b9" />