### PR TITLE
Update simplywall.st dynamic theme fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30459,7 +30459,7 @@ img[alt="google-five-stars"]
 img[alt="SP Global logo"]
 img.snowflake-image
 button[data-cy-id="button-apple-login"] svg
-svg.mx-auto path
+svg.mx-auto:not(.mb-3) path
 
 CSS
 html[data-darkreader-scheme="dark"] .sc-l2psw8-0 svg path {


### PR DESCRIPTION
My last change introduced two issues.
This pull request fixes them.

See -> https://simplywall.st/register

<img width="1781" height="1040" alt="Screenshot 2026-05-30 060412" src="https://github.com/user-attachments/assets/976de81a-488b-4a1e-8e00-c0df4756c9ae" />

See -> https://simplywall.st/welcome

<img width="1781" height="1040" alt="Screenshot 2026-05-30 060446" src="https://github.com/user-attachments/assets/440517ad-3ecd-4f52-baed-f0f2eba3a486" />
