### PR TITLE
Update dynamic-theme-fixes.config (pcgamingwiki.com)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23776,7 +23776,18 @@ pcgamingwiki.com
 
 INVERT
 img[alt="Gamesplanet logo.svg"]
-div.infobox-steamdb
+
+CSS
+div.svg-icon {
+    background-size: contain !important;
+}
+.headerSort {
+    background-size: initial !important;
+}
+
+IGNORE IMAGE ANALYSIS
+.thumbs-down
+.tickcross-false
 
 ================================
 


### PR DESCRIPTION
Thumbs-down/Tickcross-false do not require inversion (they are a strong enough red to show clearly; the inverted colour was also a near-white pink, somewhat diminishing the highlight effect of the red colour choice in the first place). 
Most other images were being correctly inverted, but were not showing correctly (or at all) due to the background-image blob specified by DR being significantly larger than the space available in their div (with the sole exception of the table header-sort arrow-icons).