### PR TITLE
jetbrains.com bi-colored product pages

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -36424,9 +36424,13 @@ www.jetbrains.com
 
 CSS
 span,
+#content :is(p, a, span[role], h1, h2, h3),
 [class^="_rs-text-2"],
 [data-test="main-submenu-column-title"] {
     color: var(--darkreader-neutral-text);
+}
+[type="button"] {
+    background-color: var(--_rs-button-background) !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
Fixes light-themed section text color inversion,
Retains button backgrounds (see e.g. https://www.jetbrains.com/pycharm/download)

Before
<img width="1860" height="1274" alt="image" src="https://github.com/user-attachments/assets/6c5d26eb-cf4c-459f-b367-b245c997016e" />

After
<img width="1860" height="1274" alt="Screenshot 2026-01-20 112313" src="https://github.com/user-attachments/assets/4589c0ca-0d7f-4e32-b099-e9facbec56b2" />
