### PR TITLE
Fix for nytimes.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24295,7 +24295,6 @@ nytimes.com
 
 INVERT
 button[aria-label="Listen to article"] path[stroke="#DFDFDF"]
-#site_header_wrapper a[aria-label="Wirecutter"]
 div[data-testid="masthead-desktop-logo"] > a > svg
 div#live-country-map.live-country-map-embed
 div#live-us-map.live-us-map-embed


### PR DESCRIPTION
Fixes logo on most Wirecutter pages.