### PR TITLE
add white background to partially-black logos on mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23256,6 +23256,12 @@ CSS
 div.mzp-c-navigation-logo {
     background: ${black} !important;
 }
+.mzp-u-data-table img[alt="Mozilla reps logo™"],
+.mzp-u-data-table img[alt="Webmaker logo"],
+.mzp-u-data-table img[alt="Firefox OS logo"],
+.mzp-u-data-table img[alt="Firefox Friends logo™"] {
+    background-color: white;
+}
 
 IGNORE IMAGE ANALYSIS
 .c-logo.t-browser-word-hor-white-xs


### PR DESCRIPTION
Before (dark mode): 
<img width="321" height="82" alt="Screenshot 2026-06-16 at 14 11 18" src="https://github.com/user-attachments/assets/c9a26ba2-d792-433d-82d9-1d0685e33842" />
<img width="282" height="113" alt="Screenshot 2026-06-16 at 14 12 04" src="https://github.com/user-attachments/assets/02dac22d-467c-499b-9a21-1bff69016c98" />
<img width="271" height="61" alt="Screenshot 2026-06-16 at 14 11 37" src="https://github.com/user-attachments/assets/fa04d104-af00-443d-aca0-1d1cac3b703a" />
<img width="265" height="99" alt="Screenshot 2026-06-16 at 14 11 49" src="https://github.com/user-attachments/assets/020af481-16cf-43e0-96c3-abb676cd6236" />


After (dark mode):
<img width="362" height="82" alt="Screenshot 2026-06-16 at 14 51 13" src="https://github.com/user-attachments/assets/42e608a6-67a5-4d7c-8cf8-c3b65fed3c61" />
<img width="352" height="130" alt="Screenshot 2026-06-16 at 14 51 20" src="https://github.com/user-attachments/assets/fc77d622-e81f-4fc9-9432-641323a5ae4d" />
<img width="296" height="72" alt="Screenshot 2026-06-16 at 14 51 29" src="https://github.com/user-attachments/assets/c28c0de6-b7a2-4e64-9b3a-1e65c17f0c50" />
<img width="333" height="112" alt="Screenshot 2026-06-16 at 14 51 38" src="https://github.com/user-attachments/assets/608ac9a9-c779-415e-a35a-0496ea78a9d8" />
