### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32077,6 +32077,9 @@ div[data-link-name="most popular"] .dcr-9rsbaa {
     background-color: var(--age-warning-background) !important;
     color: var(--age-warning-text) !important;
 }
+div[role="progressbar"] > span {
+    background-color: var(--video-progress-bar-value) !important;
+}
 gu-island[name="SlotBodyEnd"] div[id="slot-body-end"] div > section {
     border-top-color: rgb(255, 229, 0) !important;
 }


### PR DESCRIPTION
Fixes video progress bars on home page.

Before:
<img width="700" height="381" alt="1" src="https://github.com/user-attachments/assets/f51bcfe4-e365-450e-8aa0-eea0e204eb28" />

After:
<img width="700" height="381" alt="2" src="https://github.com/user-attachments/assets/41087636-3959-4256-b818-d99e7af23bae" />