### PR TITLE
Add venturebanners.co.uk as already-dark

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1232,6 +1232,7 @@ ussr.obys.agency
 v3.wttr.in
 vanillatweaks.net
 vcjhwebdev.github.io/useless-translator/
+venturebanners.co.uk
 victordarras.fr/cssgame
 vid.puffyan.us
 viddit.red


### PR DESCRIPTION
Just adding our site as an already-dark site to the list.