### PR TITLE
Fix for instagram.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15384,6 +15384,9 @@ div > a[tabindex],
 div > span > a[tabindex] {
     border-color: transparent !important;
 }
+main > div > div > div > div > div > div > div > span {
+    color: ${rgb(199, 199, 199)} !important;
+}
 ._ac3p {
     background-color: rgb(180, 180, 180) !important;
 }


### PR DESCRIPTION
Uses grayed-out text on posts with limited comments.

Before:
![1](https://github.com/user-attachments/assets/76a39e58-9c04-4a30-aad3-f82ac1f7f03c)

After:
![2](https://github.com/user-attachments/assets/24f083d9-cd57-48cb-b5ee-46a58f0473c9)