### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31300,6 +31300,8 @@ theguardian.com
 INVERT
 a[data-sponsor="guardian.org"]
 a[data-sponsor="open society foundations"]
+div[data-gu-name="body"] div[data-testid="sign-in-gate-main"] > div > button > svg
+div[data-gu-name="body"] div[data-testid="sign-in-gate-main"] > div > svg
 div[data-link-name="Crosswords"] input
 div[data-link-name="Crosswords"] text
 section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
@@ -31350,12 +31352,12 @@ gu-island[name="StickyBottomBanner"] div > svg {
 gu-island[name="StickyBottomBanner"] div.dcr-bxrjkt > div {
     background-color: ${rgb(5, 41, 98)} !important;
 }
-header[data-component="header"] a[data-link-name="header : logo"] svg {
-    fill: var(--darkreader-text--masthead-nav-link-text) !important;
-}
-header[data-component="header"] .dcr-1nulcij {
+gu-island[name="TopBar"] span > a {
     background: rgb(255, 229, 0) !important;
     color: rgb(5, 41, 98) !important;
+}
+header[data-component="header"] a[data-link-name="header : logo"] svg {
+    fill: var(--darkreader-text--masthead-nav-link-text) !important;
 }
 header[data-component="header"] .dcr-b3mn8w {
     background-color: var(--masthead-veggie-burger-background) !important;


### PR DESCRIPTION
- Fixes graphics on sign-in gate on some article pages.
- Updates fix in #13789 for header on most pages.
  - Improves fix by relying less on generated class name.
  - Improves visibility and readability of "Support us" button on mobile view by using site-specific colors.

Before:
<img width="700" height="225" alt="1" src="https://github.com/user-attachments/assets/5651c091-ae4f-4471-a77b-64fe5bf84b8b" />
<img width="700" height="457" alt="2" src="https://github.com/user-attachments/assets/e4e67bf5-0f4d-405b-8cf6-9e2117ec2252" />

After:
<img width="700" height="225" alt="3" src="https://github.com/user-attachments/assets/60b66a25-673e-4f2d-b8c4-ae6d599d1b20" />
<img width="700" height="457" alt="4" src="https://github.com/user-attachments/assets/07bd5351-031e-4705-a538-9dc725e309b7" />