### PR TITLE
Update msn.com dark theme detection

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -768,7 +768,7 @@ MATCH
 
 msn.com
 
-NO DARK THEME
+SYSTEM THEME
 
 ================================
 


### PR DESCRIPTION
msn.com uses the system theme.