### PR TITLE
Removed gianmarco.gg from dark-sites.config

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -523,7 +523,6 @@ gfverse.info
 ggapp.io
 ghidra-sre.org
 gi.yatta.moe
-gianmarco.gg
 giantbomb.com
 gibber.cc
 gibbu.github.io/ThemePreview/


### PR DESCRIPTION
No longer dark by default since last year.