### PR TITLE
Invert third party logos at shopify.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30777,7 +30777,7 @@ INVERT
 .header-country-select__trigger
 .lia-message-count::before
 .DateTime::before
-img[class^="_Logo_"]
+img[src*="logo-black"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -30777,6 +30777,7 @@ INVERT
 .header-country-select__trigger
 .lia-message-count::before
 .DateTime::before
+img[class^="_Logo_"]
 
 ================================
 


### PR DESCRIPTION
Invert logos from third parties at the shopify authentication page.
In order to reproduce open:
https://en.giesswein.com/
and proceed with the login process.
<img width="1814" height="1044" alt="Screenshot 2026-06-15 173502" src="https://github.com/user-attachments/assets/19f8e6d0-5e87-45f2-99a3-145a8def13f7" />
