### PR TITLE
Fix 2 bugs in MV3 state persistence causing auto-sync with system dark mode to fail in chromium

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -129,10 +129,9 @@ export class Extension {
         if (isDark === null) {
             // Attempt to restore data from storage
             return Extension.systemColorStateManager.loadState();
-        } else if (Extension.wasLastColorSchemeDark !== isDark) {
-            Extension.wasLastColorSchemeDark = isDark;
-            return Extension.systemColorStateManager.saveState();
         }
+        Extension.wasLastColorSchemeDark = isDark;
+        return Extension.systemColorStateManager.saveState();
     }
 
     private static alarmListener = (alarm: chrome.alarms.Alarm): void => {

--- a/src/utils/state-manager-impl.ts
+++ b/src/utils/state-manager-impl.ts
@@ -132,7 +132,7 @@ export class StateManagerImpl<T extends Record<string, unknown>> {
     private collectState() {
         const state = {} as T;
         for (const key of Object.keys(this.defaults) as Array<keyof T>) {
-            state[key] = this.parent[key] || this.defaults[key];
+            state[key] = this.parent[key] ?? this.defaults[key];
         }
         return state;
     }

--- a/tests/browser/e2e/toggle.tests.ts
+++ b/tests/browser/e2e/toggle.tests.ts
@@ -92,6 +92,11 @@ describe('Toggling the extension', () => {
             ['h1', 'color', 'rgb(255, 0, 0)'],
             ['a', 'color', 'rgb(0, 0, 238)'],
         ]);
+        if ((await backgroundUtils.getManifest()).manifest_version === 3) {
+            expect(await backgroundUtils.getChromeStorage('local', ['system-color-state'])).toEqual({
+                'system-color-state': {wasLastColorSchemeDark: false},
+            });
+        }
 
         await emulateColorScheme('dark');
 


### PR DESCRIPTION
Fixes #15554 

This fixes a regression for chromium in version 4.9.125. I had Codex narrow it down these two specific bugs. I still not entirely sure why these two long-standing bugs suddently resulted in a regression but the reasoning seems plausible.

Bug 1: Commit 8714273c (#9619) set `Extension.wasLastColorSchemeDark = isDark ` before calling `MV3syncSystemColorStateManager`  so `else if (Extension.wasLastColorSchemeDark !== isDark) ` was always guarenteed to be false, `Extension.systemColorStateManager.saveState();` was never called, so the system color state was never saved to local storage.

Bug 2:  StateManager's `collectState` incorrectly used || instead of ??, meaning that the boolean value `false` fails to be persisted and gets converted to the default value (darkMode = true). This would cause us to get stuck in dark mode, even if we fixed Bug 1.

Now I believe b2a5b4a6d59fa6d7f57b1f0d6ee0f36319894e04 (in version 4.9.125) made `MV3syncSystemColorStateManager` synchonous which triggered Bug 1. Previously, this function ran async so we bypassed both of these bugs by dumb luck. But this is just speculation at this point.