### PR TITLE
Fix for windsurf.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -35191,6 +35191,13 @@ CSS
 
 ================================
 
+windsurf.com
+
+INVERT
+img[src*="windsurf-black-wordmark.svg"]
+
+================================
+
 winehq.org
 *.winehq.org
 


### PR DESCRIPTION
Invert logo for inner pages like https://windsurf.com/profile

Before:
<img width="726" height="326" alt="image" src="https://github.com/user-attachments/assets/68ee4aa8-b3c9-46a0-88e5-8bed00a6abd1" />

After:
<img width="726" height="326" alt="image" src="https://github.com/user-attachments/assets/b0592e9b-ce60-4ff3-a0a6-4cb9d5f12535" />
