### PR TITLE
fix: correct docs.rs dark theme detection behavior

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -367,7 +367,6 @@ docs.adonisjs.com
 docs.baobun.dev
 docs.gofiber.io
 docs.quad9.net
-docs.rs
 dodi-repacks.site
 doesitarm.com
 doge.gov

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -349,6 +349,17 @@ MATCH
 
 ================================
 
+docs.rs
+
+TARGET
+html
+
+MATCH
+[data-theme="dark"]
+[data-theme="ayu"]
+
+================================
+
 ecosia.org
 
 TARGET


### PR DESCRIPTION
docs.rs has an light theme available, marking it for removal from the dark-sites list, it additionally provides two variations of a dark theme, "dark" and "ayu."