### PR TITLE
add blog.miguelgrinberg.com site to dark theme hints

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -130,6 +130,16 @@ MATCH
 
 ================================
 
+blog.miguelgrinberg.com
+
+TARGET
+html
+
+MATCH
+[data-bs-theme="dark"]
+
+================================
+
 blog.stevezmt.top
 blog-preview.stevezmt.top
 


### PR DESCRIPTION
Added https://blog.miguelgrinberg.com/ site to the dark theme hints config file. Now the dark reader will not override its dark theme.