### PR TITLE
feat(tasks/translate): preserve en.config key order across all locales

### DIFF
--- a/tasks/translate.js
+++ b/tasks/translate.js
@@ -46,7 +46,7 @@ async function translateEnMessage(messageId) {
                 const translated = await translate(enMessage, locale);
                 locMessages.set(messageId, translated);
 
-                const output = stringifyLocale(locMessages);
+                const output = stringifyLocale(reorderLocale(enMessages, locMessages));
                 await writeFile(locFile, output);
                 log(`${locale}: ${translated}`);
             }
@@ -93,7 +93,7 @@ async function translateNewEnMessages() {
                 log(`${locale}: ${translated}`);
             }
 
-            const output = stringifyLocale(locMessages);
+            const output = stringifyLocale(reorderLocale(enMessages, locMessages));
             await writeFile(locFile, output);
         }
     }
@@ -127,6 +127,26 @@ function parseLocale(content) {
         messages.set(id, value.trim());
     });
     return messages;
+}
+
+/**
+ * @param {Map<string, string>} enMessages
+ * @param {Map<string, string>} locMessages
+ * @returns {Map<string, string>}
+ */
+function reorderLocale(enMessages, locMessages) {
+    const reordered = new Map();
+    for (const key of enMessages.keys()) {
+        if (locMessages.has(key)) {
+            reordered.set(key, locMessages.get(key));
+        }
+    }
+    for (const key of locMessages.keys()) {
+        if (!reordered.has(key)) {
+            reordered.set(key, locMessages.get(key));
+        }
+    }
+    return reordered;
 }
 
 /**

--- a/tasks/translate.js
+++ b/tasks/translate.js
@@ -182,7 +182,7 @@ async function getLocaleFiles(locale) {
     const walk = async (dir) => {
         const entries = await fs.readdir(dir);
         const matched = entries.filter((f) => f === `${locale}.config` || f.endsWith(`.${locale}.config`));
-        results.push(...matched);
+        results.push(...matched.map((f) => `${dir}/${f}`));
 
         for (const e of entries) {
             const p = `${dir}/${e}`;


### PR DESCRIPTION
## Summary 
Noticed locale `.config` files were being written with inconsistent key ordering after running `translate-en-message`.

This was prompted while adding localizations in #15203, the output looked wrong given the rest of the project is pretty strictly ordered (filters alphabetized by URL/subdomain, etc.).

## Changes
- Both `translateEnMessage` and `translateNewEnMessages` now write keys in the same order as `en.config`
- Fixed a bug where the full config path was not used in `getLocaleFiles`

## Note
the script `translate-new-en-messages` and its eventual callee `translateNewEnMessages` is misnamed, the function doesn't translate new messages, it retranslates all of them. I can follow this up with a fix that makes it actually do what the name says (only translate keys missing from the locale file), if that's wanted.