### PR TITLE
Add fantasy.works to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -460,6 +460,7 @@ fakeupdate.net/wnc
 fakeupdate.net/xp
 fallout-area.de
 fandango.com
+fantasy.works
 fastro.dev
 fedidb.org
 filegarden.com


### PR DESCRIPTION
It's just a bird video. DR interfers with the text legibility.