### PR TITLE
Add dark theme detection hints for geizhals

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -688,6 +688,18 @@ MATCH
 
 ================================
 
+geizhals.at
+geizhals.de
+geizhals.eu
+
+TARGET
+body
+
+MATCH
+[data-darkmode="on"]
+
+================================
+
 gemini.google.com
 
 TARGET


### PR DESCRIPTION
Dark reader detects a dark theme for these websites even when light mode is selected.
https://geizhals.at/
https://geizhals.de/
https://geizhals.eu/
