### PR TITLE
Fix detexify.kirelabs.org in dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8432,8 +8432,12 @@ IGNORE INLINE STYLE
 
 detexify.kirelabs.org
 
-INVERT
-.symbol
+CSS
+.symbol > img {
+    background-color: rgba(0, 0, 0, 0) !important;
+    background-image: url(https://detexify.kirelabs.org/images/symbols-a95e7763.png) !important;
+    filter: invert(1) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8432,11 +8432,13 @@ IGNORE INLINE STYLE
 
 detexify.kirelabs.org
 
+INVERT
+.symbol > img
+
 CSS
 .symbol > img {
     background-color: rgba(0, 0, 0, 0) !important;
     background-image: url(https://detexify.kirelabs.org/images/symbols-a95e7763.png) !important;
-    filter: invert(1) !important;
 }
 
 ================================


### PR DESCRIPTION
Symbols in https://detexify.kirelabs.org were not inverted correctly.

I have no idea why `backgound-image` in `.symbols > img` is overwritten with:
`url("blob:https://detexify.kirelabs.org/875e9562-3745-41cd-b978-58c3b4f07d1d")`
only when dark reader is active.

The only solution I found was to hard-code back the correct image:
`url(https://detexify.kirelabs.org/images/symbols-a95e7763.png)`.