### PR TITLE
Added croxyproxy.com fix to dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -8654,6 +8654,15 @@ CSS
 
 ================================
 
+croxyproxy.com
+
+CSS
+html:not([__cpp]) > body {
+    background-image: unset !important;
+}
+
+================================
+
 crunchbase.com
 
 INVERT


### PR DESCRIPTION
Fixed full-page background image that negatively impacted dynamic dark mode.  Included code (`html:not([__cpp])`) to not affect background images of target sites.