### PR TITLE
Fix delayed style injection before body exists

### DIFF
--- a/src/inject/dynamic-theme/injection.ts
+++ b/src/inject/dynamic-theme/injection.ts
@@ -9,14 +9,14 @@ const hostsBreakingOnStylePosition = [
     'zhale.me',
 ];
 
-const mode = hostsBreakingOnStylePosition.includes(location.hostname) ? 'away' : 'next'
+const mode = hostsBreakingOnStylePosition.includes(location.hostname) ? 'away' : 'next';
 
 export function getStyleInjectionMode() {
     return mode;
 }
 
 const stylesWaitingForBody = new Set<HTMLStyleElement | SVGStyleElement>();
-let bodyObserver: MutationObserver | null;
+let bodyObserver: MutationObserver | null = null;
 
 export function injectStyleAway(styleElement: HTMLStyleElement | SVGStyleElement) {
     if (!document.body) {
@@ -30,6 +30,7 @@ export function injectStyleAway(styleElement: HTMLStyleElement | SVGStyleElement
                     stylesWaitingForBody.clear();
                 }
             });
+            bodyObserver.observe(document, {childList: true, subtree: true});
         }
         return;
     }
@@ -66,6 +67,8 @@ let containerObserver: MutationObserver;
 
 export function removeStyleContainer() {
     bodyObserver?.disconnect();
+    bodyObserver = null;
+    stylesWaitingForBody.clear();
     containerObserver?.disconnect();
     document.querySelector('.darkreader-style-container')?.remove();
 }

--- a/tests/inject/dynamic/injection.tests.ts
+++ b/tests/inject/dynamic/injection.tests.ts
@@ -1,0 +1,58 @@
+import {injectStyleAway, removeStyleContainer} from '../../../src/inject/dynamic-theme/injection';
+import {timeout} from '../support/test-utils';
+
+describe('STYLE INJECTION', () => {
+    let originalBody: HTMLElement;
+
+    beforeEach(() => {
+        removeStyleContainer();
+        originalBody = document.body;
+        originalBody.remove();
+    });
+
+    afterEach(() => {
+        removeStyleContainer();
+        document.body?.remove();
+        document.documentElement.append(originalBody);
+    });
+
+    it('should inject a queued style when the body becomes available', async () => {
+        const style = document.createElement('style');
+        style.textContent = 'body { color: white; }';
+
+        injectStyleAway(style);
+        expect(style.isConnected).toBe(false);
+
+        const body = document.createElement('body');
+        document.documentElement.append(body);
+        await timeout(0);
+
+        const container = body.querySelector('.darkreader-style-container');
+        expect(container).not.toBeNull();
+        expect(container!.lastElementChild).toBe(style);
+        expect(style.sheet!.cssRules.length).toBe(1);
+    });
+
+    it('should clear queued styles and allow observing a new body', async () => {
+        const discardedStyle = document.createElement('style');
+        injectStyleAway(discardedStyle);
+        removeStyleContainer();
+
+        const firstBody = document.createElement('body');
+        document.documentElement.append(firstBody);
+        await timeout(0);
+
+        expect(firstBody.querySelector('.darkreader-style-container')).toBeNull();
+        expect(discardedStyle.isConnected).toBe(false);
+
+        firstBody.remove();
+        const injectedStyle = document.createElement('style');
+        injectStyleAway(injectedStyle);
+
+        const secondBody = document.createElement('body');
+        document.documentElement.append(secondBody);
+        await timeout(0);
+
+        expect(secondBody.querySelector('.darkreader-style-container')?.lastElementChild).toBe(injectedStyle);
+    });
+});


### PR DESCRIPTION
This was causing issues with bloomberg.com articles loading dark text on dark background: https://github.com/darkreader/darkreader/issues/14603