### PR TITLE
Add detector hint for alternate websites

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1,3 +1,15 @@
+*.alternate.*
+*.alternate-b2b.*
+*.business.alternate.*
+
+TARGET
+html
+
+MATCH
+[data-bs-theme="dark"]
+
+================================
+
 *.arxiv.org
 arxiv.org
 


### PR DESCRIPTION
https://business.alternate.be/
https://fr.alternate.be/
https://fr.business.alternate.be/
https://www.alternate-b2b.at/
https://www.alternate-b2b.ch/
https://www.alternate-b2b.de/
https://www.alternate-b2b.es/
https://www.alternate.at/
https://www.alternate.be/
https://www.alternate.ch/
https://www.alternate.de/
https://www.alternate.dk/
https://www.alternate.es/
https://www.alternate.fr/
https://www.alternate.it/
https://www.alternate.lu/
https://www.alternate.nl/
https://zakelijk.alternate.nl/