### PR TITLE
Fix edgeapi.rubyonrails.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -3266,6 +3266,7 @@ CSS
 ================================
 
 api.rubyonrails.org
+edgeapi.rubyonrails.org
 
 CSS
 div.tree > ul > li {


### PR DESCRIPTION
This PR apply the same fix as for `api.rubyonrails.org` to `edgeapi.rubyonrails.org`:
Before:
<img width="474" height="420" alt="Screenshot from 2026-07-27 09-25-40" src="https://github.com/user-attachments/assets/9243edfe-8db8-44ef-adb4-a9b790a67091" />
After:
<img width="474" height="420" alt="Screenshot from 2026-07-27 09-25-28" src="https://github.com/user-attachments/assets/dae1bb04-a2ea-4841-9ed5-a0b3bf2e1814" />
