### PR TITLE
Fix for www.PlayInterference.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24472,6 +24472,379 @@ body {
 
 ================================
 
+www.playinterference.com
+
+CSS
+.fa-circle {
+    visibility: hidden !important;
+}
+.col div[style*="background-color: rgb(255, 255, 255)"],
+.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
+    background-color: rgb(255, 255, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(102, 102, 102)"],
+.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
+    background-color: rgb(102, 102, 102) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 128, 128)"],
+.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
+    background-color: rgb(255, 128, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 179, 128)"],
+.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
+    background-color: rgb(255, 179, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 255, 128)"],
+.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
+    background-color: rgb(255, 255, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(128, 255, 128)"],
+.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
+    background-color: rgb(128, 255, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(179, 255, 255)"],
+.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
+    background-color: rgb(179, 255, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(153, 204, 255)"],
+.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
+    background-color: rgb(153, 204, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(179, 128, 255)"],
+.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
+    background-color: rgb(179, 128, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 128, 255)"],
+.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
+    background-color: rgb(255, 128, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(128, 230, 204)"],
+.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
+    background-color: rgb(128, 230, 204) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(247, 215, 196)"],
+.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
+    background-color: rgb(247, 215, 196) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(204, 204, 204)"],
+.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
+    background-color: rgb(204, 204, 204) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 51, 51)"],
+.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
+    background-color: rgb(51, 51, 51) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 0, 0)"],
+.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
+    background-color: rgb(255, 0, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 102, 0)"],
+.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
+    background-color: rgb(255, 102, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 255, 0)"],
+.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
+    background-color: rgb(255, 255, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 255, 0)"],
+.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
+    background-color: rgb(0, 255, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(102, 255, 255)"],
+.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
+    background-color: rgb(102, 255, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 153, 255)"],
+.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
+    background-color: rgb(51, 153, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(102, 0, 255)"],
+.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
+    background-color: rgb(102, 0, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 0, 255)"],
+.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
+    background-color: rgb(255, 0, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 204, 153)"],
+.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
+    background-color: rgb(0, 204, 153) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(142, 86, 46)"],
+.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
+    background-color: rgb(142, 86, 46) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(153, 153, 153)"],
+.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
+    background-color: rgb(153, 153, 153) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 0, 0)"],
+.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
+    background-color: rgb(0, 0, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 0, 0)"],
+.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
+    background-color: rgb(127, 0, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 51, 0)"],
+.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
+    background-color: rgb(127, 51, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 127, 0)"],
+.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
+    background-color: rgb(127, 127, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 127, 0)"],
+.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
+    background-color: rgb(0, 127, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 127, 127)"],
+.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
+    background-color: rgb(51, 127, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(25, 76, 127)"],
+.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
+    background-color: rgb(25, 76, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 0, 127)"],
+.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
+    background-color: rgb(51, 0, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 0, 127)"],
+.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
+    background-color: rgb(127, 0, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 102, 76)"],
+.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
+    background-color: rgb(0, 102, 76) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 25, 0)"],
+.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
+    background-color: rgb(51, 25, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 255, 255)"],
+.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
+    background-color: rgb(255, 255, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(102, 102, 102)"],
+.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
+    background-color: rgb(102, 102, 102) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 128, 128)"],
+.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
+    background-color: rgb(255, 128, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 179, 128)"],
+.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
+    background-color: rgb(255, 179, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 255, 128)"],
+.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
+    background-color: rgb(255, 255, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(128, 255, 128)"],
+.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
+    background-color: rgb(128, 255, 128) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(179, 255, 255)"],
+.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
+    background-color: rgb(179, 255, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(153, 204, 255)"],
+.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
+    background-color: rgb(153, 204, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(179, 128, 255)"],
+.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
+    background-color: rgb(179, 128, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 128, 255)"],
+.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
+    background-color: rgb(255, 128, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(128, 230, 204)"],
+.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
+    background-color: rgb(128, 230, 204) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(247, 215, 196)"],
+.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
+    background-color: rgb(247, 215, 196) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(204, 204, 204)"],
+.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
+    background-color: rgb(204, 204, 204) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 51, 51)"],
+.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
+    background-color: rgb(51, 51, 51) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 0, 0)"],
+.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
+    background-color: rgb(255, 0, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 102, 0)"],
+.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
+    background-color: rgb(255, 102, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 255, 0)"],
+.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
+    background-color: rgb(255, 255, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 255, 0)"],
+.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
+    background-color: rgb(0, 255, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(102, 255, 255)"],
+.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
+    background-color: rgb(102, 255, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 153, 255)"],
+.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
+    background-color: rgb(51, 153, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(102, 0, 255)"],
+.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
+    background-color: rgb(102, 0, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(255, 0, 255)"],
+.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
+    background-color: rgb(255, 0, 255) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 204, 153)"],
+.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
+    background-color: rgb(0, 204, 153) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(142, 86, 46)"],
+.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
+    background-color: rgb(142, 86, 46) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(153, 153, 153)"],
+.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
+    background-color: rgb(153, 153, 153) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 0, 0)"],
+.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
+    background-color: rgb(0, 0, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 0, 0)"],
+.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
+    background-color: rgb(127, 0, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 51, 0)"],
+.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
+    background-color: rgb(127, 51, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 127, 0)"],
+.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
+    background-color: rgb(127, 127, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 127, 0)"],
+.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
+    background-color: rgb(0, 127, 0) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 127, 127)"],
+.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
+    background-color: rgb(51, 127, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(25, 76, 127)"],
+.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
+    background-color: rgb(25, 76, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 0, 127)"],
+.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
+    background-color: rgb(51, 0, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(127, 0, 127)"],
+.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
+    background-color: rgb(127, 0, 127) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(0, 102, 76)"],
+.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
+    background-color: rgb(0, 102, 76) !important;
+    border-width: 0px !important;
+}
+.col div[style*="background-color: rgb(51, 25, 0)"],
+.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
+    background-color: rgb(51, 25, 0) !important;
+    border-width: 0px !important;
+}
+.col-auto.disable-select table,
+.row.no-gutters.justify-content-between.disable-select {
+    background-color: rgb(49, 49, 49) !important;
+}
+
+================================
+
 playstation.com
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24472,168 +24472,6 @@ body {
 
 ================================
 
-www.playinterference.com
-
-CSS
-.col.col-1 div:not(.selected-colour) {
-    border-color: rgba(0,0,0,0) !important;
-}
-.selected-colour:not(.anything) {
-    border-color: black !important;
-}
-.fa-circle:not(.selected-colour .fa-circle) {
-    visibility: hidden !important;
-}
-.p-1 div {
-    border-color: rgb(185,185,185) !important;
-}
-.col div[style*="background-color: rgb(255, 255, 255)"],
-.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
-    background-color: rgb(255, 255, 255) !important;
-}
-.col div[style*="background-color: rgb(102, 102, 102)"],
-.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
-    background-color: rgb(102, 102, 102) !important;
-}
-.col div[style*="background-color: rgb(255, 128, 128)"],
-.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
-    background-color: rgb(255, 128, 128) !important;
-}
-.col div[style*="background-color: rgb(255, 179, 128)"],
-.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
-    background-color: rgb(255, 179, 128) !important;
-}
-.col div[style*="background-color: rgb(255, 255, 128)"],
-.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
-    background-color: rgb(255, 255, 128) !important;
-}
-.col div[style*="background-color: rgb(128, 255, 128)"],
-.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
-    background-color: rgb(128, 255, 128) !important;
-}
-.col div[style*="background-color: rgb(179, 255, 255)"],
-.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
-    background-color: rgb(179, 255, 255) !important;
-}
-.col div[style*="background-color: rgb(153, 204, 255)"],
-.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
-    background-color: rgb(153, 204, 255) !important;
-}
-.col div[style*="background-color: rgb(179, 128, 255)"],
-.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
-    background-color: rgb(179, 128, 255) !important;
-}
-.col div[style*="background-color: rgb(255, 128, 255)"],
-.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
-    background-color: rgb(255, 128, 255) !important;
-}
-.col div[style*="background-color: rgb(128, 230, 204)"],
-.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
-    background-color: rgb(128, 230, 204) !important;
-}
-.col div[style*="background-color: rgb(247, 215, 196)"],
-.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
-    background-color: rgb(247, 215, 196) !important;
-}
-.col div[style*="background-color: rgb(204, 204, 204)"],
-.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
-    background-color: rgb(204, 204, 204) !important;
-}
-.col div[style*="background-color: rgb(51, 51, 51)"],
-.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
-    background-color: rgb(51, 51, 51) !important;
-}
-.col div[style*="background-color: rgb(255, 0, 0)"],
-.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
-    background-color: rgb(255, 0, 0) !important;
-}
-.col div[style*="background-color: rgb(255, 102, 0)"],
-.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
-    background-color: rgb(255, 102, 0) !important;
-}
-.col div[style*="background-color: rgb(255, 255, 0)"],
-.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
-    background-color: rgb(255, 255, 0) !important;
-}
-.col div[style*="background-color: rgb(0, 255, 0)"],
-.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
-    background-color: rgb(0, 255, 0) !important;
-}
-.col div[style*="background-color: rgb(102, 255, 255)"],
-.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
-    background-color: rgb(102, 255, 255) !important;
-}
-.col div[style*="background-color: rgb(51, 153, 255)"],
-.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
-    background-color: rgb(51, 153, 255) !important;
-}
-.col div[style*="background-color: rgb(102, 0, 255)"],
-.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
-    background-color: rgb(102, 0, 255) !important;
-}
-.col div[style*="background-color: rgb(255, 0, 255)"],
-.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
-    background-color: rgb(255, 0, 255) !important;
-}
-.col div[style*="background-color: rgb(0, 204, 153)"],
-.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
-    background-color: rgb(0, 204, 153) !important;
-}
-.col div[style*="background-color: rgb(142, 86, 46)"],
-.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
-    background-color: rgb(142, 86, 46) !important;
-}
-.col div[style*="background-color: rgb(153, 153, 153)"],
-.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
-    background-color: rgb(153, 153, 153) !important;
-}
-.col div[style*="background-color: rgb(0, 0, 0)"],
-.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
-    background-color: rgb(0, 0, 0) !important;
-}
-.col div[style*="background-color: rgb(127, 0, 0)"],
-.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
-    background-color: rgb(127, 0, 0) !important;
-}
-.col div[style*="background-color: rgb(127, 51, 0)"],
-.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
-    background-color: rgb(127, 51, 0) !important;
-}
-.col div[style*="background-color: rgb(127, 127, 0)"],
-.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
-    background-color: rgb(127, 127, 0) !important;
-}
-.col div[style*="background-color: rgb(0, 127, 0)"],
-.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
-    background-color: rgb(0, 127, 0) !important;
-}
-.col div[style*="background-color: rgb(51, 127, 127)"],
-.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
-    background-color: rgb(51, 127, 127) !important;
-}
-.col div[style*="background-color: rgb(25, 76, 127)"],
-.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
-    background-color: rgb(25, 76, 127) !important;
-}
-.col div[style*="background-color: rgb(51, 0, 127)"],
-.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
-    background-color: rgb(51, 0, 127) !important;
-}
-.col div[style*="background-color: rgb(127, 0, 127)"],
-.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
-    background-color: rgb(127, 0, 127) !important;
-}
-.col div[style*="background-color: rgb(0, 102, 76)"],
-.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
-    background-color: rgb(0, 102, 76) !important;
-}
-.col div[style*="background-color: rgb(51, 25, 0)"],
-.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
-    background-color: rgb(51, 25, 0) !important;
-}
-
-================================
-
 playstation.com
 
 CSS
