### PR TITLE
Fix for docs.google.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -599,6 +599,9 @@ INVERT
 div[title="Profile"]
 .kix-embeddedobject-image
 
+NO INVERT
+a[dir="auto"] > img[alt="Google"]
+
 ================================
 
 docs.microsoft.com


### PR DESCRIPTION
Fixes logo on forms.

Before:
<img width="640" height="218" alt="1" src="https://github.com/user-attachments/assets/027e3369-1f96-49a1-b057-8938dbd864ea" />

After:
<img width="640" height="218" alt="2" src="https://github.com/user-attachments/assets/6179d648-2dbc-4764-8b0a-8ead5739223a" />