### PR TITLE
Add dynamic theme fixes for web.telegram.org, moodle.u-paris.fr and linuxhowtos.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -525,27 +525,6 @@ CSS
 
 ================================
 
-linuxhowtos.org
-
-CSS
-#background {
-    visibility: hidden !important;
-}
-#mc {
-    background-blend-mode: difference !important;
-    background-color: cadetblue !important;
-}
-#leftcontent {
-    background-image: none !important;
-}
-.shadr,
-.shadb,
-.shadt {
-    visibility: hidden !important;
-}
-
-================================
-
 *.maricopa.edu
 
 CSS
@@ -19457,6 +19436,27 @@ CSS
 body {
     background-color: var(--darkreader-neutral-background) !important;
     background-image: none !important;
+}
+
+================================
+
+linuxhowtos.org
+
+CSS
+#background {
+    visibility: hidden !important;
+}
+#mc {
+    background-blend-mode: difference !important;
+    background-color: cadetblue !important;
+}
+#leftcontent {
+    background-image: none !important;
+}
+.shadr,
+.shadb,
+.shadt {
+    visibility: hidden !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22132,6 +22132,18 @@ INVERT
 
 ================================
 
+moodle.u-pariscite.fr
+
+CSS
+img.logo {
+    filter: invert(100%) hue-rotate(220deg);
+}
+input.form-control::placeholder {
+    color: white !important;
+}
+
+================================
+
 moovitapp.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -35527,6 +35527,9 @@ CSS
 .progress-bar {
     background-color: rgba(255,255,255,.9) !important;
 }
+canvas.chat-background-item-canvas {
+    opacity: 0 !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -525,6 +525,27 @@ CSS
 
 ================================
 
+*.linuxhowtos.org
+
+CSS
+#background {
+    visibility: hidden !important;
+}
+#mc {
+    background-blend-mode: difference !important;
+    background-color: cadetblue !important;
+}
+#leftcontent {
+    background-image: none !important;
+}
+.shadr,
+.shadb,
+.shadt {
+    visibility: hidden !important;
+}
+
+================================
+
 *.maricopa.edu
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -525,7 +525,7 @@ CSS
 
 ================================
 
-*.linuxhowtos.org
+linuxhowtos.org
 
 CSS
 #background {

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1593,6 +1593,19 @@ CSS
     color: var(--darkreader-neutral-background);
 }
 
+
+================================
+
+linuxhowtos.org
+
+REMOVE BG
+td
+
+CSS
+#background {
+    visibility : hidden;
+}
+
 ================================
 
 mail.google.com
@@ -1755,6 +1768,13 @@ body
 .top > .menu
 #upload-filelist
 .file-url
+
+================================
+
+moodle.u-pariscite.fr
+
+NO INVERT
+.logo
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1593,7 +1593,6 @@ CSS
     color: var(--darkreader-neutral-background);
 }
 
-
 ================================
 
 linuxhowtos.org
@@ -1603,7 +1602,7 @@ td
 
 CSS
 #background {
-    visibility : hidden;
+    display: none !important;
 }
 
 ================================


### PR DESCRIPTION
### Disclaimer: this contribution is part of work carried out as a student at Université Paris-Cité.
Apologies if this is inappropriate or if the contribution does not meet the project’s standards. Any feedback is welcome.

Add : 
- Fix dynamic theme only for [web.telegram.org](https://web.telegram.org) where the bright background wasn't correctly replaced
- Fix dynamic and filter theme for [moodle.u-pariscite.fr](https://moodle.u-pariscite.fr) where the logo wasn't redeable
- Fix dynamic and filter theme for [linuxhowtos.org](https://linuxhowtos.org)

just a comparatif for www.linuxhowtos.org :

**without darkreader :** <img width="2328" height="1295" alt="Image" src="https://github.com/user-attachments/assets/2edcae06-6009-4f36-8ca4-bac06dcf4478" />

**before, with darkreader activated :** <img width="2332" height="1297" alt="Image" src="https://github.com/user-attachments/assets/ec666496-344b-4fd7-97ce-6545aadaf35b" />

**after, with darkreader activated :** <img width="2332" height="1298" alt="Image" src="https://github.com/user-attachments/assets/68786ea0-2f26-4501-814d-ff1cda633c03" />

