### PR TITLE
Add dark theme detection hint for react.dev

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1290,6 +1290,7 @@ NO DARK THEME
 ================================
 
 react.dev
+reactbits.dev
 
 TARGET
 html

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1290,7 +1290,6 @@ NO DARK THEME
 ================================
 
 react.dev
-reactbits.dev
 
 TARGET
 html

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1289,6 +1289,16 @@ NO DARK THEME
 
 ================================
 
+react.dev
+
+TARGET
+html
+
+MATCH
+.dark
+
+================================
+
 reddit.com
 new.reddit.com
 


### PR DESCRIPTION
Add dark theme detection hint for:
https://react.dev/