### PR TITLE
Add dark theme detection for websites that share design with electrek.co

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -48,6 +48,21 @@ MATCH
 
 ================================
 
+9to5google.com
+9to5mac.com
+9to5toys.com
+dronedj.com
+electrek.co
+spaceexplored.com
+
+TARGET
+body
+
+MATCH
+.darkmode--activated
+
+================================
+
 account.protonvpn.com
 
 TARGET
@@ -436,16 +451,6 @@ html
 
 MATCH
 [data-theme="dark"]
-
-================================
-
-electrek.co
-
-TARGET
-body
-
-MATCH
-.darkmode--activated
 
 ================================
 


### PR DESCRIPTION
The following websites belong to the same entity and share the same design.
Note that the websites are all linked on each other.
Dark theme detection hint is the same.

https://9to5google.com/
https://9to5mac.com/
https://9to5toys.com/
https://dronedj.com/
https://electrek.co/
https://spaceexplored.com/