### PR TITLE
fix for openingtree.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23798,6 +23798,13 @@ IGNORE INLINE STYLE
 
 ================================
 
+openingtree.com
+
+IGNORE IMAGE ANALYSIS
+*
+
+================================
+
 openoffice.org
 
 INVERT


### PR DESCRIPTION
Switched off IGNORE IMAGE ANALYSIS on site.
Fixes black pieces mentioned in https://github.com/darkreader/darkreader/pull/14710