### PR TITLE
Add dark mode styles to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19255,6 +19255,10 @@ div[class*="bym"][role="navigation"],
 table {
     color: ${black} !important;
 }
+.gb_Dd.gb_Ed,
+.gb_3a.gb_H .gb_Dd.gb_Ed {
+    background: var(--darkreader-neutral-background);
+}
 
 IGNORE INLINE STYLE
 .at


### PR DESCRIPTION
Added styles for dark mode support in dynamic theme. Fixed background color of search bar in Gmail when selected to start typing.


Without fix:

<img width="1866" height="70" alt="Screenshot 2025-10-18 075120" src="https://github.com/user-attachments/assets/bcefa0ca-3f1d-4e9a-8f15-63fa15e2c596" />


With fix:
<img width="1858" height="60" alt="Screenshot 2025-10-18 075430" src="https://github.com/user-attachments/assets/d2bb1dd3-3e49-4c0d-8ad4-524efb62e159" />

