### PR TITLE
Fix/add inoreader site to dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -605,6 +605,7 @@ infocon.org
 infosec.exchange
 inker.app
 inker.co
+inoreader.com
 intactphone.com
 intothetrenches.1917.movie
 iskdeusingqt6.org


### PR DESCRIPTION
https://www.inoreader.com/dashboard

This site has a dark mode implemented, so this site should be added into the Global Dark List