### PR TITLE
Tweaks for PCGamesN.com (text and link colors)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24169,6 +24169,29 @@ path
 
 ================================
 
+pcgamesn.com
+
+CSS
+article a.text_link,
+.entry-meta.end-of-post a,
+.article_affiliate_disclaimer a {
+    background-image: none !important;
+    color: var(--primary-color) !important;
+    text-decoration: none !important;
+}
+[data-darkreader-scheme="dimmed"] article a.text_link,
+[data-darkreader-scheme="dimmed"] .entry-meta.end-of-post a,
+[data-darkreader-scheme="dimmed"] .article_affiliate_disclaimer a {
+    filter: brightness(0.6) saturate(2) !important;
+}
+article p,
+aside li a,
+.article_affiliate_disclaimer {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 pcgamingwiki.com
 
 INVERT


### PR DESCRIPTION
Added some readability tweaks for PCGamesN.com, such as:

- Making light mode text more readable by increasing contrast
- Making main article links more visible using the site's own primary color instead of the nearly-invisible underline

## Original (Dark Reader Disabled)
![Hollow Knight Silksong Hunter’s March bench location -  September 08 @ 07-59-35 AM](https://github.com/user-attachments/assets/0d8b3e96-0626-436a-aa2d-e010c5159d6e)

## Dark

| Before          |  After |
| --- | --- |
![Dark - Before](https://github.com/user-attachments/assets/6db4525e-4134-4303-b5f3-37494e1177d5) | ![Dark - After](https://github.com/user-attachments/assets/20c89d34-d790-4143-bc8f-e806479b7ec9)

## Light

| Before          |  After |
| --- | --- |
![Dimmed - Before](https://github.com/user-attachments/assets/809e0435-b15c-42c9-9476-e2ac6d93d443) | ![Dimmed - After](https://github.com/user-attachments/assets/a97b91ba-43e4-4b98-8728-91c46b8d2270)

