### PR TITLE
Add INVERT configurations for PayPal

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2064,6 +2064,13 @@ INVERT
 
 ================================
 
+paypal.com
+
+INVERT
+.css-1g2endo-item_list-item_list_desktop
+
+================================
+
 perforce.com
 
 INVERT


### PR DESCRIPTION
Added a inversion fix to paypal.com dashboard


Original
<img width="1918" height="364" alt="image" src="https://github.com/user-attachments/assets/51cf776c-e663-479b-913e-fc4a8e475a21" />


With Fix
<img width="1900" height="361" alt="image" src="https://github.com/user-attachments/assets/fa1961d3-048a-41d3-863b-c9f8e5c90545" />
