### PR TITLE
fix for artconomy.com and subdomains

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -53,6 +53,7 @@ adridoesthings.com
 adventofcode.com
 agent-stats.com
 ageofempires.com
+agorawr.artconomy.com
 agfy.co
 airconsole.com
 ajay.app
@@ -102,6 +103,7 @@ ard.social
 ardov.me
 ari.lt
 armaforces.com
+artconomy.com
 artixlinux.org
 artlist.io
 arweave.app
@@ -574,6 +576,7 @@ hacktoberfest-projects.vercel.app
 hadesblack.com
 halotracker.com
 halowaypoint.com
+handbook.artconomy.com
 hang.fm
 hardforum.com
 hardstuck.gg
@@ -1089,6 +1092,7 @@ spotfy.one
 spoticord.com
 spyware.neocities.org
 srrdb.com
+stage.artconomy.com
 star-made.org
 starbreeze.com
 starlink.com

--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -53,8 +53,8 @@ adridoesthings.com
 adventofcode.com
 agent-stats.com
 ageofempires.com
-agorawr.artconomy.com
 agfy.co
+agorawr.artconomy.com
 airconsole.com
 ajay.app
 akkoma.dev


### PR DESCRIPTION
Fixes Artconomy and its dark-moded subdomains (not all Artconomy subdomains are default dark, but most are.)