### PR TITLE
Add dynamic theme fixes for additional sapo.pt websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -704,6 +704,7 @@ span.w {
 
 *.sapo.pt
 forum.pplware.com
+sapo.pt
 
 INVERT
 div.bsu-v4-sub-menu-splitter
@@ -730,8 +731,17 @@ span[class$="-accordion-icon"]
 div.toggle-header-search span
 a#mobile-menu-icon span.tie-mobile-menu-icon
 
-IGNORE INLINE STYLE
-svg#sapoLogo path
+CSS
+svg#sapoLogo path:is([d^="M34.56"], [d^="M63.99"]),
+li.logo svg path:is([d^="M33.96"], [d^="M63.39"]) {
+    fill: #000000 !important;
+}
+html[data-darkreader-scheme="dark"] div#bsu-footer.bsu-footer-light a.bsu-footer-logo {
+    background-position: 0 -60px !important;
+}
+html[data-theme="dark"][data-darkreader-scheme="dark"] div#bsu-footer div.bsu-footer-text {
+    filter: none !important;
+}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -720,8 +720,15 @@ img[src$="/ED_LOGO.png"]
 img[src$="/2016-logo-risco-cor.png"]
 img[src$="/AutoM-cor-1-no-bg.png"]
 img[src$="/E-goi-logo.png"]
+img[src$="/Beira-Alta-TV-2023-preto.png"]
+img.tie-logo-img[src^="https://diariodistrito.sapo.pt"]
+img[src$="/forever-young-logo-1.png"]
+img.logo[alt="Green eFact"]
+div.logo img[src^="https://estrelaseouricos.sapo.pt"]
 span[class$="-accordion-chevron"]
 span[class$="-accordion-icon"]
+div.toggle-header-search span
+a#mobile-menu-icon span.tie-mobile-menu-icon
 
 IGNORE INLINE STYLE
 svg#sapoLogo path


### PR DESCRIPTION
Add dynamic theme fixes for the following websites:
https://beiraaltatv.sapo.pt/
https://cidadehoje.sapo.pt/
https://diariodistrito.sapo.pt/
https://estrelaseouricos.sapo.pt/
https://foreveryoung.sapo.pt/
https://greenefact.sapo.pt/