### PR TITLE
Add NO DARK THEME tag under mh.co.za

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1080,6 +1080,12 @@ MATCH
 
 ================================
 
+mh.co.za
+
+NO DARK THEME
+
+================================
+
 modelcontextprotocol.io
 
 TARGET


### PR DESCRIPTION
Fix dark theme incorrectly detected:
https://mh.co.za/inside-libho-gezas-mindset/