### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21692,6 +21692,17 @@ CSS
 
 ================================
 
+meneame.net
+
+CSS
+.ads-interlinks {
+    display: flex !important;
+    height: auto !important;
+    width: auto !important;
+}
+
+================================
+
 menti.com
 
 INVERT


### PR DESCRIPTION
The goal is for the banner containing the advertisement to fit the available space on the left and not overlap with the right side of the page. Also, if there's no banner ad, the div shouldn't expand.

Examples:
<img width="2911" height="1332" alt="1_without_DR" src="https://github.com/user-attachments/assets/5daf245a-3079-4362-b9dd-8da7b23052c4" />
<img width="2911" height="1332" alt="2_with_DR" src="https://github.com/user-attachments/assets/98595d4c-2387-4364-b887-563e5c641c01" />
<img width="2911" height="1332" alt="3_with_filter" src="https://github.com/user-attachments/assets/e0475b09-f6e2-4ee1-82c2-241aebea3a05" />
