### PR TITLE
Fix for usps.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33061,14 +33061,33 @@ INVERT
 div[data-gtm-subsection="search"] > div > div > a > img
 img[src$="hamburger.svg"]
 img[src$="search.svg"]
+span.carousel-control-next-icon
+span.carousel-control-prev-icon
 ul.nav-list > li.menuheader::after
 ul.nav-list > li.qt-nav > div > ul > li > a > img
 #usps-logo
 
 CSS
-.jumbotron.premium.track-opt p a {
-    border: 1px solid var(--darkreader-text-ffffff) !important;
+a.button--primary {
+    background-color: ${#333366} !important;
+    border: 1px ${#333366} solid !important;
+    color: var(--darkreader-neutral-background) !important;
 }
+a.button--primary:hover {
+    background-color: ${#EDEDED} !important;
+    border: 1px ${#EDEDED} solid !important;
+    color: ${#333366} !important;
+}
+ol.carousel-indicators li {
+    border-color: ${#333366} !important;
+}
+ol.carousel-indicators li.active {
+    background-color: ${#333366} !important;
+}
+
+IGNORE IMAGE ANALYSIS
+span.carousel-control-next-icon
+span.carousel-control-prev-icon
 
 ================================
 


### PR DESCRIPTION
- Fixes carousel buttons on home page.
- Improves button visibility on most pages.
- Deletes outdated fix (introduced in #13620) for button visibility on home page.

Before:
<img width="350" height="171" alt="1" src="https://github.com/user-attachments/assets/43b70456-8f60-4351-9770-fe36662af8a1" />
<img width="350" height="100" alt="2" src="https://github.com/user-attachments/assets/ea2ea740-f68f-4697-a791-803383375c82" />

After:
<img width="350" height="171" alt="3" src="https://github.com/user-attachments/assets/3dca33c6-79d2-4703-8d1a-faf11024be80" />
<img width="350" height="100" alt="4" src="https://github.com/user-attachments/assets/fd47ff9e-390a-4f2a-968e-34d498988459" />