### PR TITLE
Add blog.velocifyer.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -171,6 +171,7 @@ blizzard.com
 blocks.pandadev.net
 blog.aractus.com
 blog.counter-strike.net
+blog.velocifyer.com
 blog.pixelexperience.org
 blox.link
 blueagle.top


### PR DESCRIPTION
This adds [blog.velocif](https://blog.velocifyer.com/Posts/0,1,2025-8-9,Firefox+is+falling+behind.html)[yer.com](https://blog.velocifyer.com/) to the dark list. 