### PR TITLE
Fix/add soundcloud site to detector hints

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1054,6 +1054,7 @@ social.cologne
 social.saarland
 social.tchncs.de
 somafm.com
+soundcloud.com
 spacestationgaming.com
 spacex.com
 spark.lucko.me

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -727,6 +727,16 @@ NO DARK THEME
 
 ================================
 
+soundcloud.com
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
+
 steamgifts.com
 
 NO DARK THEME


### PR DESCRIPTION
https://soundcloud.com/discover

This site already has dark mode implemented, so it will be good to have this site added to detector hints.