### PR TITLE
add figma site to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -438,6 +438,7 @@ fallout-area.de
 fandango.com
 fastro.dev
 fedidb.org
+figma.com
 filegarden.com
 filmmakermode.com
 filterblade.xyz


### PR DESCRIPTION
https://www.figma.com/

This site already has dark mode implemented . So it is good to have it in Global Dark List as it breaks parts of its UI.