### PR TITLE
Add puuilo.fi

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27142,6 +27142,19 @@ CSS
 
 ================================
 
+puuilo.fi
+
+CSS
+#customSearchInput {
+    background-image: linear-gradient(var(--darkreader-neutral-background), var(--darkreader-neutral-background)) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
+.custom-search-submit svg {
+    stroke: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 pycheung.com/checker/
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
puuilo.fi sets `background-color: #F8F6F4 !important` inline on the search input, which Dark Reader cannot override via standard `background-color` rules. As a result the input keeps the light background while the rest of the site is dark, leaving the typed text and placeholder near-invisible.

Fix: paint the background via `background-image` linear gradient (not locked by inline style) using `--darkreader-neutral-background`, and set text/icon colors via `--darkreader-neutral-text`. Works in both dark and light DR schemes.