### PR TITLE
Fix for star-history.com chart images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -11,6 +11,7 @@ a[data-testid="headerMediumLogo"]>svg
 .d2l-iframe-loading-container
 div.mc-ip-hide[style*="background: rgb(255, 255, 255) !important"]
 [style*="color: rgb(0, 0, 1) !important;"]
+img[data-canonical-src*="api.star-history.com"]:not([data-canonical-src*="theme=dark"])
 
 CSS
 .vimvixen-hint {


### PR DESCRIPTION
Fix star-history.com embedded chart images in dark mode.

Star-history.com provides an API that generates SVG charts. When embedded on other sites (like GitHub README), these charts appear as light images on dark backgrounds, making them hard to read.

I was browsing trending GitHub repos at 2 AM (as every good developer does) and noticed star-history charts showing up as bright white blobs. After some investigation, I realized these charts come from api.star-history.com with a data-canonical-src attribute.

This fix:
- Inverts images from api.star-history.com that don't already have theme=dark
- Uses CSS :not() selector to avoid double-inversion for images that already use the dark theme parameter

For developers who somehow missed that theme=dark exists in the API (seriously, it's right there in the README) - your charts will now be readable in dark mode too.