### PR TITLE
Fix system theme on syzygy-tables.info

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1019,6 +1019,12 @@ NO DARK THEME
 
 ================================
 
+syzygy-tables.info
+
+SYSTEM THEME
+
+================================
+
 t-j.ru
 
 TARGET


### PR DESCRIPTION
The website follows the system theme correctly, however dark theme detection does not work for it for some reason.