### PR TITLE
Fix for cruxvis.withgoogle.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7985,6 +7985,15 @@ INVERT
 
 ================================
 
+cruxvis.withgoogle.com
+
+CSS
+.input-wrapper {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 cryptostorm.is
 
 INVERT


### PR DESCRIPTION
[Example link](https://cruxvis.withgoogle.com/#/?view=cwvsummary&url=https%3A%2F%2Fblog.deepchirp.com%2F&identifier=origin&device=ALL&periodStart=0&periodEnd=-1&display=p75s). The text in the input box above is black and cannot be displayed properly in dark mode.

Before:

<img width="1920" height="951" alt="Screenshot 2025-10-23 at 11-18-17 CrUX Vis - Core Web Vitals" src="https://github.com/user-attachments/assets/c8df781c-f2da-4884-860e-a3d554a3f305" />

After:

<img width="1920" height="951" alt="Screenshot 2025-10-23 at 11-19-03 CrUX Vis - Core Web Vitals" src="https://github.com/user-attachments/assets/8e41ff36-b58e-4c01-9299-1916a9100fb7" />
