### PR TITLE
Add new websites to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -792,7 +792,6 @@ mstdn.social
 mtv.com
 musedash.moe
 music.com
-music.apple.com
 music.youtube.com
 muttwizard.com
 mutualaiddisasterrelief.org

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -534,6 +534,7 @@ git.gnous.eu
 github1s.com
 gitkraken.com
 gitmoji.kaki87.net
+globoplay.globo.com
 glow.phoesion.com
 glowing-bear.org
 glslsandbox.com
@@ -590,6 +591,7 @@ hiserod.github.io
 hitnmix.com
 hiveon.net
 hkamran.com
+homicide.igarape.org.br
 hostedtalk.net
 hotstar.com
 howlongtobeat.com
@@ -790,6 +792,7 @@ mstdn.social
 mtv.com
 musedash.moe
 music.com
+music.apple.com
 music.youtube.com
 muttwizard.com
 mutualaiddisasterrelief.org
@@ -804,6 +807,7 @@ nanobun.tv
 nationsglory.com
 nationsglory.es
 nationsglory.fr
+ncased.com
 neal.fun/size-of-space
 nee.lv
 nemanjadragun.com
@@ -950,6 +954,7 @@ raidbots.com
 raider.io
 raidplan.io
 rakowiecki.pl
+rakuten.tv
 rate.house
 raunaksitoula.com
 ravenation.club


### PR DESCRIPTION
Add the following websites to the global dark list:

https://homicide.igarape.org.br/
https://ncased.com/

And the following websites from streaming services:

https://music.apple.com/
https://globoplay.globo.com/
https://www.rakuten.tv/