### PR TITLE
Invert share logos at hsnstore.*

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17070,6 +17070,7 @@ hsnstore.*
 INVERT
 img[src$="/qualitylogo-square-hsn.webp"]
 footer img[src^="/media/wysiwyg/footer-quality-and-guarantees/"]:not([alt="eco"])
+img.cursor-pointer:is([alt="X Logo"], [alt="Email Logo"], [alt="Clipboard Logo"])
 
 CSS
 :is(div, img).mix-blend-multiply,


### PR DESCRIPTION
Click the three dots at:
https://www.hsnstore.pt/marcas/raw-series/creatina-monoidrato-em-po-200-mesh
You will find the X, Email, and Clipboard logos on that window.
