### PR TITLE
Fix for fire.ca.gov

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11783,11 +11783,13 @@ INVERT
 fire.ca.gov
 
 CSS
+.hero-banner__bg:after,
 .page-header__bg:after {
-    border-bottom-color: transparent !important;
+    border-bottom-color: var(--darkreader-neutral-background) !important;
 }
+.hero-banner__bg:before,
 .page-header__bg:before {
-    border-left-color: transparent !important;
+    border-left-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
Fixes background on incident pages.

Before:
<img width="700" height="429" alt="1" src="https://github.com/user-attachments/assets/821cf180-5de9-4cc0-abb9-3d08c0d8f517" />

After:
<img width="700" height="429" alt="2" src="https://github.com/user-attachments/assets/3f0d548c-293f-4e44-916b-ea245bd44757" />