### PR TITLE
Update dynamic theme fixes for Hearst magazine websites - fix logo inversion

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5110,9 +5110,7 @@ esquire.com
 goodhousekeeping.com
 housebeautiful.com
 oprahdaily.com
-popularmechanics.com
 prevention.com
-redbookmag.com
 runnersworld.com
 seventeen.com
 sex.cosmopolitan.com
@@ -5122,12 +5120,12 @@ womenshealthmag.com
 INVERT
 img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 nav[data-tracking-id="topNav"] div:not(.nav-bar-container) > button[aria-label="Sidepanel Button"] > svg:not([style="--primary:#ffffff;"])
-nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i], [src$="primary=%25231c6a65" i], [src$="primary=%2523d30c4f" i])
+nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i])
 nav[data-tracking-id="topNav"] svg:is([alt="Logo"], [alt="Caret Right Icon"])
 nav#sidepanel button[aria-label="Close"] svg
 nav#sidepanel > div > ul::before
 div.footer svg[alt="Logo"]
-footer.footer img[alt="Logo"]:not([src$="primary=%2523ffffff" i], [src$="primary=%2523d4d4d4" i], [src$="primary=%25231c6a65" i])
+footer.footer img[alt="Logo"]:not([src$="primary=%2523ffffff" i], [src$="primary=%2523d4d4d4" i])
 main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 main figure:has(audio) input
 
@@ -9681,8 +9679,6 @@ CSS
 delish.com
 elle.com
 harpersbazaar.com
-menshealth.com
-townandcountrymag.com
 
 INVERT
 img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
@@ -22084,6 +22080,24 @@ CSS
 
 ================================
 
+menshealth.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
+nav#sidepanel button[aria-label="Close"] svg
+nav#sidepanel > div > ul::before
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src^="/_assets/design-tokens/menshealth/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%2523d2232e" i])
+main figure:has(audio) input
+
+CSS
+nav#sidepanel li button {
+    filter: brightness(2) !important;
+}
+
+================================
+
 menti.com
 
 INVERT
@@ -27278,6 +27292,16 @@ svg.home *
 
 ================================
 
+popularmechanics.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+main img[src^="/_assets/design-tokens/popularmechanics/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%25231c6a65" i])
+main figure:has(audio) input
+
+================================
+
 poradnikzdrowie.pl
 
 INVERT
@@ -28456,6 +28480,17 @@ body > div.t3-wrapper > div > div.section-wrap.bg-wrap1 > div > div > div.custom
 #t3-header > div > div.col-xs-3.visible-xs-block > button.globe-toggle {
     background-color: inherit !important;
 }
+
+================================
+
+redbookmag.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+footer.footer img[alt="Logo"]
+main img[src^="/_assets/design-tokens/redbookmag/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%2523d30c4f" i])
+main figure:has(audio) input
 
 ================================
 
@@ -34332,6 +34367,18 @@ IGNORE INLINE STYLE
 span[style^="text-shadow"]
 span[style*="background: linear-gradient"]
 a *
+
+================================
+
+townandcountrymag.com
+
+INVERT
+img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
+nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
+nav#sidepanel button[aria-label="Close"] svg
+div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
+main img[src^="/_assets/design-tokens/townandcountrymag/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%25239a0500" i])
+main figure:has(audio) input
 
 ================================
 


### PR DESCRIPTION
Some websites have logos in the main part that do not require inversion.
To deal with this issue I had to separate the code for such websites.
See for example the respective magazine logo in the main part of the webpage:
https://www.menshealth.com/gift-subscriptions/
https://www.popularmechanics.com/gift-subscriptions/
https://www.townandcountrymag.com/gift-subscriptions/
