### PR TITLE
chore: fix koya.gg

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -694,6 +694,7 @@ knockout.chat
 kocowa.com
 kodenames.io
 korino.dev
+koya.gg
 krisoneil.com/home
 kristal.cc
 krunker.io


### PR DESCRIPTION
- add `koya.gg` to the list

(`*.koya.gg` is already present but does not support base site)