### PR TITLE
Add dark theme detection for carbuzz.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -230,6 +230,12 @@ MATCH
 
 ================================
 
+carbuzz.com
+
+SYSTEM THEME
+
+================================
+
 cezarywalenciuk.pl
 
 NO DARK THEME


### PR DESCRIPTION
Website uses the system theme:

https://carbuzz.com/