### PR TITLE
Fix Document Picture-in-Picture missing font-face rules

### DIFF
--- a/src/inject/dynamic-theme/index.ts
+++ b/src/inject/dynamic-theme/index.ts
@@ -648,6 +648,7 @@ function tryInvertChromePDF() {
  * TODO: expose this function to API builds via src/api function enable()
  */
 export function createOrUpdateDynamicTheme(theme: Theme, dynamicThemeFixes: DynamicThemeFix[], iframe: boolean): void {
+    setupDocumentPiPFontFix();
     const dynamicThemeFix = selectRelevantFix(document.location.href, dynamicThemeFixes);
 
     // Most websites will have only the generic fix applied ('*'), some will have generic fix and one site-specific fix (two in total),
@@ -785,6 +786,69 @@ function removeProxy() {
 }
 
 const cleaners: Array<() => void> = [];
+
+let pipListenerRegistered = false;
+
+function setupDocumentPiPFontFix(): void {
+    if (pipListenerRegistered) {
+        return;
+    }
+    const docPiP = (window as any).documentPictureInPicture;
+    if (!docPiP) {
+        return;
+    }
+    pipListenerRegistered = true;
+
+    function collectFontSheetCSS(): string {
+        const fontSheetRules: string[] = [];
+        for (const sheet of document.styleSheets) {
+            try {
+                const rules = Array.from(sheet.cssRules);
+                if (rules.some((rule) => rule instanceof CSSFontFaceRule)) {
+                    rules.forEach((rule) => fontSheetRules.push(rule.cssText));
+                }
+            } catch (e) {
+                // Cross-origin sheets may throw
+            }
+        }
+        return fontSheetRules.join('\n');
+    }
+
+    function injectFontCSS(pipDoc: Document, fontCSS: string): void {
+        if (pipDoc.querySelector('.darkreader--font-fix')) {
+            return;
+        }
+        const style = pipDoc.createElement('style');
+        style.classList.add('darkreader');
+        style.classList.add('darkreader--font-fix');
+        style.textContent = fontCSS;
+        (pipDoc.head || pipDoc.documentElement).appendChild(style);
+    }
+
+    function onPiPEnter(): void {
+        const pipWindow = docPiP.window;
+        if (!pipWindow) {
+            return;
+        }
+        const fontCSS = collectFontSheetCSS();
+        if (!fontCSS) {
+            return;
+        }
+        const pipDoc = pipWindow.document;
+        injectFontCSS(pipDoc, fontCSS);
+        const observer = new MutationObserver(() => {
+            injectFontCSS(pipDoc, fontCSS);
+        });
+        observer.observe(pipDoc, {childList: true, subtree: true});
+        pipWindow.addEventListener('unload', () => observer.disconnect());
+    }
+
+    docPiP.addEventListener('enter', onPiPEnter);
+    cleaners.push(() => {
+        docPiP.removeEventListener('enter', onPiPEnter);
+        pipListenerRegistered = false;
+    });
+}
 
 export function removeDynamicTheme(): void {
     document.documentElement.removeAttribute(`data-darkreader-mode`);


### PR DESCRIPTION
Fixes #14614

## Problem

When Dark Reader is active, the Document Picture-in-Picture (PiP) window (used by Google Meet when switching tabs) loses `@font-face` declarations and associated CSS rules. This causes icon fonts like Google Symbols to render as plain text (e.g., "mic", "videocam" instead of icons).

## Root cause

Dark Reader's presence on the main page causes the site's PiP style cloning logic to skip the font stylesheet entirely. The PiP window ends up missing:
- The `@font-face` declaration for the icon font
- Associated CSS rules that set `font-family` on icon elements

Dark Reader does not inject into the PiP window itself. The issue is that the site's own style cloning skips the font stylesheet when Dark Reader is active.

## Fix

Listen for the `enter` event on `documentPictureInPicture`. When a PiP window is created, collect all CSS rules from stylesheets that contain `@font-face` declarations and inject them into the PiP document. A MutationObserver re-injects if the site rebuilds the PiP content after creation.

## Testing

- Google Meet: start/join a call with Dark Reader enabled, switch to another tab to trigger PiP popup
- Icons (mic, camera, share screen, etc.) render correctly in the floating popup
- All existing tests pass (`npm test`)
- Lint passes (`npm run code-style`)