### PR TITLE
Update inversion-fixes.config for Google Street View

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1054,6 +1054,7 @@ INVERT
 .irc_bg
 .RY3tic
 canvas.circle
+div.iBPHvd[aria-label="Street View"]
 #app-container.vasquette.app-imagery-mode .widget-scene-canvas
 #app-container.vasquette.app-globe-mode .widget-scene-canvas
 


### PR DESCRIPTION
Finally resolving Filter inversion on Google Street View!

Before:
<img width="865" height="619" alt="screenshot-2025-09-20_10-google-street-view-darkreader-fix-cropped-before" src="https://github.com/user-attachments/assets/67556f94-f8de-4174-bfb5-b03e9091292a" />

After:
<img width="868" height="625" alt="screenshot-2025-09-20_10-google-street-view-darkreader-fix-cropped-after" src="https://github.com/user-attachments/assets/2d5e7cae-2aab-4ae1-a45d-7899478d91f0" />
