### PR TITLE
Add dynamic theme fixes for faceofit.com, gigxp.com, and soundmaxpro.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12440,6 +12440,16 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+faceofit.com
+
+INVERT
+div.menu-icon
+a::before
+circle.progress__value
+div.percent-number
+
+================================
+
 fairhotel.org
 
 INVERT
@@ -14495,6 +14505,15 @@ INVERT
 .InnerGIGABYTEContent .scroll_bg_01 > *
 .InnerGIGABYTEContent .eagle_build_strong
 .InnerGIGABYTEContent .eagle_build_strong > *
+
+================================
+
+gigxp.com
+
+INVERT
+div.menu-icon
+circle.progress__value
+div.percent-number
 
 ================================
 
@@ -30842,6 +30861,15 @@ body,
 .headerSearch__input {
     background: ${#f1f4f6} !important;
 }
+
+================================
+
+soundmaxpro.com
+
+INVERT
+div.menu-icon
+circle.progress__value
+div.percent-number
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12441,6 +12441,8 @@ IGNORE IMAGE ANALYSIS
 ================================
 
 faceofit.com
+gigxp.com
+soundmaxpro.com
 
 INVERT
 div.menu-icon
@@ -14505,15 +14507,6 @@ INVERT
 .InnerGIGABYTEContent .scroll_bg_01 > *
 .InnerGIGABYTEContent .eagle_build_strong
 .InnerGIGABYTEContent .eagle_build_strong > *
-
-================================
-
-gigxp.com
-
-INVERT
-div.menu-icon
-circle.progress__value
-div.percent-number
 
 ================================
 
@@ -30861,15 +30854,6 @@ body,
 .headerSearch__input {
     background: ${#f1f4f6} !important;
 }
-
-================================
-
-soundmaxpro.com
-
-INVERT
-div.menu-icon
-circle.progress__value
-div.percent-number
 
 ================================
 


### PR DESCRIPTION
See:

https://www.faceofit.com/

<img width="1766" height="1040" alt="Screenshot 2026-05-29 045105" src="https://github.com/user-attachments/assets/f3614c4c-b185-4f52-9b20-ffa9e4c99dd6" />

<img width="1766" height="1040" alt="Screenshot 2026-05-29 045146" src="https://github.com/user-attachments/assets/8f3ac602-42cc-43d9-8b75-25081ade1a75" />

See also:
https://gigxp.com/
https://www.soundmaxpro.com/

These websites share the same design; therefore, I do not provide screenshots of them.
