### PR TITLE
fix for popup at dreamwidth.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -311,13 +311,13 @@ footer,
     background-image: none !important;
 }
 html[data-darkreader-scheme="dark"] #logo {
-    filter: invert(90%) hue-rotate(180deg);
+    filter: invert(90%) hue-rotate(180deg) !important;
 }
 html[data-darkreader-scheme="dimmed"] #logo {
-    filter: brightness(85%);
+    filter: brightness(85%) !important;
 }
 .ContextualPopup {
-    background: var(--darkreader-neutral-background);
+    background: var(--darkreader-neutral-background) !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
the popup background won't change when loading a page for the first time and only applies on refresh. adding !important to code increases consistency.

example can be seen here: https://dw-news.dreamwidth.org/44219.html

<img width="650" height="200" alt="Untitled-1" src="https://github.com/user-attachments/assets/7fe61b52-9d41-4470-b25e-23a3b498e2e7" />
<img width="650" height="200" alt="Untitled-2" src="https://github.com/user-attachments/assets/922d41a0-a998-4aad-adf4-ea03b525505d" />
