### PR TITLE
Fix for src.fedoraproject.org and pagure.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28153,6 +28153,9 @@ INVERT
 src.fedoraproject.org
 pagure.io
 
+INVERT
+#pagureLogo
+
 IGNORE INLINE STYLE
 #cal-heatmap svg rect
 


### PR DESCRIPTION
Invert logos. (Make them look more natural and more align with the bright version).

Before:
![image](https://github.com/user-attachments/assets/ad69a53e-005c-4110-946e-cb5da5026329)
![image](https://github.com/user-attachments/assets/14c7a5cb-03c2-4ff7-99b2-251810d2718f)

After:
![image](https://github.com/user-attachments/assets/e04b0b01-13aa-4401-a2f0-55e6c0fb3630)
![image](https://github.com/user-attachments/assets/0e8a8386-eb80-41a6-87fb-17a20b637e72)
