### PR TITLE
Fix for wwww.septa.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27894,10 +27894,12 @@ div[aria-label$="stars"]
 ================================
 
 septa.org
+wwww.septa.org
 
 INVERT
 .checked > label > div > .switch-marker
 .clear-btn
+.kt-blocks-accordion-icon-trigger
 .leaflet-control-attribution
 .leaflet-popup
 .listbox-row[role="presentation"] > svg-icon


### PR DESCRIPTION
Fixes collapsible sections on some bulletin pages.

Before:
<img width="458" height="425" alt="1" src="https://github.com/user-attachments/assets/14a20b07-ba48-44b1-9fdf-53723ea80503" />
<img width="700" height="431" alt="2" src="https://github.com/user-attachments/assets/8dfddede-6769-42c0-b598-e8b0cadd743b" />

After:
<img width="458" height="425" alt="3" src="https://github.com/user-attachments/assets/3bf57ce8-e40e-4433-8f98-c9d90bf98e7d" />
<img width="700" height="431" alt="4" src="https://github.com/user-attachments/assets/c80efc92-d5c7-4746-a8e8-dcc790c96cfe" />