### PR TITLE
fix for wiki

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19795,8 +19795,7 @@ table.layouttemplate {
 .ext-discussiontools-init-targetcomment {
     background-color: rgba(192,192,255,0.25) !important;
 }
-.mw-parser-output .ib-company-logo img,
-table.wikitable * {
+.mw-parser-output .ib-company-logo img {
     background-color: transparent !important;
 }
 html[data-darkreader-scheme="dark"] img[src*="Eagle_with_fasces.svg"],


### PR DESCRIPTION
Fix issue mentioned in https://github.com/darkreader/darkreader/discussions/14493

Removes table.wikitable * selector as it is not needed anymore when checked the #14421 issue.