### PR TITLE
fix for www1.bmo.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -36656,6 +36656,15 @@ INVERT
 
 ================================
 
+www1.bmo.com
+
+CSS
+otp-app input[type="checkbox"]:not(:checked) {
+    background-image: none !important;
+}
+
+================================
+
 www1.flightrising.com
 
 INVERT


### PR DESCRIPTION
Fixes #15197

On the BMO 2FA page the checkbox's checkmark is rendered as a CSS background-image using an inline SVG data URI with a white fill. The site only has a light theme so the glyph is normally invisible when unchecked because it matches the white background and only becomes visible once the checked state paints a blue background behind it.

From what I can tell, Dark Reader changes the fill color of inline SVG images so they stay visible against a dark background. That causes the checkmark to appear in the unchecked state as well, making the box look permanently ticked.

The fix removes the background-image only in the unchecked state leaving the checked state untouched.

Note about the URL:
I’m using www1.bmo.com rather than bmo.com because the issue only exists on the 2FA page of the authenticated banking app (which is hosted on the www1 subdomain). I can broaden it to bmo.com if preferred. From my understanding www.bmo.com is just their information/marketing site so I thought using bmo.com would be broader than needed for this fix.

Before (broken):
Appears ticked when it's not:
<img width="1276" height="1426" alt="2FA before fix - checkbox unselected (broken)" src="https://github.com/user-attachments/assets/78aad10e-027b-4a8f-9043-bc7f15f88fbd" />
When actually ticked:
<img width="1246" height="1416" alt="2FA before fix- checkbox selected" src="https://github.com/user-attachments/assets/8995e1b6-0433-4db1-bbde-16a7ee663e15" />

After (fix applied):
Unchecked now renders correctly:
<img width="1322" height="1450" alt="After fix - Unchecked" src="https://github.com/user-attachments/assets/50f69cc4-c5b2-4f0b-86eb-80351075616a" />
Checked state remains unaffected:
<img width="1282" height="1438" alt="After fix - Checked" src="https://github.com/user-attachments/assets/12263a04-4fd1-484e-b19c-ba9cf058bdc8" />

I verified other checkboxes on the site (sign-in homepage, settings) remain unaffected.

Let me know if anything’s missing or needs adjusting, happy to make changes.