### PR TITLE
Fix for www-awu.aleks.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -37649,6 +37649,7 @@ www-awu.aleks.com
 
 INVERT
 div > .ansed_root > .ansed_canvas
+div > .ansed_root > .ansed_caret
 
 ================================
 


### PR DESCRIPTION
Fix dark mode having hard to see type indicator.
Without fix
<img width="55" height="39" alt="image" src="https://github.com/user-attachments/assets/7bb8f8b0-0388-48c3-9231-a148923da305" />
With fix
<img width="56" height="45" alt="image" src="https://github.com/user-attachments/assets/c9f4a8ad-6432-47b3-a68f-c6b009819667" />
Dark Reader light mode fixed applied
<img width="56" height="38" alt="image" src="https://github.com/user-attachments/assets/b2e2a8d7-fd9e-42c4-92e9-ffcb8fae6f3f" />
