### PR TITLE
add play.hbomax.com to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -7,7 +7,6 @@
 *.draftbot.gg
 *.furaffinity.net
 *.hadesblack.com
-*.hbomax.com
 *.iaas.store
 *.iaasdev.ru
 *.koya.gg
@@ -911,6 +910,7 @@ planetneverwinter.de
 plasticuproject.com
 platinumgod.co.uk
 play.geforcenow.com
+play.hbomax.com
 playclassic.games
 pluto.tv
 poal.co


### PR DESCRIPTION
The dark list already has hbomax.com but looks like it doesn't work when logged in. When you're logged in it's using play.hbomax.com which does not work on global dark list without wild card.