### PR TITLE
Add dynamic theme fixes for Smithsonian websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -31012,12 +31012,40 @@ CSS
 
 ================================
 
+smithsonian.com
+
+INVERT
+div.logos-wrapper img
+
+================================
+
+smithsonianbooks.com
+
+INVERT
+img[src$="/books-logo-black.d7875c6914c9.svg"]
+div#mobileMenuButton > span
+
+================================
+
+smithsonianjourneys.org
+
+INVERT
+img[src$="/Journeys-Logo-black.50b2dd0b2d72.svg"]
+
+================================
+
 smithsonianmag.com
 
 INVERT
-.site-logo
-.footerLogo > a > img
 #mobile-icon > span
+
+================================
+
+smithsonianstore.com
+
+INVERT
+img[src$="/smithsonian-institution-vector-logo.svg"]
+span.navbar-toggler-icon
 
 ================================
 


### PR DESCRIPTION
Added dynamic theme fixes for the following Smithsonian websites:
https://www.smithsonian.com/
https://www.smithsonianbooks.com/
https://www.smithsonianjourneys.org/
https://www.smithsonianmag.com/
https://www.smithsonianstore.com/
