### PR TITLE
Add dark mode detection hint for electrek.co

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -412,6 +412,16 @@ MATCH
 
 ================================
 
+electrek.co
+
+TARGET
+body
+
+MATCH
+.darkmode--activated
+
+================================
+
 elettronew.com
 
 NO DARK THEME


### PR DESCRIPTION
Dark theme detection at electrek.co is inconsistent:

https://electrek.co/