### PR TITLE
handle email embedded content with inline important color text override (global fix)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -21878,6 +21878,9 @@ CSS
         background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_compact_v1_2x.png) !important;
     }
 }
+.a3s [data-darkreader-inline-color] {
+    -webkit-text-fill-color: var(--darkreader-inline-color) !important;
+}
 .buk {
     background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_default_v1_1x.png) !important;
 }

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -228,6 +228,10 @@ body.mediawiki.skin-vector #mw-page-base {
 .overflow-hidden .solid-bg {
     background: transparent !important;
 }
+*[style*="color: rgb(0,0,0) !imoprtant"][style*="--darkreader-inline-color"],
+*[style*="color: rgb(0, 0, 0) !important"][style*="--darkreader-inline-color"] {
+    -webkit-text-fill-color: var(--darkreader-inline-color) !important;
+}
 
 IGNORE CSS URL
 ^https://fonts.googleapis.com/
@@ -21877,9 +21881,6 @@ CSS
     .buj {
         background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_compact_v1_2x.png) !important;
     }
-}
-.a3s [data-darkreader-inline-color] {
-    -webkit-text-fill-color: var(--darkreader-inline-color) !important;
 }
 .buk {
     background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/rfr/density_default_v1_1x.png) !important;


### PR DESCRIPTION
## Description

Certain emails embed HTML tables with fonts explicitly set with `color: rgb(0, 0, 0) !important;`.
Because of the inline `!important`, the text does not get inverted even though `--darkreader-inline-color` correctly gets applied, since the inline color takes CSS priority. 

<img width="416" height="147" alt="image" src="https://github.com/user-attachments/assets/e5aeb6d4-4a8e-46c7-8c6e-fa1d61534809" />

To ensure the text color inversion applies as intended, this fix supplies the `-webkit-text-fill-color` which is less traditionally employed by embedded contents. It reuses the resolved `--darkreader-inline-color` to ensure consistent result. The scope is limited to the Gmail content container `.a3s` where the rule was detected for inline color inversion.

## Before Fix

<img width="1235" height="1222" alt="image" src="https://github.com/user-attachments/assets/106f3361-d9f0-431b-bf6e-5c6027554402" />

## After Fix

<img width="1219" height="1069" alt="image" src="https://github.com/user-attachments/assets/0e430185-8ed2-43f1-b0cb-b1f3269b5f81" />
