### PR TITLE
Added_neetcode.io_to_listof_dark_sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -788,6 +788,7 @@ nationsglory.es
 nationsglory.fr
 neal.fun/size-of-space
 nee.lv
+neetcode.io/roadmap
 nemanjadragun.com
 nerimity.com
 netflix.com


### PR DESCRIPTION
This PR adds https://neetcode.io/roadmap to the dark sites list. This page is actively used by many and already has a native dark theme, and Dark Reader's override causes visibility and readability issues. Adding it to the dark sites list resolves this by preventing unnecessary styling.