### PR TITLE
Fix cdc.gov map and legend

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6200,6 +6200,10 @@ INVERT
 .cdc-logo path[fill="#000"]
 img[src="/niosh/images/si-no-left-vp4.png"]
 
+IGNORE INLINE STYLE
+.map-container svg g
+.legend-item
+
 ================================
 
 cdimage.ubuntu.com


### PR DESCRIPTION
https://www.cdc.gov/nchs/state-stats/deaths/infant-mortality.html

Fixes page styling to look like image below

<img width="975" height="1108" alt="image" src="https://github.com/user-attachments/assets/014f6272-75ec-4628-a336-1478adb37532" />
