### PR TITLE
Swordofsecrets

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30792,12 +30792,12 @@ swordofsecrets.com
 
 CSS
 .matrix-bg {
-    content-visibility: hidden !important;
+    display: none !important;
 }
 .title {
+    -webkit-background-clip: text;
     animation: none !important;
-    background: none !important;
-    color: var(--darkreader-selection-text) !important;
+    background-clip: text;
     text-shadow: none !important;
 }
 


### PR DESCRIPTION
Multiple readability issues:
* Scrolling matrix-inspired background text interferes with text legibility
* Title is ... all wrong

Example URL:
* https://swordofsecrets.com/mini-rv32ima.html

The fix sets the matrix-inspired background to not be visible, and overrides some properties on the title text so it appears clear.

<hr/>
<details><summary>Original non-dark site</summary>
<p>

<img width="537" height="93" alt="image" src="https://github.com/user-attachments/assets/47dbc58f-8e49-4013-ba54-d7d3c69615c6" />

Note: load live to appreciate.

</p>
</details> <hr/>
<details><summary>Without the fix</summary>
<p>

<img width="535" height="133" alt="image" src="https://github.com/user-attachments/assets/cc430cbc-8044-45cf-8a8f-a6d0d2800a06" />

</p>
</details> <hr/>
<details><summary>With the fix</summary>
<p>

<img width="586" height="143" alt="image" src="https://github.com/user-attachments/assets/307ce84a-9b6e-4b7c-b71b-0f83419eee17" />


</p>
</details> 

