### PR TITLE
Remove techpowerup.com logo inversion settings

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -32737,13 +32737,6 @@ a[class^="headerTemplate__logo"]
 
 ================================
 
-techpowerup.com
-
-INVERT
-.page-header__logo
-
-================================
-
 techspot.com
 
 INVERT


### PR DESCRIPTION
Removed configuration for techpowerup.com logo inversion.
First screenshot with current settings:

<img width="1770" height="1040" alt="Screenshot 2026-05-29 004757" src="https://github.com/user-attachments/assets/439bff28-36bb-41f2-953b-bcde6c18fa78" />

Second screenshot after proposed modifications:

<img width="1770" height="1040" alt="Screenshot 2026-05-29 004922" src="https://github.com/user-attachments/assets/8b5e88fb-f588-416b-a677-6955f9e72412" />

There is better visibility after proposed changes.
