### PR TITLE
Fixes for BrickLink's Color Guide (v2)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -34687,7 +34687,7 @@ img[alt="BrickLink Logo"]
 
 CSS
 div[data-testid="feature-banner"][style] {
-    background: none !important;
+    --bl-castor-feature-banner-background: ${rgb(255, 213, 2)} !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
These fixes are intended to prevent Dark Reader from inadvertently styling color swatches in [BrickLink's Color Guide](https://v2.bricklink.com/en-us/catalog/color-guide).