### PR TITLE
Update dynamic-theme-fixes.config (color-hex.com)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7165,6 +7165,26 @@ IGNORE INLINE STYLE
 .colordvaline
 .colordva
 .palettecolordiv
+.sp-val
+.sp-picker-container
+.sp-container
+.sp-thumb-inner
+.sp-preview-inner
+.sp-hue
+.colordivbig
+.hexcolor
+.red
+.green
+.blue
+.cyan
+.magenta
+.yellow
+.preview
+.previewbox
+td
+.wheel
+.overlay
+.colorwell
 
 ================================
 


### PR DESCRIPTION
Modified fix for color-hex.com by including additional elements to ignored style list to preserve their color accuracy