### PR TITLE
Add dark theme detection hint for overclocking.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1184,6 +1184,16 @@ MATCH
 
 ================================
 
+overclocking.com
+
+TARGET
+body
+
+MATCH
+.darkmode--activated
+
+================================
+
 pass.proton.me
 
 TARGET


### PR DESCRIPTION
See the bottom left at:
https://overclocking.com/