### PR TITLE
Fix for nature.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21794,6 +21794,8 @@ INVERT
 nature.com
 
 INVERT
+.c-header__item--dropdown-menu > a[aria-expanded="false"] > svg
+.c-header__link--search[aria-expanded="false"] > svg
 .c-header__logo
 [href="#search-menu"] > svg
 .c-header__link--chevron > svg


### PR DESCRIPTION
Fixes navigation bar.

Before:
<img width="700" height="66" alt="1" src="https://github.com/user-attachments/assets/fc2a182d-e72d-40b2-b6ee-da7cb49d7312" />

After:
<img width="700" height="66" alt="2" src="https://github.com/user-attachments/assets/ef06fcdd-2da3-4e93-8920-0ad54d56e2d7" />