### PR TITLE
Fix spaces in code blocks on palletsprojects.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23278,6 +23278,15 @@ img[src="images/vpsserver.png"]
 
 ================================
 
+*.palletsprojects.com
+
+CSS
+span.w {
+    color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 palshovon.wixsite.com
 
 INVERT


### PR DESCRIPTION
Some of the spaces in code blocks on *.palletsprojects.com appear as white underscores in dark mode, which makes the code more difficult to read. You can see this in the first code block on https://flask.palletsprojects.com/en/stable/async-await/. There should be a space, not an underscore, between `def` and `get`.

![Screenshot from 2025-06-19 01-45-03](https://github.com/user-attachments/assets/5c1989d6-32b0-4bed-a7bc-b3775b33f2cc)

The bug appears to be present for every instance of `def` in a code block throughout the site.

This PR changes those underscores to the same color as the background.