### PR TITLE
Update dynamic theme fixes for techpowerup.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33686,6 +33686,9 @@ a[class^="headerTemplate__logo"]
 
 techpowerup.com
 
+INVERT
+a.page-header__logo
+
 CSS
 html[data-darkreader-scheme="dark"] img.icon,
 html[data-darkreader-scheme="dark"] img.newsicon {


### PR DESCRIPTION
The logo now needs to be inverted.
Maybe due to the new version 4.9.128 .
