### PR TITLE
Add NO DARK THEME tag for ldlc.com and ldlc.pro

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -904,6 +904,13 @@ MATCH
 
 ================================
 
+ldlc.com
+ldlc.pro
+
+NO DARK THEME
+
+================================
+
 learn.standardresume.co
 
 TARGET

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -35,6 +35,13 @@ MATCH
 
 ================================
 
+*.ldlc.com
+*.ldlc.pro
+
+NO DARK THEME
+
+================================
+
 *.mediawiki.org
 *.wikibooks.org
 *.wikidata.org
@@ -901,13 +908,6 @@ html
 
 MATCH
 .dark-theme
-
-================================
-
-ldlc.com
-ldlc.pro
-
-NO DARK THEME
 
 ================================
 


### PR DESCRIPTION
Fix dark theme detected at:
https://www.ldlc.com/n5315/younited/