### PR TITLE
Fixes for v2.bricklink.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -36925,7 +36925,7 @@ INVERT
 v2.bricklink.com
 
 INVERT
-img[alt="BrickLink logo"]
+img[alt="BrickLink Logo" i]
 
 CSS
 [data-testid="feature-banner"][style] {

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -36925,16 +36925,14 @@ INVERT
 v2.bricklink.com
 
 INVERT
-img[alt="BrickLink Logo"]
+img[alt="BrickLink logo"]
 
 CSS
-div[data-testid="feature-banner"][style] {
+[data-testid="feature-banner"][style] {
     --bl-castor-feature-banner-background: ${rgb(255, 213, 2)} !important;
 }
 
 IGNORE INLINE STYLE
-*[data-testid*="Swatch"]
-*[data-testid*="swatch"]
 *[class*="swatch"]
 
 ================================


### PR DESCRIPTION
Invert: BrickLink logo alt text case changed
CSS: Removed element type specifier from banner style to make it work again
Ignore inline style: Removed obsolete entries

Example page: https://v2.bricklink.com/en-us/catalog/color-guide