### PR TITLE
Update LinkedIn URLs in detector-hints.config

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -629,7 +629,8 @@ MATCH
 
 ================================
 
-linkedin.com
+linkedin.com/mypreferences
+linkedin.com/my-items
 
 TARGET
 html

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -629,8 +629,22 @@ MATCH
 
 ================================
 
+linkedin.com/feed
+linkedin.com/mynetwork
+linkedin.com/jobs
+
+TARGET
+body
+
+MATCH
+[data-color-scheme="dark"]
+
+================================
+
 linkedin.com/mypreferences
 linkedin.com/my-items
+linkedin.com/messaging
+linkedin.com/notifications
 
 TARGET
 html


### PR DESCRIPTION
Fix #15398
The two classes are not found on the other linkedin.com subdomains anymore. That is why dark theme detection fails for the other subdomains. However, dark reader is detecting the presence or absence of a dark theme in the other subdomains without any hint.