### PR TITLE
Update theguardian.com crosswords

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30894,8 +30894,8 @@ theguardian.com
 INVERT
 a[data-sponsor="guardian.org"]
 a[data-sponsor="open society foundations"]
-div[data-link-name="Crosswords"] .crossword__cell-number
-div[data-link-name="Crosswords"] .crossword__cell-text
+div[data-link-name="Crosswords"] input
+div[data-link-name="Crosswords"] text
 section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
 section[data-component="headlines"] .dcr-d4xwbm > svg
 section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand texture"]


### PR DESCRIPTION
Guardian overhauled their crossword puzzle JS a while back. This makes the text and clue numbers visible again in Dark Mode.