### PR TITLE
changes for code blocks at modelrailroadforums.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22288,8 +22288,7 @@ pre {
     outline: none !important;
     padding: 0.5em !important;
 }
-[data-darkreader-scheme="dark"]
-code.bbCodeInline,
+[data-darkreader-scheme="dark"] code.bbCodeInline,
 pre {
     color: ${#00cc00} !important;
 }


### PR DESCRIPTION
Add new site, modelrailroadforums.com and CSS for code blocks.

See [this model railroad forum post by me](https://modelrailroadforums.com/forum/index.php?threads/i-love-this-forums-software-thank-you-bob.39190/post-667575)

<img width="1235" height="866" alt="dark-reader-off" src="https://github.com/user-attachments/assets/2544d3c3-025f-4fb3-b677-75014f8a8c3a" />
<img width="1236" height="874" alt="dark-reader-light-theme" src="https://github.com/user-attachments/assets/9bda42cb-ae6e-451d-ab8c-0461c5846f46" />
<img width="1242" height="851" alt="dark-reader-dark-theme" src="https://github.com/user-attachments/assets/33aefe09-e1b5-4c22-bc98-51404bf28903" />
