### PR TITLE
Fix to D2L Content screen to remove background

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -176,7 +176,7 @@ d2l-empty-state-simple {
 .d2l-loading-spinner-wrapper svg circle {
     fill: var(--darkreader-neutral-background) !important;
 }
-.d2l-twopanelselector-side-bg.d2l-twopanelselector-side-sep {
+.d2l-twopanelselector-side.d2l-twopanelselector-side-sep {
     background: var(--darkreader-bg--d2l-color-mica) !important;
 }
 .d2l-le-TreeAccordionItem-anchor::before {


### PR DESCRIPTION
Remove background image / gradient from the left-side content navigation panel. Replaced with subtle (but still high-contrast) coloring using standard d2l color variables.