### PR TITLE
Update dynamic-theme-fixes.config (Shopify Admin)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1666,6 +1666,10 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 
+.banner {
+background-color: var(--darkreader-neutral-background) !important;
+}
+
 ================================
 
 afterpay.com

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1666,7 +1666,7 @@ CSS
     background-color: var(--darkreader-neutral-background) !important;
 }
 .banner {
-background-color: var(--darkreader-neutral-background) !important;
+    background-color: var(--darkreader-neutral-background) !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1665,7 +1665,6 @@ CSS
 .level-1 {
     background-color: var(--darkreader-neutral-background) !important;
 }
-
 .banner {
 background-color: var(--darkreader-neutral-background) !important;
 }


### PR DESCRIPTION
Apparently I missed one. Fixing the inversion of this banner in the confirmation section as shown here: 

Without Dark Reader:

<img width="1229" height="129" alt="image" src="https://github.com/user-attachments/assets/668ff252-31b1-430d-9f2d-fbd972f51821" />

Before Fix: 
<img width="1267" height="129" alt="image" src="https://github.com/user-attachments/assets/4f274529-aa6b-43bb-bb72-c557ee50ea67" />

After Fix: 
<img width="1227" height="129" alt="image" src="https://github.com/user-attachments/assets/3b4df5ea-3236-4c6d-b87f-597e9c5be5ce" />
