### PR TITLE
Fix for qr codes ending with qr-code.png

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9,6 +9,7 @@ img.Wirisformula
 a[data-testid="headerMediumLogo"]>svg
 .d2l-navigation-link-image-container
 .d2l-iframe-loading-container
+img[src$="qr-code.png"]
 
 CSS
 .vimvixen-hint {


### PR DESCRIPTION
Invert all images where the img src attribute ends with the string "qr-code.png".