### PR TITLE
Update detector hint for developer.mozilla.org

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -298,7 +298,7 @@ TARGET
 html
 
 MATCH
-.dark
+[data-theme*="dark"]
 
 ================================
 


### PR DESCRIPTION
Site had a redesign. I could use `[data-theme="dark"]`, but it doesn't work with OS default theme settings.