### PR TITLE
Add color fixes for registry.terraform.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25558,6 +25558,20 @@ canvas
 
 ================================
 
+registry.terraform.io
+
+CSS
+.input {
+    border-color: var(--darkreader-neutral-text) !important;
+}
+.button,
+.menu-list a,
+a.dropdown-item {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 reheader.glitch.me
 
 INVERT


### PR DESCRIPTION
The dynamic template for registry.terraform.io adds red accents to input fields and buttons. Also the background color of the sidebar makes it hard to read. This fix is using neutral background instead.

Before:
![grafik](https://github.com/user-attachments/assets/ae939070-2fdf-44f2-9d68-702fd1f1857e)

After:
![grafik](https://github.com/user-attachments/assets/cf2f9ee2-4bc9-42d8-ba17-c0acd06d3a8d)
