### PR TITLE
Add reset site settings button to popup

### DIFF
--- a/src/_locales/en.config
+++ b/src/_locales/en.config
@@ -91,6 +91,9 @@ Only for
 @only_for_description
 Apply settings to current website only
 
+@reset_site_settings
+Reset site settings
+
 @site_list
 Site list
 

--- a/src/ui/popup/components/custom-settings-toggle/index.tsx
+++ b/src/ui/popup/components/custom-settings-toggle/index.tsx
@@ -1,17 +1,28 @@
 import {m} from 'malevic';
 
-import type {ExtWrapper} from '../../../../definitions';
+import type {ExtWrapper, Theme} from '../../../../definitions';
 import {getLocalMessage} from '../../../../utils/locales';
 import {getURLHostOrProtocol, isURLInList} from '../../../../utils/url';
 import {Button} from '../../../controls';
 
 declare const __THUNDERBIRD__: boolean;
 
+function themesAreEqual(a: Theme, b: Theme) {
+    return Object.keys(a).every((key) => a[key as keyof Theme] === b[key as keyof Theme]);
+}
+
 export default function CustomSettingsToggle({data, actions}: ExtWrapper) {
     const tab = data.activeTab;
     const host = getURLHostOrProtocol(tab.url);
 
-    const isCustom = data.settings.customThemes.some(({url}) => isURLInList(tab.url, url));
+    const custom = data.settings.customThemes.find(({url}) => isURLInList(tab.url, url));
+    const isCustom = Boolean(custom);
+    const hasCustomThemeChanges = custom ? !themesAreEqual(custom.theme, data.settings.theme) : false;
+
+    function resetSiteSettings() {
+        const filtered = data.settings.customThemes.filter(({url}) => !isURLInList(tab.url, url));
+        actions.changeSettings({customThemes: filtered});
+    }
 
     const urlText = host
         .split('.')
@@ -20,30 +31,43 @@ export default function CustomSettingsToggle({data, actions}: ExtWrapper) {
             `${i > 0 ? '.' : ''}${part}`
         ), []);
 
+    const resetSiteSettingsLabel = getLocalMessage('reset_site_settings') || 'Reset site settings';
+
     return (
-        <Button
-            class={{
-                'custom-settings-toggle': true,
-                'custom-settings-toggle--checked': isCustom,
-                'custom-settings-toggle--disabled': __THUNDERBIRD__ || tab.isProtected,
-            }}
-            onclick={(e) => {
-                if (isCustom) {
-                    const filtered = data.settings.customThemes.filter(({url}) => !isURLInList(tab.url, url));
-                    actions.changeSettings({customThemes: filtered});
-                } else {
-                    const extended = data.settings.customThemes.concat({
-                        url: [host],
-                        theme: {...data.settings.theme},
-                    });
-                    actions.changeSettings({customThemes: extended});
-                    (e.currentTarget as HTMLElement).classList.add('custom-settings-toggle--checked'); // Speed-up reaction
-                }
-            }}
-        >
-            <span class="custom-settings-toggle__wrapper">
-                {getLocalMessage('only_for')} <span class="custom-settings-toggle__url" >{urlText}</span>
-            </span>
-        </Button>
+        <span class="custom-settings-toggle__group">
+            <Button
+                class={{
+                    'custom-settings-toggle': true,
+                    'custom-settings-toggle--checked': isCustom,
+                    'custom-settings-toggle--disabled': __THUNDERBIRD__ || tab.isProtected,
+                }}
+                onclick={(e) => {
+                    if (isCustom) {
+                        resetSiteSettings();
+                    } else {
+                        const extended = data.settings.customThemes.concat({
+                            url: [host],
+                            theme: {...data.settings.theme},
+                        });
+                        actions.changeSettings({customThemes: extended});
+                        (e.currentTarget as HTMLElement).classList.add('custom-settings-toggle--checked'); // Speed-up reaction
+                    }
+                }}
+            >
+                <span class="custom-settings-toggle__wrapper">
+                    {getLocalMessage('only_for')} <span class="custom-settings-toggle__url" >{urlText}</span>
+                </span>
+            </Button>
+            {hasCustomThemeChanges ? (
+                <Button
+                    class="custom-settings-toggle__reset"
+                    onclick={resetSiteSettings}
+                >
+                    <span class="custom-settings-toggle__reset__text">
+                        {resetSiteSettingsLabel === 'reset_site_settings' ? 'Reset site settings' : resetSiteSettingsLabel}
+                    </span>
+                </Button>
+            ) : null}
+        </span>
     );
 }

--- a/src/ui/popup/components/custom-settings-toggle/style.less
+++ b/src/ui/popup/components/custom-settings-toggle/style.less
@@ -4,6 +4,12 @@
     color: @color-fore;
     white-space: normal;
 
+    &__group {
+        display: flex;
+        flex-direction: column;
+        gap: @indent-small;
+    }
+
     &--checked,
     &:active,
     &--checked:hover {
@@ -28,5 +34,20 @@
         display: inline-flex;
         justify-content: center;
         min-width: @popup-content-width - 2 * @size-border;
+    }
+
+    &__reset {
+        background-color: transparent;
+
+        &__text {
+            white-space: nowrap;
+        }
+
+        .button__wrapper {
+            align-items: center;
+            display: inline-flex;
+            justify-content: center;
+            min-width: @popup-content-width - 2 * @size-border;
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a "Reset" button in the popup interface to allow users to quickly clear custom settings for the current website and revert to global theme settings.