### PR TITLE
Fix invisible logo at liquor.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -20230,6 +20230,13 @@ div.qrcode > canvas
 
 ================================
 
+liquor.com
+
+INVERT
+svg.icon.icon-logo
+
+================================
+
 lirc.org
 
 CSS


### PR DESCRIPTION
Invert top and bottom logo at:
https://www.liquor.com/