### PR TITLE
Add dark theme support for phonepe.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24039,6 +24039,21 @@ CSS
 
 ================================
 
+phonepe.com
+
+INVERT
+.logo
+.brand-logo
+img[alt*="phonepe" i]
+img[alt*="logo" i]
+
+CSS
+.header {
+    background: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 phonescoop.com
 
 INVERT


### PR DESCRIPTION
- Invert logos and brand elements for better dark mode visibility
- Fix header background to use neutral background color
- Minimal targeted fixes for essential UI elements