### PR TITLE
Fix some elements of California Legislative Information website disappearing in dynamic mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17739,6 +17739,21 @@ CSS
 
 ================================
 
+leginfo.legislature.ca.gov
+
+CSS
+@media screen and (min-width: 768px) {
+    #tab_panel,
+    #system,
+    #quick_search,
+    #bill_version,
+    #breadcrumbs {
+        display: block !important;
+    }
+}
+
+================================
+
 lemonde.fr
 
 INVERT


### PR DESCRIPTION
Closes #14425

1. Added [leginfo.legislature.ca.gov](leginfo.legislature.ca.gov) to `dynamic-theme-fixes.config`
2. Restores hidden elements at viewport ≥ 768 px 
3. Verified with `npm test` and `npm run debug`