### PR TITLE
Fix Tailwind bg-current/10 background flattening

### DIFF
--- a/src/inject/dynamic-theme/modify-css.ts
+++ b/src/inject/dynamic-theme/modify-css.ts
@@ -310,6 +310,12 @@ function getColorModifier(prop: string, value: string, rule: CSSStyleRule): stri
         unparsableColors.has(value.toLowerCase()) &&
         !(prop === 'color' && value === 'initial')
     ) {
+        // CSSOM returns the currentcolor fallback for rules like Tailwind's bg-current/10,
+        // while the effective style comes from a nested @supports color-mix() block.
+        // Skipping modification preserves the original rule structure.
+        if (prop.includes('background') && value.toLowerCase() === 'currentcolor') {
+            return null;
+        }
         return value;
     }
     let rgb: RGBA | null = null;

--- a/tests/inject/dynamic/style-override.tests.ts
+++ b/tests/inject/dynamic/style-override.tests.ts
@@ -47,6 +47,37 @@ describe('STYLE ELEMENTS', () => {
         expect((override.cssRules[1] as CSSStyleRule).style.getPropertyValue('color')).toBe('var(--darkreader-text-000000, #ffffff)');
     });
 
+    it('should not flatten background-color: currentcolor with nested color-mix', () => {
+        const style = document.createElement('style');
+        style.textContent = multiline(
+            '.bg-current\\/10 {',
+            '  background-color: currentcolor;',
+            '  @supports (color: color-mix(in lab, red, red)) {',
+            '    background-color: color-mix(currentcolor 10%, transparent);',
+            '  }',
+            '}',
+            '.text-red { color: red; }',
+        );
+        container.append(style);
+
+        const modifier = createStyleSheetModifier();
+        const overrideStyle = document.createElement('style');
+        container.append(overrideStyle);
+        const override = overrideStyle.sheet!;
+        modifier.modifySheet({
+            theme,
+            sourceCSSRules: style.sheet!.cssRules,
+            ignoreImageAnalysis: [],
+            force: false,
+            prepareSheet: () => override,
+            isAsyncCancelled: () => false,
+        });
+
+        const selectors = Array.from(override.cssRules).map((rule) => (rule as CSSStyleRule).selectorText);
+        expect(selectors).not.toContain('.bg-current\\/10');
+        expect(selectors).toContain('.text-red');
+    });
+
     it('should override User Agent style', async () => {
         container.innerHTML = multiline(
             '<span>Text</span>',


### PR DESCRIPTION
## Summary
- Skip Dark Reader modification of `background-color: currentcolor` declarations
- Preserves Tailwind 4's nested `@supports color-mix(...)` progressive enhancement pattern
- Fixes invisible text on `bg-current/10` elements

Fixes #15243

## Test plan
- [x] `npm test` (unit tests)
- [x] New inject test passes in ChromeHeadless
- [x] Manual repro confirms text stays visible with Dark Reader enabled