### PR TITLE
Add dynamic theme fixes for teslarati.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32919,6 +32919,13 @@ CSS
 
 ================================
 
+teslarati.com
+
+INVERT
+div.mvp-fly-but-wrap
+
+================================
+
 testudo.umd.edu
 
 CSS


### PR DESCRIPTION
Improve visibility of hamburger icon at:

https://www.teslarati.com/

<img width="1746" height="1043" alt="Screenshot 2026-05-28 051757" src="https://github.com/user-attachments/assets/378c19a4-2c51-4770-8df8-07210cac7b77" />

<img width="1746" height="1043" alt="Screenshot 2026-05-28 051816" src="https://github.com/user-attachments/assets/004f805d-5b00-4b66-8909-5c1fabdc80ee" />

This fix inverts both icons.
