### PR TITLE
Fix Petdex sprite rendering

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -25680,6 +25680,16 @@ h1.pals-header
 
 ================================
 
+petdex.crafter.run
+
+IGNORE INLINE STYLE
+.pet-sprite
+
+IGNORE IMAGE ANALYSIS
+.pet-sprite
+
+================================
+
 petri.com
 
 INVERT


### PR DESCRIPTION
When Dark Reader is enabled, sprites disappear on Petdex. This proposes a dynamic-theme fix.

Preserves `.pet-sprite` inline styles and image analysis so WebP spritesheets remain visible in Dark Reader dark mode.

Before
<img width="843" height="471" alt="image" src="https://github.com/user-attachments/assets/5a9e668e-c167-470e-8940-b44452d1ecbb" />


After
<img width="847" height="459" alt="image" src="https://github.com/user-attachments/assets/cadac29a-7545-448e-bc99-031637164046" />
