### PR TITLE
Add dynamic theme fixes for pcmag.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26041,6 +26041,14 @@ INVERT
 
 ================================
 
+pcmag.com
+
+INVERT
+label[aria-label="Hamburger Menu Toggle"]
+label.after\:bg-gray-700::after
+
+================================
+
 pcmonitors.info
 
 CSS


### PR DESCRIPTION
See -> https://www.pcmag.com/

<img width="3533" height="2088" alt="Screenshot 2026-05-29 035116" src="https://github.com/user-attachments/assets/15405d58-04ad-4fe6-b62d-2d52246279e8" />

<img width="1766" height="1044" alt="Screenshot 2026-05-29 035243" src="https://github.com/user-attachments/assets/b43628d7-6077-454f-9f39-604aaee4d5e0" />
