### PR TITLE
Fix Vlerick Canvas logo in Dynamic mode

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19830,6 +19830,15 @@ CSS
 
 ================================
 
+learning.vlerick.com
+
+CSS
+.ic-app-header__logomark {
+    background-image: var(--ic-brand-header-image) !important;
+}
+
+================================
+
 learningstylequiz.com
 *.learningstylequiz.com
 


### PR DESCRIPTION
Fixes the Vlerick Canvas logo on learning.vlerick.com in Dynamic mode.

The Canvas header logo uses `background-image: var(--ic-brand-header-image)`.
In Dynamic mode, Dark Reader currently causes the computed `background-image`
for `.ic-app-header__logomark` to become `none`, so the logo disappears.

This fix restores the Canvas branding image variable for the logo element.

Tested:
- Dynamic mode
- Light mode
- Dark mode
- Firefox