### PR TITLE
Modify simplywall.st dark theme detection based on URLs

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1141,7 +1141,35 @@ NO DARK THEME
 
 ================================
 
-simplywall.st
+simplywall.st/ai-terms
+simplywall.st/plans
+simplywall.st/*/plans
+simplywall.st/privacy-policy
+simplywall.st/register
+simplywall.st/terms-and-conditions
+simplywall.st/welcome
+
+NO DARK THEME
+
+================================
+
+simplywall.st/article
+simplywall.st/community
+simplywall.st/dashboard
+simplywall.st/discover
+simplywall.st/*/discover
+simplywall.st/gift-card
+simplywall.st/markets
+simplywall.st/news
+simplywall.st/portfolio
+simplywall.st/*/portfolio
+simplywall.st/screener
+simplywall.st/*/screener
+simplywall.st/stocks
+simplywall.st/*/stocks
+simplywall.st/user
+simplywall.st/*/user
+simplywall.st/watchlist
 
 TARGET
 body


### PR DESCRIPTION
The following webpages have the body[data-theme="dark"] attribute but have predominantly light backgrounds:

https://simplywall.st/ai-terms
https://simplywall.st/plans
https://simplywall.st/es/plans
https://simplywall.st/fr/plans
...
https://simplywall.st/privacy-policy
https://simplywall.st/register
https://simplywall.st/terms-and-conditions
https://simplywall.st/welcome

For this reason, dark reader is not processing these webpages. I have separated dark theme detection into urls that have a body[data-theme="dark"] attribute and have actual dark backgrounds, and urls which also have the mentioned attribute but have light backgrounds. I expect this to be a temporary fix, until the simplywall.st team provides a better fix.