### PR TITLE
Fix plaintext files display in Firefox

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -16,6 +16,7 @@ twitterwidget
 .sr-backdrop
 iframe:fullscreen
 [class="opinary-iframe"]
+html > body > pre:nth-child(1):not([class])
 
 NO INVERT
 [style*="background:url"] *


### PR DESCRIPTION
To me, in Firefox with default settings and Dark Reader using "Filter" mode, all plain text files (ex: <https://raw.githubusercontent.com/darkreader/darkreader/refs/heads/main/src/config/inversion-fixes.config>) display with dark letters on a dark background (black on black basically).
This is a fix for that specific behavior: 1st non-class &lt;pre&gt; element on a plain html page (which is created by Firefox to display plaintext files) is inverted. Background stays dark but the text is readable now.