### PR TITLE
Fix breadcrumbs and text in Jenkins

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17176,21 +17176,6 @@ jenkins.*.local
 jenkins.*.com
 *.jenkins.*.local
 *.jenkins.*.com
-
-INVERT
-#breadcrumbBar
-.jenkins-breadcrumbs__list-item
-
-CSS
-* {
-    color: var(--darkreader-neutral-text) !important;
-}
-
-IGNORE INLINE STYLE
-.logo-jenkins *
-
-================================
-
 jenkins.io
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
The existing "fixes" actually break Jenkins.  The breadcrumbs are dark text on dark background, and all text is forced to be white, which prevents you from easily differentiating between build statuses, links, etc.