### PR TITLE
added geeksforgeeks.org to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -487,6 +487,7 @@ gamejolt.com
 gamersnexus.net
 gaming.amazon.com
 garudalinux.org
+geeksforgeeks.org
 geektyper.com
 genshin-impact.fandom.com
 genshin.gg


### PR DESCRIPTION
https://www.geeksforgeeks.org

This site already has a dark mode implementation in place, so it would be nice if it were included in the global dark list.