### PR TITLE
Fix for mox.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20542,6 +20542,13 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+mox.com
+
+INVERT
+.logo
+
+================================
+
 mozilla.net
 
 INVERT


### PR DESCRIPTION
Invert logo

Before:
![image](https://github.com/user-attachments/assets/77e55d9c-51bd-418e-99e3-d918d7a44a90)

After:
![image](https://github.com/user-attachments/assets/4a675c3f-7dc0-44f3-a56b-6ec605e82560)
