### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32769,12 +32769,6 @@ div[data-component="youtube-atom"] .dcr-1n5sax3 {
 div[data-component="youtube-atom"] .play-icon {
     background-color: rgba(18, 18, 18, 0.6) !important;
 }
-div[data-gu-name="media"] .dcr-ctvcrj,
-div[data-gu-name="standfirst"] .dcr-rruuos,
-main .dcr-1q3os16,
-main .dcr-pdifrs {
-    background-color: var(--star-rating-background) !important;
-}
 div[data-link-name="most popular"] .dcr-9rsbaa {
     background-color: var(--age-warning-background) !important;
     color: var(--age-warning-text) !important;
@@ -32805,9 +32799,12 @@ header[data-component="header"] a[data-link-name="header : logo"] svg {
 header[data-component="header"] .dcr-b3mn8w {
     background-color: var(--masthead-veggie-burger-background) !important;
 }
-main .dcr-1o2pyn8 {
+main div.dcr-e1ey7b {
     background-color: var(--pill-background) !important;
     color: var(--pill-text) !important;
+}
+main div.dcr-hxw8zi {
+    background-color: var(--star-rating-background) !important;
 }
 section[data-component="documentaries"] p {
     border-top: 1px solid #ffffff50 !important;


### PR DESCRIPTION
- Improves visibility of star ratings on "Reviews" page and some article pages by using site-specific colors.
  - Updates fix introduced in #14067.
  - Deletes outdated class names.
- Fixes "pill" graphic on video thumbnails on some article pages.
  - Updates fix introduced in #14067.
  - Also clarifies this fix to allow for easier identification and sorting.

Before:
<img width="700" height="394" alt="1" src="https://github.com/user-attachments/assets/68ca7478-5ad6-409b-9d95-85d76f4c23e0" />
<img width="700" height="412" alt="2" src="https://github.com/user-attachments/assets/1b9f0d20-15bf-4213-a885-09a87bbc01b1" />

After:
<img width="700" height="394" alt="3" src="https://github.com/user-attachments/assets/de394bc3-242f-449b-839c-d0508253aae4" />
<img width="700" height="412" alt="4" src="https://github.com/user-attachments/assets/4dc9ed9d-5200-4439-bd16-d15daf3a9ace" />