### PR TITLE
Update detector-hints with NO DARK THEME for practers.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1324,6 +1324,12 @@ MATCH
 
 ================================
 
+practers.com
+
+NO DARK THEME
+
+================================
+
 privacyjournal.net
 
 TARGET


### PR DESCRIPTION
Added NO DARK THEME for practers.com to prevent fake dark theme detection.