### PR TITLE
Add rules and CSS fixes for nytimes.com "Spelling Bee" and "Spelling …

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24059,6 +24059,7 @@ div#live-us-map.live-us-map-embed
 .pz-nav__hamburger-box
 div.Domino-module_dotsWrapper__fkTri
 .cell-letter
+.sb-input-invalid
 
 CSS
 .letter.filled.remaining {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24061,6 +24061,12 @@ div.Domino-module_dotsWrapper__fkTri
 .cell-letter
 
 CSS
+.letter.filled.remaining {
+    background-color: var(--darkreader-bg--spelling-bee-light-yellow) !important;
+}
+polygon.cell-fill {
+    stroke: var(--darkreader-bg--stroke) !important;
+}
 button[aria-label="Listen to article"] path[d="M22 38L37 28L22 18V38Z"],
 button[aria-label="Save article for reading later..."] .saved-stroke {
     fill: var(--darkreader-neutral-text) !important;


### PR DESCRIPTION
…Bee Buddy"

### Spelling Bee
#### Before
<img width="300" height="377" alt="image" src="https://github.com/user-attachments/assets/f4738c1a-df9c-4b79-bb9d-0f043deedcbe" />

#### After
<img width="331" height="388" alt="image" src="https://github.com/user-attachments/assets/3df6b277-2c71-40c1-bb13-b67ba2d5e85d" />

### Spelling Bee Buddy
#### Before
<img width="456" height="1005" alt="image" src="https://github.com/user-attachments/assets/3c9bae1f-2a6b-4550-bc56-6b78e9437709" />


#### After
<img width="447" height="866" alt="image" src="https://github.com/user-attachments/assets/8737fcc9-3f91-4a73-bc2c-18082ff3488d" />
