### PR TITLE
Rectifying the fix for 2700chess.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -844,9 +844,6 @@ body {
 
 2700chess.com
 
-INVERT
-#live-ratings-table td *:not(.flag):last-child
-
 IGNORE IMAGE ANALYSIS
 .cg-wrap piece.rook.black
 .cg-wrap piece.knight.black


### PR DESCRIPTION
Removes incorrect inversion of 2700chess.com live ratings board table items.

The inversion fix that was committed some time ago (https://github.com/darkreader/darkreader/pull/13560) now seems to be break the correct inversion by darkreader