### PR TITLE
Fix background image selector for login.microsoftonline.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18895,7 +18895,7 @@ CSS
 login.microsoftonline.com
 
 INVERT
-.backgroundImage
+div#backgroundImage
 
 ================================
 


### PR DESCRIPTION
previous selector did not work anymore