### PR TITLE
fix(background): correct file:// enabled state in popup on Firefox

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -409,7 +409,18 @@ export class Extension {
             Newsmaker.getLatest(),
             Extension.getShortcuts(),
             Extension.getActiveTabInfo(),
-            new Promise<boolean>((r) => chrome.extension.isAllowedFileSchemeAccess(r)),
+            new Promise<boolean>((resolve) => {
+                // Firefox always returns false from isAllowedFileSchemeAccess()
+                // We are also not going to assume <all_urls> always grants file scheme access
+                if (isFirefox) {
+                    chrome.permissions.contains(
+                        {origins: ['file:///*']},
+                        resolve
+                    );
+                } else {
+                    chrome.extension.isAllowedFileSchemeAccess(resolve);
+                }
+            }),
             UIHighlights.getHighlightsToShow(),
         ]);
         return {


### PR DESCRIPTION
## Summary 

On Firefox, the extension popup shows the site toggle as disabled (x) on `file://` pages even though Dark Reader is actively theming them. Clicking the toggle turns the theme off, confirming it was on.

`collectData()` passes this value to the popup as `isAllowedFileSchemeAccess`.
The popup's `isURLEnabled()` call uses it to gate the site toggle state, so on Firefox it always renders `file://` pages as disabled, even though `getTabMessage()` (which doesn't pass the flag, defaulting to `true`) is happily applying the theme.

Chrome and Firefox handle file URL access differently:

**Chrome**
  - Has a per extension "Allow access to file URLs" toggle, `chrome.extension.isAllowedFileSchemeAccess()` reflects that setting.
 
**Firefox**
  - Has no such toggle, access is declared via `<all_urls>` in the manifest, and `isAllowedFileSchemeAccess()` always returns `false`.

## Fix

Manually verify permissions at runtime.

Alternatively since Dark Reader is only shipped as Firefox MV2 and the manifest's `<all_urls>` already covers `file://`, we could just return `true` immediately. Although, I think it's better to just go ahead and check anyway.

## Before

<img width="243" height="62" alt="image" src="https://github.com/user-attachments/assets/9c55ebfb-cf2f-488f-9411-d9ab8a6872b7" />
<br><br>
<img width="243" height="79" alt="image" src="https://github.com/user-attachments/assets/cae22d9f-5fd9-4657-acfa-faf9321b9b4c" />

## After

<img width="221" height="71" alt="image" src="https://github.com/user-attachments/assets/2772b2d5-5b4c-49f7-9cb4-d4abab79d565" />
<br><br>
<img width="218" height="79" alt="image" src="https://github.com/user-attachments/assets/128c8a58-1778-4e6f-a4a2-9a51ddd15149" />

