### PR TITLE
Fix for gitlab.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14255,7 +14255,6 @@ table.code .line_content *:not(pre),
 .mr-tree-list:not(.tree-list-blobs) .tree-list-parent::before {
     background-color: transparent !important;
 }
-
 #one-time-password-authenticator-otp > div > div {
     background-color: white !important;
 }


### PR DESCRIPTION
Addressing issue #15046. Added fix for the QR code generated for 2FA, so that the black/white colors aren't inverted for those elements within id selector #one-time-password-authenticator-otp. Tested with dev tools.

QR code without DR enabled:
<img width="702" height="524" alt="image" src="https://github.com/user-attachments/assets/a65edc0c-f6ba-459d-988c-b7888fc733e0" />

DR enabled (pre-fix). QR code colors are inverted:
<img width="698" height="524" alt="image" src="https://github.com/user-attachments/assets/4103c38c-d4e9-4046-8ba2-cee5c4e7c35a" />

Post-fix:

<img width="696" height="521" alt="image" src="https://github.com/user-attachments/assets/e85d59c6-9dca-4cd2-bcf5-a29da215a69b" />
