### PR TITLE
Add dark site and adjust README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ For Dark Reader, the option "Run on sites with restrictions" is not shown becaus
 
 The fact that it is a Recommended extension means that it meets the "highest standards of security, functionality, and user experience". The quarantined domains are only related to extension security. Because Dark Reader is considered secure by Mozilla, that option is not shown, meaning **it will always run even on quarantined domains** (but will still obey the "restricted domains" list if it is not empty).
 
-Regarding quarantined domains specifically, there is this [comment from Firefox's source code:](https://searchfox.org/mozilla-central/source/toolkit/components/extensions/Extension.sys.mjs#2937-2938)
+Regarding quarantined domains specifically, there is this [comment from Firefox's source code](https://searchfox.org/mozilla-central/rev/1838f847aa3bf909c3d34a94a8f0cd7e37fca086/toolkit/components/extensions/Extension.sys.mjs#3470-3471):
 
 ```
 // Privileged extensions and any extensions with a recommendation state are

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1128,6 +1128,7 @@ textures.com
 tf2mart.net
 tgw1916.net/bacteria_abis.html
 thecolonialtheatre.com
+thegrimoire.deadbydaylight.com
 thehomelab.wiki
 thelastofus.fandom.com
 thelinuxcast.org


### PR DESCRIPTION
This PR adds a dark site to the list and adjusts the README to use a permanent link for the Firefox's source code (otherwise, the link position gets invalidated after new commits).

The site added to the list is a quest mini-game that is played via the browser, and Dark Reader makes some parts of it invisible.