### PR TITLE
Remove bg from help.ubuntu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14427,6 +14427,7 @@ div,
 td,
 tt,
 pre {
+    background: none;
     font-size: 100% !important;
 }
 div#username,


### PR DESCRIPTION
Remove awkward speckled background from help.ubuntu.com.  Closes #13842.