### PR TITLE
Remove sober.vinegarhq.org from the global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1085,7 +1085,6 @@ smithed.net
 snazzah.com
 snoozing.com
 snowsta.mp
-sober.vinegarhq.org
 social.bund.de
 social.cologne
 social.saarland


### PR DESCRIPTION
I believe the website's design has updated so it's no longer dark by default.