### PR TITLE
Add reflektclothing.co.uk to dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -961,6 +961,7 @@ razorsecure.com
 redasm.io
 redeclipse.net
 reelgood.com
+reflektclothing.co.uk
 relay.firefox.com/faq
 renderlab.net
 reniguide.carrd.co


### PR DESCRIPTION
Fix #14762