### PR TITLE
Fixed orteil.dashnet.org homepage

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -37746,3 +37746,20 @@ CSS
 .zyimage {
     background-color: var(--darkreader-neutral-text) !important;
 }
+
+================================
+
+orteil.dashnet.org
+
+CSS
+html {
+    background-color:#5d00a8;
+    background-image:url(shadedEdges.png),url(bg.png);
+	background-size:100% 100%,auto;
+}
+CSS
+#firstBox,#Wgames,#Wtoys,#Wexps,#Wlinks
+{
+   background-color:#333;
+   color:#fff;
+}


### PR DESCRIPTION
I just added in a rule to fix the homepage of `orteil.dashnet.org`, I tested it, it does not break Cookie Clicker it seems.