### PR TITLE
Add darkreader-lock meta tag for website dark mode opt-out

### DIFF
--- a/src/_locales/ar.config
+++ b/src/_locales/ar.config
@@ -234,6 +234,9 @@ a bug in your browser
 @dark_theme_detected
 تم اكتشاف مظهر داكن
 
+@darkreader_lock_detected
+الموقع يدير الوضع الداكن
+
 @website_toggle_shortcut
 موقع ويب تبديل اختصار لوحة المفاتيح
 

--- a/src/_locales/be.config
+++ b/src/_locales/be.config
@@ -234,6 +234,9 @@ Dark Reader святкуе 10-годдзе.
 @dark_theme_detected
 Выяўлена цёмная тэма
 
+@darkreader_lock_detected
+Сайт кіруе цёмным рэжымам
+
 @website_toggle_shortcut
 Спалучэнне клавіш для пераключэння вэб-сайта
 

--- a/src/_locales/bg.config
+++ b/src/_locales/bg.config
@@ -234,6 +234,9 @@ Dark Reader празнува 10 години.
 @dark_theme_detected
 Открита е тъмна тема
 
+@darkreader_lock_detected
+Уебсайтът управлява тъмния режим
+
 @website_toggle_shortcut
 Клавишна комб. за превключване на уебсайт
 

--- a/src/_locales/bn.config
+++ b/src/_locales/bn.config
@@ -234,6 +234,9 @@ a bug in your browser
 @dark_theme_detected
 গাঢ় থিম শনাক্ত করা হয়েছে
 
+@darkreader_lock_detected
+ওয়েবসাইট ডার্ক মোড পরিচালনা করে
+
 @website_toggle_shortcut
 ওয়েবসাইট টগল কীবোর্ড শর্টকাট
 

--- a/src/_locales/cs.config
+++ b/src/_locales/cs.config
@@ -234,6 +234,9 @@ Zjistěte vlastní temné téma webu
 @dark_theme_detected
 Byl zjištěn tmavý motiv
 
+@darkreader_lock_detected
+Web spravuje tmavý režim
+
 @website_toggle_shortcut
 Klávesová zkratka pro přepínání webových stránek
 

--- a/src/_locales/da-DK.config
+++ b/src/_locales/da-DK.config
@@ -234,6 +234,9 @@ Opdag hjemmesidens eget mørke tema
 @dark_theme_detected
 Mørkt tema registreret
 
+@darkreader_lock_detected
+Webstedet håndterer mørk tilstand
+
 @website_toggle_shortcut
 Skift tastaturgenvej til websted
 

--- a/src/_locales/de.config
+++ b/src/_locales/de.config
@@ -234,6 +234,9 @@ Dunkles Theme der Website erkennen
 @dark_theme_detected
 Dunkles Theme erkannt
 
+@darkreader_lock_detected
+Website verwaltet den Dunkelmodus
+
 @website_toggle_shortcut
 Tastenkombination zum Umschalten der Website
 

--- a/src/_locales/el.config
+++ b/src/_locales/el.config
@@ -234,6 +234,9 @@ Sepia
 @dark_theme_detected
 Εντοπίστηκε σκούρο θέμα
 
+@darkreader_lock_detected
+Ο ιστότοπος διαχειρίζεται τη σκούρα λειτουργία
+
 @website_toggle_shortcut
 Συντόμευση πληκτρολογίου εναλλαγής ιστότοπου
 

--- a/src/_locales/en-GB.config
+++ b/src/_locales/en-GB.config
@@ -234,6 +234,9 @@ Detect the website's dark theme
 @dark_theme_detected
 Dark theme detected
 
+@darkreader_lock_detected
+Website manages dark mode
+
 @website_toggle_shortcut
 Website toggle keyboard shortcut
 

--- a/src/_locales/en-US.config
+++ b/src/_locales/en-US.config
@@ -234,6 +234,9 @@ Detect the website's dark theme
 @dark_theme_detected
 Dark theme detected
 
+@darkreader_lock_detected
+Website manages dark mode
+
 @website_toggle_shortcut
 Website toggle keyboard shortcut
 

--- a/src/_locales/en.config
+++ b/src/_locales/en.config
@@ -234,6 +234,9 @@ Detect the website's dark theme
 @dark_theme_detected
 Dark theme detected
 
+@darkreader_lock_detected
+Website manages dark mode
+
 @website_toggle_shortcut
 Website toggle keyboard shortcut
 

