### PR TITLE
fix for dark text in inpost e-mails

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10,6 +10,7 @@ a[data-testid="headerMediumLogo"]>svg
 .d2l-navigation-link-image-container
 .d2l-iframe-loading-container
 div.mc-ip-hide[style*="background: rgb(255, 255, 255) !important"]
+[style*="color: rgb(0, 0, 1) !important;"]
 
 CSS
 .vimvixen-hint {


### PR DESCRIPTION
Before:
<img width="629" height="208" alt="obraz" src="https://github.com/user-attachments/assets/c659f39b-6575-4a2b-87f4-0b352306896c" />

After:
<img width="598" height="240" alt="obraz" src="https://github.com/user-attachments/assets/1d2bcaf4-a3e5-45b7-ad45-0165fe3c5011" />
