### PR TITLE
Add dark theme detection for revistacarros.pt

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1103,6 +1103,16 @@ MATCH
 
 ================================
 
+revistacarros.pt
+
+TARGET
+body
+
+MATCH
+.jnews-dark-mode
+
+================================
+
 satisfactory.wiki.gg
 
 TARGET


### PR DESCRIPTION
Detect dark theme at:

https://www.revistacarros.pt/
