### PR TITLE
Update dark-sites.config: add openingtree.com

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -848,6 +848,7 @@ onlyfors.com
 open.spotify.com
 opendota.com
 openemu.org
+openingtree.com
 openrazer.github.io
 openrgb.org
 orama-interactive.itch.io/pixelorama


### PR DESCRIPTION
https://github.com/darkreader/darkreader/issues/10757

Site is dark by default, though the chessboard is still broken with darkreader turned on, with all combinations of darkreader light/dark / site light/dark. Apologies for the mis-wording of previous commit, it's not "complete" because it's still broken