### PR TITLE
Add zbhavyai.github.io under dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1263,6 +1263,7 @@ you.dj
 your.gg
 yts.*
 zaufanatrzeciastrona.pl
+zbhavyai.github.io
 zee5.com
 zerodayinitiative.com
 zkillboard.com


### PR DESCRIPTION
My portfolio site, [https://zbhavyai.github.io](https://zbhavyai.github.io),  is dark only, and shall remain like that. Please include it in the `dark-sites.config`.

Thank you!
