### PR TITLE
Fix for inquirer.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15255,13 +15255,11 @@ CSS
 inquirer.com
 
 CSS
-.footer-share-bar-container > a > svg,
-.search-bar > .relative button svg {
+footer a > svg,
+header button[aria-label="Search"] > svg {
     fill: var(--darkreader-neutral-text) !important;
 }
-.hamburger-inner,
-.hamburger-inner::after,
-.hamburger-inner::before {
+header button[aria-label="Full navigation"] > div.bg-black {
     background-color: var(--darkreader-neutral-text) !important;
 }
 


### PR DESCRIPTION
Updates fix in #14167 for icons on most pages.

Before:
![1](https://github.com/user-attachments/assets/56ed6098-004b-4709-be66-7001694aa8c5)
![2](https://github.com/user-attachments/assets/07873b26-98a5-4cc0-83e6-79bc28d5aacc)

After:
![3](https://github.com/user-attachments/assets/d4872c76-2edd-4c54-a627-b6debdde19e3)
![4](https://github.com/user-attachments/assets/53f63c43-f546-4241-90b2-a2f5f5fd95af)