@@ -35620,6 +35458,168 @@ INVERT
 .ghdsp__logo
 .sidebar-visible-button
 ._search-field-visible-button
+
+================================
+
+www.playinterference.com
+
+CSS
+.col.col-1 div:not(.selected-colour) {
+    border-color: rgba(0,0,0,0) !important;
+}
+.selected-colour:not(.anything) {
+    border-color: black !important;
+}
+.fa-circle:not(.selected-colour .fa-circle) {
+    visibility: hidden !important;
+}
+.p-1 div {
+    border-color: rgb(185,185,185) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 255)"],
+.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
+    background-color: rgb(255, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(102, 102, 102)"],
+.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
+    background-color: rgb(102, 102, 102) !important;
+}
+.col div[style*="background-color: rgb(255, 128, 128)"],
+.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
+    background-color: rgb(255, 128, 128) !important;
+}
+.col div[style*="background-color: rgb(255, 179, 128)"],
+.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
+    background-color: rgb(255, 179, 128) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 128)"],
+.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
+    background-color: rgb(255, 255, 128) !important;
+}
+.col div[style*="background-color: rgb(128, 255, 128)"],
+.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
+    background-color: rgb(128, 255, 128) !important;
+}
+.col div[style*="background-color: rgb(179, 255, 255)"],
+.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
+    background-color: rgb(179, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(153, 204, 255)"],
+.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
+    background-color: rgb(153, 204, 255) !important;
+}
+.col div[style*="background-color: rgb(179, 128, 255)"],
+.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
+    background-color: rgb(179, 128, 255) !important;
+}
+.col div[style*="background-color: rgb(255, 128, 255)"],
+.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
+    background-color: rgb(255, 128, 255) !important;
+}
+.col div[style*="background-color: rgb(128, 230, 204)"],
+.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
+    background-color: rgb(128, 230, 204) !important;
+}
+.col div[style*="background-color: rgb(247, 215, 196)"],
+.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
+    background-color: rgb(247, 215, 196) !important;
+}
+.col div[style*="background-color: rgb(204, 204, 204)"],
+.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
+    background-color: rgb(204, 204, 204) !important;
+}
+.col div[style*="background-color: rgb(51, 51, 51)"],
+.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
+    background-color: rgb(51, 51, 51) !important;
+}
+.col div[style*="background-color: rgb(255, 0, 0)"],
+.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
+    background-color: rgb(255, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(255, 102, 0)"],
+.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
+    background-color: rgb(255, 102, 0) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 0)"],
+.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
+    background-color: rgb(255, 255, 0) !important;
+}
+.col div[style*="background-color: rgb(0, 255, 0)"],
+.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
+    background-color: rgb(0, 255, 0) !important;
+}
+.col div[style*="background-color: rgb(102, 255, 255)"],
+.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
+    background-color: rgb(102, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(51, 153, 255)"],
+.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
+    background-color: rgb(51, 153, 255) !important;
+}
+.col div[style*="background-color: rgb(102, 0, 255)"],
+.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
+    background-color: rgb(102, 0, 255) !important;
+}
+.col div[style*="background-color: rgb(255, 0, 255)"],
+.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
+    background-color: rgb(255, 0, 255) !important;
+}
+.col div[style*="background-color: rgb(0, 204, 153)"],
+.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
+    background-color: rgb(0, 204, 153) !important;
+}
+.col div[style*="background-color: rgb(142, 86, 46)"],
+.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
+    background-color: rgb(142, 86, 46) !important;
+}
+.col div[style*="background-color: rgb(153, 153, 153)"],
+.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
+    background-color: rgb(153, 153, 153) !important;
+}
+.col div[style*="background-color: rgb(0, 0, 0)"],
+.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
+    background-color: rgb(0, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 0, 0)"],
+.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
+    background-color: rgb(127, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 51, 0)"],
+.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
+    background-color: rgb(127, 51, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 127, 0)"],
+.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
+    background-color: rgb(127, 127, 0) !important;
+}
+.col div[style*="background-color: rgb(0, 127, 0)"],
+.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
+    background-color: rgb(0, 127, 0) !important;
+}
+.col div[style*="background-color: rgb(51, 127, 127)"],
+.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
+    background-color: rgb(51, 127, 127) !important;
+}
+.col div[style*="background-color: rgb(25, 76, 127)"],
+.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
+    background-color: rgb(25, 76, 127) !important;
+}
+.col div[style*="background-color: rgb(51, 0, 127)"],
+.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
+    background-color: rgb(51, 0, 127) !important;
+}
+.col div[style*="background-color: rgb(127, 0, 127)"],
+.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
+    background-color: rgb(127, 0, 127) !important;
+}
+.col div[style*="background-color: rgb(0, 102, 76)"],
+.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
+    background-color: rgb(0, 102, 76) !important;
+}
+.col div[style*="background-color: rgb(51, 25, 0)"],
+.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
+    background-color: rgb(51, 25, 0) !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24478,11 +24478,14 @@ CSS
 .col.col-1 div:not(.selected-colour) {
     border-color: rgba(0,0,0,0) !important;
 }
