### PR TITLE
Add gchq github io to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -753,6 +753,7 @@ mixxx.org
 mizik.eu
 mmorpg.com
 mnsr.win
+modelcontextprotocol.io
 modworkshop.net
 monaspace.githubnext.com
 monitoror.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -487,6 +487,7 @@ gamejolt.com
 gamersnexus.net
 gaming.amazon.com
 garudalinux.org
+gchq.github.io
 geektyper.com
 genshin-impact.fandom.com
 genshin.gg


### PR DESCRIPTION
https://gchq.github.io/CyberChef/

This site already has a dark mode implemented, so it will be good to have the site added into Global Dark List