### PR TITLE
Add `abhiyandhakal.com.np` to dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -35,6 +35,7 @@
 a-maze.jothin.tech
 aagaming.me
 abhiyan.me
+abhiyandhakal.com.np
 absolucy.moe
 academy.hackthebox.com
 account.bhvr.com


### PR DESCRIPTION
The site [abhiyandhakal.com.np](https://abhiyandhakal.com.np/) is dark by default. So, I'm adding the site to the dark-sites.config