### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21692,6 +21692,17 @@ CSS
 
 ================================
 
+meneame.net
+
+CSS
+.ads-interlinks {
+    display: flex !important;
+    height: auto !important;
+    width: auto !important;
+}
+
+================================
+
 menti.com
 
 INVERT


### PR DESCRIPTION
The goal is for the banner containing the advertisement to fit the available space on the left and not overlap with the right side of the page. Also, if there's no banner ad, the div shouldn't expand.

<img width="2911" height="1332" alt="1_without_DR" src="https://github.com/user-attachments/assets/4c85eb4b-c03b-4490-bc25-11d14ae6bbe3" />
<img width="2911" height="1332" alt="2_with_DR" src="https://github.com/user-attachments/assets/16e22ad3-94a9-46db-b47f-e3383b456b8d" />
<img width="2911" height="1332" alt="3_with_filter" src="https://github.com/user-attachments/assets/859360c8-862b-46be-b8e2-e92e17ed4ea4" />
