### PR TITLE
removing background for web.telegram.org in dark theme

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -525,27 +525,6 @@ CSS
 
 ================================
 
-linuxhowtos.org
-
-CSS
-#background {
-    visibility: hidden !important;
-}
-#mc {
-    background-blend-mode: difference !important;
-    background-color: cadetblue !important;
-}
-#leftcontent {
-    background-image: none !important;
-}
-.shadr,
-.shadb,
-.shadt {
-    visibility: hidden !important;
-}
-
-================================
-
 *.maricopa.edu
 
 CSS
@@ -19457,6 +19436,27 @@ CSS
 body {
     background-color: var(--darkreader-neutral-background) !important;
     background-image: none !important;
+}
+
+================================
+
+linuxhowtos.org
+
+CSS
+#background {
+    visibility: hidden !important;
+}
+#mc {
+    background-blend-mode: difference !important;
+    background-color: cadetblue !important;
+}
+#leftcontent {
+    background-image: none !important;
+}
+.shadr,
+.shadb,
+.shadt {
+    visibility: hidden !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -22132,6 +22132,18 @@ INVERT
 
 ================================
 
+moodle.u-pariscite.fr
+
+CSS
+img.logo {
+    filter: invert(100%) hue-rotate(220deg);
+}
+input.form-control::placeholder {
+    color: white !important;
+}
+
+================================
+
 moovitapp.com
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -35527,6 +35527,9 @@ CSS
 .progress-bar {
     background-color: rgba(255,255,255,.9) !important;
 }
+canvas.chat-background-item-canvas {
+    opacity: 0 !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -525,6 +525,27 @@ CSS
 
 ================================
 
+*.linuxhowtos.org
+
+CSS
+#background {
+    visibility: hidden !important;
+}
+#mc {
+    background-blend-mode: difference !important;
+    background-color: cadetblue !important;
+}
+#leftcontent {
+    background-image: none !important;
+}
+.shadr,
+.shadb,
+.shadt {
+    visibility: hidden !important;
+}
+
+================================
+
 *.maricopa.edu
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -525,7 +525,7 @@ CSS
 
 ================================
 
-*.linuxhowtos.org
+linuxhowtos.org
 
 CSS
 #background {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19440,27 +19440,6 @@ body {
 
 ================================
 
-linuxhowtos.org
-
-CSS
-#background {
-    visibility: hidden !important;
-}
-#mc {
-    background-blend-mode: difference !important;
-    background-color: cadetblue !important;
-}
-#leftcontent {
-    background-image: none !important;
-}
-.shadr,
-.shadb,
-.shadt {
-    visibility: hidden !important;
-}
-
-================================
-
 linuxuprising.com
 
 INVERT
@@ -22150,18 +22129,6 @@ moodle.herzen.spb.ru
 
 INVERT
 .img-responsive
-
-================================
-
-moodle.u-pariscite.fr
-
-CSS
-img.logo {
-    filter: invert(100%) hue-rotate(220deg);
-}
-input.form-control::placeholder {
-    color: white !important;
-}
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1593,6 +1593,19 @@ CSS
     color: var(--darkreader-neutral-background);
 }
 
+
+================================
+
+linuxhowtos.org
+
+REMOVE BG
+td
+
+CSS
+#background {
+    visibility : hidden;
+}
+
 ================================
 
 mail.google.com
@@ -1755,6 +1768,13 @@ body
 .top > .menu
 #upload-filelist
 .file-url
+
+================================
+
+moodle.u-pariscite.fr
+
+NO INVERT
+.logo
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1595,18 +1595,6 @@ CSS
 
 ================================
 
-linuxhowtos.org
-
-REMOVE BG
-td
-
-CSS
-#background {
-    display: none !important;
-}
-
-================================
-
 mail.google.com
 
 CSS
@@ -1767,13 +1755,6 @@ body
 .top > .menu
 #upload-filelist
 .file-url
-
-================================
-
-moodle.u-pariscite.fr
-
-NO INVERT
-.logo
 
 ================================
 

--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -1593,7 +1593,6 @@ CSS
     color: var(--darkreader-neutral-background);
 }
 
-
 ================================
 
 linuxhowtos.org
@@ -1603,7 +1602,7 @@ td
 
 CSS
 #background {
-    visibility : hidden;
+    display: none !important;
 }
 
 ================================


### PR DESCRIPTION
### Disclaimer: this contribution is part of work carried out as a student at Université Paris-Cité.
Apologies if this is inappropriate or if the contribution does not meet the project’s standards. Any feedback is welcome.

This pull request is the last part of an older pull request (https://github.com/darkreader/darkreader/pull/15218) that @alexanderby advised me to split into several smaller pull requests.
Thanks to @Myshor and @alexanderby for the feedback on the changes and advice.

Add : 
- Fix dynamic theme only for [web.telegram.org](https://web.telegram.org/) where the bright background wasn't correctly replaced

## just some example : 

### Before :
**without darkreader :**
<img width="1680" height="941" alt="image" src="https://github.com/user-attachments/assets/4dba0e0b-0e10-4cbd-a3a8-9904f5ab3bba" />

**with darkreader :** 
<img width="1682" height="947" alt="image" src="https://github.com/user-attachments/assets/dd6bc1c6-6abf-4dd5-9749-26f22576d0f2" />

### After : 

**with darkreader :** 
<img width="1677" height="940" alt="image" src="https://github.com/user-attachments/assets/d73ef594-2df9-4cfd-ac8a-c2bba138980d" />