### PR TITLE
fix for docs.google.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9726,6 +9726,9 @@ input.docs-title-input {
 .gb_Ha.gb_1a.gb_Nd {
     background-color: var(--darkreader-neutral-background) !important;
 }
+header#gb {
+    background-color: var(--darkreader-bg--gm3-sys-color-surface-container-low, var(--darkreader-background-f8fafd, #1b1d1e)) !important;
+}
 
 IGNORE INLINE STYLE
 .cell-input > span


### PR DESCRIPTION
Fixed title ribbon color in docs.google.com homepage

Dark Reader Off
<img width="1899" height="76" alt="Screenshot 2025-11-02 142422" src="https://github.com/user-attachments/assets/ac0d0d49-45bb-4ee2-81ed-c02f54ce3dd3" />

Dark Reader On
<img width="1899" height="78" alt="Screenshot 2025-11-02 142352" src="https://github.com/user-attachments/assets/bfa01d62-002a-4157-bdf5-7f5c460e33da" />

Dark Reader With Patch
<img width="1904" height="78" alt="Screenshot 2025-11-02 142604" src="https://github.com/user-attachments/assets/67d2657a-5194-45ec-85e1-5af5a21f6f5f" />

Does not seem to break the light mode version of dark reader as well (similar to #14725)
