### PR TITLE
fix duden.de separator line staying black

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10107,6 +10107,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+duden.de
+
+INVERT
+.segment::before
+
+================================
+
 duo.google.com
 
 INVERT


### PR DESCRIPTION
example: https://www.duden.de/suchen/dudenonline/wort

before:
<img width="536" height="366" alt="image" src="https://github.com/user-attachments/assets/6832a0c5-63dd-4e15-8d1b-a217896d624a" />

after:
<img width="536" height="366" alt="image" src="https://github.com/user-attachments/assets/6d0fbc82-0511-4367-a6f5-f0d2ca66486a" />
