### PR TITLE
Fixes for *.seoul.go.kr

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -465,6 +465,14 @@ INVERT
 
 ================================
 
+*.seoul.go.kr
+
+INVERT
+.h-logo
+.s-live-icon
+
+================================
+
 *.service-now.com
 
 INVERT


### PR DESCRIPTION
- Invert logo
- Invert live icon

Before:
![image](https://github.com/user-attachments/assets/0eb10101-8467-4137-9cc2-fb62a4c558f0)

After:
![image](https://github.com/user-attachments/assets/2334787f-c49b-420f-b79c-84fc8e972b4f)
