### PR TITLE
Fix for white header on Google Docs main pages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9735,6 +9735,11 @@ input.docs-title-input {
 .gb_Ha.gb_1a.gb_Nd {
     background-color: var(--darkreader-neutral-background) !important;
 }
+.gb_Md {
+    -webkit-transition: none;
+    background-color: var(--darkreader-neutral-background) !important;
+    transition: none;
+}
 
 IGNORE INLINE STYLE
 .cell-input > span


### PR DESCRIPTION
Fix for white header on Google Docs main pages:
https://docs.google.com/spreadsheets/u/0/
https://docs.google.com/document/u/0/
https://docs.google.com/presentation/u/0/
https://docs.google.com/videos/u/0/
https://docs.google.com/forms/u/0/