### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27518,6 +27518,13 @@ ymaps[class$="ground-pane"]
 
 ================================
 
+scdsb.elearningontario.ca
+
+INVERT
+.my-activities
+
+================================
+
 schnucks.com
 
 CSS


### PR DESCRIPTION
Fixed the posts on the Activity Feed of the Simcoe County District Schoolboard version of D2L to appear dark.

Added the following code:

scdsb.elearningontario.ca

INVERT
.my-activities

================================