### PR TITLE
Fix jenkins installations in dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16012,13 +16012,6 @@ span
 
 ================================
 
-jenkins.io
-
-IGNORE INLINE STYLE
-.logo-jenkins *
-
-================================
-
 jenkins.*.local
 jenkins.*.com
 *.jenkins.*.local
@@ -16032,6 +16025,13 @@ CSS
 * {
     color: var(--darkreader-neutral-text) !important;
 }
+
+IGNORE INLINE STYLE
+.logo-jenkins *
+
+================================
+
+jenkins.io
 
 IGNORE INLINE STYLE
 .logo-jenkins *


### PR DESCRIPTION
This is a fix for [Jenkins](https://www.jenkins.io), a popular build tool.

This fixes the navigation bar (breadcrumbs) and most of the text not being inverted correctly.

_The red boxes in the screenshots are only for redacting text and not present on the actual website_
**Before:**
![image](https://github.com/user-attachments/assets/d46da56c-9b0a-4ff8-b605-cf1860c50b89)

**After:**
![image](https://github.com/user-attachments/assets/86e3ed58-a168-4119-9765-674319c19c91)
![image](https://github.com/user-attachments/assets/a832ad4a-3e18-4cc2-8d67-7da947d48111)



The tool is usually self-hosted by some company and exposed under their respective internal domain. The URLs in the config file are my best guess of what those URLs might look like. For example:
- jenkins.mycompany.com
- jenkins.mycompany.local
- teamXjenkins.mycompany.com