### PR TITLE
Fix for joc.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16335,6 +16335,27 @@ CSS
 
 ================================
 
+joc.com
+
+INVERT
+header img
+
+CSS
+div[data-cy="welcome-section"] div {
+    mix-blend-mode: normal !important;
+}
+.chartdiv {
+    filter: brightness(0.5) !important;
+}
+
+IGNORE INLINE STYLE
+.chartdiv *
+
+IGNORE IMAGE ANALYSIS
+.chartdiv *
+
+================================
+
 joemonster.org
 
 INVERT


### PR DESCRIPTION
Fixed header logo, image in main section and charts on joc.com

Before:
<img width="1275" height="725" alt="image" src="https://github.com/user-attachments/assets/6335dfd7-9929-4f60-a5af-1b6810d366d1" />
<img width="1155" height="726" alt="image" src="https://github.com/user-attachments/assets/c5f4943b-8c03-41c9-86c1-d219ec264fb3" />


After:
<img width="1296" height="737" alt="image" src="https://github.com/user-attachments/assets/e4f195a5-8d61-4b6f-a5e1-8d90fce9599b" />
<img width="1158" height="736" alt="image" src="https://github.com/user-attachments/assets/622b4e10-35bb-4923-97dd-10988a54562b" />
