### PR TITLE
Correct background color for nytimes games logo in dynamic fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24055,7 +24055,7 @@ div#live-us-map.live-us-map-embed
 .vmap-layer-container > g > text
 .vmap-zoom-buttons
 #xwd-board
-.pz-nav__logo
+.pz-nav__logo > path
 .pz-nav__hamburger-box
 div.Domino-module_dotsWrapper__fkTri
 .cell-letter
@@ -24077,6 +24077,9 @@ a[data-testid] > svg {
 }
 .headline-link div:hover {
     color: ${#555} !important;
+}
+.pz-nav__logo > rect {
+    fill: var(--darkreader-bg--bg-page);
 }
 .svelte-15nnlbj {
     font-weight: bold !important;


### PR DESCRIPTION
Added styles for .pz-nav__logo path and rect elements.

#### Before 
<img width="212" height="45" alt="image" src="https://github.com/user-attachments/assets/d015e628-e21e-48f5-81b0-91882272a822" />
#### After
<img width="212" height="51" alt="image" src="https://github.com/user-attachments/assets/26774aec-3678-4ff3-98fb-dba7c37ff34b" />

