### PR TITLE
add tuf site to dark theme hints

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -719,6 +719,16 @@ NO DARK THEME
 
 ================================
 
+takeuforward.org
+
+TARGET
+body
+
+MATCH
+.dark
+
+================================
+
 telex.hu
 
 TARGET


### PR DESCRIPTION
Added https://takeuforward.org/ to dark theme hints config file.