### PR TITLE
Add dark theme detection for sites that share design with revistacarros.pt

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -819,6 +819,19 @@ MATCH
 
 ================================
 
+motomais.motosport.com.pt
+motosport.com.pt
+mundonautico.pt
+revistacarros.pt
+
+TARGET
+body
+
+MATCH
+.jnews-dark-mode
+
+================================
+
 msn.com
 
 SYSTEM THEME
@@ -1139,16 +1152,6 @@ link[href*="dark.css"]
 
 MATCH
 *
-
-================================
-
-revistacarros.pt
-
-TARGET
-body
-
-MATCH
-.jnews-dark-mode
 
 ================================
 


### PR DESCRIPTION
The following websites share the same design and are all linked on each other; therefore, I grouped them all together:

https://motomais.motosport.com.pt/
https://www.motosport.com.pt/
https://mundonautico.pt/
https://www.revistacarros.pt/