### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9625,6 +9625,8 @@ body[itemtype*="PresentationObject"] #docs-titlebar-share-client-button .scb-but
 g.punch-filmstrip-indicator > image
 .docs-gm .docos-icon-overflow-three-dots-size
 .docs-grille-gm3 .docs-sheet-status-avs .goog-flat-menu-button-dropdown
+.gb_Ha
+.gb_Id.gb_Ld.gb_Wd
 
 CSS
 .docs-preview-palette-item {


### PR DESCRIPTION
added 2 selectors that fix the top bar for google docs and sheets

Without fix

<img width="942" height="296" alt="image" src="https://github.com/user-attachments/assets/36d072d7-7fb0-4ae1-9152-72e22f814a60" />
<img width="940" height="338" alt="image" src="https://github.com/user-attachments/assets/79d383ca-bf88-426b-ada2-799f67503b16" />


With fix
<img width="950" height="304" alt="image" src="https://github.com/user-attachments/assets/8fc8d7e4-385b-4067-a2ed-8ee3a70d5582" />
<img width="940" height="340" alt="image" src="https://github.com/user-attachments/assets/99c7f65d-5411-4129-9f4a-33167f533eaf" />
