### PR TITLE
Add toolbrew.org to global whitelist

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1186,6 +1186,7 @@ tio.run
 title-case-converter.vercel.app
 tommytran.io
 toneden.io
+toolbrew.org
 toolscord.com
 top.gg
 tostories.app


### PR DESCRIPTION
Line 1189 at the time of adding to the list.