### PR TITLE
Fix contrast of strain effect bars on leafly.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19990,6 +19990,18 @@ CSS
 
 ================================
 
+leafly.com
+
+CSS
+.bg-light-grey.rounded-full.relative {
+    background-color: #383838 !important;
+}
+.bg-light-grey.rounded-full.relative > .bg-default.rounded-full {
+    background-color: #8aa07f !important;
+}
+
+================================
+
 leagueoflegends.com
 
 INVERT


### PR DESCRIPTION
* Added rule to dynamic theme fix for display of effect bars for cannabis strain info page at Leafly.com. 
* In Dark Mode, the full part of bar was undistinguishable - it had the same tint as the empty background part. 
* I chose the hardcoded color based on the color palette of terpene "capsules" ui elements near it.
* The background, unfilled bar area color was also adjusted for better contrast and accessibility.

Before change:
<img width="2080" height="1330" alt="image" src="https://github.com/user-attachments/assets/94490001-cf8a-4e46-bc08-ad673423917e" />

After the change:
<img width="2080" height="1330" alt="image" src="https://github.com/user-attachments/assets/b138e3d2-af03-41b1-8cf9-b4357f888124" />
