### PR TITLE
Add dark theme support for swiggy.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29590,6 +29590,21 @@ CSS
 
 ================================
 
+swiggy.com
+
+INVERT
+.logo
+.brand-logo
+img[alt*="swiggy" i]
+img[alt*="logo" i]
+
+CSS
+.search-container {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 svgrepo.com
 
 INVERT


### PR DESCRIPTION
- Invert logos and brand elements for better dark mode visibility
- Fix search container background to use neutral background color
- Minimal targeted fixes for essential UI elements