### PR TITLE
fix for dreamwidth.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -436,19 +436,24 @@ html[data-darkreader-scheme="dimmed"] .tropo #logo {
 .ContextualPopup {
     background: var(--darkreader-neutral-background) !important;
 }
-*[style*="color: rgba(0,0,0,"],
-*[style*="color: rgba(0, 0, 0,"],
-*[style*="color:#000"],
-*[style*="color:black"],
-*[style*="color:#282828"],
-*[style*="color:#444"],
-*[style*="background:#fff"],
-*[style*="background-color:#fff"],
-*[bgcolor="#F5F5F5"],
-*[style*="background-color: #F5F5F5"],
-*[style*="background:#f9f9f9"] {
-    background: var(--darkreader-neutral-background) !important;
-    color: var(--darkreader-neutral-text) !important;
+:is(.entry-content,.comment-content) :is([style*="color: rgba(0,0,0,"]:not([style*="color: rgba(0,0,0,0)"]),
+[style*="color: rgba(0, 0, 0,"]:not([style*="color: rgba(0, 0, 0, 0)"]),
+[style*="color:#000"],
+[style*="color:black"],
+[style*="color:#282828"],
+[style*="color:#444"],
+[style*="color: #222222"],
+[style*="background:#fff"],
+[style*="background-color:#fff"],
+[style*="background: #fff"],
+[bgcolor="#F5F5F5"],
+[style*="background-color: #F5F5F5"],
+[style*="background: #e6e6e6"],
+[style*="background: rgb(255, 255, 255) !important"] *:not(a),
+[style*="background-color: rgb(254, 254, 254) !important"] *:not(a),
+[style*="background:#f9f9f9"]) {
+    background-color: inherit !important;
+    color: inherit !important;
 }
 
 IGNORE INLINE STYLE


### PR DESCRIPTION
Manually updating fixes for dynamic theme's global wildcard selectors, because they override "ignore inline style" and create unreadable text.