### PR TITLE
add UPS subdomain to existing fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33803,6 +33803,7 @@ a.permalink {
 ================================
 
 ups.com
+wwwapps.ups.com
 
 INVERT
 img[data-icon-name="search"]


### PR DESCRIPTION
this site includes the cost calculator, for which the navbar was stuck without the fix