### PR TITLE
Add dark theme detection for tv.apple.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -848,6 +848,7 @@ SYSTEM THEME
 ================================
 
 music.apple.com
+tv.apple.com
 
 SYSTEM THEME
 


### PR DESCRIPTION
tv.apple.com uses the system theme.