### PR TITLE
Fix links and support card on upcloud.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -34484,12 +34484,7 @@ a.permalink {
     box-shadow: 0 -12px 16px var(--darkreader-neutral-background) !important;
 }
 .support-card {
-    background-image: linear-gradient(
-    254deg,
-    #961114 -14.82%,
-    #7b00ff 50.93%,
-    #2e045d 108.08%
-  ) !important;
+    background-image: linear-gradient(254deg, #961114 -14.82%, #7b00ff 50.93%, #2e045d 108.08%) !important;
 }
 .support-card .button-white:hover {
     background-color: rgba(255, 255, 255, 0.85) !important;


### PR DESCRIPTION
Gradients on various links caused them to completely disappear unless hovered on. "Scroll to top" link has a shadow that stayed white when in dark mode making it look hideous. And the support card gradient was unnecessarily stripped, looks good as is on both light and dark modes.