### PR TITLE
Fix arcaea.lowiro.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2856,13 +2856,13 @@ img.lock
 img.line-dark
 
 IGNORE IMAGE ANALYSIS
-.memory-options .memory-select[data-v-6b2b4ba0]
-.memory-options .memory-select.deselected[data-v-6b2b4ba0]
-.memory-options .memory-select.disabled[data-v-6b2b4ba0]
-.memory-options .currency[data-v-6b2b4ba0]
-.memory-options .currency.deselected[data-v-6b2b4ba0]
-.memory-options .currency.disabled[data-v-6b2b4ba0]
-.memory-options .memory-select .selector[data-v-6b2b4ba0]
+.memory-options .memory-select[data-v-85bcc7aa]
+.memory-options .memory-select.deselected[data-v-85bcc7aa]
+.memory-options .memory-select.disabled[data-v-85bcc7aa]
+.memory-options .currency[data-v-85bcc7aa]
+.memory-options .currency.deselected[data-v-85bcc7aa]
+.memory-options .currency.disabled[data-v-85bcc7aa]
+.memory-options .memory-select .selector[data-v-85bcc7aa]
 .logout-button[data-v-59affef8]
 .memories .memories-purchase[data-v-2634d0c1]
 img.footer-logo


### PR DESCRIPTION
Fix the purchase page after Lowiro update their website. Previous fix of this site can be found by searching `arcaea` in closed PRs.

I believe this website is built using Vue or a similar tool, and darkreader uses the `[data-v-]` attribute in the stylesheet to modify styles. I wonder if there is a way to fix this without using the `[data-v]` attribute but still allow darkreader to apply the fix. If this cannot be done, constantly manually updating the fix will be a significant burden for maintenance.