### PR TITLE
Removed defunct host hotel.meituan.com from dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -15951,14 +15951,6 @@ button.btn-t:hover {
 
 ================================
 
-hotel.meituan.com
-
-INVERT
-.poi-hotellbs-map
-.small-map
-
-================================
-
 howbuy.com
 
 INVERT


### PR DESCRIPTION
Host has been defunct for several years.