### PR TITLE
Invert and fix pdfViewer in hypothes.is (revised)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -410,6 +410,33 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+*.hypothes.is
+
+INVERT
+a[href="https://hypothes.is"] > svg[aria-labelledby="logo-title"] > g > path[fill-rule="nonzero"]
+img[class="fusion-standard-logo"]
+.pdfViewer .canvasWrapper
+
+CSS
+.pdfViewer .textLayer {
+    opacity: 1 !important;
+}
+.pdfViewer .hypothesis-highlight {
+    background-color: var(--darkreader-bg--highlight-color) !important;
+}
+.pdfViewer .hypothesis-shape-highlight {
+    border-color: rgba(128,128,128,0.3) !important;
+    outline: none !important;
+}
+.toolbarButton::before,
+.secondaryToolbarButton::before,
+.dropdownToolbarButton::after,
+.treeItemToggler::before {
+    background-color: var(--toolbar-icon-bg-color) !important;
+}
+
+================================
+
 *.iherb.com
 
 INVERT
@@ -15190,14 +15217,6 @@ CSS
 .p-navgroup-link--search {
     color: ${rgb(214, 210, 205)} !important;
 }
-
-================================
-
-hypothes.is
-
-INVERT
-a[href="https://hypothes.is"] > svg[aria-labelledby="logo-title"] > g > path[fill-rule="nonzero"]
-img[class="fusion-standard-logo"]
 
 ================================
 


### PR DESCRIPTION
Fixes need to apply to multiiple hosts, so switched to wildcard format. Fixed toolbar icons that were not displayed. I suppose not everyone wants the PDF Viewer inverted, but for me it's a severe accessibility issue. I also had to fix some really bad CSS issues (yellow on white with an opacity of 0.4 and alpha of 0.3 = TOTALLY INVISIBLE to me, even inverted). If it is possible to apply these only if the user has opted to invert PDF's, that may be desirable.