### PR TITLE
fix for chessprogramming.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6462,6 +6462,18 @@ INVERT
 .mw-parser-output div[class^='float'] > a > img:not(.thumbimage):not(.thumbborder)
 .mw-wiki-logo
 
+CSS
+table.fentt div.sq {
+    background-color: #FFCE9E !important;
+    color: #D18B47 !important;
+}
+table.fentt div.pcbg {
+    color: white !important;
+}
+table.fentt div.pcfg {
+    color: black !important;
+}
+
 IGNORE IMAGE ANALYSIS
 .mw-wiki-logo
 


### PR DESCRIPTION
Undo incorrect board colors inversion
https://www.chessprogramming.org/Forsyth-Edwards_Notation#Samples

Screenshots:
<img width="569" height="315" alt="image" src="https://github.com/user-attachments/assets/9085574a-ce83-4192-86ec-762f4f385db9" />
<img width="561" height="318" alt="image" src="https://github.com/user-attachments/assets/0409f6d6-2459-4ca9-a177-6d445f2787ee" />
