### PR TITLE
Add account.ncased.com to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -44,6 +44,7 @@ absolucy.moe
 academy.hackthebox.com
 account.bhvr.com
 account.hackthebox.com
+account.ncased.com
 accursedfarms.com
 aceship.github.io
 acespace.love


### PR DESCRIPTION
Add the following website:

https://account.ncased.com/

which is completely dark without a light option.
The website in question is related to the also dark website:

https://ncased.com/

which was proposed to the dark site list in a previous pull request.