### PR TITLE
Fix SVG badge colors on fifa.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13668,6 +13668,17 @@ img[src$="assets/images/bg-cloud.png"]
 
 ================================
 
+fifa.com
+
+CSS
+[class^="player-badge-card_badgeCardBackground"] svg,
+[class^="manager-badge-card_badgeCardBackground"] svg {
+    fill: var(--darkreader-neutral-background) !important;
+    stroke: color-mix(in srgb, var(--darkreader-neutral-background) 80%, white) !important;
+}
+
+================================
+
 figma.com
 
 CSS


### PR DESCRIPTION
Fix SVG badge colors on:
https://www.fifa.com/en/tournaments/mens/worldcup/canadamexicousa2026/teams/argentina/squad
https://www.fifa.com/en/tournaments/mens/worldcup/canadamexicousa2026/teams/argentina/team-news

Before:
<img width="1286" height="1025" alt="imagen" src="https://github.com/user-attachments/assets/c8d24e66-452e-437f-bb78-d3d842af4668" />

After:
<img width="1286" height="1021" alt="imagen" src="https://github.com/user-attachments/assets/28a24c55-87ae-4efc-9892-9f5bc4f6de39" />
