### PR TITLE
Fix for libreoffice.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18075,6 +18075,15 @@ footer::before
 
 ================================
 
+libreoffice.org
+
+CSS
+a > .green {
+    color: #00A500 !important;
+}
+
+================================
+
 libretexts.org
 
 CSS


### PR DESCRIPTION
Fixes icons on home page.

Before:
<img width="700" height="228" alt="1" src="https://github.com/user-attachments/assets/2d525f69-e0b9-4096-bf56-c646790fb809" />

After:
<img width="700" height="228" alt="2" src="https://github.com/user-attachments/assets/d0285f4e-73a2-4d9b-ab57-b55cb7c0a245" />