### PR TITLE
fix: google classroom top left corner being white instead of using darkreader colours

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6587,7 +6587,7 @@ div[style="bottom: 0px;"] > div[style^="opacity:"] div[role="button"] > div:not(
 li[guidedhelpid="classworkTopicListGh"]:not(hover) > div {
     opacity: 99% !important;
 }
-svg.n8gX0b path {
+#yDmH0d > div:nth-child(2) > div.gdOsje > div.RTIHo > svg > path {
     fill: var(--darkreader-neutral-background) !important;
 }
 


### PR DESCRIPTION
before: 

![image](https://github.com/user-attachments/assets/26c25a07-04ef-480e-be28-c1995c308d3a)

after:

![image](https://github.com/user-attachments/assets/7624f57b-7e0d-4984-8f14-d58ca996c189)
