### PR TITLE
Update dynamic theme fixes for Medialivre websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13730,6 +13730,8 @@ sabado.pt
 
 INVERT
 :is(.header, div.topBar, div#mainMenu) button span
+img[src^="/i/"]
+button.closeBtn span
 
 ================================
 
@@ -20525,7 +20527,7 @@ record.pt
 INVERT
 b.burger-menu
 a.burger-close
-img[src$="/logo-indica.svg"]
+img[src^="/i/"]
 
 CSS
 div.dialog.dialog--alerta.dialog--main-menu,


### PR DESCRIPTION
https://www.flash.pt/
https://www.jornaldenegocios.pt/
https://www.maxima.pt/
https://www.must.jornaldenegocios.pt/
https://www.sabado.pt/
https://www.record.pt/
https://liga.record.pt/