### PR TITLE
Salesforce setup > Sandbox buttons fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -853,6 +853,31 @@ main.about header#msi-key-visual.kv div.kv__content h1 {
 
 ================================
 
+*.my.salesforce-setup.com
+
+CSS
+body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell,
+body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell,
+body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell td.rich-tab-active,
+body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell td.rich-tab-inactive {
+    background-image: none !important;
+}
+body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell {
+    background-color: color-mix(in srgb, var(--darkreader-neutral-background) 90%, gray) !important;
+    border: 1px solid var(--darkreader-neutral-text) !important;
+    border-bottom: none !important;
+}
+body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell {
+    background-color: color-mix(in srgb, var(--darkreader-neutral-background) 80%, white) !important;
+    border: 1px solid var(--darkreader-neutral-text) !important;
+    border-bottom: none !important;
+}
+body .rich-tab-header {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 *.myconnectwise.net
 
 CSS
@@ -24149,31 +24174,6 @@ INVERT
 .menu-button
 img[alt="desktop icon"]
 img[alt="mobile icon"]
-
-================================
-
-*.my.salesforce-setup.com
-
-CSS
-body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell,
-body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell,
-body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell td.rich-tab-active,
-body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell td.rich-tab-inactive {
-    background-image: none !important;
-}
-body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell {
-    background-color: color-mix(in srgb, var(--darkreader-neutral-background) 90%, gray) !important;
-    border: 1px solid var(--darkreader-neutral-text) !important;
-    border-bottom: none !important;
-}
-body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell {
-    background-color: color-mix(in srgb, var(--darkreader-neutral-background) 80%, white) !important;
-    border: 1px solid var(--darkreader-neutral-text) !important;
-    border-bottom: none !important;
-}
-body .rich-tab-header {
-    color: var(--darkreader-neutral-text) !important;
-}
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -24152,6 +24152,31 @@ img[alt="mobile icon"]
 
 ================================
 
+*.my.salesforce-setup.com
+
+CSS
+body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell,
+body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell,
+body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell td.rich-tab-active,
+body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell td.rich-tab-inactive {
+    background-image: none !important;
+}
+body .rich-tabhdr-cell-inactive > table[id$="shifted"] td.rich-tabhdr-side-cell {
+    background-color: color-mix(in srgb, var(--darkreader-neutral-background) 90%, gray) !important;
+    border: 1px solid var(--darkreader-neutral-text) !important;
+    border-bottom: none !important;
+}
+body .rich-tabhdr-cell-active > table[id$="shifted"] td.rich-tabhdr-side-cell {
+    background-color: color-mix(in srgb, var(--darkreader-neutral-background) 80%, white) !important;
+    border: 1px solid var(--darkreader-neutral-text) !important;
+    border-bottom: none !important;
+}
+body .rich-tab-header {
+    color: var(--darkreader-neutral-text) !important;
+}
+
+================================
+
 my.vega.ua
 
 INVERT


### PR DESCRIPTION
Salesforce setup page > sandboxes, has un-inverted buttons with background images, unfortunately directly inverting them messes up the text color, which is very onerous to select correctly. so i just manually fixed them by removing the background image and recoloring.

Salesforce setup has custom tenents in the domain like ***companyname**.my.salesforce-setup.com* hence the *

Before
<img width="426" height="428" alt="{2FE1F9CE-148C-484C-B46D-D8A34E7F0E46}" src="https://github.com/user-attachments/assets/55eca845-2027-4b26-9e5f-7c08aeea9c7b" />


After (the chosen fix)
<img width="464" height="430" alt="{90E8E09E-A02D-443C-8293-F06A91550EF8}" src="https://github.com/user-attachments/assets/9d0a2512-2897-4aa4-b84c-ec6038cf5aab" />


Direct Invert (i couldnt figure out how to fix the text when inverting the image)
<img width="448" height="410" alt="{8420CECF-D58F-4B0F-93D1-C0AF1C1F3EFA}" src="https://github.com/user-attachments/assets/88b24473-55a2-4d04-81fb-beac9fe927c3" />

