### PR TITLE
Added a dark website which got disturbed when the Darkreader applied.

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1277,3 +1277,4 @@ zt64.github.io
 ztdp.ca
 zunivers.zerator.com
 zyrenth.dev
+element.io


### PR DESCRIPTION
In this  "https://element.io "  website darkreader should not be applied because it is already a dark website  but darkreader is 

applicable for this website and icon's of website got disappeared when we apllied the darkreader.