### PR TITLE
Update douban.com with new rules

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -646,7 +646,11 @@ INVERT
 
 CSS
 .nav-search .inp input {
-    color: #000 !important;
+    background-color: var(--darkreader-neutral-text) !important;
+    color: var(--darkreader-neutral-background) !important;
+}
+#db-nav-movie {
+    background-color: ${#f0f3f5} !important;
 }
 
 ================================


### PR DESCRIPTION
Fixed the dark theme for the navigation bar and search box.

Website Examples:

[https://movie.douban.com/](https://movie.douban.com/)

[https://search.douban.com/movie/subject_search?search_text=%E8%91%AC%E9%80%81%E7%9A%84%E8%8A%99%E8%8E%89%E8%8E%B2&cat=1002](https://search.douban.com/movie/subject_search?search_text=%E8%91%AC%E9%80%81%E7%9A%84%E8%8A%99%E8%8E%89%E8%8E%B2&cat=1002)

[https://www.douban.com/](https://www.douban.com/)

[https://book.douban.com/](https://book.douban.com/)

[https://music.douban.com/](https://music.douban.com/)