### PR TITLE
Fix colors for the connection game on nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22479,17 +22479,23 @@ a[data-testid] > svg {
 #xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
     fill: ${blue} !important;
 }
-[class^=SolvedCategory-module_solvedCategory][data-level="0"] {
+[class*=SolvedCategory-module_solvedCategory][data-level="0"] {
     background-color: rgb(153, 140, 41) !important;
 }
-[class^=SolvedCategory-module_solvedCategory][data-level="1"] {
+[class*=SolvedCategory-module_solvedCategory][data-level="1"] {
     background-color: rgb(82, 133, 40) !important;
 }
-[class^=SolvedCategory-module_solvedCategory][data-level="2"] {
+[class*=SolvedCategory-module_solvedCategory][data-level="2"] {
     background-color: rgb(60, 116, 144) !important;
 }
-[class^=SolvedCategory-module_solvedCategory][data-level="3"] {
+[class*=SolvedCategory-module_solvedCategory][data-level="3"] {
     background-color: rgb(120, 58, 133) !important;
+}
+[class*=Card-module_label] {
+    background-color: #242424 !important;
+}
+[class*=Card-module_label][class*=Card-module_selected] {
+    background-color: #404040 !important;
 }
 
 IGNORE INLINE STYLE

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22479,20 +22479,23 @@ a[data-testid] > svg {
 #xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
     fill: ${blue} !important;
 }
-[class*=SolvedCategory-module_solvedCategory][data-level="0"] {
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="0"] {
     background-color: rgb(153, 140, 41) !important;
 }
-[class*=SolvedCategory-module_solvedCategory][data-level="1"] {
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="1"] {
     background-color: rgb(82, 133, 40) !important;
 }
-[class*=SolvedCategory-module_solvedCategory][data-level="2"] {
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="2"] {
     background-color: rgb(60, 116, 144) !important;
 }
-[class*=SolvedCategory-module_solvedCategory][data-level="3"] {
+html[data-darkreader-scheme="dimmed"] [class*=SolvedCategory-module_solvedCategory][data-level="2"] {
+    background-color: var(--bg-connections-medium) !important;
+}
+html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory][data-level="3"] {
     background-color: rgb(120, 58, 133) !important;
 }
 [class*=Card-module_label] {
-    background-color: #242424 !important;
+    background-color: ${#dbdbdb} !important;
 }
 [class*=Card-module_label][class*=Card-module_selected] {
     background-color: #404040 !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22479,6 +22479,18 @@ a[data-testid] > svg {
 #xwd-board rect[class*="xwd__cell--penciled"] ~ text[text-anchor^="middle"] {
     fill: ${blue} !important;
 }
+[class^=SolvedCategory-module_solvedCategory][data-level="0"] {
+    background-color: rgb(153, 140, 41) !important;
+}
+[class^=SolvedCategory-module_solvedCategory][data-level="1"] {
+    background-color: rgb(82, 133, 40) !important;
+}
+[class^=SolvedCategory-module_solvedCategory][data-level="2"] {
+    background-color: rgb(60, 116, 144) !important;
+}
+[class^=SolvedCategory-module_solvedCategory][data-level="3"] {
+    background-color: rgb(120, 58, 133) !important;
+}
 
 IGNORE INLINE STYLE
 line[style="stroke: var(--tie); stroke: black;"]


### PR DESCRIPTION
This makes the colors used in the nytimes.com game "connections" more accurate to the intended colors (especially the blue category)

# Without darkreader (original)
![image](https://github.com/user-attachments/assets/60701f04-1a65-42a2-8a92-ea847de47e43)
![image](https://github.com/user-attachments/assets/69d01c38-2ee8-4a0e-a680-88cfbb2b6eb0)

# With darkreader (before)
![image](https://github.com/user-attachments/assets/ab70c78f-fc06-4261-b833-5fc445113787)
![image](https://github.com/user-attachments/assets/891e7f8f-a83c-43e4-8af0-2f9dfd791c5a)

# With darkreader (after)
![image](https://github.com/user-attachments/assets/7eef856b-9bf7-4ab8-9cdb-2eaabc1cd12c)
![image](https://github.com/user-attachments/assets/bcefe003-d55a-43aa-9057-a669f83ccf78)
