### PR TITLE
Fix for tripadvisor.com.hk

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30810,6 +30810,7 @@ img.partner-img
 ================================
 
 tripadvisor.com
+tripadvisor.com.hk
 tripadvisor.com.tw
 *.tripadvisor.com
 


### PR DESCRIPTION
Invert logo. Same as other tripadvisor domains.