### PR TITLE
Update dynamic-theme-fixes.config

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27195,6 +27195,9 @@ INVERT
 
 procyclingstats.com
 
+IGNORE INLINE STYLE
+.svg_shirt
+
 IGNORE IMAGE ANALYSIS
 .flag
 .flag.w32


### PR DESCRIPTION
procyclingstats.com - Ignore inline styles on .svg_shirt so jersey images render the correct color