### PR TITLE
Fix broken Apple Pay QR codes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3061,6 +3061,13 @@ INVERT
 
 ================================
 
+applepay.cdn-apple.com
+
+IGNORE INLINE STYLE
+app-clip-code *
+
+================================
+
 apps.microsoft.com
 
 INVERT


### PR DESCRIPTION
Apple Pay QR codes are already a white code on a dark background. DarkReader was changing the code itself, making it un-scannable.