### PR TITLE
add ecosia.org to detector-hints

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -349,6 +349,16 @@ MATCH
 
 ================================
 
+ecosia.org
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
+
 effect.website
 
 TARGET


### PR DESCRIPTION
Adding detector after removing site from dark-sites in https://github.com/darkreader/darkreader/pull/15180