### PR TITLE
Fix for elon.io

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10756,6 +10756,15 @@ elle.com
 INVERT
 .css-lgctud .e1ccpyf90
 
+===============================
+
+elon.io
+
+CSS
+.hangmanchar {
+    color: var(--darkreader-neutral-text) !important;
+}
+
 ================================
 
 elp.northumbria.ac.uk


### PR DESCRIPTION
Answer input fields letters get treated like `--darkreader-text-00000000` instead of `--darkreader-neutral-text` causing the text to be barely visible against the dark background

Before:
<img width="227" height="147" alt="image" src="https://github.com/user-attachments/assets/7b345157-e208-46aa-b94b-3e355ee426da" />

After:
<img width="247" height="141" alt="image" src="https://github.com/user-attachments/assets/4ebd40c9-6007-4f01-a5dc-b9625da1fcc2" />
