### PR TITLE
Add sub-domain support for baobun.dev in dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1,4 +1,3 @@
-*.baobun.dev
 *.cases.gg
 *.clash.gg
 *.cncnet.org
@@ -128,6 +127,7 @@ badboybill.com
 badlion.net
 baldursgate3.game
 banfeed.com
+baobun.dev
 based.cooking
 battle.net
 battlefieldtracker.com
@@ -302,6 +302,7 @@ darkmodelist.com
 darkmodesites.com
 darkreader.org
 dartpad.dev
+dash.baobun.dev
 dashy.to
 datomatic.no-intro.org
 davros.netlify.app
@@ -362,6 +363,7 @@ distrobox.it
 djflame.tech
 dlive.tv
 docs.adonisjs.com
+docs.baobun.dev
 docs.gofiber.io
 docs.quad9.net
 docs.rs


### PR DESCRIPTION
This is added as baobun.dev has multiple sub-domains (dash.baobun.dev and docs.baobun.dev) which are all dark mode by default. Previously, only baobun.dev was in this list, which only worked on the main site.