### PR TITLE
Fix porcporc.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25555,13 +25555,11 @@ INVERT
 
 porcporc.com
 
-CSS
-.top-logo img,
-.search-trigger img,
-.header-account-link-customer img,
-.menu-logo img {
-    filter: brightness(0) invert(1) !important;
-}
+INVERT
+.top-logo img
+.search-trigger img
+.header-account-link-customer img
+.menu-logo img
 
 ================================
 


### PR DESCRIPTION
Fix not inverted imgs from the page header

Before:

<img width="2344" height="170" alt="image" src="https://github.com/user-attachments/assets/1d067f95-2b42-4219-b8c6-3d5cbe98196c" />

After:

<img width="2347" height="104" alt="image" src="https://github.com/user-attachments/assets/acf23633-b274-49ef-a7f4-a530d23a85ec" />
