### PR TITLE
Fix for forum.qt.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12482,6 +12482,13 @@ a[data-mentionid],
 
 ================================
 
+forum.qt.io
+
+INVERT
+img[alt="Brand Logo"]
+
+================================
+
 forums.ankiweb.net
 
 CSS


### PR DESCRIPTION
Invert logo.

Before:
<img width="744" height="254" alt="image" src="https://github.com/user-attachments/assets/e5db2ca9-a8f1-4b16-83eb-b855683ddde2" />

After:
<img width="744" height="254" alt="image" src="https://github.com/user-attachments/assets/cd3db1b0-fce0-4b29-8a7b-1863ae1c27ff" />
