### PR TITLE
Add NO DARK THEME tag for manfrotto.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1027,6 +1027,12 @@ NO DARK THEME
 
 ================================
 
+manfrotto.com
+
+NO DARK THEME
+
+================================
+
 materiel.net
 
 NO DARK THEME


### PR DESCRIPTION
Dark theme is detected sometimes at:
https://www.manfrotto.com/global-es/