### PR TITLE
Dynamic theme fixes for freecommander.eu (previously freecommander.com)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13592,17 +13592,13 @@ CSS
 
 ================================
 
-freecommander.com
+freecommander.eu
 
 CSS
-.am-body,
 #subsilver-nav-topic {
     background-image: none !important;
 }
-.forabg,
-.forumbg,
-.header > .row-item,
-.body-blok-h3 h3 {
+.forumbg {
     background: var(--darkreader-neutral-background) !important;
 }
 


### PR DESCRIPTION
The previous fixes (which were mostly written by me) were for the FreeCommander English forums.  Those forums recently moved to freecommander.eu, so I updated the TLD.

Also, some of the fixes don't seem to be needed any longer, so I removed them.