### PR TITLE
Added TFQueue (queue.tf) to dark-sites.config.

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -957,6 +957,7 @@ pylon.bot
 q1dian.github.io
 qalculator.xyz
 quad9.net
+queue.tf
 raceday.watch
 raidbots.com
 raider.io


### PR DESCRIPTION
(Our implementation of "darkreader-lock" seems to be breaking the site for Firefox users.)