--- a/src/_locales/es-419.config
+++ b/src/_locales/es-419.config
@@ -234,6 +234,9 @@ Detectar el tema oscuro propio del sitio web
 @dark_theme_detected
 Tema oscuro detectado
 
+@darkreader_lock_detected
+El sitio web gestiona el modo oscuro
+
 @website_toggle_shortcut
 Método abreviado de teclado para alternar sitio web
 

--- a/src/_locales/es.config
+++ b/src/_locales/es.config
@@ -234,6 +234,9 @@ Detectar el tema oscuro propio del sitio web
 @dark_theme_detected
 Tema oscuro detectado
 
+@darkreader_lock_detected
+El sitio web gestiona el modo oscuro
+
 @website_toggle_shortcut
 Método abreviado de teclado para alternar sitio web
 

--- a/src/_locales/fa-IR.config
+++ b/src/_locales/fa-IR.config
@@ -234,6 +234,9 @@ a bug in your browser
 @dark_theme_detected
 طرح زمینه تیره شناسایی شد
 
+@darkreader_lock_detected
+وب‌سایت حالت تیره را مدیریت می‌کند
+
 @website_toggle_shortcut
 میانبر صفحه کلید تغییر وضعیت وب سایت
 

--- a/src/_locales/fa.config
+++ b/src/_locales/fa.config
@@ -234,6 +234,9 @@ a bug in your browser
 @dark_theme_detected
 طرح زمینه تیره شناسایی شد
 
+@darkreader_lock_detected
+وب‌سایت حالت تیره را مدیریت می‌کند
+
 @website_toggle_shortcut
 میانبر صفحه کلید تغییر وضعیت وب سایت
 

--- a/src/_locales/fil.config
+++ b/src/_locales/fil.config
@@ -234,6 +234,9 @@ Alamin ang sariling madilim na tema ng website
 @dark_theme_detected
 Natukoy ang madilim na tema
 
+@darkreader_lock_detected
+Pinamamahalaan ng website ang madilim na mode
+
 @website_toggle_shortcut
 Website toggle keyboard shortcut
 

--- a/src/_locales/fr.config
+++ b/src/_locales/fr.config
@@ -234,6 +234,9 @@ Détecter le thème sombre du site
 @dark_theme_detected
 Thème sombre détecté
 
+@darkreader_lock_detected
+Le site gère le mode sombre
+
 @website_toggle_shortcut
 Raccourci clavier pour activer/désactiver sur le site
 

--- a/src/_locales/he.config
+++ b/src/_locales/he.config
@@ -234,6 +234,9 @@ Dev tools
 @dark_theme_detected
 זוהה נושא כהה
 
+@darkreader_lock_detected
+האתר מנהל מצב כהה
+
 @website_toggle_shortcut
 החלפת מקשי קיצור באתר
 

--- a/src/_locales/hi.config
+++ b/src/_locales/hi.config
@@ -234,6 +234,9 @@ a bug in your browser
 @dark_theme_detected
 गहरे रंग वाली थीम का पता चला
 
+@darkreader_lock_detected
+वेबसाइट डार्क मोड प्रबंधित करती है
+
 @website_toggle_shortcut
 वेबसाइट टॉगल कीबोर्ड शॉर्टकट
 

--- a/src/_locales/id.config
+++ b/src/_locales/id.config
@@ -234,6 +234,9 @@ Mendeteksi tema gelap situs web itu sendiri
 @dark_theme_detected
 Tema gelap terdeteksi
 
+@darkreader_lock_detected
+Situs web mengelola mode gelap
+
 @website_toggle_shortcut
 Pintasan keyboard beralih situs web
 

--- a/src/_locales/it.config
+++ b/src/_locales/it.config
@@ -234,6 +234,9 @@ Rileva il tema scuro del sito
 @dark_theme_detected
 Tema scuro rilevato
 
+@darkreader_lock_detected
+Il sito gestisce la modalità scura
+
 @website_toggle_shortcut
 Combinazione per commutare il sito
 

--- a/src/_locales/ja.config
+++ b/src/_locales/ja.config
@@ -234,6 +234,9 @@ QRコードをスキャンするだけでインストールできます。
 @dark_theme_detected
 ダークテーマを検出
 
+@darkreader_lock_detected
+ウェブサイトがダークモードを管理
+
 @website_toggle_shortcut
 サイト上で切り替えるキーボード ショートカット
 

--- a/src/_locales/ko.config
+++ b/src/_locales/ko.config
@@ -234,6 +234,9 @@ QR코드를 스캔하시면 간단하게 설치하실 수 있습니다.
 @dark_theme_detected
 다크 모드 감지됨
 
