### PR TITLE
fix: improved detector hint for github.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -377,6 +377,7 @@ TARGET
 html
 
 MATCH
+[data-color-mode="auto"]
 [data-color-mode="dark"]
 
 ================================


### PR DESCRIPTION
When `data-color-mode` set to `auto`, we expect the website to have a native dark mode.