### PR TITLE
Fix invisible hamburger icon in new Crowdmark grading interface

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -2494,6 +2494,15 @@ INVERT
 
 ================================
 
+app.crowdmark.com
+
+CSS
+.grading-e-icon-button {
+    mix-blend-mode: normal;
+}
+
+================================
+
 app.daily.dev
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
Crowdmark has recently released a new beta grading interface, which has a minor compatibility issue with Dark Reader in dynamic mode.

Without fix:

<img width="278" height="50" alt="image" src="https://github.com/user-attachments/assets/d51e3b23-f926-47c1-a969-377ad1805d39" />

With fix:

<img width="275" height="48" alt="image" src="https://github.com/user-attachments/assets/f20631fa-c05e-445d-8cc5-68cac4bb2817" />

The original CSS styling from Crowdmark uses `mix-blend-mode: multiply`. The hover effect still works fine in dark mode without it.