### PR TITLE
Fix for *.tripadvisor.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -569,6 +569,13 @@ CSS
 
 ================================
 
+*.tripadvisor.com
+
+INVERT
+img[alt="Tripadvisor"]
+
+================================
+
 *.webex.com
 
 CSS


### PR DESCRIPTION
Invert logo.

Before:
![image](https://github.com/user-attachments/assets/119e7c5e-ed86-463e-892f-04d4d9173eaf)

After:
![image](https://github.com/user-attachments/assets/41b45816-ad1f-4ff6-bd30-3a487177f9cc)
