### PR TITLE
Add echoarchives.net to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -402,6 +402,7 @@ dyno.gg
 e-z.bio
 e-z.host
 eagle.cool
+echoarchives.net
 eclipse.menu
 ecys.xyz
 edi.social


### PR DESCRIPTION
echoarchives.net uses a dark design by default across the site.

Dark Reader currently causes issues with the site's background colors and hero image.

This adds the domain to `dark-sites.config` so the site's native dark design is preserved.
