### PR TITLE
Adding music.amazon.com to dark-sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -793,6 +793,7 @@ ms-paint-i.de
 mstdn.social
 mtv.com
 musedash.moe
+music.amazon.com
 music.com
 music.youtube.com
 muttwizard.com


### PR DESCRIPTION
Quick workaround for #15658