### PR TITLE
fix hover/focus select text on mozilla.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23258,7 +23258,7 @@ div.mzp-c-navigation-logo {
 }
 select:hover,
 select:focus {
-    color: black;
+    background-image: none !important;
 }
 
 IGNORE IMAGE ANALYSIS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23256,6 +23256,10 @@ CSS
 div.mzp-c-navigation-logo {
     background: ${black} !important;
 }
+select:hover,
+select:focus {
+    color: black;
+}
 
 IGNORE IMAGE ANALYSIS
 .c-logo.t-browser-word-hor-white-xs


### PR DESCRIPTION
Before (hover):
<img width="496" height="105" alt="Screenshot 2026-06-16 at 15 02 04" src="https://github.com/user-attachments/assets/4da10206-1f30-45b1-b99d-3aedc1efa43a" />

After (hover):
<img width="485" height="95" alt="Screenshot 2026-06-16 at 15 02 47" src="https://github.com/user-attachments/assets/424c9a52-be01-46a9-bad9-2ef35aa43a94" />

Before (focus):
<img width="469" height="91" alt="Screenshot 2026-06-16 at 15 02 27" src="https://github.com/user-attachments/assets/7cc21bfd-f13b-4c17-be33-db264b8b1300" />

After (focus):
<img width="471" height="97" alt="Screenshot 2026-06-16 at 15 02 54" src="https://github.com/user-attachments/assets/dd92757c-b932-4633-ac92-a2f8ebe3610e" />

I checked light mode and it looks fine (no changes, since text was already black).