### PR TITLE
Add dark theme detection for Global Media Group, SA websites

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -387,6 +387,19 @@ NO DARK THEME
 
 ================================
 
+dinheirovivo.dn.pt
+dn.pt
+dnbrasil.dn.pt
+
+TARGET
+body
+
+MATCH
+[style*="background-color: rgb(29, 29, 29)"]
+[style*="background-color: rgb(0, 0, 0)"]
+
+================================
+
 discord.com
 
 TARGET
@@ -798,6 +811,17 @@ NO DARK THEME
 
 ================================
 
+menshealth.pt
+womenshealth.pt
+
+TARGET
+body
+
+MATCH
+.sk-dark-theme
+
+================================
+
 mermaid.live/edit
 
 TARGET
@@ -838,6 +862,16 @@ body
 
 MATCH
 .jnews-dark-mode
+
+================================
+
+motor24.pt
+
+TARGET
+body
+
+MATCH
+.active-dark-mode
 
 ================================
 


### PR DESCRIPTION
Add dark theme detection for Global Media Group, SA online newspapers and magazines:

https://dinheirovivo.dn.pt/
https://www.dn.pt/
https://dnbrasil.dn.pt/
https://menshealth.pt/
https://www.womenshealth.pt/
https://www.motor24.pt/