### PR TITLE
fixes on CompTIA practice site

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -18685,6 +18685,13 @@ INVERT
 
 ================================
 
+learn.comptia.org
+
+INVERT
+.logo-item
+
+================================
+
 learn.inside.dtu.dk
 
 INVERT
@@ -35988,6 +35995,14 @@ CSS
 
 IGNORE INLINE STYLE
 .goog-te-gadget-simple > span > a > span
+
+================================
+
+wmx-api-production.s3.amazonaws.com
+
+INVERT
+g
+img
 
 ================================
 


### PR DESCRIPTION
- fixed logo, looked washed out
- fixed iframe inversion on the practice assessment for PBQ (performance-based questions) hosted on AWS S3, may need further fixes for image overlay contrast (e.g. drag and drop questions) but only open with an account

I can try to go back in and look at it again soon + static fixes, but because all the results view gets reset and I can't do that yet, maybe next week