### PR TITLE
fix: improve accessibility with ARIA labels and keyboard navigation

### DIFF
--- a/src/ui/controls/toggle/index.tsx
+++ b/src/ui/controls/toggle/index.tsx
@@ -30,17 +30,34 @@ export default function Toggle(props: ToggleProps) {
         'toggle__btn--active': !checked,
     };
 
+    const handleKeyDown = (e: KeyboardEvent, newValue: boolean) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onChange && onChange(newValue);
+        }
+    };
+
     return (
-        <span class={cls}>
+        <span class={cls} role="group" aria-label={`Toggle is ${checked ? 'on' : 'off'}`}>
             <span
                 class={clsOn}
+                role="button"
+                tabindex="0"
+                aria-pressed={checked}
+                aria-label="Toggle on"
                 onclick={onChange ? () => !checked && onChange(true) : undefined}
+                onkeydown={onChange ? (e) => handleKeyDown(e, true) : undefined}
             >
                 {props.labelOn}
             </span>
             <span
                 class={clsOff}
+                role="button"
+                tabindex="0"
+                aria-pressed={!checked}
+                aria-label="Toggle off"
                 onclick={onChange ? () => checked && onChange(false) : undefined}
+                onkeydown={onChange ? (e) => handleKeyDown(e, false) : undefined}
             >
                 {props.labelOff}
             </span>

--- a/src/ui/icons/settings-icon.tsx
+++ b/src/ui/icons/settings-icon.tsx
@@ -3,11 +3,12 @@ import {m} from 'malevic';
 interface SettingsIconProps {
     class?: string;
     color?: string;
+    ariaHidden?: boolean;
 }
 
 export function SettingsIcon(props: SettingsIconProps): Malevic.Child {
     return (
-        <svg viewBox="0 0 16 16" class={props.class}>
+        <svg viewBox="0 0 16 16" class={props.class} aria-hidden={props.ariaHidden ?? true}>
             <defs>
                 <path id="cog" d="M-1.25,-6.5 h2.5 l1,3 h-4.5 z" />
             </defs>

--- a/src/ui/icons/sun-moon-icon.tsx
+++ b/src/ui/icons/sun-moon-icon.tsx
@@ -6,13 +6,14 @@ interface SunMoonIconProps {
     date: Date;
     latitude: number;
     longitude: number;
+    ariaHidden?: boolean;
 }
 
-export function SunMoonIcon({date, latitude, longitude}: SunMoonIconProps): Malevic.Child {
+export function SunMoonIcon({date, latitude, longitude, ariaHidden = true}: SunMoonIconProps): Malevic.Child {
     if (latitude == null || longitude == null) {
         // question mark icon
         return (
-            <svg viewBox="0 0 16 16">
+            <svg viewBox="0 0 16 16" aria-hidden={ariaHidden}>
                 <text
                     fill="white"
                     font-size="16"
@@ -28,7 +29,7 @@ export function SunMoonIcon({date, latitude, longitude}: SunMoonIconProps): Male
     if (isNightAtLocation(latitude, longitude, date)) {
         // moon icon
         return (
-            <svg viewBox="0 0 16 16">
+            <svg viewBox="0 0 16 16" aria-hidden={ariaHidden}>
                 <path fill="white" stroke="none" d="M 6 3 Q 10 8 6 13 Q 12 13 12 8 Q 12 3 6 3" />
             </svg>
         );
@@ -36,7 +37,7 @@ export function SunMoonIcon({date, latitude, longitude}: SunMoonIconProps): Male
 
     // sun icon
     return (
-        <svg viewBox="0 0 16 16">
+        <svg viewBox="0 0 16 16" aria-hidden={ariaHidden}>
             <circle fill="white" stroke="none" cx="8" cy="8" r="3" />
             <g fill="none" stroke="white" stroke-linecap="round" stroke-width="1.5">
                 {...(Array.from({length: 8}).map((_, i) => {

--- a/src/ui/icons/system-icon.tsx
+++ b/src/ui/icons/system-icon.tsx
@@ -1,8 +1,12 @@
 import {m} from 'malevic';
 
-export function SystemIcon(): Malevic.Child {
+interface SystemIconProps {
+    ariaHidden?: boolean;
+}
+
+export function SystemIcon(props: SystemIconProps): Malevic.Child {
     return (
-        <svg viewBox="0 0 16 16">
+        <svg viewBox="0 0 16 16" aria-hidden={props.ariaHidden ?? true}>
             <path
                 fill="white"
                 stroke="none"

--- a/src/ui/icons/watch-icon.tsx
+++ b/src/ui/icons/watch-icon.tsx
@@ -4,10 +4,11 @@ interface WatchIconProps {
     color?: string;
     hours: number;
     minutes: number;
+    ariaHidden?: boolean;
 }
 
 export function WatchIcon(props: WatchIconProps): Malevic.Child {
-    const {hours, minutes, color = 'white'} = props;
+    const {hours, minutes, color = 'white', ariaHidden = true} = props;
     const cx = 8;
     const cy = 8.5;
     const lenHour = 3;
@@ -23,7 +24,7 @@ export function WatchIcon(props: WatchIconProps): Malevic.Child {
     const my = cy - lenMinute * Math.cos(am);
 
     return (
-        <svg viewBox="0 0 16 16">
+        <svg viewBox="0 0 16 16" aria-hidden={ariaHidden}>
             <circle fill="none" stroke={color} stroke-width="1.5" cx={cx} cy={cy} r={clockR} />
             <line stroke={color} stroke-width="1.5" x1={cx} y1={cy} x2={hx} y2={hy} />
             <line stroke={color} stroke-width="1.5" opacity="0.67" x1={cx} y1={cy} x2={mx} y2={my} />

--- a/src/ui/popup/components/header/index.tsx
+++ b/src/ui/popup/components/header/index.tsx
@@ -88,7 +88,7 @@ function Header(props: HeaderProps) {
 
     return (
         <header class="header">
-            <a class="header__logo" href={HOMEPAGE_URL} target="_blank" rel="noopener noreferrer">
+            <a class="header__logo" href={HOMEPAGE_URL} target="_blank" rel="noopener noreferrer" aria-label="Dark Reader homepage (opens in new tab)">
                 Dark Reader
             </a>
             <div class="header__control header__site-toggle">
@@ -101,9 +101,18 @@ function Header(props: HeaderProps) {
                         'header__more-settings-button': true,
                         'header__more-settings-button--off': !isSiteEnabled,
                     }}
+                    role="button"
+                    tabindex="0"
+                    aria-label="Site settings"
                     onclick={onMoreSiteSettingsClick}
+                    onkeydown={(e: KeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            onMoreSiteSettingsClick();
+                        }
+                    }}
                 >
-                    <SettingsIcon class="header__more-settings-button__icon" />
+                    <SettingsIcon class="header__more-settings-button__icon" ariaHidden={true} />
                     {siteToggleMessage}
                 </span>
             </div>
@@ -114,9 +123,18 @@ function Header(props: HeaderProps) {
                         'header__more-settings-button': true,
                         'header__more-settings-button--off': !data.isEnabled,
                     }}
+                    role="button"
+                    tabindex="0"
+                    aria-label="Automation settings"
                     onclick={onMoreToggleSettingsClick}
+                    onkeydown={(e: KeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault();
+                            onMoreToggleSettingsClick();
+                        }
+                    }}
                 >
-                    <SettingsIcon class="header__more-settings-button__icon" />
+                    <SettingsIcon class="header__more-settings-button__icon" ariaHidden={true} />
                     {automationMessage}
                 </span>
                 <span
@@ -124,12 +142,13 @@ function Header(props: HeaderProps) {
                         'header__app-toggle__time': true,
                         'header__app-toggle__time--active': isAutomation,
                     }}
+                    aria-label={isAutomation ? 'Automation is active' : 'Automation is inactive'}
                 >
                     {(isTimeAutomation
-                        ? <WatchIcon hours={now.getHours()} minutes={now.getMinutes()} />
+                        ? <WatchIcon hours={now.getHours()} minutes={now.getMinutes()} ariaHidden={true} />
                         : (isLocationAutomation
-                            ? (<SunMoonIcon date={now} latitude={data.settings.location.latitude!} longitude={data.settings.location.longitude!} />)
-                            : <SystemIcon />))}
+                            ? (<SunMoonIcon date={now} latitude={data.settings.location.latitude!} longitude={data.settings.location.longitude!} ariaHidden={true} />)
+                            : <SystemIcon ariaHidden={true} />))}
                 </span>
             </div>
         </header>

--- a/src/ui/popup/components/site-toggle/checkmark-icon.tsx
+++ b/src/ui/popup/components/site-toggle/checkmark-icon.tsx
@@ -1,8 +1,8 @@
 import {m} from 'malevic';
 
-export default function CheckmarkIcon({isChecked}: {isChecked: boolean}) {
+export default function CheckmarkIcon({isChecked}: {isChecked: boolean; ariaHidden?: boolean}) {
     return (
-        <svg viewBox="0 0 8 8">
+        <svg viewBox="0 0 8 8" aria-hidden={ariaHidden ?? true}>
             <path
                 d={(isChecked ?
                     'M1,4 l2,2 l4,-4 v1 l-4,4 l-2,-2 Z' :


### PR DESCRIPTION
## Summary

This PR adds multiple accessibility improvements to Dark Reader's popup UI, making it more usable for people who rely on assistive technologies.

## Changes

### 1. Toggle Component
- Added `role='button'` and `tabindex='0'` for keyboard focus
- Added `aria-pressed` to indicate toggle state  
- Added `aria-label` to the toggle group
- Added keyboard event handlers (Enter/Space) for activation

### 2. Header Component
- Added `aria-label` to logo link describing it opens in new tab
- Added `role='button'`, `tabindex='0'`, and `aria-label` to settings buttons
- Added keyboard event handlers for settings buttons
- Added `aria-label` to time/automation indicator
- Added `aria-hidden='true'` to decorative SVG icons

### 3. Icon Components
- Added `ariaHidden` prop to SettingsIcon, SystemIcon, WatchIcon, SunMoonIcon
- Default to `aria-hidden='true'` for decorative icons
- Added `ariaHidden` prop to CheckmarkIcon

## Accessibility Benefits

These changes improve:
- **Screen reader support**: Proper ARIA labels describe the purpose of interactive elements
- **Keyboard navigation**: Users can now tab to and activate toggle buttons and settings using keyboard only
- **Visual accessibility**: Decorative icons are properly hidden from screen readers

## Testing

To verify these fixes:
1. Use a screen reader (NVDA, VoiceOver, etc.) to navigate the popup
2. Test keyboard-only navigation (Tab, Enter, Space)
3. Verify toggle buttons announce their state correctly

This PR bundles 8+ individual accessibility fixes into one cohesive improvement.