### PR TITLE
fix: background of dark images for louis.* and louis-moto.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19562,6 +19562,16 @@ CSS
 
 ================================
 
+louis.*
+louis-moto.*
+
+CSS
+.product-image {
+    mix-blend-mode: normal !important;
+}
+
+================================
+
 lovekrakow.pl
 
 INVERT


### PR DESCRIPTION
before:
<img width="897" height="351" alt="image" src="https://github.com/user-attachments/assets/34ff62d4-91c7-4184-be19-aefa77647f98" />

after:
<img width="864" height="361" alt="image" src="https://github.com/user-attachments/assets/7ece4866-a969-43e9-ac2d-a1be1487e6a9" />
