### PR TITLE
Fix: Improve background detection for SVG elements

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19023,6 +19023,15 @@ CSS
 
 ================================
 
+maketext.io
+
+CSS
+#landing {
+    background-image: none !important;
+}
+
+================================
+
 makeuseof.com
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
what does this PR do?
This PR Improve background detection for SVG elements for the site maketext.io .

Fixes: #14524

SCREENSHOTS:

BEFORE:

<img width="1588" height="930" alt="Screenshot 2025-07-22 232555" src="https://github.com/user-attachments/assets/784d13db-95ef-4aab-91c8-39fea05a4f75" />

AFTER:

<img width="1516" height="919" alt="Screenshot 2025-07-22 232900" src="https://github.com/user-attachments/assets/10756abe-c1dd-4022-bce7-379a3f6d044f" />


