### PR TITLE
add monaspace.githubnext.com into dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -752,6 +752,7 @@ mizik.eu
 mmorpg.com
 mnsr.win
 modworkshop.net
+monaspace.githubnext.com
 monitoror.com
 monkeytype.com
 morethantech.it


### PR DESCRIPTION
Fix #14368