### PR TITLE
Add q1dian.github.io to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -926,6 +926,7 @@ ptdtw.fun
 pvplegacy.net
 pxseu.com
 pylon.bot
+q1dian.github.io
 qalculator.xyz
 quad9.net
 raidbots.com


### PR DESCRIPTION
Would like to add personal website to the global dark list as the color theme gets screwed by inverted coloring. :)