### PR TITLE
Add dark theme detection for agroportal.pt

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -97,6 +97,16 @@ MATCH
 
 ================================
 
+agroportal.pt
+
+TARGET
+body
+
+MATCH
+.jnews-dark-mode
+
+================================
+
 alarabiya.net
 
 TARGET


### PR DESCRIPTION
Dark reader does not detect dark theme at:

https://www.agroportal.pt/