### PR TITLE
config: add blog.miguelgrinberg.com to dark sites

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -130,6 +130,16 @@ MATCH
 
 ================================
 
+blog.miguelgrinberg.com
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
+
 blog.stevezmt.top
 blog-preview.stevezmt.top
 


### PR DESCRIPTION
Fixes #14518

## Summary

This PR adds `blog.miguelgrinberg.com` to the `DARK_CONFIG` hints to improve Dark Reader's detection on sites that use internal `.dark` class toggling.

## Reason

The blog already supports a dark theme natively using the `.dark` CSS class. However, when the system or user preference is set to light, Dark Reader may fail to auto-detect the site’s dark mode capability. Adding this to `DARK_CONFIG` improves automatic handling.

### Detection Hint Added
```
blog.miguelgrinberg.com

TARGET
html

MATCH
.dark

```