### PR TITLE
Picrew color picker fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27478,7 +27478,7 @@ picrew.me
 
 IGNORE INLINE STYLE
 .imagemaker_colorpalette li
-label.svelte-1dvi8sd
+.color-list li label
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -27478,6 +27478,7 @@ picrew.me
 
 IGNORE INLINE STYLE
 .imagemaker_colorpalette li
+label.svelte-1dvi8sd
 
 ================================
 


### PR DESCRIPTION
The colors in the color picker are often shown incorrectly, and this seems to fix it. Tested in picrew.me/en/image_maker/644129 by comparing the skin color options in both the dark and light versions of the page.

I did not test if this issue is present in the desktop website, but it is in the mobile version.