### PR TITLE
Fix supercoach.com.au

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31093,7 +31093,7 @@ INVERT
 
 ================================
 
-supercoach.heraldsun.com.au
+supercoach.com.au
 
 IGNORE INLINE STYLE
 svg *


### PR DESCRIPTION
Website address changed:

supercoach.heraldsun.com.au > supercoach.com.au