### PR TITLE
Google docs comment counter pill (dark mode)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -10680,6 +10680,12 @@ input.docs-title-input {
 .gb_Ha.gb_1a.gb_Nd {
     background-color: var(--darkreader-neutral-background) !important;
 }
+g.chapterDocoIndicatorViewContainer svg {
+    fill: color-mix(in oklab, var(--darkreader-neutral-background), white);
+}
+.chapter-item-label-and-buttons-container-selected g.chapterDocoIndicatorViewContainer svg {
+    fill: color-mix(in oklab, var(--darkreader-neutral-background), white 25%) !important;
+}
 
 IGNORE INLINE STYLE
 .cell-input > span


### PR DESCRIPTION
Fixed indicators for comment count on document tabs pills.

The current dynamic version lacks contrast, making it impossible to see the number.

## Unmodified (Light mode, default):
<img width="365" height="311" alt="image" src="https://github.com/user-attachments/assets/2ddebdc0-2a6f-402d-b337-a7ec898bbe3a" />

## Default (Dynamic Theme):
<img width="366" height="336" alt="image" src="https://github.com/user-attachments/assets/f81faae1-0de7-4c7e-9dfe-8026ce1a6f41" />

## My proposed fix:
<img width="378" height="406" alt="image" src="https://github.com/user-attachments/assets/b8a976bc-c7bf-4017-b341-e8925db0a6b9" />