+@darkreader_lock_detected
+웹사이트가 다크 모드를 관리함
+
 @website_toggle_shortcut
 웹사이트 토글 키보드 단축키
 

--- a/src/_locales/ms.config
+++ b/src/_locales/ms.config
@@ -234,6 +234,9 @@ Kesan tema gelap tapak web itu sendiri
 @dark_theme_detected
 Tema gelap dikesan
 
+@darkreader_lock_detected
+Laman web menguruskan mod gelap
+
 @website_toggle_shortcut
 Pintasan papan kekunci togol tapak web
 

--- a/src/_locales/nl.config
+++ b/src/_locales/nl.config
@@ -234,6 +234,9 @@ Detecteer het eigen donkere thema van de website
 @dark_theme_detected
 Donker thema gedetecteerd
 
+@darkreader_lock_detected
+Website beheert donkere modus
+
 @website_toggle_shortcut
 Sneltoets voor het wisselen van de website
 

--- a/src/_locales/no.config
+++ b/src/_locales/no.config
@@ -234,6 +234,9 @@ Oppdag nettstedets eget mørke tema
 @dark_theme_detected
 Mørkt tema oppdaget
 
+@darkreader_lock_detected
+Nettstedet håndterer mørk modus
+
 @website_toggle_shortcut
 Bytt tastatursnarvei for nettsted
 

--- a/src/_locales/pl.config
+++ b/src/_locales/pl.config
@@ -234,6 +234,9 @@ Wykryj witryny mające własny ciemny motyw
 @dark_theme_detected
 Wykryto ciemny motyw
 
+@darkreader_lock_detected
+Strona zarządza trybem ciemnym
+
 @website_toggle_shortcut
 Skrót klawiszowy przełączający bieżącą witrynę
 

--- a/src/_locales/pt-BR.config
+++ b/src/_locales/pt-BR.config
@@ -234,6 +234,9 @@ Detectar o próprio tema escuro do site
 @dark_theme_detected
 Tema escuro detectado
 
+@darkreader_lock_detected
+O site gerencia o modo escuro
+
 @website_toggle_shortcut
 Atalho de teclado de alternância de site
 

--- a/src/_locales/pt-PT.config
+++ b/src/_locales/pt-PT.config
@@ -234,6 +234,9 @@ Detectar o próprio tema escuro do site
 @dark_theme_detected
 Tema escuro detectado
 
+@darkreader_lock_detected
+O site gere o modo escuro
+
 @website_toggle_shortcut
 Atalho de teclado de alternância de site
 

--- a/src/_locales/ro.config
+++ b/src/_locales/ro.config
@@ -234,6 +234,9 @@ Detectați propria temă întunecată a site-ului
 @dark_theme_detected
 Temă întunecată detectată
 
+@darkreader_lock_detected
+Site-ul gestionează modul întunecat
+
 @website_toggle_shortcut
 Comandă rapidă de la tastatură pentru comutarea site-ului
 

--- a/src/_locales/ru.config
+++ b/src/_locales/ru.config
@@ -234,6 +234,9 @@ Dark Reader отмечает 10-летие.
 @dark_theme_detected
 Обнаружена темная тема
 
+@darkreader_lock_detected
+Сайт управляет тёмным режимом
+
 @website_toggle_shortcut
 Сочетание клавиш для переключения веб-сайтов
 

--- a/src/_locales/si.config
+++ b/src/_locales/si.config
@@ -234,6 +234,9 @@ Dark Reader භාවිතයට ගෙවන්න
 @dark_theme_detected
 අඳුරු තේමාව අනාවරණය විය
 
+@darkreader_lock_detected
+වෙබ් අඩවිය අඳුරු ප්‍රකාරය කළමනාකරණය කරයි
+
 @website_toggle_shortcut
 අඩවියට යොදන යතුරුපුවරුවේ කෙටිමග
 

--- a/src/_locales/sk.config
+++ b/src/_locales/sk.config
@@ -234,6 +234,9 @@ Zistite vlastnú temnú tému webovej stránky
 @dark_theme_detected
 Bol rozpoznaný tmavý motív
 
+@darkreader_lock_detected
+Webová stránka spravuje tmavý režim
+
 @website_toggle_shortcut
 Klávesová skratka na prepínanie webových stránok
 

--- a/src/_locales/sr.config
+++ b/src/_locales/sr.config
@@ -234,6 +234,9 @@ Dark Reader слави 10 година.
 @dark_theme_detected
 Тамна тема је откривена
 
