### PR TITLE
Add React Bits Site to Global Dark List

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -964,6 +964,7 @@ raycast.com
 razeenf.ca
 razer.com
 razorsecure.com
+reactbits.dev
 redeclipse.net
 reelgood.com
 reflektclothing.co.uk


### PR DESCRIPTION
**Website:**   https://reactbits.dev/
This Site already provides a native dark theme. Applying Dark Reader on top of the website is unnecessary and may lead to visual inconsistencies.