### PR TITLE
Add mcp site to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -753,6 +753,7 @@ mixxx.org
 mizik.eu
 mmorpg.com
 mnsr.win
+modelcontextprotocol.io
 modworkshop.net
 monaspace.githubnext.com
 monitoror.com


### PR DESCRIPTION
https://modelcontextprotocol.io/introduction

This site already has dark mode implemented, so it will be good to have this site added into the Global Dark List