### PR TITLE
Add dark mode detector hint for developer.mozilla.org

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -246,6 +246,16 @@ NO DARK THEME
 
 ================================
 
+developer.mozilla.org
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
+
 dictionary.com
 
 NO DARK THEME


### PR DESCRIPTION
https://developer.mozilla.org/en-US/

MDN now uses the class "dark" on the <html> element to indicate dark mode. Previously it was unexpectedly changing the UI. 
This adds a detector hint for proper dark mode matching.