-.selected-colour:not(.anything) {
-    border-color: rgb(0,0,0) !important;
+.selected-colour {
+    --darkreader-border-000000: rgb(0,0,0) !important;
 }
 .fa-circle:not(.selected-colour .fa-circle) {
     visibility: hidden !important;
+}
+.fa-circle {
+    color: rgb(255,255,255) !important;
 }
 .p-1 div {
     border-color: rgb(185,185,185) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24472,6 +24472,168 @@ body {
 
 ================================
 
+playinterference.com
+
+CSS
+.col.col-1 div:not(.selected-colour) {
+    border-color: rgba(0,0,0,0) !important;
+}
+.selected-colour:not(.anything) {
+    border-color: black !important;
+}
+.fa-circle:not(.selected-colour .fa-circle) {
+    visibility: hidden !important;
+}
+.p-1 div {
+    border-color: rgb(185,185,185) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 255)"],
+.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
+    background-color: rgb(255, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(102, 102, 102)"],
+.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
+    background-color: rgb(102, 102, 102) !important;
+}
+.col div[style*="background-color: rgb(255, 128, 128)"],
+.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
+    background-color: rgb(255, 128, 128) !important;
+}
+.col div[style*="background-color: rgb(255, 179, 128)"],
+.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
+    background-color: rgb(255, 179, 128) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 128)"],
+.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
+    background-color: rgb(255, 255, 128) !important;
+}
+.col div[style*="background-color: rgb(128, 255, 128)"],
+.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
+    background-color: rgb(128, 255, 128) !important;
+}
+.col div[style*="background-color: rgb(179, 255, 255)"],
+.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
+    background-color: rgb(179, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(153, 204, 255)"],
+.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
+    background-color: rgb(153, 204, 255) !important;
+}
+.col div[style*="background-color: rgb(179, 128, 255)"],
+.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
+    background-color: rgb(179, 128, 255) !important;
+}
+.col div[style*="background-color: rgb(255, 128, 255)"],
+.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
+    background-color: rgb(255, 128, 255) !important;
+}
+.col div[style*="background-color: rgb(128, 230, 204)"],
+.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
+    background-color: rgb(128, 230, 204) !important;
+}
+.col div[style*="background-color: rgb(247, 215, 196)"],
+.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
+    background-color: rgb(247, 215, 196) !important;
+}
+.col div[style*="background-color: rgb(204, 204, 204)"],
+.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
+    background-color: rgb(204, 204, 204) !important;
+}
+.col div[style*="background-color: rgb(51, 51, 51)"],
+.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
+    background-color: rgb(51, 51, 51) !important;
+}
+.col div[style*="background-color: rgb(255, 0, 0)"],
+.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
+    background-color: rgb(255, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(255, 102, 0)"],
+.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
+    background-color: rgb(255, 102, 0) !important;
+}
+.col div[style*="background-color: rgb(255, 255, 0)"],
+.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
+    background-color: rgb(255, 255, 0) !important;
+}
+.col div[style*="background-color: rgb(0, 255, 0)"],
+.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
+    background-color: rgb(0, 255, 0) !important;
+}
+.col div[style*="background-color: rgb(102, 255, 255)"],
+.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
+    background-color: rgb(102, 255, 255) !important;
+}
+.col div[style*="background-color: rgb(51, 153, 255)"],
+.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
+    background-color: rgb(51, 153, 255) !important;
+}
+.col div[style*="background-color: rgb(102, 0, 255)"],
+.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
+    background-color: rgb(102, 0, 255) !important;
+}
+.col div[style*="background-color: rgb(255, 0, 255)"],
+.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
+    background-color: rgb(255, 0, 255) !important;
+}
+.col div[style*="background-color: rgb(0, 204, 153)"],
+.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
+    background-color: rgb(0, 204, 153) !important;
+}
+.col div[style*="background-color: rgb(142, 86, 46)"],
+.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
+    background-color: rgb(142, 86, 46) !important;
+}
+.col div[style*="background-color: rgb(153, 153, 153)"],
+.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
+    background-color: rgb(153, 153, 153) !important;
+}
+.col div[style*="background-color: rgb(0, 0, 0)"],
+.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
+    background-color: rgb(0, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 0, 0)"],
+.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
+    background-color: rgb(127, 0, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 51, 0)"],
+.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
+    background-color: rgb(127, 51, 0) !important;
+}
+.col div[style*="background-color: rgb(127, 127, 0)"],
+.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
+    background-color: rgb(127, 127, 0) !important;
+}
+.col div[style*="background-color: rgb(0, 127, 0)"],
+.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
+    background-color: rgb(0, 127, 0) !important;
+}
+.col div[style*="background-color: rgb(51, 127, 127)"],
+.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
+    background-color: rgb(51, 127, 127) !important;
+}
+.col div[style*="background-color: rgb(25, 76, 127)"],
+.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
+    background-color: rgb(25, 76, 127) !important;
+}
+.col div[style*="background-color: rgb(51, 0, 127)"],
+.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
+    background-color: rgb(51, 0, 127) !important;
+}
+.col div[style*="background-color: rgb(127, 0, 127)"],
+.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
+    background-color: rgb(127, 0, 127) !important;
+}
+.col div[style*="background-color: rgb(0, 102, 76)"],
+.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
+    background-color: rgb(0, 102, 76) !important;
+}
+.col div[style*="background-color: rgb(51, 25, 0)"],
+.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
+    background-color: rgb(51, 25, 0) !important;
+}
+
+================================
+
 playstation.com
 
 CSS
