### PR TITLE
Invert math equation img on tutorialspoint.com in dynamic-theme-fixes…

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32018,6 +32018,7 @@ i.fal
 img.tp-logo
 button.slick-prev.slick-arrow::before
 button.slick-next.slick-arrow::before
+span.MathJax img
 
 ================================
 


### PR DESCRIPTION
….config

Letters/numbers/symbols in math equations on tutorialspoint.com, both inline and not-inline, are black images. 
Ref page with affected equations: https://www.tutorialspoint.com/modulation-property-of-fourier-transform 
Note for testing/reproduction: It might be something on my end, but the page actually loads with everything in the right color initially. After 10-15 seconds, all the math equations (besides the fraction bars for some reason) suddenly turn black. So when testing/reproducing, even if the equations look right when the page first loads, it'd be appreciated if it was double-checked that nothing changes in the next 20 seconds or so.