### PR TITLE
Add dynamic theme fixes for Hearst magazines

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3779,9 +3779,33 @@ INVERT
 ================================
 
 autoweek.com
+roadandtrack.com
 
 INVERT
-.nav-logo
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not(nav#sidepanel img, footer img):not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i])
+nav#sidepanel img:not([src$="primary=%2523ffffff" i], [src$="primary=%2523b4b3b3" i])
+main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+button[data-open-web-class^="modal-feedback-option"]::before
+button[data-open-web-class^="modal-feedback-option"] svg
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+button[data-open-web-class^="modal-feedback-option"] {
+    position: relative;
+    z-index: 0;
+}
+button[data-open-web-class^="modal-feedback-option"]::before {
+    background: inherit;
+    content: "";
+    filter: none;
+    inset: 0;
+    position: absolute;
+    z-index: -1;
+}
 
 ================================
 
@@ -5027,6 +5051,56 @@ body,
 .listicle-card h2,
 .newsletter h3 {
     color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
+bestproducts.com
+bicycling.com
+cosmopolitan.com
+countryliving.com
+esquire.com
+goodhousekeeping.com
+housebeautiful.com
+oprahdaily.com
+popularmechanics.com
+prevention.com
+redbookmag.com
+runnersworld.com
+seventeen.com
+sex.cosmopolitan.com
+womansday.com
+womenshealthmag.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] div:not(.nav-bar-container) > button[aria-label="Sidepanel Button"] > svg:not([style="--primary:#ffffff;"])
+nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i], [src$="primary=%25231c6a65" i], [src$="primary=%2523d30c4f" i])
+nav[data-tracking-id="topNav"] svg:is([alt="Logo"], [alt="Caret Right Icon"])
+nav#sidepanel button[aria-label="Close"] svg
+nav#sidepanel > div > ul::before
+div.footer svg[alt="Logo"]
+footer.footer img[alt="Logo"]:not([src$="primary=%2523ffffff" i], [src$="primary=%2523d4d4d4" i], [src$="primary=%25231c6a65" i])
+main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+button[data-open-web-class^="modal-feedback-option"]::before
+button[data-open-web-class^="modal-feedback-option"] svg
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+button[data-open-web-class^="modal-feedback-option"] {
+    position: relative;
+    z-index: 0;
+}
+button[data-open-web-class^="modal-feedback-option"]::before {
+    background: inherit;
+    content: "";
+    filter: none;
+    inset: 0;
+    position: absolute;
+    z-index: -1;
 }
 
 ================================
@@ -6945,6 +7019,42 @@ caramba-switcher.com
 
 INVERT
 .t996__cover
+
+================================
+
+caranddriver.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] :is(img, svg)[alt="Logo"]
+nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+nav#sidepanel button[aria-label="Close"] svg
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src^="/_assets/design-tokens/caranddriver/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main img[src^="/_assets/design-tokens/caranddriver/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+button[data-open-web-class^="modal-feedback-option"]::before
+button[data-open-web-class^="modal-feedback-option"] svg
+
+CSS
+nav#sidepanel div.open + div a[data-id="mega-footer-social-link"] > img {
+    display: none !important;
+}
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+button[data-open-web-class^="modal-feedback-option"] {
+    position: relative;
+    z-index: 0;
+}
+button[data-open-web-class^="modal-feedback-option"]::before {
+    background: inherit;
+    content: "";
+    filter: none;
+    inset: 0;
+    position: absolute;
+    z-index: -1;
+}
 
 ================================
 
@@ -9549,6 +9659,18 @@ CSS
 
 ================================
 
+delish.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] svg:is([alt="Logo"], [alt="Caret Right Icon"])
+nav#sidepanel button[aria-label="Close"] svg
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src^="/_assets/design-tokens/delish/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+
+================================
+
 dell.com
 
 INVERT
@@ -11826,9 +11948,39 @@ td[id="navstart"] {
 ================================
 
 elle.com
+harpersbazaar.com
+menshealth.com
+townandcountrymag.com
 
 INVERT
-.css-lgctud .e1ccpyf90
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] a[aria-label="ELLE"] :is(img, svg)[alt="Logo"]
+nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
+nav#sidepanel a[aria-label="Harper's BAZAAR"] svg[alt="Logo"]
+nav#sidepanel button[aria-label="Close"] svg
+nav#sidepanel > div > ul::before
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+main figure:has(audio) input
+button[data-open-web-class^="modal-feedback-option"]::before
+button[data-open-web-class^="modal-feedback-option"] svg
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+button[data-open-web-class^="modal-feedback-option"] {
+    position: relative;
+    z-index: 0;
+}
+button[data-open-web-class^="modal-feedback-option"]::before {
+    background: inherit;
+    content: "";
+    filter: none;
+    inset: 0;
+    position: absolute;
+    z-index: -1;
+}
 
 ================================
 
@@ -12069,18 +12221,6 @@ esphome.io
 
 INVERT
 img.component-image
-
-================================
-
-esquire.com
-
-INVERT
-.nav-logo
-
-CSS
-.marquee-logo-link > svg {
-    background-color: ${black} !important;
-}
 
 ================================
 
@@ -21923,17 +22063,6 @@ CSS
 
 ================================
 
-menshealth.com
-
-INVERT
-div.footer svg[alt="Logo"]
-button[alt="Open share options"]
-img[alt="Subscription Icon"]
-img[alt="Close"]
-svg[alt="Caret Right Icon"]
-
-================================
-
 menti.com
 
 INVERT
@@ -23554,6 +23683,14 @@ myfood4less.com
 
 INVERT
 .elementor-widget-theme-site-logo
+
+================================
+
+mylo.id
+
+INVERT
+div[data-testid="brandLogo"] img:not([alt="Popular Mechanics"], [alt="Redbook"], [alt="Town & Country"])
+a.apple-login-button svg
 
 ================================
 


### PR DESCRIPTION
Add dynamic theme fixes for the following Hearst websites:

https://www.autoweek.com/
https://www.roadandtrack.com/

https://www.bestproducts.com/
https://www.bicycling.com/
https://www.cosmopolitan.com/
https://www.countryliving.com/
https://www.esquire.com/
https://www.goodhousekeeping.com/
https://www.housebeautiful.com/
https://www.oprahdaily.com/
https://www.popularmechanics.com/
https://www.prevention.com/
https://www.redbookmag.com/
https://www.runnersworld.com/
https://www.womansday.com/
https://www.womenshealthmag.com/

https://www.elle.com/
https://www.harpersbazaar.com/
https://www.menshealth.com/
https://www.townandcountrymag.com/

https://www.caranddriver.com/

https://www.delish.com/

and their login system provided by:
https://www.mylo.id/

The websites design is similar with some minor differences. I organized them by similarity, and when it was more difficult, I put those websites separately.