### PR TITLE
Remove hard-coded text-shadow in Filter mode

### DIFF
--- a/src/generators/css-filter.ts
+++ b/src/generators/css-filter.ts
@@ -77,13 +77,6 @@ export function cssFilterStyleSheetTemplate(filterRoot: string, filterValue: str
         lines.push(createTextStyle(config));
     }
 
-    // Fix bad font hinting after inversion
-    lines.push('');
-    lines.push('/* Text contrast */');
-    lines.push('html {');
-    lines.push('  text-shadow: 0 0 0 !important;');
-    lines.push('}');
-
     // Full screen fix
     lines.push('');
     lines.push('/* Full screen */');


### PR DESCRIPTION
Remove the hard-coded text-shadow that slightly embolden fonts in Filter and Filter+ modes.

This text-shadow was intentionally added by #18, but didn't leave you the choice to remove it. 

You can now increase **More > Text stroke** to get back the (imperceptibly) same result as the removed text-shadow.

Fix darkreader/darkreader#15090