+@darkreader_lock_detected
+Веб-сајт управља тамним режимом
+
 @website_toggle_shortcut
 Пречица на тастатури за пребацивање сајта
 

--- a/src/_locales/sv.config
+++ b/src/_locales/sv.config
@@ -234,6 +234,9 @@ Upptäck webbplatsens egna mörka tema
 @dark_theme_detected
 Mörkt tema upptäcktes
 
+@darkreader_lock_detected
+Webbplatsen hanterar mörkt läge
+
 @website_toggle_shortcut
 Kortkommando för att slå på/av webbplats
 

--- a/src/_locales/te.config
+++ b/src/_locales/te.config
@@ -234,6 +234,9 @@ a bug in your browser
 @dark_theme_detected
 ముదురు రంగు థీమ్ కనుగొనబడింది
 
+@darkreader_lock_detected
+వెబ్‌సైట్ డార్క్ మోడ్‌ను నిర్వహిస్తుంది
+
 @website_toggle_shortcut
 వెబ్‌సైట్ టోగుల్ కీబోర్డ్ సత్వరమార్గం
 

--- a/src/_locales/th.config
+++ b/src/_locales/th.config
@@ -234,6 +234,9 @@ Dark Reader ฉลองครบรอบ 10 ปี
 @dark_theme_detected
 ตรวจพบธีมมืด
 
+@darkreader_lock_detected
+เว็บไซต์จัดการโหมดมืด
+
 @website_toggle_shortcut
 แป้นพิมพ์ลัดสลับเว็บไซต์
 

--- a/src/_locales/tr.config
+++ b/src/_locales/tr.config
@@ -234,6 +234,9 @@ Web sitesinin koyu temasını algıla
 @dark_theme_detected
 Koyu tema algılandı
 
+@darkreader_lock_detected
+Web sitesi karanlık modu yönetiyor
+
 @website_toggle_shortcut
 Web sitesi aç/kapat klavye kısayolu
 

--- a/src/_locales/uk.config
+++ b/src/_locales/uk.config
@@ -234,6 +234,9 @@ Dark Reader святкує 10-річчя
 @dark_theme_detected
 Виявлено темну тему
 
+@darkreader_lock_detected
+Сайт керує темним режимом
+
 @website_toggle_shortcut
 Комбінація клавіш для перемикання веб-сайту
 

--- a/src/_locales/vi.config
+++ b/src/_locales/vi.config
@@ -234,6 +234,9 @@ Phát hiện chủ đề tối của trang
 @dark_theme_detected
 Đã phát hiện chủ đề tối
 
+@darkreader_lock_detected
+Trang web quản lý chế độ tối
+
 @website_toggle_shortcut
 Phím tắt đổi chủ đề của trang
 

--- a/src/_locales/zh-CN.config
+++ b/src/_locales/zh-CN.config
@@ -234,6 +234,9 @@ Dark Reader 庆祝 10 周年。
 @dark_theme_detected
 检测到暗色主题
 
+@darkreader_lock_detected
+网站管理深色模式
+
 @website_toggle_shortcut
 网站切换键盘快捷键
 

--- a/src/_locales/zh-TW.config
+++ b/src/_locales/zh-TW.config
@@ -234,6 +234,9 @@
 @dark_theme_detected
 偵測到深色主題
 
+@darkreader_lock_detected
+網站管理深色模式
+
 @website_toggle_shortcut
 網站切換鍵盤快捷鍵
 

