### PR TITLE
Add '*.dw.com' to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -5,6 +5,7 @@
 *.curseforge.com
 *.draftbot.fr
 *.draftbot.gg
+*.dw.com
 *.furaffinity.net
 *.hadesblack.com
 *.iaas.store


### PR DESCRIPTION
All known Deutsche Welle websites use a dark blue background:
https://akademie.dw.com/
https://corporate.dw.com/
https://learngerman.dw.com/
https://www.dw.com/
