### PR TITLE
Fix invisible logo on q.utoronto.ca

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27836,6 +27836,7 @@ CSS
 :root {
     --darkreader-bg--ic-brand-global-nav-bgd: var(--ic-brand-global-nav-bgd) !important;
     --darkreader-bg--ic-brand-global-nav-logo-bgd: var(--ic-brand-global-nav-logo-bgd) !important;
+    --darkreader-bgimg--ic-brand-header-image: var(--ic-brand-header-image) !important;
     --darkreader-border--ic-brand-global-nav-avatar-border: var(--ic-brand-global-nav-avatar-border) !important;
     --ic-brand-global-nav-ic-icon-svg-fill--active: var(--darkreader-text--ic-link-color) !important;
 }


### PR DESCRIPTION
This is a workaround for https://github.com/darkreader/darkreader/issues/12790. (I am assuming the proper fix for it is nontrivial, given how long it's been open.)

The relevant CSS from the site is:
```css
.ic-app-header__logomark {
  background-image:var(--ic-brand-header-image);
}
```

This element is used to display a logo at the top of the site's sidebar.

When Dark Reader is enabled, it injects a style block that overrides `background-image` to `var(--darkreader-bgimg--ic-brand-header-image)`. The `--darkreader-bgimg--ic-brand-header-image` variable is not set, so the logo disappears.

The sidebar background is consistent across light and dark mode so no change to the original image is required. The workaround thus makes `--darkreader-bgimg--ic-brand-header-image` an alias for the real variable. This solves the issue in my testing.

Before and after:

<img width="86" height="165" alt="image" src="https://github.com/user-attachments/assets/d834a1e9-b5f5-48cd-9681-90a96a46b691" />
<img width="84" height="156" alt="image" src="https://github.com/user-attachments/assets/3ff3ea2b-e909-421e-9d71-854544a3cde4" />
