### PR TITLE
Fixes for merriam-webster.com (dynamic)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23286,7 +23286,7 @@ ul.topten > li:hover > .bg {
 }
 .other-dictionary-results-heading,
 .spelling-suggestion-text {
-     background: linear-gradient(90deg, ${#f9f2d9}, ${#faf4ff}), linear-gradient(0deg, var(--Colors-Gold-50, ${#fcf8eb}), var(--Colors-Gold-50, ${#fcf8eb})) !important;
+     background: linear-gradient(90deg, ${#f9f2d9}, ${#faf4ff}), linear-gradient(0deg, ${#fcf8eb}, ${#fcf8eb}) !important;
 }
 a[part="result"] {
     -webkit-text-fill-color: var(--darkreader-neutral-text) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23286,7 +23286,7 @@ ul.topten > li:hover > .bg {
 }
 .other-dictionary-results-heading,
 .spelling-suggestion-text {
-     background: linear-gradient(90deg, ${#f9f2d9}, ${#faf4ff}) !important;
+    background: linear-gradient(90deg, ${#f9f2d9}, ${#faf4ff}) !important;
 }
 a[part="result"] {
     -webkit-text-fill-color: var(--darkreader-neutral-text) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23286,7 +23286,7 @@ ul.topten > li:hover > .bg {
 }
 .other-dictionary-results-heading,
 .spelling-suggestion-text {
-     background: linear-gradient(90deg, ${#f9f2d9}, ${#faf4ff}), linear-gradient(0deg, ${#fcf8eb}, ${#fcf8eb}) !important;
+     background: linear-gradient(90deg, ${#f9f2d9}, ${#faf4ff}) !important;
 }
 a[part="result"] {
     -webkit-text-fill-color: var(--darkreader-neutral-text) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23273,7 +23273,7 @@ circle.outline.Oval
 CSS
 .mw-logo path[fill="white"],
 .navbar-brand path[fill="white"] {
-    fill: var(--darkreader-neutral-background) !important;
+    fill: #dcdad7 !important;
 }
 .content-section-header > h2 {
     -webkit-text-fill-color: var(--darkreader-neutral-text) !important;
@@ -23286,7 +23286,7 @@ ul.topten > li:hover > .bg {
 }
 .other-dictionary-results-heading,
 .spelling-suggestion-text {
-    color: ${#ffc677} !important;
+     background: linear-gradient(90deg, ${#f9f2d9}, ${#faf4ff}), linear-gradient(0deg, var(--Colors-Gold-50, ${#fcf8eb}), var(--Colors-Gold-50, ${#fcf8eb})) !important;
 }
 a[part="result"] {
     -webkit-text-fill-color: var(--darkreader-neutral-text) !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -23271,8 +23271,26 @@ INVERT
 circle.outline.Oval
 
 CSS
-.logo-cnt path[fill="#004990"] {
-    fill: ${#0085e0} !important;
+.mw-logo path[fill="white"],
+.navbar-brand path[fill="white"] {
+    fill: var(--darkreader-neutral-background) !important;
+}
+.content-section-header > h2 {
+    -webkit-text-fill-color: var(--darkreader-neutral-text) !important;
+}
+ul.topten > li > .bg {
+    background: linear-gradient(90deg, ${#f4f4f4}, ${#dfd2a5}) !important;
+}
+ul.topten > li:hover > .bg {
+    background: var(--solid-blue-800, #284e64) !important;
+}
+.other-dictionary-results-heading,
+.spelling-suggestion-text {
+    color: ${#ffc677} !important;
+}
+a[part="result"] {
+    -webkit-text-fill-color: var(--darkreader-neutral-text) !important;
+    background: var(--darkreader-neutral-background) !important;
 }
 
 ================================


### PR DESCRIPTION
- Fixes for dark mode on [merriam-webster.com](https://www.merriam-webster.com/dictionary/off-white) (light mode is mostly unchanged):
  - Fixes SVG logos
  - Fixes dictionary/thesaurus headers
  - Fixes "Top Lookups" entries
  - Fixes "no results" paragraphs
  - Fixes search suggestions

Changes were tested in both light and dark mode on Firefox.

<details>
<summary>Before/After screenshots</summary>
<a href="https://www.merriam-webster.com/dictionary/off-white">Example dictionary page</a>:
<img width="1415" height="497" alt="before #1" src="https://github.com/user-attachments/assets/83bd01a8-d5ea-40d7-92e8-f87986aab161" />
<img width="1413" height="502" alt="after #1" src="https://github.com/user-attachments/assets/b2dbbe8d-d30c-4c0e-8461-d481461d5c2c" />
<a href="https://www.merriam-webster.com/thesaurus/off-white">Example thesaurus page</a>:
<img width="754" height="604" alt="before #2" src="https://github.com/user-attachments/assets/4877f2ce-f61f-4cc7-b391-83f9cd246a79" />
<img width="738" height="570" alt="after #2" src="https://github.com/user-attachments/assets/2301c7f8-f58c-41d9-b51c-f456b81b7d47" />
</details>