### PR TITLE
Fix for rosettacode.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27971,6 +27971,25 @@ CSS
 
 ================================
 
+rosettacode.org
+
+INVERT
+.mwe-math-fallback-image-inline
+
+CSS
+.wrong-element-colors {
+    background-color: ${white} !important;
+    color: ${black} !important;
+}
+
+IGNORE INLINE STYLE
+.color-picker
+
+IGNORE IMAGE ANALYSIS
+.logo
+
+================================
+
 roskomsvoboda.org
 
 INVERT


### PR DESCRIPTION
This is a fix for Issue #15042

Before:
<img width="1001" height="658" alt="Screenshot 2026-02-23 112002" src="https://github.com/user-attachments/assets/c16d380c-5cc7-406b-bf83-90f3154eabab" />


After:
<img width="978" height="738" alt="Screenshot 2026-02-23 111803" src="https://github.com/user-attachments/assets/9e29fd9a-f243-4f5a-b51a-0b5b22522c4d" />
