### PR TITLE
Add dark theme detection hints for additional sapo.pt websites

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -77,11 +77,12 @@ MATCH
 ================================
 
 24noticias.sapo.pt
-blogs.sapo.pt
-sapo.pt
-tek.sapo.pt
 
-SYSTEM THEME
+TARGET
+body
+
+MATCH
+.black-in-black
 
 ================================
 
@@ -297,6 +298,16 @@ MATCH
 
 ================================
 
+blogs.sapo.pt
+
+TARGET
+html
+
+MATCH
+[data-theme="dark"]
+
+================================
+
 calendar.cron.com
 
 TARGET
@@ -448,6 +459,18 @@ MATCH
 dictionary.com
 
 NO DARK THEME
+
+================================
+
+digitalinside.com.br
+digitalinside.es
+digitalinside.sapo.pt
+
+TARGET
+body
+
+MATCH
+.darkmode
 
 ================================
 
@@ -1270,6 +1293,12 @@ link[href*="dark.css"]
 
 MATCH
 *
+
+================================
+
+sapo.pt
+
+SYSTEM THEME
 
 ================================
 

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -288,6 +288,13 @@ MATCH
 
 ================================
 
+blogs.sapo.pt
+sapo.pt
+
+SYSTEM THEME
+
+================================
+
 calendar.cron.com
 
 TARGET
@@ -1261,12 +1268,6 @@ link[href*="dark.css"]
 
 MATCH
 *
-
-================================
-
-sapo.pt
-
-SYSTEM THEME
 
 ================================
 

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -79,6 +79,7 @@ MATCH
 24noticias.sapo.pt
 blogs.sapo.pt
 sapo.pt
+tek.sapo.pt
 
 SYSTEM THEME
 

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -76,6 +76,14 @@ MATCH
 
 ================================
 
+24noticias.sapo.pt
+blogs.sapo.pt
+sapo.pt
+
+SYSTEM THEME
+
+================================
+
 9to5google.com
 9to5mac.com
 9to5toys.com
@@ -285,13 +293,6 @@ body
 
 MATCH
 .mdui-theme-layout-dark
-
-================================
-
-blogs.sapo.pt
-sapo.pt
-
-SYSTEM THEME
 
 ================================
 


### PR DESCRIPTION
See:
https://24noticias.sapo.pt/
https://blogs.sapo.pt/
