### PR TITLE
Add dynamic theme fixes for various *.sapo.pt websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -668,17 +668,28 @@ span.w {
 ================================
 
 *.sapo.pt
+forum.pplware.com
 
 INVERT
-svg#sapoLogo path[fill="#000000"]
+div.bsu-v4-sub-menu-splitter
 :is(div, h1).logo img[alt^="SAPO"]
 body:not(.home) header div.logo a[aria-label^="AutoSAPO"]
 footer div.logo a[aria-label^="AutoSAPO"]
 img[src$="/logo_vendaja_black.png"]
-img[src$="/jornal21/logo.png"]
-div.bsu-v4-sub-menu-splitter
+img.img-logo[src^="https://avozdecastelobranco.sapo.pt"]
 body.wp-theme-zox-news div.mvp-fly-but-wrap span
 body.wp-theme-zox-news div.mvp-search-but-wrap span
+img[src$="/econtas-logo.png"]
+img[src$="/ED_LOGO-900x183.png"]
+img[src$="/ED_LOGO.png"]
+img[src$="/2016-logo-risco-cor.png"]
+img[src$="/AutoM-cor-1-no-bg.png"]
+img[src$="/E-goi-logo.png"]
+span[class$="-accordion-chevron"]
+span[class$="-accordion-icon"]
+
+IGNORE INLINE STYLE
+svg#sapoLogo path
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -667,6 +667,21 @@ span.w {
 
 ================================
 
+*.sapo.pt
+
+INVERT
+svg#sapoLogo path[fill="#000000"]
+:is(div, h1).logo img[alt^="SAPO"]
+body:not(.home) header div.logo a[aria-label^="AutoSAPO"]
+footer div.logo a[aria-label^="AutoSAPO"]
+img[src$="/logo_vendaja_black.png"]
+img[src$="/jornal21/logo.png"]
+div.bsu-v4-sub-menu-splitter
+body.wp-theme-zox-news div.mvp-fly-but-wrap span
+body.wp-theme-zox-news div.mvp-search-but-wrap span
+
+================================
+
 *.seoul.go.kr
 
 INVERT


### PR DESCRIPTION
Add dynamic theme fixes for the following websites:
https://mail.sapo.pt/
https://ajuda.sapo.pt/
https://auto.sapo.pt/
https://emprego.sapo.pt/
https://promos.sapo.pt/
https://eco.sapo.pt/
https://jornaleconomico.sapo.pt/
https://anacao.sapo.pt/
https://avozdafeira.sapo.pt/
https://avozdebraganca.sapo.pt/
https://avozdecastelobranco.sapo.pt/
https://avozdematosinhos.sapo.pt/
https://avozdeevora.sapo.pt/
https://jornalaltoalentejo.sapo.pt/
https://almadense.sapo.pt/
https://amarantemagazine.sapo.pt/
https://greensavers.sapo.pt/
https://executivedigest.sapo.pt/
https://pplware.sapo.pt/
https://usados.pplware.sapo.pt/
https://kids.pplware.sapo.pt/
http://forum.pplware.com/
