### PR TITLE
Update dynamic theme fixes for guitarworld.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16041,7 +16041,7 @@ p.promo_price
 guitarworld.com
 
 INVERT
-.site-logo
+img[src="/media/img/GW_logo.svg"]
 
 ================================
 


### PR DESCRIPTION
The logo class changed, it is not being inverted anymore.
https://www.guitarworld.com/
