### PR TITLE
Add dark theme detection hint for Wikimedia Foundation domains

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -20,6 +20,7 @@ MATCH
 
 *.mediawiki.org
 *.wikipedia.org
+*.wiktionary.org
 
 TARGET
 html

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -19,8 +19,17 @@ MATCH
 ================================
 
 *.mediawiki.org
+*.wikibooks.org
+*.wikidata.org
+*.wikifunctions.org
+*.wikimedia.org
 *.wikipedia.org
+*.wikiquote.org
+*.wikisource.org
+wikisource.org
 *.wiktionary.org
+*.wikiversity.org
+*.wikivoyage.org
 
 TARGET
 html

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -18,6 +18,17 @@ MATCH
 
 ================================
 
+*.mediawiki.org
+*.wikipedia.org
+
+TARGET
+html
+
+MATCH
+.skin-theme-clientpref-night
+
+================================
+
 *.msi.com
 funtoro.com
 
@@ -52,16 +63,6 @@ html
 
 MATCH
 .dark
-
-================================
-
-*.wikipedia.org
-
-TARGET
-html
-
-MATCH
-.skin-theme-clientpref-night
 
 ================================
 

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -55,6 +55,16 @@ MATCH
 
 ================================
 
+*.wikipedia.org
+
+TARGET
+html
+
+MATCH
+.skin-theme-clientpref-night
+
+================================
+
 9to5google.com
 9to5mac.com
 9to5toys.com


### PR DESCRIPTION
Dark theme detection frequently fails with wikipedia.