### PR TITLE
Update dark theme detection hint for newscientist.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1162,7 +1162,7 @@ TARGET
 html
 
 MATCH
-.Dark
+[data-theme="dark"]
 
 ================================
 


### PR DESCRIPTION
https://www.newscientist.com/