### PR TITLE
fix douban

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -9995,6 +9995,26 @@ CSS
 
 ================================
 
+douban.com
+book.douban.com
+movie.douban.com
+music.douban.com
+search.douban.com
+
+INVERT
+.nav
+
+CSS
+body * {
+    color: var(--darkreader-neutral-text);
+    mix-blend-mode: normal;
+}
+.nav-search .inp input {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 downloads.khinsider.com
 
 CSS

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -635,19 +635,6 @@ INVERT
 
 ================================
 
-douban.com
-book.douban.com
-movie.douban.com
-music.douban.com
-search.douban.com
-
-CSS
-.nav-search .inp input {
-    color: #000 !important;
-}
-
-================================
-
 draw.io
 
 INVERT


### PR DESCRIPTION
Fix the issue where the Douban navigation bar styles were not inverted, as well as the text color issue on detail pages.

Website Examples:

[https://movie.douban.com/](https://movie.douban.com/)

[https://search.douban.com/movie/subject_search?search_text=%E8%91%AC%E9%80%81%E7%9A%84%E8%8A%99%E8%8E%89%E8%8E%B2&cat=1002](https://search.douban.com/movie/subject_search?search_text=%E8%91%AC%E9%80%81%E7%9A%84%E8%8A%99%E8%8E%89%E8%8E%B2&cat=1002)

[https://www.douban.com/](https://www.douban.com/)

[https://book.douban.com/](https://book.douban.com/)

[https://music.douban.com/](https://music.douban.com/)

