### PR TITLE
CSS fix for doctor.webmd.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9824,6 +9824,15 @@ CSS
 
 ================================
 
+doctor.webmd.com
+
+CSS
+.profile-topcard {
+    background: ${white} !important;
+}
+
+================================
+
 doctorswithoutborders.org
 
 INVERT


### PR DESCRIPTION
Fix for white background of top profile card

[Example page](https://doctor.webmd.com/doctor/kathleen-bagley-ae63a120-01f3-421e-84cc-0e29e686b1e8-overview)