### PR TITLE
invert black logos on mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23251,6 +23251,9 @@ img.sidebar-icon
 h1.c-logo
 .c-navigation-logo-image
 .m24-c-navigation-logo-image
+.mzp-u-data-table img[alt="Mozilla Wordmark"]
+.mzp-u-data-table img[alt="Mozilla Wordmark + Symbol"]
+.mzp-u-data-table img[alt="Symbol"]
 
 CSS
 div.mzp-c-navigation-logo {


### PR DESCRIPTION
Before:
<img width="396" height="151" alt="Screenshot 2026-06-16 at 13 07 20" src="https://github.com/user-attachments/assets/7c86f4bb-e085-4021-99c3-ee573974c998" />
<img width="402" height="105" alt="Screenshot 2026-06-16 at 13 07 37" src="https://github.com/user-attachments/assets/90fc9655-8db3-490a-aaef-0e1852908ee4" />

After:
<img width="385" height="156" alt="Screenshot 2026-06-16 at 13 08 10" src="https://github.com/user-attachments/assets/6e1d68a4-5f93-49eb-ac24-f08266be48a3" />
<img width="403" height="101" alt="Screenshot 2026-06-16 at 13 07 55" src="https://github.com/user-attachments/assets/03553a96-c6e6-4df0-b830-d0411fb64270" />

I checked light mode and it looks fine (no change).