### PR TITLE
Fix opensecrets.org (resolves #14933)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24019,6 +24019,13 @@ CSS
 
 ================================
 
+opensecrets.org
+
+INVERT
+.dc-header__logo
+
+================================
+
 openspeedtest.com
 
 CSS


### PR DESCRIPTION
Fix logo on opensecrets.org (resolves #14933)

Example page:
https://www.opensecrets.org/outside-spending/top_donors