### PR TITLE
fix: close mobile or news panel when selecting links in the bottom section

### DIFF
--- a/src/ui/popup/components/body.tsx
+++ b/src/ui/popup/components/body.tsx
@@ -101,11 +101,11 @@ function Body(props: BodyProps & {fonts: string[]} & {installation: {date: numbe
         if (state.newsOpen && unreadNews.length > 0) {
             props.actions.markNewsAsRead(unreadNews.map(({id}) => id));
         }
-        setState({newsOpen: !state.newsOpen, didNewsSlideIn: state.didNewsSlideIn || !state.newsOpen});
+        setState({newsOpen: !state.newsOpen, mobileLinksOpen: false, didNewsSlideIn: state.didNewsSlideIn || !state.newsOpen});
     }
 
     function toggleMobileLinks() {
-        setState({mobileLinksOpen: !state.mobileLinksOpen, didMobileLinksSlideIn: state.didMobileLinksSlideIn || !state.mobileLinksOpen});
+        setState({mobileLinksOpen: !state.mobileLinksOpen, newsOpen: false, didMobileLinksSlideIn: state.didMobileLinksSlideIn || !state.mobileLinksOpen});
         if (state.mobileLinksOpen && props.data.uiHighlights.includes('mobile-links')) {
             disableMobileLinksSlideIn();
         }


### PR DESCRIPTION
Bug description: In the bottom section of the Dark Reader extension (ex. Help, News, Mobile). The positions for the panel that slide up for News and Mobile are static. In that, the mobile panel is always in front while the news panel is always behind regardless of the order that the panels are selected. In other words, if the mobile panel appears first, then the news panel will appear behind the news panel.

What changed: updated the setState function call in toggleNews and toggleMobileLink to include the mobileLinksOpen and newOpen properties respectively. Each toggle causes the other panel to close now.

fixes #15339