### PR TITLE
fix(parser): getSitesFixesFor always caches undefined, defeating the cache

### DIFF
--- a/src/generators/utils/parse.ts
+++ b/src/generators/utils/parse.ts
@@ -140,7 +140,7 @@ export function getSitesFixesFor<T extends SiteProps>(url: string, text: string,
         const [start, length] = offset;
         const block = text.slice(start, start + length);
         const fix = parse(block)[0];
-        siteFixesCache.set(offset, cache);
+        siteFixesCache.set(offset, fix);
         return fix;
     });
 


### PR DESCRIPTION
## Summary

`getSitesFixesFor` builds a cache of parsed site fixes keyed by offset, so the config text doesn't need to be re-parsed on every lookup. However, since its introduction in 12558c5e, the cache write has always stored `undefined` instead of the parsed fix.

## Fix

```diff
  const cache = siteFixesCache.get(offset);
  if (cache) {
    return cache;
  }
  const [start, length] = offset;
  const block = text.slice(start, start + length);
  const fix = parse(block)[0];
- siteFixesCache.set(offset, cache);
+ siteFixesCache.set(offset, fix);
  return fix;
```