### PR TITLE
Additional fixes for yami.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -36733,6 +36733,12 @@ body {
 
 yami.com
 
+INVERT
+.category__item__left--active > .category-item__image
+.category__list__item
+img[alt="Yami logo"]
+span[class="cat-txt"]
+
 CSS
 .bff-item__img,
 .bff-item__imgbox--wrapper,
@@ -36746,6 +36752,10 @@ CSS
 .cms-component-slide_swiperSlide__8TzRv [data-darkreader-inline-color] {
     color: ${white} !important;
 }
+
+IGNORE INLINE STYLE
+.box_title[data-font-color]
+.box_row[data-font-color]
 
 ================================
 


### PR DESCRIPTION
Fixes main logo and text color in the dropdown navigation.

Before:

Hard to see the main logo at the top left and the dark text in the dropdown nav
<img width="1908" height="1058" alt="before-yami-logo-nav-dropdown" src="https://github.com/user-attachments/assets/6cd4d600-4038-47f2-a760-6bfe08650965" />

 Hard to see text in dropdown nav list when hovering
<img width="1879" height="1058" alt="after-yami-highlight" src="https://github.com/user-attachments/assets/fdc30de2-93f2-4166-bd28-baa254bb6345" />


After:

Fix for the main logo at the top left and the text in the dropdown navigation
<img width="1903" height="1058" alt="after-yami-logo-nav-dropdown" src="https://github.com/user-attachments/assets/240a8a20-28e3-4e9b-bf63-619dc6b5e945" />

Hover over text in dropdown nav list fixed:
<img width="2236" height="1053" alt="after-yami-highlight" src="https://github.com/user-attachments/assets/71bb7ed3-7f80-4d87-a77e-228a775e8971" />




