### PR TITLE
Fix TikTok logo icon in mobile version of tiktok.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33565,6 +33565,7 @@ svg[class*="StyledLinkLogo"]
 svg[class*="SvgPlayIcon"]
 #svg-music-note > path
 img[alt="TikTok Logo"]:not(#site-footer img, #footer img)
+img[alt="TikTok Logo Icon"]
 img[alt="search icon"]
 svg[alt="TikTok"] path
 img[data-e2e="Header-index-img"]


### PR DESCRIPTION
The mobile version of:

https://www.tiktok.com/about?lang=en

has an inverted icon on the top left corner.

<img width="564" height="914" alt="www tiktok com_about_lang=en" src="https://github.com/user-attachments/assets/2edb7504-1afc-40eb-80e1-74fa4cafe318" />
