### PR TITLE
Fix for act.dsausa.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1393,6 +1393,19 @@ CSS
 
 ================================
 
+act.dsausa.org
+
+INVERT
+.dsa-sibd-logo
+.text--centered > .pure-img
+
+CSS
+.ak-page-header {
+    background-color: #ec1f27 !important;
+}
+
+================================
+
 action.com
 
 CSS


### PR DESCRIPTION
Fixes inconsistent and bright backgrounds on "Join Us" page.

Before:
<img width="250" height="208" alt="1" src="https://github.com/user-attachments/assets/17ea2b1e-9e5a-4339-86bf-145a46a73c05" />
<img width="250" height="132" alt="2" src="https://github.com/user-attachments/assets/b64c6474-02f4-445c-ad62-61b90deb4e8b" />

After:
<img width="250" height="208" alt="3" src="https://github.com/user-attachments/assets/f7e6c9e9-6659-4444-aa1d-67b5cfc6e9bc" />
<img width="250" height="132" alt="4" src="https://github.com/user-attachments/assets/39e0e24c-467c-4790-abaf-669c36f01889" />