### PR TITLE
Add dark theme detection hints for *.dw.com websites

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -877,16 +877,6 @@ MATCH
 
 ================================
 
-learngerman.dw.com
-
-TARGET
-html
-
-MATCH
-.theme-dark
-
-================================
-
 learn.standardresume.co
 
 TARGET
@@ -894,6 +884,17 @@ html
 
 MATCH
 .dark
+
+================================
+
+learngerman.dw.com
+
+TARGET
+html
+
+MATCH
+
+.theme-dark
 
 ================================
 

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -181,6 +181,17 @@ MATCH
 
 ================================
 
+akademie.dw.com
+corporate.dw.com
+
+TARGET
+body
+
+MATCH
+[data-theme="dark"]
+
+================================
+
 alarabiya.net
 
 TARGET
@@ -549,6 +560,12 @@ MATCH
 
 ================================
 
+dw.com
+
+SYSTEM THEME
+
+================================
+
 ecosia.org
 
 TARGET
@@ -857,6 +874,16 @@ html
 
 MATCH
 .dark-theme
+
+================================
+
+learngerman.dw.com
+
+TARGET
+html
+
+MATCH
+.theme-dark
 
 ================================
 


### PR DESCRIPTION
https://akademie.dw.com/
https://corporate.dw.com/
https://learngerman.dw.com/
https://www.dw.com/
