### PR TITLE
Add inversion rules for Mimecast logo and header icon

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21994,6 +21994,14 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+mimecast.com
+
+INVERT
+img[alt="Mimecast Logo"]
+.header__hamburger-icon
+
+================================
+
 mindfactory.de
 
 INVERT


### PR DESCRIPTION
The Mimecast logo (`img[alt="Mimecast Logo"]`) and hamburger menu icon (`.header__hamburger-icon`) are nearly invisible in dark mode due to being dark-colored already. 

Added **INVERT** rules for both elements to restore visibility. Mimecast uses a white version of their logo in other contexts (e.g., https://login.mimecast.com/), so inverting to white is consistent with their own branding.

### Before
<img width="585" height="351" alt="image" src="https://github.com/user-attachments/assets/4b34b9a6-7c14-41f7-9573-f1f54f43f3fc" />

### After
<img width="585" height="352" alt="image" src="https://github.com/user-attachments/assets/529e2623-167a-4546-85ff-1b125c23d064" />
