### PR TITLE
Added loaded.com to global list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -228,7 +228,6 @@ cascadr.co
 catvibers.me
 cc.com
 ccugame.app
-cdkeys.com
 cdn.minlor.net
 cdnnow.pro
 changelog.pandadev.net
@@ -728,6 +727,7 @@ listen.moe
 littlealchemy2.com
 livesplit.org
 liveweave.com
+loaded.com
 loadout.tf
 login.eveonline.com
 logseq.com


### PR DESCRIPTION
cdkeys.com now redirects to loaded.com, so I opted to remove the old domain, I hope that's fine.