### PR TITLE
Remove sitefixes for large fonts on wiki.debian.org and wiki.ubuntu.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8436,47 +8436,6 @@ body {
 .header-logged-out {
     background-color: transparent !important;
 }
-body,
-b,
-em,
-a,
-span,
-div,
-p,
-td,
-tt,
-pre {
-    font-size: 100% !important;
-}
-div#username,
-#breadcrumbs,
-#footer,
-div.tip,
-div.important,
-div.warning,
-div.note,
-div.trans-note {
-    font-size: 0.75em !important;
-}
-ul#credits * {
-    font-size: 1em !important;
-}
-h1 {
-    font-size: 1.8em !important;
-}
-h2 {
-    font-size: 1.4em !important;
-}
-.position-em.date-as-calendar .day {
-    font-size: 1.2em !important;
-}
-.position-em.date-as-calendar .month,
-.position-em.date-as-calendar .year {
-    font-size: 0.6em !important;
-}
-#pageinfo {
-    display: inherit !important;
-}
 
 IGNORE IMAGE ANALYSIS
 #splash h1
@@ -34693,61 +34652,6 @@ body,
 div.vectorTabs ul li.selected a,
 #searchInput::placeholder {
     color: var(--darkreader-neutral-text) !important;
-}
-
-================================
-
-wiki.ubuntu.com
-
-CSS
-body,
-b,
-em,
-a,
-span,
-div,
-td,
-tt,
-pre {
-    font-size: 100% !important;
-}
-div#username,
-#breadcrumbs,
-#footer,
-div.tip,
-div.important,
-div.warning,
-div.note,
-div.trans-note {
-    font-size: 0.75em !important;
-}
-ul#credits * {
-    font-size: 1em !important;
-}
-h1 {
-    font-size: 1.8em !important;
-}
-h2 {
-    font-size: 36px !important;
-}
-h3 {
-    font-size: 16px !important;
-}
-.position-em.date-as-calendar .day {
-    font-size: 1.2em !important;
-}
-p {
-    font-size: 13px !important;
-}
-#footer p {
-    font-size: 10px !important;
-}
-.position-em.date-as-calendar .month,
-.position-em.date-as-calendar .year {
-    font-size: 0.6em !important;
-}
-#pageinfo {
-    display: inherit !important;
 }
 
 ================================


### PR DESCRIPTION
Removing sitefixes fixed by Alexander's commit https://github.com/darkreader/darkreader/commit/a8783b72f11921286494a004d9bc92b3e2b75d55 and included from Dark Reader 4.9.115