### PR TITLE
Fix drop down menu items on d2l.lonestar.edu

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8077,6 +8077,15 @@ img[src$=".svg"]
 
 ================================
 
+d2l.lonestar.edu
+
+CSS
+.d2l-navigation-s-menu-item-root {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 daily.afisha.ru
 
 INVERT


### PR DESCRIPTION
fixed the background color of all drop down menu items. previously only some menu items had a dark background while other were white

Before:
<img width="212" height="446" alt="image" src="https://github.com/user-attachments/assets/0cbd4c09-7443-4148-86fc-940bffbfb10a" />

After:
<img width="214" height="461" alt="image" src="https://github.com/user-attachments/assets/6d3df598-fd0f-4e0a-85e2-d4a90175c2a8" />
