### PR TITLE
Add 'fulu.org' to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -485,8 +485,8 @@ freecodecamp.org/$
 freecodecamp.org/learn/
 freeipa.org
 frozensand.com
-funnyjunk.com
 fulu.org
+funnyjunk.com
 furry.engineer
 fusengine.github.io/apaxy-v2
 fv.pro


### PR DESCRIPTION
fulu.org only has dark theme on their website.