### PR TITLE
Update logo selector in dynamic-theme-fixes.config tidal.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33502,7 +33502,7 @@ img[alt="TIDAL | McIntosh"]
 img[alt="TIDAL | Venues logo"]
 img[alt="TIDAL | Volkswagen"]
 img.icon-image
-img.logo
+div.text-left > img.logo
 
 IGNORE INLINE STYLE
 svg.tidal-header-logo--image


### PR DESCRIPTION
We need to be more specific as regards img.logo, otherwise we will be observing unwanted element inversion at:

https://tidal.com/partners/maserati
https://tidal.com/partners/turtlebeach
https://tidal.com/partners/waze

Fix #15468
