### PR TITLE
Remove INVERT and .chakra-image styles from rakuten.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27030,9 +27030,6 @@ body {
 rakuten.com
 *.rakuten.com
 
-INVERT
-.chakra-image
-
 CSS
 span[class*="Checkbox_checkmark"]::after {
     border-color: rgb(207, 203, 201) !important;


### PR DESCRIPTION
Removed INVERT and .chakra-image styles from dynamic theme fixes from rakuten.com