### PR TITLE
Fix for secure.runescape.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29045,6 +29045,20 @@ html {
 
 ================================
 
+secure.runescape.com
+
+CSS
+.hiscoretitlebground,
+.titleBackground {
+    background-color: transparent !important;
+    background-image: url("https://www.runescape.com/img/rsp777/hiscores/hiscores_title.gif") !important;
+}
+.hiscoretitleframe {
+    background-color: transparent !important;
+}
+
+================================
+
 secureage.com
 
 INVERT


### PR DESCRIPTION
This is a fix for Issue #15092.

I fixed the background image in the title segment to work with Dark Mode.