### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31482,6 +31482,7 @@ div.main_content {
 ================================
 
 theguardian.com
+interactive.guim.co.uk
 
 INVERT
 a[data-sponsor="guardian.org"]
@@ -31490,6 +31491,7 @@ div[data-gu-name="body"] div[data-testid="sign-in-gate-main"] > div > button > s
 div[data-gu-name="body"] div[data-testid="sign-in-gate-main"] > div > svg
 div[data-link-name="Crosswords"] input
 div[data-link-name="Crosswords"] text
+html > body > div > div > .artboard-light-mode > img
 section[data-component="documentaries"] a[href="https://www.theguardian.com/documentaries"] > svg
 section[data-component="headlines"] .dcr-d4xwbm > svg
 section[data-component="olympic-medal-table"] img[alt="Multi-coloured sand texture"]


### PR DESCRIPTION
Fixes map graphics on some article pages.

Before:
<img width="600" height="742" alt="1" src="https://github.com/user-attachments/assets/f0c1df2d-01c2-4ac9-92d3-2f05edc1fb08" />

After:
<img width="600" height="742" alt="2" src="https://github.com/user-attachments/assets/643e7050-bcbb-438c-a5c6-cebf1f66397c" />