### PR TITLE
Fix for qrz.com and subdomains

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26838,6 +26838,17 @@ qrcg-generator-qr-code *
 
 ================================
 
+qrz.com
+forums.qrz.com
+logbook.qrz.com
+shop.qrz.com
+
+INVERT
+img[src$="qrz_com.svgz"]
+.site-header__logo-image
+
+================================
+
 qt.io
 
 CSS


### PR DESCRIPTION
I've opted to identify their subdomains, but this could probably also be a *.qrz.com rule. Annoyingly, they use two different logo images, but I've opted to put them both together as this is effectively one site for most use cases.

The logo image needs to be inverted. Everything else is usable enough not to worry about.