### PR TITLE
Add dark theme detection for archdaily.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -163,6 +163,12 @@ MATCH
 
 ================================
 
+archdaily.com
+
+SYSTEM THEME
+
+================================
+
 arstechnica.com
 
 TARGET

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -165,7 +165,11 @@ MATCH
 
 archdaily.com
 
-SYSTEM THEME
+TARGET
+body
+
+MATCH
+.dark
 
 ================================
 


### PR DESCRIPTION
Website uses the system theme:

https://www.archdaily.com/