### PR TITLE
Add dark theme detection for all remaining archdaily websites

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -174,7 +174,11 @@ MATCH
 
 ================================
 
+archdaily.cl
+archdaily.cn
 archdaily.com
+archdaily.com.br
+archdaily.mx
 
 TARGET
 body


### PR DESCRIPTION
Add dark theme detection for the following websites:

https://www.archdaily.cl/
https://www.archdaily.cn/
https://www.archdaily.com.br/
https://www.archdaily.mx/