### PR TITLE
Remove robinhood.com from the global dark site list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -988,7 +988,6 @@ rimasmusic.com
 ripped.guide
 ritsuka.moe
 rl6mans.com
-robinhood.com
 rokoko.com
 roleypoly.com
 roosterteeth.fandom.com


### PR DESCRIPTION
See -> https://robinhood.com/eu/en/support/

<img width="3623" height="2079" alt="Screenshot 2026-05-29 214834" src="https://github.com/user-attachments/assets/8bb3cc3d-d15d-4be7-b4e5-002bcf62c851" />
