### PR TITLE
Fix player controls on shadertoy.com

### DIFF
--- a/src/config/inversion-fixes.config
+++ b/src/config/inversion-fixes.config
@@ -2360,6 +2360,9 @@ shadertoy.com
 INVERT
 canvas#demogl
 
+NO INVERT
+.uiButton
+
 ================================
 
 shiyanlou.com


### PR DESCRIPTION
When using Filter/Filter+ mode, the player controls are currently difficult to see:
<img width="823" height="570" alt="Screenshot 2026-08-07 at 11 28 42" src="https://github.com/user-attachments/assets/2f1d7b76-f511-4379-a2a3-1d497da9dc6d" />

This fix makes sure the controls get inverted properly:
<img width="831" height="577" alt="Screenshot 2026-08-07 at 11 28 29" src="https://github.com/user-attachments/assets/104dc56c-44fa-497b-ba5b-a2c649f86442" />
