### PR TITLE
fix for minecraftitemids.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20844,6 +20844,22 @@ body,
 
 ================================
 
+minecraftitemids.com
+
+CSS
+.cc-tbl--full-color {
+    background-color: rgba(var(--col-rgb), 1) !important;
+    color: rgba(var(--col-rgb-text), 1) !important;
+}
+.cc-tbl--copy-row {
+    color: #444 !important;
+}
+.cc-tbl-copy-btn > svg {
+    fill: rgba(0, 0, 0, 0.4) !important;
+}
+
+================================
+
 minecraftskins.com
 
 CSS


### PR DESCRIPTION
Fix #14753 
Fixed color code table elements.
Before:
<img width="1134" height="572" alt="image" src="https://github.com/user-attachments/assets/e22a20e5-2560-4783-a676-da0f39b5abdf" />
After:
<img width="841" height="562" alt="image" src="https://github.com/user-attachments/assets/57901bc2-b560-4205-b12f-797b48f5e9ae" />
