### PR TITLE
[swagger.emby.media] (emby media server api swagger UI), invert svg, banner color

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30119,6 +30119,20 @@ code {
 
 ================================
 
+swagger.emby.media
+
+INVERT
+svg.arrow
+svg.locked
+button.close-modal
+div.view-line-link
+
+CSS
+.swagger-ui select {
+    background: ${#f7f7f7} url("data:image/svg+xml;charset=utf-8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\"><path fill=\"white\" d=\"M13.418 7.859a.695.695 0 0 1 .978 0 .68.68 0 0 1 0 .969l-3.908 3.83a.697.697 0 0 1-.979 0l-3.908-3.83a.68.68 0 0 1 0-.969.695.695 0 0 1 .978 0L10 11l3.418-3.141z\"/></svg>") right 10px center no-repeat !important;
+}
+
+================================
 swiatrolnika.info
 
 INVERT


### PR DESCRIPTION
the banner was the same color as the background.
the SVG down arrow to uncollapse were black, same as the locks and close modal x. the `.view-line-link` is set on a button to copy to clipboard, inverted looks better IMO.

the CSS is for the down arrow of a select box.
i had to copy paste the SVG used by the original CSS and add the `fill="white"`. it now appears bigger, and I don't know why, nor do I care enough to know why. originally it was set to `background-image: url("blob:http://swagger.emby.media/eb40c362-ec66-409d-88a4-958bf5380c22");`, which means I can't modify it, or give some selector for an element, since it isn't one.

NOTE: to actually get something shown to which these rules apply, you'd need to enter the (probably locally hosted) URL of an [emby](https://emby.media/) server.