### PR TITLE
Add new rules for dynamic theme fixes for https://www.nytimes.com/puz…

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24089,6 +24089,13 @@ line[style="stroke: var(--tie); stroke: black;"]
 
 ================================
 
+nytimes.com/puzzles/spelling-bee/*
+
+INVERT
+.cell-letter
+
+================================
+
 nzbget.*
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24007,6 +24007,7 @@ div#live-us-map.live-us-map-embed
 .pz-nav__logo
 .pz-nav__hamburger-box
 div.Domino-module_dotsWrapper__fkTri
+.cell-letter
 
 CSS
 button[aria-label="Listen to article"] path[d="M22 38L37 28L22 18V38Z"],
@@ -24086,13 +24087,6 @@ html[data-darkreader-scheme="dark"] [class*=SolvedCategory-module_solvedCategory
 
 IGNORE INLINE STYLE
 line[style="stroke: var(--tie); stroke: black;"]
-
-================================
-
-nytimes.com/puzzles/spelling-bee/*
-
-INVERT
-.cell-letter
 
 ================================
 


### PR DESCRIPTION
…zles/spelling-bee*

Before

<img width="343" height="461" alt="image" src="https://github.com/user-attachments/assets/cc6e9098-3d8c-4e1a-96f7-cb6ebc8d509d" />


After

<img width="418" height="569" alt="image" src="https://github.com/user-attachments/assets/e017abb0-af27-4b33-9cb0-182171923baa" />
