### PR TITLE
Fix for weather.gov

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32725,6 +32725,7 @@ forecast.weather.gov
 INVERT
 .header-content > .header-doc
 .header-content > .header-nws
+#headline-container > .headline-bar.headline-watch
 #page-header > #header-doc
 #page-header > #header-noaa
 #page-header > #header-nws


### PR DESCRIPTION
Improves readability of text on some forecast pages by inverting "Extreme Heat Watch" graphics.

Before:
![1](https://github.com/user-attachments/assets/f83a7c0b-cac9-4b73-870d-a5d63502fd62)

After:
![2](https://github.com/user-attachments/assets/4f957c76-70e3-4de5-983d-8c5856b31c17)