### PR TITLE
Added Dynamic Theme fixes for 'blog.mozilla.org'

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6114,9 +6114,9 @@ CSS
 #page {
     background-image: none !important;
 }
-.ft-c-header__logo a {
-    background-image: url("/wp-content/themes/foxtail/assets/images/distilled-logo.svg") !important;
-}
+
+IGNORE IMAGE ANALYSIS
+.ft-c-header__logo a
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6098,6 +6098,14 @@ blog.mozilla.org
 INVERT
 .content > .logo > [href^="https://www.mozilla.org/"]
 .nav-global-donate > [href^="https://donate.mozilla.org/"]
+.ft-c-header__search-icon
+div.ft-c-header__logo
+div.ft-c-hamburger
+img.ft-c-post-share__icon
+div.ft-c-post-meta > [alt="author"]
+div.ft-c-post-meta > [alt="calendar"]
+#previous-post > img
+#next-post > img
 
 CSS
 .nav-global-donate > [href^="https://donate.mozilla.org/"] {
@@ -6105,6 +6113,9 @@ CSS
 }
 #page {
     background-image: none !important;
+}
+.ft-c-header__logo a {
+    background-image: url("/wp-content/themes/foxtail/assets/images/distilled-logo.svg") !important;
 }
 
 ================================


### PR DESCRIPTION
## Overview

Added new Dynamic Theme fixes for Mozilla's blog pages. This fixes various discrepancies on the main blog page and within the posts themselves.

- Fixed "Distilled" logo in the top right
- Corrected various obscured icons

You can test with the [main blog page](https://blog.mozilla.org/en) and [this example post](https://blog.mozilla.org/en/privacy-security/keeping-the-web-open-and-private-in-the-bot-era/).

## Fix "Distilled" Logo

The "Distilled" Logo in the top right links back to the blog's main page, but it gets replaced with a blank `.svg` image.

<img width="892" height="172" alt="image" src="https://github.com/user-attachments/assets/667be1a0-f78c-4f7b-8580-8a4c7480ba51" />

First restore the logo via the CSS rule:

```css
CSS
/* ... other CSS selectors here ... */
.ft-c-header__logo a {
    background-image: url("/wp-content/themes/foxtail/assets/images/distilled-logo.svg") !important;
}
```

<img width="847" height="167" alt="image" src="https://github.com/user-attachments/assets/92917995-2499-45e4-a648-c88784f00dd3" />

Then add `.ft-c-header__logo` as an `INVERT` entry.

<img width="851" height="215" alt="image" src="https://github.com/user-attachments/assets/992514bb-090b-4ac5-b7dd-e3e0b7daaacf" />

## Corrected Various Icons

Inverted the colors for various icons:

- Search icon: `.ft-c-header__search-icon`
- Hamburger icon: `div.ft-c-hamburger`
- Share Icons (blog posts only): `img.ft-c-post-share__icon`
- Author and Calendar Icons (blog posts only) 
  - `div.ft-c-post-meta > [alt="author"]`
  - `div.ft-c-post-meta > [alt="calendar"]`
- Previous and Next post arrows (blog posts only):
  - `#previous-post > img`
  - `#next-post > img`

### Distilled Logo, Hamburger Icon, and Author/Calendar Icon Fixes

#### Before

<img width="486" height="466" alt="image" src="https://github.com/user-attachments/assets/efcfd37e-ab39-461d-ba2c-a3e96fef93ec" />

#### After

<img width="483" height="464" alt="image" src="https://github.com/user-attachments/assets/f5f27a13-45a4-4d72-9fd9-f5a62243ca74" />

### Social Media, Previous Post, and Next Post Icon Fixes

#### Before

<img width="839" height="576" alt="image" src="https://github.com/user-attachments/assets/aa59dda1-9ecf-4ca9-b47b-66d869db1242" />

#### After

<img width="1029" height="548" alt="image" src="https://github.com/user-attachments/assets/124a1b62-cc05-43a1-8748-78c1dfb77b01" />

### Search Icon Fix

#### Before

<img width="337" height="92" alt="image" src="https://github.com/user-attachments/assets/dc947dfb-96b0-4dd0-8b24-bf9adba60808" />

#### After

<img width="303" height="104" alt="image" src="https://github.com/user-attachments/assets/317bb0a5-eb9b-4a54-9cb4-70073131d744" />

---

_Tested in Edge (pictured)_