### PR TITLE
fix for mozillafoundation.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21414,7 +21414,7 @@ INVERT
 mozillafoundation.org
 
 CSS
-.moz-logoa {
+.moz-logo {
     background-image: url("https://assets.mofoprod.net/static/legacy_apps/_images/mozilla-on-black.9aed40133293.svg") !important;
 }
 


### PR DESCRIPTION
Fix selector (removed additional "a" which accidently appeared after needed one)