### PR TITLE
Added Dynamic Theme fixes for 'writings.stephenwolfram.com'

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -38386,7 +38386,10 @@ div.post_content img
 
 CSS
 .comment-byline::after {
-    background: url('https://writings.stephenwolfram.com/wp-content/themes/sw-writings/images/comment-arrow.gif');
+    filter: invert(10%) hue-rotate(180deg) !important;
+    opacity: 0.8 !important;
+}
+#bt2 {
     filter: invert(90%) hue-rotate(180deg) !important;
 }
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -38383,14 +38383,15 @@ writings.stephenwolfram.com
 INVERT
 div.post_content img
 #nav ul li .social a:not(:hover)
+#bt1
+#bt2
 
 CSS
-.comment-byline::after {
-    filter: invert(10%) hue-rotate(180deg) !important;
-    opacity: 0.8 !important;
+html[data-darkreader-scheme="dark"] .comment-content-body {
+    --darkreader-border-dddddd: #999999 !important;
 }
-#bt2 {
-    filter: invert(90%) hue-rotate(180deg) !important;
+html[data-darkreader-scheme="dimmed"] .comment-byline::after {
+    mix-blend-mode: multiply !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -38378,6 +38378,20 @@ span
 
 ================================
 
+writings.stephenwolfram.com
+
+INVERT
+div.post_content img
+#nav ul li .social a:not(:hover)
+
+CSS
+.comment-byline::after {
+    background: url('https://writings.stephenwolfram.com/wp-content/themes/sw-writings/images/comment-arrow.gif');
+    filter: invert(90%) hue-rotate(180deg) !important;
+}
+
+================================
+
 wszystkoconajwazniejsze.pl
 
 CSS


### PR DESCRIPTION
## Overview

Added Dynamic Theme fixes for Stephen Wolfram's Blog [_Writings_](https://writings.stephenwolfram.com/).

- Inverted dark images in posts
- Inverted social media link images (when not hovered)
- Fixed comment box "tail" from appearing the wrong color

You may use this [blog post](https://writings.stephenwolfram.com/2023/02/what-is-chatgpt-doing-and-why-does-it-work/) as an example.

### Blog Post Body Images

A lot of the "images" on this site are rendered code examples. Inverting all instances of `div.post_content img` fixes this issue.

#### Before

<img width="733" height="838" alt="image" src="https://github.com/user-attachments/assets/3cfa8a6f-1ac1-4576-bab3-7804cfbb373d" />

#### After

<img width="719" height="840" alt="image" src="https://github.com/user-attachments/assets/e3da496a-f925-46d9-b1c4-488d685cc357" />

### Social Media Link Images

The un-hovered state of the social media link images were a little too bright. Hovering over them revealed the actual icon colors. Adding `#nav ul li .social a:not(:hover)` as an `INVERT` entry inverts the images to help bring the default state to match. Include`:not(:hover)` to keep it from reverting the actual brand logo color on hover.

#### Before

<img width="1232" height="97" alt="image" src="https://github.com/user-attachments/assets/b415a2fd-69b5-4f6b-ad85-8d7302187bcb" />

#### After

<img width="1246" height="95" alt="image" src="https://github.com/user-attachments/assets/6af7f10a-cbe2-4c51-a4de-474cd320ab8b" />

#### Without  `:not(:hover)`

<img width="647" height="92" alt="image" src="https://github.com/user-attachments/assets/cfa20825-371e-44bc-98aa-8295035ec72a" />

#### With `:not(:hover)`

<img width="582" height="89" alt="image" src="https://github.com/user-attachments/assets/a4a4a44f-a764-4589-afcb-c73d889e1a08" />

### Message box "tails"

Each comment in the comments list looks like a speech bubble, and the "tails" appear the incorrect color. These tails are defined in the `::after` selector of the `.comment-byline` class, and are a background image. Inverting it _just a bit_ and setting it to be somewhat transparent mitigates the jarring change a bit. It's not exact, but it gets close.

#### Before

<img width="718" height="422" alt="image" src="https://github.com/user-attachments/assets/2682f01d-7afa-4bf8-9b69-2bc64ba3115f" />

#### After

<img width="716" height="426" alt="image" src="https://github.com/user-attachments/assets/0aca6214-323d-4638-966b-67c9a38daed6" />

---

_Tested in Edge (pictured)_

