### PR TITLE
Remove arkenfox.github.io/TZP/ from dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -104,7 +104,6 @@ ard.social
 ardov.me
 ari.lt
 arialfx.com
-arkenfox.github.io/TZP/
 armaforces.com
 artixlinux.org
 artlist.io


### PR DESCRIPTION
Fix #14731