### PR TITLE
add w3schools to detector-hints.config

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -823,6 +823,16 @@ MATCH
 
 ================================
 
+w3schools.com
+
+TARGET
+html
+
+MATCH
+body.darktheme.darkpagetheme
+
+================================
+
 wccftech.com
 
 TARGET


### PR DESCRIPTION
Added w3schools in detector-hints.config file. Now it detects dark theme also it will not override its dark theme.