### PR TITLE
Fix/add inoreader site to darklist

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -605,6 +605,7 @@ infocon.org
 infosec.exchange
 inker.app
 inker.co
+inoreader.com
 intactphone.com
 intothetrenches.1917.movie
 iskdeusingqt6.org

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -753,6 +753,7 @@ mixxx.org
 mizik.eu
 mmorpg.com
 mnsr.win
+modelcontextprotocol.io
 modworkshop.net
 monaspace.githubnext.com
 monitoror.com

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -369,6 +369,16 @@ NO DARK THEME
 
 ================================
 
+inoreader.com
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
+
 kaosx.us
 
 TARGET


### PR DESCRIPTION
Added https://www.inoreader.com/dashboard site to the dark theme hints config file. Now the dark reader will not override its dark theme.