--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -454,6 +454,7 @@ export class Extension {
         if (UserStorage.settings.detectDarkTheme) {
             isDarkThemeDetected = TabManager.isTabDarkThemeDetected(tab);
         }
+        const isDarkReaderLockDetected = TabManager.isTabDarkReaderLockDetected(tab);
         const id = tab && tab.id || null;
         return {
             id,
@@ -463,6 +464,7 @@ export class Extension {
             isProtected,
             isInjected,
             isDarkThemeDetected,
+            isDarkReaderLockDetected,
         };
     }
 
@@ -600,7 +602,8 @@ export class Extension {
         }
 
         const darkThemeDetected = settings.enabledByDefault && settings.detectDarkTheme && tab.isDarkThemeDetected;
-        if (!settings.enabledByDefault || isInDarkList || darkThemeDetected) {
+        const darkReaderLockDetected = settings.enabledByDefault && tab.isDarkReaderLockDetected;
+        if (!settings.enabledByDefault || isInDarkList || darkThemeDetected || darkReaderLockDetected) {
             const toggledList = getToggledList(settings.enabledFor);
             Extension.changeSettings({enabledFor: toggledList}, true);
             return;
@@ -699,10 +702,11 @@ export class Extension {
                 theme = {...theme, mode};
             }
             const detectorHints = settings.detectDarkTheme ? getDetectorHintsFor(url, ConfigManager.DETECTOR_HINTS_RAW!, ConfigManager.DETECTOR_HINTS_INDEX!) : null;
+            const isForceEnabled = isURLInList(tabURL, settings.enabledFor);
             const detectDarkTheme = (
                 settings.detectDarkTheme &&
                 (isTopFrame || detectorHints?.some((h) => h.iframe)) &&
-                !isURLInList(tabURL, settings.enabledFor) &&
+                !isForceEnabled &&
                 !isPDF(tabURL)
             );
 
@@ -717,6 +721,7 @@ export class Extension {
                             css: createCSSFilterStylesheet(theme, url, isTopFrame, ConfigManager.INVERSION_FIXES_RAW!, ConfigManager.INVERSION_FIXES_INDEX!),
                             detectDarkTheme,
                             detectorHints,
+                            isForceEnabled,
                             theme,
                         },
                     };
@@ -729,6 +734,7 @@ export class Extension {
                                 css: createSVGFilterStylesheet(theme, url, isTopFrame, ConfigManager.INVERSION_FIXES_RAW!, ConfigManager.INVERSION_FIXES_INDEX!),
                                 detectDarkTheme,
                                 detectorHints,
+                                isForceEnabled,
                                 theme,
                             },
                         };
@@ -741,6 +747,7 @@ export class Extension {
                             svgReverseMatrix: getSVGReverseFilterMatrixValue(),
                             detectDarkTheme,
                             detectorHints,
+                            isForceEnabled,
                             theme,
                         },
                     };
@@ -754,6 +761,7 @@ export class Extension {
                                 createStaticStylesheet(theme, url, isTopFrame, ConfigManager.STATIC_THEMES_RAW!, ConfigManager.STATIC_THEMES_INDEX!),
                             detectDarkTheme: settings.detectDarkTheme,
                             detectorHints,
+                            isForceEnabled,
                             theme,
                         },
                     };
@@ -768,6 +776,7 @@ export class Extension {
                             isIFrame: !isTopFrame,
                             detectDarkTheme,
                             detectorHints,
+                            isForceEnabled,
                         },
                     };
                 }

