### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5771,6 +5771,15 @@ body {
 
 ================================
 
+c64os.com
+
+CSS
+img {
+    background: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 cabinet.tax.gov.ua
 
 INVERT


### PR DESCRIPTION
Fixes black-on-black PNGs on pages like https://c64os.com/post/Vic20C64SuperChart