### PR TITLE
Removed references to gsuite from other Google hosts

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6032,7 +6032,6 @@ calendar.google.com
 
 INVERT
 div[style*="gm_add_black"]
-img[src$="google_gsuite"]
 .wRfGxb > svg > path:first-child
 
 CSS
@@ -7679,7 +7678,6 @@ contacts.google.com
 
 INVERT
 img[src*="rotate"]
-img[src$="google_gsuite"]
 
 CSS
 img[src^="https://ssl.gstatic.com/social/contactsui/images/emptycontacts/emptycontacts_animation_"],
@@ -9727,7 +9725,6 @@ INVERT
 .share-butter-copy-icon
 .doc-previews-indicator-popover .docs-link-bubble-mime-icon
 img[src$="googlelogo_dark_clr_74x24px.svg"]
-img[src$="google_gsuite"]
 .exportUnderline
 .freebirdMaterialIconIconEl
 .quantumWizTogglePapercheckboxCheckMark
@@ -10044,7 +10041,6 @@ div[data-label="nd"] > div > div > svg > path[fill="#000000"]
 div[role="document"] > div[role="button"] .a-b-c
 div > svg > circle[fill="white"]
 img[src*="empty_state_trash"]
-img[src$="google_gsuite"]
 div[tabindex="-1"][role="toolbar"] > div > div > div > svg > path[d^="M10 18h4v-2h-4v2zM3"]
 button[class="ao-search-infolder ao-hint"]
 button[aria-checked="true"] > div > svg > path
@@ -17226,7 +17222,6 @@ CSS
 keep.google.com
 
 INVERT
-img[src$="google_gsuite"]
 .gb_hc
 
 ================================
@@ -19381,7 +19376,6 @@ INVERT
 .d-Na-N-M7-JX.d-Na-J3
 .ita-icon-0
 .ita-icon-1
-img[src$="google_gsuite"]
 img[src$="profile_mask2.png"]
 .rY>.sa
 .buh


### PR DESCRIPTION
Likely safe to remove all these given that gsuite is defunct.  You may want to verify, as I only performed a cursory verification, but it's likely safe.