### PR TITLE
Add developers.openai.com to dark sites config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -332,6 +332,7 @@ devanbuggay.com
 developer.valvesoftware.com
 developerinsider.co
 developers.cloudflare.com
+developers.openai.com
 di.fm
 diablogame.de
 dicebear.com


### PR DESCRIPTION
Default is dark on light sys theme.