### PR TITLE
Add mcp site to dark theme hints

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -421,6 +421,7 @@ MATCH
 .dark-theme
 
 ================================
+
 modelcontextprotocol.io
 
 TARGET

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -421,6 +421,15 @@ MATCH
 .dark-theme
 
 ================================
+modelcontextprotocol.io
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
 
 msn.com
 


### PR DESCRIPTION
Added https://modelcontextprotocol.io/introduction site to the dark theme hints config file. Now the dark reader will not override its dark theme.