### PR TITLE
Update dynamic theme fixes for hsnstore.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -16998,6 +16998,9 @@ div#view-related-button::before {
     background-image: url(/static/frontend/Hiberus/hsn/en_US/images/chevron-right.svg) !important;
 }
 
+IGNORE INLINE STYLE
+main div.bg-white svg *
+
 IGNORE IMAGE ANALYSIS
 *
 


### PR DESCRIPTION
Ignore svg logos with white background.

<img width="1778" height="1040" alt="Screenshot 2026-06-30 212131" src="https://github.com/user-attachments/assets/eb31abb1-15d4-46ca-b11f-578f33a4c9e6" />
