### PR TITLE
Add react site to global Dark List

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -964,6 +964,7 @@ raycast.com
 razeenf.ca
 razer.com
 razorsecure.com
+react.dev
 redeclipse.net
 reelgood.com
 reflektclothing.co.uk


### PR DESCRIPTION
https://react.dev/

This Site already had Dark mode Implemented , So it will be good to have this site added into the Global Dark List.