### PR TITLE
fix: correct Snapchat dark theme detection

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -970,6 +970,12 @@ MATCH
 
 ================================
 
+accounts.snapchat.com/v2/login
+www.snapchat.com
+NO DARK THEME
+
+================================
+
 slack.com
 *.slack.com
 

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -970,8 +970,9 @@ MATCH
 
 ================================
 
-accounts.snapchat.com/v2/login
-www.snapchat.com
+accounts.snapchat.com
+snapchat.com
+
 NO DARK THEME
 
 ================================


### PR DESCRIPTION
## Summary

Fixes #15410

This PR adds Snapchat pages to detector hints so Dark Reader does not incorrectly detect light Snapchat pages as already-dark pages.

## Changes

- Added detector hint for accounts.snapchat.com/v2/login
- Added detector hint for www.snapchat.com
- Marked these pages as NO DARK THEME

## Testing

Ran:

```bash
npm run code-style
npm test
```