### PR TITLE
feat(detector-hints): add atlassian controlled domains

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1,3 +1,13 @@
+*.atlassian.com
+
+TARGET
+html
+
+MATCH
+[data-color-mode="dark"]
+
+================================
+
 *.autotask.net
 
 TARGET
@@ -140,6 +150,16 @@ NO DARK THEME
 
 ================================
 
+atlassian.design
+
+TARGET
+html
+
+MATCH
+[data-color-mode="dark"]
+
+================================
+
 bandaancha.eu
 
 NO DARK THEME
@@ -153,6 +173,16 @@ body
 
 MATCH
 .dark-theme
+
+================================
+
+bitbucket.org
+
+TARGET
+html
+
+MATCH
+[data-color-mode="dark"]
 
 ================================
 
@@ -1036,6 +1066,16 @@ MATCH
 thurrott.com
 
 NO DARK THEME
+
+================================
+
+trello.com
+
+TARGET
+html
+
+MATCH
+[data-color-mode="dark"]
 
 ================================
 


### PR DESCRIPTION
Some Atlassian subdomains do not have theming implemented, however nearly all set `data-color-mode="light"` in this scenario, implying a shared theming architecture across Atlassian domains.