### PR TITLE
Fix for theguardian.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32130,8 +32130,8 @@ div[role="progressbar"] > span {
 gu-island[name="SlotBodyEnd"] div[id="slot-body-end"] div > section {
     border-top-color: rgb(255, 229, 0) !important;
 }
-gu-island[name="SlotBodyEnd"] label > div:hover > input[type="radio"],
-gu-island[name="SlotBodyEnd"] label.dcr-gamt6q > div > input[type="radio"] {
+gu-island[name="SlotBodyEnd"] label > div > input[type="radio"]:checked,
+gu-island[name="SlotBodyEnd"] label > div:hover > input[type="radio"] {
     border: 2px solid rgb(255, 229, 0) !important;
 }
 gu-island[name="StickyBottomBanner"] div > div > div > div > div.dcr-1xq78ib {


### PR DESCRIPTION
- Fixes carousel buttons on home page.
- Updates fix (introduced in #13979) for support appeal on some article pages.

Before:
<img width="700" height="493" alt="1" src="https://github.com/user-attachments/assets/e9d0af71-f186-49ac-a385-74c806a295bb" />

After:
<img width="700" height="493" alt="2" src="https://github.com/user-attachments/assets/3e8960fb-16ca-4f86-8247-1cd125e89149" />