### PR TITLE
Allow specifying `file:///` URIs inside Dev tools > Dynamic Theme Editor > Per Site Editor

### DIFF
--- a/src/ui/stylesheet-editor/components/body.tsx
+++ b/src/ui/stylesheet-editor/components/body.tsx
@@ -86,6 +86,7 @@ export default function Body({data, actions}: ExtWrapper) {
                     Reset changes
                     {dialog}
                 </Button>
+                <!--one of the functions triggered by this button caused `TypeError: can't access property "url", fix is undefined`-->
                 <Button onclick={apply}>Apply</Button>
             </div>
             <Overlay />


### PR DESCRIPTION
TL;DR: I commented what I want to fix in the source which is causing [this](https://postimg.cc/SnfJc5n3)



Here is an example:

```
mkdir -p ~/baf76686-ef9c-11f0-b6e5-8e390d695a9c && cd $_
wget "https://download.oracle.com/otn_software/java/jdk/25.0.1+8/2fbf10d8c78e40bd87641c434705079d/jdk-25.0.1_doc-all.zip"
unzip *
firefox docs/index.html
```

Dark mode for this site only works well with 'Static' mode, yet I want all other site to be in 'Dynamic' mode. Only way to do this seemed to be ` Dev tools > Dynamic Theme Editor > Per Site Editor`: actually you can get it done via GUI [like this](https://postimg.cc/ns1cQQP9), but that's hacky and hard to come up with (that special menu started appearing once I had opened `Dev tools` in a new window).

funnily enough, if in the same prompt we run

```
python -m http.server && firefox http://0.0.0.0:8000/
```

we can get around the `file://` problem as well.

The point is: if this is possible and could help some users, why don't we make the Dark Reader tool more flexible and allow `file://` URIs (or potentially others if that would be even better), instead of being in my opinion overly restrictive?

Not that I didn't get it to work in the end, this is mainly to help future users have to do less tinkering and access the feature more easily :)