### PR TITLE
Add dynamic theme fix for learn.uwaterloo.ca

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18245,6 +18245,35 @@ d2l-list-item-generic-layout {
 
 ================================
 
+learn.uwaterloo.ca
+
+INVERT
+#ContentModuleTree .d2l-le-TreeAccordionItem.d2l-le-TreeAccordionItem-Selected > a.d2l-le-TreeAccordionItem-anchor:link::before
+.d2l-labs-navigation-link-image-container
+#viewerContainer
+
+CSS
+.d2l-box.d2l-box-h.d2l-twopanelselector-side.d2l-twopanelselector-side-sep.d2l-repsonsive-collapse-layout.d2l-twopanelselector-padding {
+    background: var(--darkreader-background-ffffff, #181a1b);
+}
+@media (max-width: 1000px) {
+    #ContentModuleTree .d2l-le-TreeAccordionItem.d2l-le-TreeAccordionItem-Selected > a.d2l-le-TreeAccordionItem-anchor:link::before {
+        background: var(--d2l-color-gypsum) !important;
+    }
+}
+* {
+    --d2l-count-badge-background-color: #242728;
+    --d2l-menu-background-color: var(--darkreader-background-ffffff, #181a1b);
+    --d2l-menu-background-color-hover: #002d41;
+    --d2l-menu-foreground-color-hover: #004489;
+    --d2l-popover-background-color: var(--darkreader-background-ffffff, #181a1b);
+}
+.d2l-page-header d2l-breadcrumbs::after {
+    display: none;
+}
+
+================================
+
 learn2.open.ac.uk
 
 CSS


### PR DESCRIPTION
Fixes some elements which retained their light mode backgrounds

There are some hard-coded hexcodes, but I found that the CSS variables didn't really work for those ones, if there's something else I should be using instead please let me know and I'll switch it over