### PR TITLE
White background color for bike24.* product images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5854,6 +5854,21 @@ CSS
 
 ================================
 
+bike24.*
+
+CSS
+.product-tile-for-carousel__image-container {
+    background-color: white !important;
+}
+.product-tile__image-container {
+    background-color: white !important;
+}
+.product-tile-gallery__slide {
+    background-color: white !important;
+}
+
+================================
+
 bikester.no
 
 CSS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5857,12 +5857,8 @@ CSS
 bike24.*
 
 CSS
-.product-tile-for-carousel__image-container {
-    background-color: white !important;
-}
-.product-tile__image-container {
-    background-color: white !important;
-}
+.product-tile-for-carousel__image-container,
+.product-tile__image-container,
 .product-tile-gallery__slide {
     background-color: white !important;
 }


### PR DESCRIPTION
The site's product images have white background and cannot be color adjusted automatically. Thus, override the container background to white. See the attached pictures for a before and after comparison.

<img width="381" height="535" alt="image" src="https://github.com/user-attachments/assets/0183be6f-c72f-446c-b1a5-552964169d46" />
 
<img width="367" height="518" alt="image" src="https://github.com/user-attachments/assets/efbc0562-2261-4a91-b9ff-a985b3230034" />
