### PR TITLE
Fix search button wrapper at teslarati.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32945,6 +32945,7 @@ teslarati.com
 
 INVERT
 div.mvp-fly-but-wrap
+div.mvp-search-but-wrap
 
 ================================
 


### PR DESCRIPTION
Click the search button and note that closing the search window will be difficult because you cannot see the close button.

https://www.teslarati.com/

<img width="1768" height="1043" alt="Screenshot 2026-05-28 181528" src="https://github.com/user-attachments/assets/96e583df-41b2-43e5-8b28-0cd8cbf6a84b" />

