### PR TITLE
Update dynamic theme fixes for Medialivre websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -799,6 +799,28 @@ CSS
 
 ================================
 
+*.jornaldenegocios.pt
+
+INVERT
+:is(header.header, div#mainMenu) button span
+div.navbar-main-nav a.toggleMenuButton
+div.header_top a.logo
+nav.header_canais div.canais::before
+nav.header_canais div.canais::after
+img[src^="/i/"]
+button.closeBtn span
+footer a.logo_footer
+footer a.reclamacoes_logo
+
+IGNORE IMAGE ANALYSIS
+.header:not(li) .header_top .logo
+.scrollingPage .header:not(li) .header_top .logo
+.footer .links .logo_footer
+.simplificado .links .icons_footer li .reclamacoes_logo
+.simplificado #ic_notificacoes .icon
+
+================================
+
 *.maricopa.edu
 
 CSS
@@ -13723,13 +13745,12 @@ body {
 ================================
 
 flash.pt
-jornaldenegocios.pt
 maxima.pt
-must.jornaldenegocios.pt
 sabado.pt
 
 INVERT
 :is(.header, div.topBar, div#mainMenu) button span
+img[src^="/i/"]
 
 ================================
 
@@ -20525,7 +20546,7 @@ record.pt
 INVERT
 b.burger-menu
 a.burger-close
-img[src$="/logo-indica.svg"]
+img[src^="/i/"]
 
 CSS
 div.dialog.dialog--alerta.dialog--main-menu,


### PR DESCRIPTION
https://www.jornaldenegocios.pt/
https://caldeiraodebolsa.jornaldenegocios.pt/
https://www.must.jornaldenegocios.pt/
https://www.flash.pt/
https://www.maxima.pt/
https://www.sabado.pt/
https://liga.record.pt/
https://www.record.pt/