--- a/src/background/tab-manager.ts
+++ b/src/background/tab-manager.ts
@@ -31,6 +31,7 @@ interface DocumentInfo {
     state: DocumentState;
     timestamp: number;
     darkThemeDetected: boolean;
+    darkReaderLockDetected: boolean;
 }
 
 interface TabManagerState extends Record<string, unknown> {
@@ -175,6 +176,7 @@ export default class TabManager {
                             isTop: isTopFrame || undefined,
                             state: DocumentState.ACTIVE,
                             darkThemeDetected: false,
+                            darkReaderLockDetected: false,
                             timestamp: TabManager.timestamp,
                         };
                         TabManager.stateManager.saveState();
@@ -192,6 +194,31 @@ export default class TabManager {
                         const frameId = Number(entry[0]);
                         const frame = entry[1];
                         frame.darkThemeDetected = true;
+                        const {documentId, scriptId} = frame;
+                        if (documentId) {
+                            const message = {
+                                type: MessageTypeBGtoCS.CLEAN_UP,
+                                scriptId,
+                            };
+                            TabManager.sendDocumentMessage(tabId, documentId, message, frameId);
+                        }
+                        if (frameId === 0) {
+                            IconManager.setIcon({tabId, isActive: false});
+                        }
+                    }
+                    break;
+                }
+
+                case MessageTypeCStoBG.DARKREADER_LOCK_DETECTED: {
+                    const tabId = sender.tab!.id!;
+                    const frames = TabManager.tabs[tabId];
+                    if (!frames) {
+                        break;
+                    }
+                    for (const entry of Object.entries(frames)) {
+                        const frameId = Number(entry[0]);
+                        const frame = entry[1];
+                        frame.darkReaderLockDetected = true;
                         const {documentId, scriptId} = frame;
                         if (documentId) {
                             const message = {
@@ -326,6 +353,7 @@ export default class TabManager {
             isTop: isTop || undefined,
             state: DocumentState.ACTIVE,
             darkThemeDetected: false,
+            darkReaderLockDetected: false,
             timestamp: TabManager.timestamp,
         };
     }
@@ -491,6 +519,10 @@ export default class TabManager {
 
     static isTabDarkThemeDetected(tab: chrome.tabs.Tab | null): boolean | null {
         return tab && TabManager.tabs[tab.id!] && TabManager.tabs[tab.id!][0] && TabManager.tabs[tab.id!][0].darkThemeDetected || null;
+    }
+
+    static isTabDarkReaderLockDetected(tab: chrome.tabs.Tab | null): boolean | null {
+        return tab && TabManager.tabs[tab.id!] && TabManager.tabs[tab.id!][0] && TabManager.tabs[tab.id!][0].darkReaderLockDetected || null;
     }
 
     static async getActiveTabURL(): Promise<string> {

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -142,6 +142,7 @@ export interface TabInfo {
     isInjected: boolean | null;
     isInDarkList: boolean;
     isDarkThemeDetected: boolean | null;
+    isDarkReaderLockDetected: boolean | null;
 }
 
 export interface MessageCStoBG {

--- a/src/inject/detector.ts
+++ b/src/inject/detector.ts
@@ -3,6 +3,7 @@ import {getSRGBLightness, parseColorWithCache} from '../utils/color';
 import {isSystemDarkModeEnabled} from '../utils/media-query';
 
 const COLOR_SCHEME_META_SELECTOR = 'meta[name="color-scheme"]';
+const DARKREADER_LOCK_META_SELECTOR = 'meta[name="darkreader-lock"]';
 
 function hasBuiltInDarkTheme() {
     const rootStyle = getComputedStyle(document.documentElement);
@@ -242,4 +243,8 @@ function detectUsingHint(hint: DetectorHint, success: () => void) {
 function stopDetectingUsingHint() {
     hintTargetObserver?.disconnect();
     hintMatchObserver?.disconnect();
+}
+
+export function hasDarkReaderLockMeta(): boolean {
+    return document.querySelector(DARKREADER_LOCK_META_SELECTOR) != null;
 }

--- a/src/inject/index.ts
+++ b/src/inject/index.ts
@@ -6,7 +6,7 @@ import {HOMEPAGE_URL} from '../utils/links';
 import {activateTheme} from '@plus/utils/theme';
 
 import {writeEnabledForHost} from './cache';
-import {runDarkThemeDetector, stopDarkThemeDetector} from './detector';
+import {hasDarkReaderLockMeta, runDarkThemeDetector, stopDarkThemeDetector} from './detector';
 import {createOrUpdateDynamicTheme, removeDynamicTheme, cleanDynamicThemeCache} from './dynamic-theme';
 import {collectCSS} from './dynamic-theme/css-collection';
 import {createOrUpdateStyle, removeStyle} from './style';
@@ -99,11 +99,14 @@ function onMessage(message: MessageBGtoCS | MessageUItoCS | DebugMessageBGtoCS) 
     switch (message.type) {
         case MessageTypeBGtoCS.ADD_CSS_FILTER:
         case MessageTypeBGtoCS.ADD_STATIC_THEME: {
-            const {css, detectDarkTheme, detectorHints} = message.data;
+            const {css, detectDarkTheme, detectorHints, isForceEnabled} = message.data;
             removeDynamicTheme();
             createOrUpdateStyle(css, message.type === MessageTypeBGtoCS.ADD_STATIC_THEME ? 'static' : 'filter');
             writeEnabledForHost(true);
-            if (detectDarkTheme) {
+            if (!isForceEnabled && hasDarkReaderLockMeta()) {
+                removeStyle();
+                onDarkReaderLockDetected();
+            } else if (detectDarkTheme) {
                 runDarkThemeDetector((hasDarkTheme) => {
                     if (hasDarkTheme) {
                         removeStyle();
@@ -114,12 +117,16 @@ function onMessage(message: MessageBGtoCS | MessageUItoCS | DebugMessageBGtoCS) 
             break;
         }
         case MessageTypeBGtoCS.ADD_SVG_FILTER: {
-            const {css, svgMatrix, svgReverseMatrix, detectDarkTheme, detectorHints} = message.data;
+            const {css, svgMatrix, svgReverseMatrix, detectDarkTheme, detectorHints, isForceEnabled} = message.data;
             removeDynamicTheme();
             createOrUpdateSVGFilter(svgMatrix, svgReverseMatrix);
             createOrUpdateStyle(css, 'filter');
             writeEnabledForHost(true);
-            if (detectDarkTheme) {
+            if (!isForceEnabled && hasDarkReaderLockMeta()) {
+                removeStyle();
+                removeSVGFilter();
+                onDarkReaderLockDetected();
+            } else if (detectDarkTheme) {
                 runDarkThemeDetector((hasDarkTheme) => {
                     if (hasDarkTheme) {
                         removeStyle();
@@ -131,11 +138,14 @@ function onMessage(message: MessageBGtoCS | MessageUItoCS | DebugMessageBGtoCS) 
             break;
         }
         case MessageTypeBGtoCS.ADD_DYNAMIC_THEME: {
-            const {theme, fixes, isIFrame, detectDarkTheme, detectorHints} = message.data;
+            const {theme, fixes, isIFrame, detectDarkTheme, detectorHints, isForceEnabled} = message.data;
             removeStyle();
             createOrUpdateDynamicTheme(theme, fixes, isIFrame);
             writeEnabledForHost(true);
-            if (detectDarkTheme) {
+            if (!isForceEnabled && hasDarkReaderLockMeta()) {
+                removeDynamicTheme();
+                onDarkReaderLockDetected();
+            } else if (detectDarkTheme) {
                 runDarkThemeDetector((hasDarkTheme) => {
                     if (hasDarkTheme) {
                         removeDynamicTheme();
@@ -204,6 +214,11 @@ function onResume() {
 function onDarkThemeDetected() {
     writeEnabledForHost(false);
     sendMessage({type: MessageTypeCStoBG.DARK_THEME_DETECTED});
+}
+
+function onDarkReaderLockDetected() {
+    writeEnabledForHost(false);
+    sendMessage({type: MessageTypeCStoBG.DARKREADER_LOCK_DETECTED});
 }
 
 // Thunderbird does not have "tabs", and emails aren't 'frozen' or 'cached'.

--- a/src/ui/connect/mock.ts
+++ b/src/ui/connect/mock.ts
@@ -93,6 +93,7 @@ export function getMockData(override = {} as Partial<ExtensionData>): ExtensionD
             isInDarkList: false,
             isInjected: true,
             isDarkThemeDetected: false,
+            isDarkReaderLockDetected: false,
         },
         uiHighlights: [],
     } as ExtensionData, override);

--- a/src/ui/popup/components/header/index.tsx
+++ b/src/ui/popup/components/header/index.tsx
@@ -59,9 +59,11 @@ export function getSiteToggleMessage(props: ExtWrapper) {
             getLocalMessage('local_files_forbidden')
             : tab.isInDarkList ?
                 getLocalMessage('page_in_dark_list')
-                : tab.isDarkThemeDetected ?
-                    getLocalMessage('dark_theme_detected')
-                    : getLocalMessage('configure_site_toggle');
+                : tab.isDarkReaderLockDetected ?
+                    getLocalMessage('darkreader_lock_detected')
+                    : tab.isDarkThemeDetected ?
+                        getLocalMessage('dark_theme_detected')
+                        : getLocalMessage('configure_site_toggle');
 }
 
 function Header(props: HeaderProps) {

--- a/src/ui/popup/main-page/site-toggle.tsx
+++ b/src/ui/popup/main-page/site-toggle.tsx
@@ -11,13 +11,15 @@ export default function SiteToggleGroup(props: ViewProps) {
     const tab = props.data.activeTab;
     const isPageEnabled = isURLEnabled(tab.url, props.data.settings, tab, props.data.isAllowedFileSchemeAccess);
     const isFile = isChromium && isLocalFile(tab.url);
-    const {isDarkThemeDetected, isProtected, isInDarkList} = tab;
+    const {isDarkThemeDetected, isDarkReaderLockDetected, isProtected, isInDarkList} = tab;
     let descriptionText = '';
 
     if (isFile && !props.data.isAllowedFileSchemeAccess) {
         descriptionText = getLocalMessage('local_files_forbidden');
     } else if (isPDF(tab.url)) {
         descriptionText = isPageEnabled ? 'Enabled for PDF files' : 'Disabled for PDF files';
+    } else if (isDarkReaderLockDetected) {
+        descriptionText = getLocalMessage('darkreader_lock_detected');
     } else if (isDarkThemeDetected) {
         descriptionText = 'Dark theme detected on page';
     } else if (isPageEnabled) {

--- a/src/ui/popup/theme/page/index.tsx
+++ b/src/ui/popup/theme/page/index.tsx
@@ -131,12 +131,12 @@ interface FontGroupsProps extends ThemeGroupProps {
 
 function FontGroup({theme, fonts, viewProps, change}: FontGroupsProps) {
     const {settings, activeTab, isAllowedFileSchemeAccess} = viewProps.data;
-    const {isDarkThemeDetected, isInDarkList, isInjected, isProtected} = activeTab;
+    const {isDarkThemeDetected, isDarkReaderLockDetected, isInDarkList, isInjected, isProtected} = activeTab;
 
     const custom = settings.customThemes.find((custom) => isURLInList(activeTab.url, custom.url));
     const engine = custom ? custom.theme.engine : settings.theme.engine;
     const canExportTheme = engine === ThemeEngine.dynamicTheme && activeTab.id
-        && !isDarkThemeDetected && !isInDarkList && !isProtected && isInjected !== false
+        && !isDarkThemeDetected && !isDarkReaderLockDetected && !isInDarkList && !isProtected && isInjected !== false
         && isURLEnabled(activeTab.url, settings, activeTab, isAllowedFileSchemeAccess);
 
     return (

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -48,6 +48,7 @@ export enum MessageTypeCStoBG {
     COLOR_SCHEME_CHANGE = 'cs-bg-color-scheme-change',
     DARK_THEME_DETECTED = 'cs-bg-dark-theme-detected',
     DARK_THEME_NOT_DETECTED = 'cs-bg-dark-theme-not-detected',
+    DARKREADER_LOCK_DETECTED = 'cs-bg-darkreader-lock-detected',
     FETCH = 'cs-bg-fetch',
     DOCUMENT_CONNECT = 'cs-bg-document-connect',
     DOCUMENT_FORGET = 'cs-bg-document-forget',

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -340,7 +340,7 @@ function isInListOptimized(url: string, list: string[]) {
     return isURLInIndexedList(url, index);
 }
 
-export function isURLEnabled(url: string, userSettings: UserSettings, {isProtected, isInDarkList, isDarkThemeDetected}: Partial<TabInfo>, isAllowedFileSchemeAccess = true): boolean {
+export function isURLEnabled(url: string, userSettings: UserSettings, {isProtected, isInDarkList, isDarkThemeDetected, isDarkReaderLockDetected}: Partial<TabInfo>, isAllowedFileSchemeAccess = true): boolean {
     if (isLocalFile(url) && !isAllowedFileSchemeAccess) {
         return false;
     }
@@ -364,7 +364,7 @@ export function isURLEnabled(url: string, userSettings: UserSettings, {isProtect
     if (isURLInEnabledList) {
         return true;
     }
-    if (isInDarkList || (userSettings.detectDarkTheme && isDarkThemeDetected)) {
+    if (isInDarkList || (userSettings.detectDarkTheme && isDarkThemeDetected) || isDarkReaderLockDetected) {
         return false;
     }
     return !isURLInDisabledList;


### PR DESCRIPTION
## Summary
- Adds support for `<meta name="darkreader-lock">` meta tag that websites can use to tell Dark Reader they manage their own dark mode
- When detected, Dark Reader defers and shows "Website manages dark mode" in the popup (distinct from "Dark theme detected")
- Users can still force-enable Dark Reader via the site toggle (adds to `enabledFor` list, which overrides the lock)

Closes #14334

## How it works
1. Website adds `<meta name="darkreader-lock">` to their `<head>`
2. Dark Reader's content script detects this meta tag before applying styles
3. If found (and the site isn't force-enabled), Dark Reader removes its styles and sends a `DARKREADER_LOCK_DETECTED` message
4. The popup shows "Website manages dark mode" and the extension icon goes inactive
5. If the user clicks the site toggle, the site is added to `enabledFor`, overriding the lock

## Files changed
- **`src/inject/detector.ts`** - Added `hasDarkReaderLockMeta()` detection function
- **`src/inject/index.ts`** - Check for lock meta before dark theme detection; skip if force-enabled
- **`src/utils/message.ts`** - Added `DARKREADER_LOCK_DETECTED` message type
- **`src/definitions.d.ts`** - Added `isDarkReaderLockDetected` to `TabInfo`
- **`src/background/tab-manager.ts`** - Handle lock message, track state per tab
- **`src/background/extension.ts`** - Include lock state in tab info; pass `isForceEnabled` flag to content script
- **`src/utils/url.ts`** - Respect lock in `isURLEnabled()`
- **`src/ui/popup/`** - Show distinct "Website manages dark mode" message
- **`src/_locales/*.config`** - Added `@darkreader_lock_detected` locale entry

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 15 test suites pass (`npm test`)
- [x] Install extension, visit a page with `<meta name="darkreader-lock">` → Dark Reader should deactivate and show "Website manages dark mode"
- [x] Click the site toggle → Dark Reader should force-enable and apply dark mode despite the lock
- [x] Visit a page without the meta tag → Normal Dark Reader behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)