### PR TITLE
fix(inline-style): watch all shadow hosts discovered in a single subtree on FireFox

### DIFF
--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -189,10 +189,10 @@ function deepWatchForInlineStyles(
             elementStyleDidChange(el);
         });
         iterateShadowHosts(node, (n) => {
-            if (discoveredNodes.has(node)) {
+            if (discoveredNodes.has(n)) {
                 return;
             }
-            discoveredNodes.add(node);
+            discoveredNodes.add(n);
             shadowRootDiscovered(n.shadowRoot!);
             deepWatchForInlineStyles(n.shadowRoot!, elementStyleDidChange, shadowRootDiscovered);
         });


### PR DESCRIPTION
## Summary

Fixes shadow host discovery in `deepWatchForInlineStyles()`, visible only on Firefox.

The callback passed to `iterateShadowHosts(node, ...)` deduplicated on `node` (the parent subtree root) instead of `n` (the iterated shadow host).

When a single DOM insertion adds a subtree containing multiple shadow hosts, only the first is passed to `shadowRootDiscovered()` and `deepWatchForInlineStyles()`.

On Chromium this is masked. `Element.prototype.attachShadow` is overridden by the proxy, so shadow roots are already registered via `__darkreader__shadowDomAttaching` before the `MutationObserver` callback runs.

On Firefox, XrayWrappers prevent prototype overrides from being visible to page code, so `discoverNodes` is the sole discovery path, making the deduplication bug observable.

## Fix

```diff
- if (discoveredNodes.has(node)) {
+ if (discoveredNodes.has(n)) {
      return;
   }
- discoveredNodes.add(node);
+ discoveredNodes.add(n);
```

## Reproduction

```html
<div id="mount"></div>

<script>
customElements.define('x-box', class extends HTMLElement {
  constructor() {
    super();
    const root = this.attachShadow({ mode: 'open' });
    root.innerHTML = `
      <div style="
        background-color: #fff;
        color: #111;
        border: 2px solid #f00;
        padding: 12px;
        margin: 4px;
      ">
        shadow box
      </div>
    `;
  }
});

const mount = document.getElementById('mount');

setTimeout(() => {
  mount.innerHTML = '';

  const wrapper = document.createElement('div');
  wrapper.append(
    document.createElement('x-box'),
    document.createElement('x-box'),
  );

  mount.append(wrapper);
}, 0);
</script>

```

### Before

<img width="156" height="111" alt="image" src="https://github.com/user-attachments/assets/903b44e5-22e4-476a-a86a-b5c77ca71451" />

<img width="2265" height="394" alt="image" src="https://github.com/user-attachments/assets/cccda42d-a7cd-4bd5-902a-f7fbfc53cd1d" />

### After

<img width="156" height="117" alt="image" src="https://github.com/user-attachments/assets/3047b774-a7a7-4008-9d8d-652fc4ca670f" />

<img width="2288" height="398" alt="image" src="https://github.com/user-attachments/assets/79daa46f-d0ec-41ed-8aeb-ab3d68297330" />
