### PR TITLE
Fixed readyStateCompleteListeners never flushing when initialized after DOM ready

### DIFF
--- a/src/inject/utils/dom.ts
+++ b/src/inject/utils/dom.ts
@@ -242,7 +242,10 @@ export function cleanReadyStateCompleteListeners(): void {
     readyStateCompleteListeners.clear();
 }
 
-if (!isDOMReady()) {
+// Listen until readyState is "complete", so that readyStateCompleteListeners
+// are flushed even when this module is initialized at readyState "interactive"
+// (e.g. when the API is enabled from a deferred script)
+if (!isReadyStateComplete()) {
     const onReadyStateChange = () => {
         if (isDOMReady()) {
             readyStateListeners.forEach((listener) => listener());


### PR DESCRIPTION
Fixes #15570

The readystatechange listener in dom.ts was only registered when the module initialized before readyState "interactive". When the API is enabled from a deferred page script, initialization happens at "interactive", so `readyStateCompleteListeners` (deferred SVG fill overrides, image loads) never ran. Register the listener while readyState is not yet "complete" instead. The handler already deals with both flush stages, and nothing changes for the extension, which initializes at document_start.
