### PR TITLE
Fix for consorsbank.de

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8301,6 +8301,21 @@ input[type=text] {
 
 ================================
 
+consorsbank.de
+
+CSS
+img[src="/content/dam/de-cb/editorial/Images/Teaser/090-Konto-Depot/010-Uebersicht/header-login-dropdown-sand.jpg"] {
+    display: none;
+}
+img[src="/content/dam/de-cb/editorial/Images/Teaser/090-Konto-Depot/010-Uebersicht/header-login-dropdown-sand-mobil.jpg"] {
+    display: none;
+}
+div.select-dropdown > select {
+    background-color: var(--darkreader-neutral-background);
+}
+
+================================
+
 consumerlab.com
 
 INVERT


### PR DESCRIPTION
Fixes two issues on the page, once logged in.

- Disabled pure white background images.
- Fixed white background color in dropdowns (with whiteish text).

The useless white background images are publicly accessible at least:

- https://www.consorsbank.de/content/dam/de-cb/editorial/Images/Teaser/090-Konto-Depot/010-Uebersicht/header-login-dropdown-sand.jpg
- https://www.consorsbank.de/content/dam/de-cb/editorial/Images/Teaser/090-Konto-Depot/010-Uebersicht/header-login-dropdown-sand-mobil.jpg