### PR TITLE
Fix for jacobin.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17285,6 +17285,9 @@ INVERT
 .pq::before
 .si-hr-nv__icon--menu
 
+IGNORE IMAGE ANALYSIS
+.hm-sd-b-ty
+
 ================================
 
 jailbreak.fce365.info


### PR DESCRIPTION
Fixes graphical element on home page.

Before:
<img width="700" height="424" alt="1" src="https://github.com/user-attachments/assets/c07aed19-90c1-4e2c-b20d-e9d7b200460e" />

After:
<img width="700" height="424" alt="2" src="https://github.com/user-attachments/assets/db854762-e454-4e7e-90b0-5718347d86b2" />