### PR TITLE
Update dynamic-theme-fixes.config by adding practers.com fix

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28619,7 +28619,7 @@ practers.com
 
 CSS
 header.sticky {
-    background-color: ${#f4f5f7} !important;
+    background-color: ${rgba(244,245,247,0.9)} !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28615,6 +28615,15 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+practers.com
+
+CSS
+header.sticky {
+    background-color: ${#f4f5f7} !important;
+}
+
+================================
+
 practicum.yandex.*
 
 INVERT

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28617,9 +28617,16 @@ IGNORE IMAGE ANALYSIS
 
 practers.com
 
+INVERT
+.company-logo-wrapper img:is([alt="Amazon"], [alt="Apple"], [alt="Uber"])
+.roles-card img
+
 CSS
 header.sticky {
     background-color: ${rgba(244,245,247,0.9)} !important;
+}
+.mix-blend-multiply {
+    mix-blend-mode: unset !important;
 }
 
 ================================


### PR DESCRIPTION
**Website:** practers.com

**Problem:**
When Dark Reader is turned on in Dynamic mode, the top navbar shows a light 
cream colour. But the real website navbar is almost white. So the colour looks 
wrong when Dark Reader is on.

**Reason:**
The navbar background is semi-transparent (#f4f5f7 at 90% opacity) and it also 
uses backdrop-blur. Because of this, Dark Reader cannot read the correct 
background colour and it picks a wrong one.

**Fix:**
I added a small fix in dynamic-theme-fixes.config to set the correct background 
colour on the header. Now it looks correct in both Light and Dark mode.

**Before Image:**
<img width="1919" height="951" alt="Screenshot 2026-07-23 012243" src="https://github.com/user-attachments/assets/26328528-e63e-405e-8de6-3c7c8149fe6b" />

**After Image:**
<img width="1919" height="956" alt="Screenshot 2026-07-23 012302" src="https://github.com/user-attachments/assets/453a2603-a1c0-4a23-a8c6-df48c16c268f" />
