### PR TITLE
add zeon site to dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1268,6 +1268,7 @@ yts.*
 zaufanatrzeciastrona.pl
 zbhavyai.github.io
 zee5.com
+zeon.dev
 zerodayinitiative.com
 zkillboard.com
 zombsroyale.io


### PR DESCRIPTION
https://zeon.dev/

This site already has dark mode . So, It will be good to have this site in Global Dark List. 