### PR TITLE
Add dynamic theme fixes for client.schwab.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7482,6 +7482,22 @@ canvas
 
 ================================
 
+client.schwab.com
+
+CSS
+#quickQuoteContainer,
+.sdps-header__bar--primary,
+.fdic-container,
+.highcharts-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.sdps-text-legal,
+.fdic-text {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 clients.servarica.com
 
 INVERT
@@ -29010,22 +29026,6 @@ schwab.com
 CSS
 .highcharts-background {
     background-color: var(--darkreader-neutral-background) !important;
-}
-
-================================
-
-client.schwab.com
-
-CSS
-#quickQuoteContainer,
-.sdps-header__bar--primary,
-.fdic-container,
-.highcharts-background {
-    background-color: var(--darkreader-neutral-background) !important;
-}
-.sdps-text-legal,
-.fdic-text {
-    color: var(--darkreader-neutral-text) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29025,7 +29025,7 @@ CSS
 }
 .sdps-text-legal,
 .fdic-text {
-    color: var(--darkreader-text-000000) !important;
+    color: var(--darkreader-neutral-text) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29014,6 +29014,22 @@ CSS
 
 ================================
 
+client.schwab.com
+
+CSS
+#quickQuoteContainer,
+.sdps-header__bar--primary,
+.fdic-container,
+.highcharts-background {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+.sdps-text-legal,
+.fdic-text {
+    color: var(--darkreader-text-000000) !important;
+}
+
+================================
+
 sci-hub.*
 
 IGNORE IMAGE ANALYSIS


### PR DESCRIPTION
Add CSS rules for dynamic theme fixes on client.schwab.com

Before:
<img width="1457" height="911" alt="image" src="https://github.com/user-attachments/assets/650c259d-ff22-4049-a323-bc475c0205cd" />

After:
<img width="1450" height="913" alt="image" src="https://github.com/user-attachments/assets/cfe817e7-4c40-4fc1-a1a4-8fa26bf61fed" />
