### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20385,7 +20385,6 @@ INVERT
 .animated-hero-media
 .section-master .section-master__image .ocr-img img:not(#mainContent > div > div > div > div.secondary-sticky-nav.aem-GridColumn.aem-GridColumn--default--12 > div.scrollspy-container > div:nth-child(9) > div > div > div.section-master__image > div > img)
 
-
 CSS
 #announce picture + div h3,
 #announce picture + div p,

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20359,6 +20359,8 @@ INVERT
 .carousel-inner .card-background
 .key-message .card-background
 .animated-hero-media
+.section-master .section-master__image .ocr-img img:not(#mainContent > div > div > div > div.secondary-sticky-nav.aem-GridColumn.aem-GridColumn--default--12 > div.scrollspy-container > div:nth-child(9) > div > div > div.section-master__image > div > img)
+
 
 CSS
 #announce picture + div h3,


### PR DESCRIPTION
Updated the configuration to include the CSS selector targeting the bright master images on microsoft.com within the invert section of the microsoft.com entry, excluding the blue master image to prevent inversion from enhancing its brightness.