### PR TITLE
chore: add draftbot.fr, draftbot.gg and koya.gg

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -3,10 +3,13 @@
 *.cncnet.org
 *.comfig.app
 *.curseforge.com
+*.draftbot.fr
+*.draftbot.gg
 *.furaffinity.net
 *.hadesblack.com
 *.iaas.store
 *.iaasdev.ru
+*.koya.gg
 *.mastercomfig.com
 *.newgrounds.com
 *.paydaythegame.com
@@ -362,7 +365,6 @@ dota2.ru
 dotabuff.com
 dotapicker.com
 draculatheme.com
-draftbot.fr
 dragonage-game.de
 drakewars.com
 drewj.la


### PR DESCRIPTION
- moved `draftbot.fr` to wildcard list
- add `*.draftbot.gg` to wildcard list (localized domain)
- add `koya.gg` to the list