### PR TITLE
segger.com - SVG background removal

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27004,21 +27004,21 @@ section[id="our-top-picks"] img
 
 ================================
 
-segger.com
-
-CSS
-.c-page-layout-bg-image {
-    background-image: none !important;
-}
-
-================================
-
 seedr.cc
 
 INVERT
 .content-item-filename
 .content-link
 div[id="folder-up"] img
+
+================================
+
+segger.com
+
+CSS
+.c-page-layout-bg-image {
+    background-image: none !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27004,6 +27004,15 @@ section[id="our-top-picks"] img
 
 ================================
 
+segger.com
+
+CSS
+.c-page-layout-bg-image {
+    background-image: none !important;
+}
+
+================================
+
 seedr.cc
 
 INVERT


### PR DESCRIPTION
Background image (typical filename `background-tracks-*.svg`) makes the text on some of the pages very difficult to read.

Example URL:
* https://www.segger.com/debug-trace-embedded-systems/#j-link-debug-probes


This very targeted fix removes the background image for one CSS class.



<hr/>
<details><summary>Original non-dark site</summary>
<p>

![image](https://github.com/user-attachments/assets/64676694-ec12-4eae-8db3-b73937cc645f)

</p>
</details> <hr/>
<details><summary>Without the fix</summary>
<p>

![image](https://github.com/user-attachments/assets/35b0d63c-d6e4-48fa-9cff-eb55f040958f)


</p>
</details> <hr/>
<details><summary>With the fix</summary>
<p>

![image](https://github.com/user-attachments/assets/455c8ea5-a25f-4d0a-a9f8-d3f539432158)


</p>
</details> 

