### PR TITLE
Fix for signin.nianticspatial.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27872,6 +27872,7 @@ svg *
 ================================
 
 signin.nianticlabs.com
+signin.nianticspatial.com
 
 INVERT
 img[alt="Niantic"]


### PR DESCRIPTION
Same logo invert for the new domain.