### PR TITLE
Fix for esim.gg

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11521,6 +11521,15 @@ section#announcements-area .container {
 
 ================================
 
+esim.gg
+
+CSS
+.bg-gradient-to-br {
+    background-image: none;
+}
+
+================================
+
 esimdb.com
 
 INVERT


### PR DESCRIPTION
Invert bright background.

Before:
<img width="1059" height="506" alt="image" src="https://github.com/user-attachments/assets/b77258a8-1fa2-48e6-b4c1-29974479a823" />

After:
<img width="1059" height="506" alt="image" src="https://github.com/user-attachments/assets/49282899-e8fe-47df-a21f-54e8eabba00b" />
