### PR TITLE
Fix for zi.tools

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -38639,13 +38639,19 @@ div.mt5
 zi.tools
 
 INVERT
-button.ant-switch-small
+button.ant-switch
+:not([aria-checked="true"]) > .ant-switch-inner
 img[src="https://ziphoenicia-1300189285.cos.ap-shanghai.myqcloud.com/home_svg/zi-tools.svg"]
 img[src^="https://ziphoenicia-1300189285.cos.ap-shanghai.myqcloud.com/icon_svg/"]
 img[src^="https://ziphoenicia-1300189285.cos.ap-shanghai.myqcloud.com/swjz/"]
-img[data-v-016f9352]
-img[data-v-f8120624]
-path[data-v-f8120624]
+
+CSS
+[style*="color: rgba(0, 0, 0, 0)"] {
+    color: rgb(0 0 0 / 0) !important;
+}
+svg {
+    fill: currentColor;
+}
 
 ================================
 


### PR DESCRIPTION
Some images being not inverted are intended.

BTW, I noticed that the global fix has CSS rule applying to `[style*="color: rgba(0, 0, 0,"]`, which is what this patch mainly fixes.  I wonder the initial intent of that because some websites (such as this) uses a color with alpha 0 to hide things, and the rule ignores the alpha channel.