### PR TITLE
Fix Instacart label colors

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15851,6 +15851,9 @@ CSS
 html[data-darkreader-scheme="dark"] button:not(:hover) {
     color: gray;
 }
+.e-im51v0 {
+    background-color: ${rgb(255, 255, 255)};
+}
 
 ================================
 


### PR DESCRIPTION
Fix button colors that incorrectly weren't being inverted by explicitly stating original color