### PR TITLE
Add tyrannytracker.org to dark sites list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -1202,6 +1202,7 @@ twnft.vercel.app
 tycrek.com
 tylerpalko.github.io
 tynker.com/ide
+tyrannytracker.org
 tyt.com
 ufplanets.com
 ultrajs.dev


### PR DESCRIPTION
https://tyrannytracker.org/