### PR TITLE
Add instagram.com and threads.com dark theme detection

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -397,6 +397,8 @@ MATCH
 ================================
 
 facebook.com
+instagram.com
+threads.com
 web.facebook.com
 
 TARGET


### PR DESCRIPTION
instagram.com, threads.com, and facebook.com webpages share similar designs. Dark theme detection currently fails sometimes at instagram.com and threads.com. The hints are more reliable.