### PR TITLE
Fix for privacypack.org

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -938,6 +938,7 @@ ppluss.de
 ppy.sh
 pr0gramm.com
 premid.app
+privacypack.org
 privacytools.io
 prizafal.com
 progettosnaps.net

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -938,7 +938,6 @@ ppluss.de
 ppy.sh
 pr0gramm.com
 premid.app
-privacypack.org
 privacytools.io
 prizafal.com
 progettosnaps.net

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28151,6 +28151,17 @@ market-filter-item {
 
 ================================
 
+privacypack.org
+
+CSS
+@layer utilities {
+    .bg-\[\#fff\]\/2 {
+        background-color: oklab(100% 0 5.96046e-8/.02) !important;
+    }
+}
+
+================================
+
 privat24.ua
 
 CSS


### PR DESCRIPTION
Fixes graphical elements on `/create` page by using site-specific colors.

Before:
<img width="350" height="145" alt="1" src="https://github.com/user-attachments/assets/cc0e7b41-c840-497b-9d53-cdf4a34aac64" />

After:
<img width="350" height="145" alt="2" src="https://github.com/user-attachments/assets/e9a58c64-239a-43ce-9354-86df0da52ab1" />