### PR TITLE
fix(stylesheet-proxy): adopted stylesheets in shadow roots never processed on Firefox

### DIFF
--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -494,7 +494,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean, enableCustomElement
                 return;
             }
             const unqueuedSheets: NodeSheet[] = [];
-            unqueuedSheets.forEach(({sheetId, sheet}) => {
+            sheets.forEach(({sheetId, sheet}) => {
                 if (queuedSheetChanges.has(sheet)) {
                     return;
                 }


### PR DESCRIPTION
## Summary

Fixes `handleSheetChangeForNode` in the Firefox adopted stylesheet path.

`unqueuedSheets` was iterated immediately after being declared as an empty array, instead of `sheets`.

Because nothing was ever pushed to `unqueuedSheets`, `sendSourceStyles` was never called for dynamically set adopted stylesheets, so Firefox never forwarded shadow root styles for processing.

Sites built with Lit/LitElement (and frameworks on top of it, like RapiDoc) assign their component styles `shadowRoot.adoptedStyleSheets` asynchronously after initial load. On Firefox, Dark Reader's dynamic theme was entirely absent from these shadow roots, static overrides were injected but the actual component styles were never inverted.

Not reproducible on Chromium because that path uses a direct prototype proxy instead of `handleSheetChangeForNode`.

## Fix
```diff
  const unqueuedSheets: NodeSheet[] = [];
- unqueuedSheets.forEach(({sheetId, sheet}) => {
+ sheets.forEach(({sheetId, sheet}) => {
```

## Reproduction

https://globalping.io/docs/api.globalping.io (discovered in #15156)

RapiDoc content inside `<rapi-doc>` shadow root renders with original light theme on Firefox.