@@ -35458,168 +35620,6 @@ INVERT
 .ghdsp__logo
 .sidebar-visible-button
 ._search-field-visible-button
-
-================================
-
-www.playinterference.com
-
-CSS
-.col.col-1 div:not(.selected-colour) {
-    border-color: rgba(0,0,0,0) !important;
-}
-.selected-colour:not(.anything) {
-    border-color: black !important;
-}
-.fa-circle:not(.selected-colour .fa-circle) {
-    visibility: hidden !important;
-}
-.p-1 div {
-    border-color: rgb(185,185,185) !important;
-}
-.col div[style*="background-color: rgb(255, 255, 255)"],
-.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
-    background-color: rgb(255, 255, 255) !important;
-}
-.col div[style*="background-color: rgb(102, 102, 102)"],
-.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
-    background-color: rgb(102, 102, 102) !important;
-}
-.col div[style*="background-color: rgb(255, 128, 128)"],
-.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
-    background-color: rgb(255, 128, 128) !important;
-}
-.col div[style*="background-color: rgb(255, 179, 128)"],
-.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
-    background-color: rgb(255, 179, 128) !important;
-}
-.col div[style*="background-color: rgb(255, 255, 128)"],
-.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
-    background-color: rgb(255, 255, 128) !important;
-}
-.col div[style*="background-color: rgb(128, 255, 128)"],
-.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
-    background-color: rgb(128, 255, 128) !important;
-}
-.col div[style*="background-color: rgb(179, 255, 255)"],
-.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
-    background-color: rgb(179, 255, 255) !important;
-}
-.col div[style*="background-color: rgb(153, 204, 255)"],
-.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
-    background-color: rgb(153, 204, 255) !important;
-}
-.col div[style*="background-color: rgb(179, 128, 255)"],
-.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
-    background-color: rgb(179, 128, 255) !important;
-}
-.col div[style*="background-color: rgb(255, 128, 255)"],
-.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
-    background-color: rgb(255, 128, 255) !important;
-}
-.col div[style*="background-color: rgb(128, 230, 204)"],
-.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
-    background-color: rgb(128, 230, 204) !important;
-}
-.col div[style*="background-color: rgb(247, 215, 196)"],
-.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
-    background-color: rgb(247, 215, 196) !important;
-}
-.col div[style*="background-color: rgb(204, 204, 204)"],
-.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
-    background-color: rgb(204, 204, 204) !important;
-}
-.col div[style*="background-color: rgb(51, 51, 51)"],
-.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
-    background-color: rgb(51, 51, 51) !important;
-}
-.col div[style*="background-color: rgb(255, 0, 0)"],
-.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
-    background-color: rgb(255, 0, 0) !important;
-}
-.col div[style*="background-color: rgb(255, 102, 0)"],
-.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
-    background-color: rgb(255, 102, 0) !important;
-}
-.col div[style*="background-color: rgb(255, 255, 0)"],
-.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
-    background-color: rgb(255, 255, 0) !important;
-}
-.col div[style*="background-color: rgb(0, 255, 0)"],
-.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
-    background-color: rgb(0, 255, 0) !important;
-}
-.col div[style*="background-color: rgb(102, 255, 255)"],
-.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
-    background-color: rgb(102, 255, 255) !important;
-}
-.col div[style*="background-color: rgb(51, 153, 255)"],
-.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
-    background-color: rgb(51, 153, 255) !important;
-}
-.col div[style*="background-color: rgb(102, 0, 255)"],
-.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
-    background-color: rgb(102, 0, 255) !important;
-}
-.col div[style*="background-color: rgb(255, 0, 255)"],
-.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
-    background-color: rgb(255, 0, 255) !important;
-}
-.col div[style*="background-color: rgb(0, 204, 153)"],
-.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
-    background-color: rgb(0, 204, 153) !important;
-}
-.col div[style*="background-color: rgb(142, 86, 46)"],
-.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
-    background-color: rgb(142, 86, 46) !important;
-}
-.col div[style*="background-color: rgb(153, 153, 153)"],
-.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
-    background-color: rgb(153, 153, 153) !important;
-}
-.col div[style*="background-color: rgb(0, 0, 0)"],
-.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
-    background-color: rgb(0, 0, 0) !important;
-}
-.col div[style*="background-color: rgb(127, 0, 0)"],
-.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
-    background-color: rgb(127, 0, 0) !important;
-}
-.col div[style*="background-color: rgb(127, 51, 0)"],
-.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
-    background-color: rgb(127, 51, 0) !important;
-}
-.col div[style*="background-color: rgb(127, 127, 0)"],
-.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
-    background-color: rgb(127, 127, 0) !important;
-}
-.col div[style*="background-color: rgb(0, 127, 0)"],
-.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
-    background-color: rgb(0, 127, 0) !important;
-}
-.col div[style*="background-color: rgb(51, 127, 127)"],
-.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
-    background-color: rgb(51, 127, 127) !important;
-}
-.col div[style*="background-color: rgb(25, 76, 127)"],
-.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
-    background-color: rgb(25, 76, 127) !important;
-}
-.col div[style*="background-color: rgb(51, 0, 127)"],
-.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
-    background-color: rgb(51, 0, 127) !important;
-}
-.col div[style*="background-color: rgb(127, 0, 127)"],
-.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
-    background-color: rgb(127, 0, 127) !important;
-}
-.col div[style*="background-color: rgb(0, 102, 76)"],
-.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
-    background-color: rgb(0, 102, 76) !important;
-}
-.col div[style*="background-color: rgb(51, 25, 0)"],
-.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
-    background-color: rgb(51, 25, 0) !important;
-}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24479,7 +24479,7 @@ CSS
     border-color: rgba(0,0,0,0) !important;
 }
 .selected-colour:not(.anything) {
-    border-color: black !important;
+    border-color: rgb(0,0,0) !important;
 }
 .fa-circle:not(.selected-colour .fa-circle) {
     visibility: hidden !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24475,372 +24475,161 @@ body {
 www.playinterference.com
 
 CSS
-.fa-circle {
+.col.col-1 div:not(.selected-colour) {
+    border-color: rgba(0,0,0,0) !important;
+}
+.selected-colour:not(.anything) {
+    border-color: black !important;
+}
+.fa-circle:not(.selected-colour .fa-circle) {
     visibility: hidden !important;
 }
-.col div[style*="background-color: rgb(255, 255, 255)"],
-.p-1 div[style*="background-color: rgb(255, 255, 255)"] {
-    background-color: rgb(255, 255, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(102, 102, 102)"],
-.p-1 div[style*="background-color: rgb(102, 102, 102)"] {
-    background-color: rgb(102, 102, 102) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 128, 128)"],
-.p-1 div[style*="background-color: rgb(255, 128, 128)"] {
-    background-color: rgb(255, 128, 128) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 179, 128)"],
-.p-1 div[style*="background-color: rgb(255, 179, 128)"] {
-    background-color: rgb(255, 179, 128) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 255, 128)"],
-.p-1 div[style*="background-color: rgb(255, 255, 128)"] {
-    background-color: rgb(255, 255, 128) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(128, 255, 128)"],
-.p-1 div[style*="background-color: rgb(128, 255, 128)"] {
-    background-color: rgb(128, 255, 128) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(179, 255, 255)"],
-.p-1 div[style*="background-color: rgb(179, 255, 255)"] {
-    background-color: rgb(179, 255, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(153, 204, 255)"],
-.p-1 div[style*="background-color: rgb(153, 204, 255)"] {
-    background-color: rgb(153, 204, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(179, 128, 255)"],
-.p-1 div[style*="background-color: rgb(179, 128, 255)"] {
-    background-color: rgb(179, 128, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 128, 255)"],
-.p-1 div[style*="background-color: rgb(255, 128, 255)"] {
-    background-color: rgb(255, 128, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(128, 230, 204)"],
-.p-1 div[style*="background-color: rgb(128, 230, 204)"] {
-    background-color: rgb(128, 230, 204) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(247, 215, 196)"],
-.p-1 div[style*="background-color: rgb(247, 215, 196)"] {
-    background-color: rgb(247, 215, 196) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(204, 204, 204)"],
-.p-1 div[style*="background-color: rgb(204, 204, 204)"] {
-    background-color: rgb(204, 204, 204) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(51, 51, 51)"],
-.p-1 div[style*="background-color: rgb(51, 51, 51)"] {
-    background-color: rgb(51, 51, 51) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 0, 0)"],
-.p-1 div[style*="background-color: rgb(255, 0, 0)"] {
-    background-color: rgb(255, 0, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 102, 0)"],
-.p-1 div[style*="background-color: rgb(255, 102, 0)"] {
-    background-color: rgb(255, 102, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 255, 0)"],
-.p-1 div[style*="background-color: rgb(255, 255, 0)"] {
-    background-color: rgb(255, 255, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(0, 255, 0)"],
-.p-1 div[style*="background-color: rgb(0, 255, 0)"] {
-    background-color: rgb(0, 255, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(102, 255, 255)"],
-.p-1 div[style*="background-color: rgb(102, 255, 255)"] {
-    background-color: rgb(102, 255, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(51, 153, 255)"],
-.p-1 div[style*="background-color: rgb(51, 153, 255)"] {
-    background-color: rgb(51, 153, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(102, 0, 255)"],
-.p-1 div[style*="background-color: rgb(102, 0, 255)"] {
-    background-color: rgb(102, 0, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(255, 0, 255)"],
-.p-1 div[style*="background-color: rgb(255, 0, 255)"] {
-    background-color: rgb(255, 0, 255) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(0, 204, 153)"],
-.p-1 div[style*="background-color: rgb(0, 204, 153)"] {
-    background-color: rgb(0, 204, 153) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(142, 86, 46)"],
-.p-1 div[style*="background-color: rgb(142, 86, 46)"] {
-    background-color: rgb(142, 86, 46) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(153, 153, 153)"],
-.p-1 div[style*="background-color: rgb(153, 153, 153)"] {
-    background-color: rgb(153, 153, 153) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(0, 0, 0)"],
-.p-1 div[style*="background-color: rgb(0, 0, 0)"] {
-    background-color: rgb(0, 0, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(127, 0, 0)"],
-.p-1 div[style*="background-color: rgb(127, 0, 0)"] {
-    background-color: rgb(127, 0, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(127, 51, 0)"],
-.p-1 div[style*="background-color: rgb(127, 51, 0)"] {
-    background-color: rgb(127, 51, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(127, 127, 0)"],
-.p-1 div[style*="background-color: rgb(127, 127, 0)"] {
-    background-color: rgb(127, 127, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(0, 127, 0)"],
-.p-1 div[style*="background-color: rgb(0, 127, 0)"] {
-    background-color: rgb(0, 127, 0) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(51, 127, 127)"],
-.p-1 div[style*="background-color: rgb(51, 127, 127)"] {
-    background-color: rgb(51, 127, 127) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(25, 76, 127)"],
-.p-1 div[style*="background-color: rgb(25, 76, 127)"] {
-    background-color: rgb(25, 76, 127) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(51, 0, 127)"],
-.p-1 div[style*="background-color: rgb(51, 0, 127)"] {
-    background-color: rgb(51, 0, 127) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(127, 0, 127)"],
-.p-1 div[style*="background-color: rgb(127, 0, 127)"] {
-    background-color: rgb(127, 0, 127) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(0, 102, 76)"],
-.p-1 div[style*="background-color: rgb(0, 102, 76)"] {
-    background-color: rgb(0, 102, 76) !important;
-    border-width: 0px !important;
-}
-.col div[style*="background-color: rgb(51, 25, 0)"],
-.p-1 div[style*="background-color: rgb(51, 25, 0)"] {
-    background-color: rgb(51, 25, 0) !important;
-    border-width: 0px !important;
+.p-1 div {
+    border-color: rgb(185,185,185) !important;
 }
 .col div[style*="background-color: rgb(255, 255, 255)"],
 .p-1 div[style*="background-color: rgb(255, 255, 255)"] {
     background-color: rgb(255, 255, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(102, 102, 102)"],
 .p-1 div[style*="background-color: rgb(102, 102, 102)"] {
     background-color: rgb(102, 102, 102) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 128, 128)"],
 .p-1 div[style*="background-color: rgb(255, 128, 128)"] {
     background-color: rgb(255, 128, 128) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 179, 128)"],
 .p-1 div[style*="background-color: rgb(255, 179, 128)"] {
     background-color: rgb(255, 179, 128) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 255, 128)"],
 .p-1 div[style*="background-color: rgb(255, 255, 128)"] {
     background-color: rgb(255, 255, 128) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(128, 255, 128)"],
 .p-1 div[style*="background-color: rgb(128, 255, 128)"] {
     background-color: rgb(128, 255, 128) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(179, 255, 255)"],
 .p-1 div[style*="background-color: rgb(179, 255, 255)"] {
     background-color: rgb(179, 255, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(153, 204, 255)"],
 .p-1 div[style*="background-color: rgb(153, 204, 255)"] {
     background-color: rgb(153, 204, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(179, 128, 255)"],
 .p-1 div[style*="background-color: rgb(179, 128, 255)"] {
     background-color: rgb(179, 128, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 128, 255)"],
 .p-1 div[style*="background-color: rgb(255, 128, 255)"] {
     background-color: rgb(255, 128, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(128, 230, 204)"],
 .p-1 div[style*="background-color: rgb(128, 230, 204)"] {
     background-color: rgb(128, 230, 204) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(247, 215, 196)"],
 .p-1 div[style*="background-color: rgb(247, 215, 196)"] {
     background-color: rgb(247, 215, 196) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(204, 204, 204)"],
 .p-1 div[style*="background-color: rgb(204, 204, 204)"] {
     background-color: rgb(204, 204, 204) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(51, 51, 51)"],
 .p-1 div[style*="background-color: rgb(51, 51, 51)"] {
     background-color: rgb(51, 51, 51) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 0, 0)"],
 .p-1 div[style*="background-color: rgb(255, 0, 0)"] {
     background-color: rgb(255, 0, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 102, 0)"],
 .p-1 div[style*="background-color: rgb(255, 102, 0)"] {
     background-color: rgb(255, 102, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 255, 0)"],
 .p-1 div[style*="background-color: rgb(255, 255, 0)"] {
     background-color: rgb(255, 255, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(0, 255, 0)"],
 .p-1 div[style*="background-color: rgb(0, 255, 0)"] {
     background-color: rgb(0, 255, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(102, 255, 255)"],
 .p-1 div[style*="background-color: rgb(102, 255, 255)"] {
     background-color: rgb(102, 255, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(51, 153, 255)"],
 .p-1 div[style*="background-color: rgb(51, 153, 255)"] {
     background-color: rgb(51, 153, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(102, 0, 255)"],
 .p-1 div[style*="background-color: rgb(102, 0, 255)"] {
     background-color: rgb(102, 0, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(255, 0, 255)"],
 .p-1 div[style*="background-color: rgb(255, 0, 255)"] {
     background-color: rgb(255, 0, 255) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(0, 204, 153)"],
 .p-1 div[style*="background-color: rgb(0, 204, 153)"] {
     background-color: rgb(0, 204, 153) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(142, 86, 46)"],
 .p-1 div[style*="background-color: rgb(142, 86, 46)"] {
     background-color: rgb(142, 86, 46) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(153, 153, 153)"],
 .p-1 div[style*="background-color: rgb(153, 153, 153)"] {
     background-color: rgb(153, 153, 153) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(0, 0, 0)"],
 .p-1 div[style*="background-color: rgb(0, 0, 0)"] {
     background-color: rgb(0, 0, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(127, 0, 0)"],
 .p-1 div[style*="background-color: rgb(127, 0, 0)"] {
     background-color: rgb(127, 0, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(127, 51, 0)"],
 .p-1 div[style*="background-color: rgb(127, 51, 0)"] {
     background-color: rgb(127, 51, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(127, 127, 0)"],
 .p-1 div[style*="background-color: rgb(127, 127, 0)"] {
     background-color: rgb(127, 127, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(0, 127, 0)"],
 .p-1 div[style*="background-color: rgb(0, 127, 0)"] {
     background-color: rgb(0, 127, 0) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(51, 127, 127)"],
 .p-1 div[style*="background-color: rgb(51, 127, 127)"] {
     background-color: rgb(51, 127, 127) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(25, 76, 127)"],
 .p-1 div[style*="background-color: rgb(25, 76, 127)"] {
     background-color: rgb(25, 76, 127) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(51, 0, 127)"],
 .p-1 div[style*="background-color: rgb(51, 0, 127)"] {
     background-color: rgb(51, 0, 127) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(127, 0, 127)"],
 .p-1 div[style*="background-color: rgb(127, 0, 127)"] {
     background-color: rgb(127, 0, 127) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(0, 102, 76)"],
 .p-1 div[style*="background-color: rgb(0, 102, 76)"] {
     background-color: rgb(0, 102, 76) !important;
-    border-width: 0px !important;
 }
 .col div[style*="background-color: rgb(51, 25, 0)"],
 .p-1 div[style*="background-color: rgb(51, 25, 0)"] {
     background-color: rgb(51, 25, 0) !important;
-    border-width: 0px !important;
-}
-.col-auto.disable-select table,
-.row.no-gutters.justify-content-between.disable-select {
-    background-color: rgb(49, 49, 49) !important;
 }
 
 ================================


### PR DESCRIPTION
This is for www. and not *. as legacy. exists

This is a drawing game - the colour palette gets modified by DarkReader, and on phone interface some dots appear with also same wrong colours for "border" on colour picker, so what you see isn't what you're drawing. This CSS fixes that and the same colours applies to .p-1 brushes preview. However, to avoid doubling the CSS, the "border-width: 0px" for colour picker squares on phone layout also applies to .p-1 brushes' DIVs, which makes the brushes borders invisible (already 1px), and adding a new ".p-1 div{border-width: 1px !important}" at the end doesn't override that. However, the brush preview should contrast enough with the dark bg which has been made sligthly clear (it was really dark and merged with the real BG and black brush preview).


This goes after trying `IGNORE INLINE STYLE` (no effect) and variables as `--darkreader-neutral-background`, etc. (still wrong palette colours)

The
> Dynamic mode supports ${COLOR} template, where COLOR is a color value before the inversion.
> Example: ${white} will become ${black} in dark mode.

...would be useful, but there's no way to simply tell DR to revert to the original colours, and we use many different ones, not standard colour names.

And this unfortunately doesn't exist yet.
https://github.com/darkreader/darkreader/issues/4144