### PR TITLE
Fix for battlelog BF3 in dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3815,6 +3815,7 @@ INVERT
 table.common-table > thead > tr > th
 .leaderboard-venice-specific > thead > tr > th
 #selected-server-settings .selected-server-setting
+.assignments_list .progress_bar
 .sodaSlider-arrow-left
 .sodaSlider-arrow-right
 
@@ -3842,6 +3843,13 @@ CSS
 }
 #selected-server-settings .selected-server-setting {
     color: ${#888} !important;
+}
+.assignments_details li {
+    background-blend-mode: soft-light !important;
+}
+#assignments-progress a {
+    background-blend-mode: soft-light !important;
+    background-color: ${#e8e8e8} !important;
 }
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
Fixed Assignments Overview section colors, Assignments List progress bar and Assignments Details progress bars.
I confirm that the page still looks correct in an original / light mode.

Before the fix:  
<img width="1287" height="516" alt="Screenshot From 2025-08-18 13-36-35" src="https://github.com/user-attachments/assets/e098373c-7888-401b-9487-d5a49e8a00c9" />

After the fix:  
<img width="1287" height="516" alt="Screenshot From 2025-08-18 13-36-24" src="https://github.com/user-attachments/assets/6e3278bb-b163-416a-abf5-6d82c566ea64" />
