### PR TITLE
Use website-themed link colors for The Verge

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31766,10 +31766,10 @@ INVERT
 
 CSS
 .duet--article--article-body-component p a {
-    color: #3cffd0 !important;
+    box-shadow: inset 0 -1px 0 0 ${#131313} !important;
 }
-.duet--content-cards--content-card p a {
-    color: #631aff !important;
+.duet--article--article-body-component p a:hover {
+    box-shadow: inset 0 -0.5em 0 0 ${#3cffd0} !important;
 }
 
 ================================


### PR DESCRIPTION
Currently, links are not highlighted when viewing articles on The Verge. The Verge uses a custom box-shadow, which Dark Reader seems to have an issue inverting. This CSS uses the box-shadow color and applies it directly to the font color, making links easily visible while maintaining the color scheme of the website.