### PR TITLE
Add dynamic theme fixes for new domain (support.simplywall.st)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31103,6 +31103,13 @@ div.sumo-nav--logo
 
 ================================
 
+support.simplywall.st
+
+INVERT
+.logo img
+
+================================
+
 surfboard.com
 
 INVERT


### PR DESCRIPTION
Addressing issue report #15041 that the website logo is invisible on dark background. Added the domain support.simplywall.st along with INVERT .logo img. Tested with dev tools

Screenshot without Dark Reader enabled:
<img width="1094" height="339" alt="image" src="https://github.com/user-attachments/assets/48c7ed2c-767c-45ef-8f84-25ccf863a572" />

With DR enabled (pre-fix):
<img width="1156" height="347" alt="image" src="https://github.com/user-attachments/assets/ae764c71-4a69-4f31-8d5f-496e6324064b" />

After fix:
<img width="1102" height="350" alt="image" src="https://github.com/user-attachments/assets/f8d87528-9715-46c8-ae94-8a4d1d0bf401" />


