### PR TITLE
Add dark theme detection hints for additional sapo.pt websites

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -456,6 +456,17 @@ MATCH
 
 ================================
 
+diariocriminal.sapo.pt
+diariodabairrada.sapo.pt
+
+TARGET
+body
+
+MATCH
+[data-cs="dark"]
+
+================================
+
 dictionary.com
 
 NO DARK THEME
@@ -647,6 +658,17 @@ body
 
 MATCH
 [data-md-color-media="(prefers-color-scheme: dark)]
+
+================================
+
+foradeserie.sapo.pt
+
+TARGET
+html
+
+MATCH
+.site-s-dark
+.s-dark
 
 ================================
 


### PR DESCRIPTION
Add detection hints for:
https://diariocriminal.sapo.pt/
https://diariodabairrada.sapo.pt/
https://foradeserie.sapo.pt/