### PR TITLE
bahaiteachings.org fixes for 404 page and mobile header

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3619,6 +3619,14 @@ CSS
 .author-page-bg {
     background: var(--darkreader-neutral-background) !important;
 }
+img[src*="404-img"] {
+    visibility: hidden;
+}
+@media (max-width: 1023.5px) {
+    .header__mobile {
+        background: var(--darkreader-neutral-background);
+    }
+}
 
 ================================
 


### PR DESCRIPTION
Removed background from 404 page ([example](https://bahaiteachings.org/how-being-a-bahai-deepened-my-definition-of-interfaith-relations/An%20Interfaith%20Wisdom%20Dialogue%20on%20COVID-19))
Neutralized mobile header background