### PR TITLE
added fix for emacsair.me

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -12538,6 +12538,15 @@ INVERT
 
 ================================
 
+emacsair.me
+
+CSS
+body {
+    background-color: var(--darkreader-neutral-background) !important;
+}
+
+================================
+
 emacswiki.org
 
 CSS


### PR DESCRIPTION
Currently the website has a central block of text with a brown background while the margins have a darker color. This PR fixes this issue.

How the website looks now:

<img width="960" height="1085" alt="preview" src="https://github.com/user-attachments/assets/ff0af0f9-be05-4198-a49e-98c0c901d5aa" />
