### PR TITLE
Add dark theme detection for sapo.pt

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1103,6 +1103,12 @@ MATCH
 
 ================================
 
+sapo.pt
+
+SYSTEM THEME
+
+================================
+
 satisfactory.wiki.gg
 
 TARGET


### PR DESCRIPTION
Dark reader often fails dark theme detection.
Website uses the system theme:

https://sapo.pt/