### PR TITLE
Add smallformfactor.net to global dark site list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1061,6 +1061,7 @@ slider.kz
 slippi.gg
 slither.com
 slither.io
+smallformfactor.net
 smithed.dev
 smithed.net
 snazzah.com


### PR DESCRIPTION
Website has three optional themes, all dark!
Dark theme detection is inconsistent on this website.

https://smallformfactor.net/
