### PR TITLE
Add dynamic theme fixes for Oxford Academic website

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1417,6 +1417,43 @@ CSS
 
 ================================
 
+academic.oup.com
+
+INVERT
+img.oup-header-image[alt="Oxford Academic"]
+img.journal-footer-logo[alt="Oxford University Press"]
+img.society-logo[alt="American Medical Informatics Association"]
+img.society-logo[alt="GigaScience Press"]
+img.society-logo[alt="International Biometric Society"]
+img.society-logo[alt="Japan Society for Occupational Health"]
+img.society-logo[alt="Oxford"]
+img.society-logo[src$="_h1-965359043.svg"][alt$="Royal Statistical Society"]
+img.journal-logo[alt="Biometrics"]
+img.journal-logo[alt="Biometrika"]
+img.journal-logo[alt="GigaScience"]
+img.journal-logo[alt="Journal of Occupational Health"]
+img.journal-logo[alt="Journal of Petrology"]
+img.journal-logo[alt^="Journal of the American Medical Informatics Association"]
+img.journal-logo[alt^="Journal of the Royal Statistical Society"]
+img.journal-logo[alt="Oxford Academic Journals"]
+img.journal-logo[alt="Significance"]
+img.journal-logo[alt="Transactions of Mathematics and Its Applications"]
+img.journal-footer-affiliations-logo[alt="Biometrics"]
+img.journal-footer-affiliations-logo[alt="Biometrika"]
+img.journal-footer-affiliations-logo[alt="GigaScience"]
+img.journal-footer-affiliations-logo[alt="Journal of Occupational Health"]
+img.journal-footer-affiliations-logo[alt="Journal of Petrology"]
+img.journal-footer-affiliations-logo[alt^="Journal of the American Medical Informatics Association"]
+img.journal-footer-affiliations-logo[alt^="Journal of the Royal Statistical Society Series D"]
+a.society-links-logo > img
+ul.listOfImagesWithLabels div.imageContainer img
+div.informationRowHead img.informationLogo
+div.siteMainName img[alt="Oxford University Press"]
+img.chat-input-logo[alt="Oxford University Press"]
+svg.information-svg-icon path.inner-shape
+
+================================
+
 academy.abeka.com
 
 INVERT


### PR DESCRIPTION
Added dynamic theme fixes for Oxford Academic website. Some journal logos are difficult to see or even invisible, while others do not require any inversion. It is difficult to detect, and journals must be checked one by one. I only checked journals under the field of Mathematics. Added fixes for the following journals:

https://academic.oup.com/biometrics
https://academic.oup.com/biomet
https://academic.oup.com/gigascience
https://academic.oup.com/imatrm
https://academic.oup.com/jamia
https://academic.oup.com/jamiaopen
https://academic.oup.com/joh
https://academic.oup.com/jrssig
https://academic.oup.com/jrsssa
https://academic.oup.com/jrsssb
https://academic.oup.com/jrsssc
https://academic.oup.com/jrsssd
https://academic.oup.com/petrology
https://academic.oup.com/rssdat
