### PR TITLE
Invert top sponsor logo at Hearst magazine websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3940,6 +3940,7 @@ INVERT
 img[src^="/_assets/design-tokens/fre/static/icons/"]:not(nav#sidepanel img, footer img):not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i])
 nav#sidepanel img:not([src$="primary=%2523ffffff" i], [src$="primary=%2523b4b3b3" i])
+div[data-tracking-id="topNavSponsor"] img
 main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 main figure:has(audio) input
 
@@ -5218,6 +5219,7 @@ nav[data-tracking-id="topNav"] img[alt="Logo"]:not([src$="primary=%2523ffffff" i
 nav[data-tracking-id="topNav"] svg:is([alt="Logo"], [alt="Caret Right Icon"])
 nav#sidepanel button[aria-label="Close"] svg
 nav#sidepanel > div > ul::before
+div[data-tracking-id="topNavSponsor"] img
 div.footer svg[alt="Logo"]
 footer.footer img[alt="Logo"]:not([src$="primary=%2523ffffff" i], [src$="primary=%2523d4d4d4" i])
 main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
@@ -7154,6 +7156,7 @@ img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255
 nav[data-tracking-id="topNav"] :is(img, svg)[alt="Logo"]
 nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
 nav#sidepanel button[aria-label="Close"] svg
+div[data-tracking-id="topNavSponsor"] img
 div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
 main img[src^="/_assets/design-tokens/caranddriver/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 main img[src^="/_assets/design-tokens/caranddriver/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src$="primary=white"], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
@@ -9782,6 +9785,7 @@ nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
 nav#sidepanel a[aria-label="Harper's BAZAAR"] svg[alt="Logo"]
 nav#sidepanel button[aria-label="Close"] svg
 nav#sidepanel > div > ul::before
+div[data-tracking-id="topNavSponsor"] img
 div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
 main img[src*="/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 main figure:has(audio) input
@@ -22188,6 +22192,7 @@ img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255
 nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
 nav#sidepanel button[aria-label="Close"] svg
 nav#sidepanel > div > ul::before
+div[data-tracking-id="topNavSponsor"] img
 div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
 main img[src^="/_assets/design-tokens/menshealth/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%2523d2232e" i])
 main figure:has(audio) input
@@ -27417,6 +27422,7 @@ popularmechanics.com
 INVERT
 img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+div[data-tracking-id="topNavSponsor"] img
 main img[src^="/_assets/design-tokens/popularmechanics/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%25231c6a65" i])
 main figure:has(audio) input
 
@@ -28611,6 +28617,7 @@ redbookmag.com
 INVERT
 img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 nav[data-tracking-id="topNav"] button[aria-label="Sidepanel Button"] > svg
+div[data-tracking-id="topNavSponsor"] img
 footer.footer img[alt="Logo"]
 main img[src^="/_assets/design-tokens/redbookmag/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%2523d30c4f" i])
 main figure:has(audio) input
@@ -34534,6 +34541,7 @@ INVERT
 img[src^="/_assets/design-tokens/fre/static/icons/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i])
 nav[data-tracking-id="topNav"] svg[alt="Caret Right Icon"]
 nav#sidepanel button[aria-label="Close"] svg
+div[data-tracking-id="topNavSponsor"] img
 div.footer :is(img[alt^="Hearst"], svg[alt="Logo"])
 main img[src^="/_assets/design-tokens/townandcountrymag/static/images/logos/"]:not([src$="primary=rgba(255%252C%2520255%252C%2520255%252C%25200.95)"], [src$="primary=%2523fff" i], [src*="primary=%2523ffffff" i], [src*="primary=%2523fbfafa" i], [src*="primary=%2523d1d5db" i], [src*="primary=%2523d4d4d4" i], [src$="primary=%25239a0500" i])
 main figure:has(audio) input


### PR DESCRIPTION
I noticed that some Hearst websites have a top sponsor logo which can sometimes become invisible. https://www.menshealth.com/health/a71390794/everything-that-happens-during-a-skin-check-so-youll-actually-book-one/ https://www.menshealth.com/health/a65093636/5-doctor-backed-tips-about-managing-ed-that-every-man-should-know/ https://www.menshealth.com/health/a69676479/tony-romo-reflects-on-his-fathers-prostate-cancer-journey-and-the-everyday-moments-that-matter-most/ https://www.menshealth.com/health/a71463686/your-primary-care-physician-may-be-the-key-to-your-whole-health/

https://www.womenshealthmag.com/health/a71184652/the-surprising-link-between-straight-teeth-and-your-health/ https://www.womenshealthmag.com/fitness/a70011384/heres-how-i-prepare-to-sleep-better-in-five-minutes/

https://www.esquire.com/lifestyle/a71432856/one-new-york-dads-tips-for-easier-travel-with-a-toddler/
