### PR TITLE
Update dynamic theme fixes for *.sloggi.com and *.triumph.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1290,6 +1290,9 @@ div.productTile div.colorDotSwatch--plp {
 .experience-component > * {
     color: var(--darkreader-neutral-text) !important;
 }
+div.colorDotSwatch img {
+    mix-blend-mode: normal !important;
+}
 
 IGNORE INLINE STYLE
 div.footer__logos svg *


### PR DESCRIPTION
Fix invisible product images in the mobile version of product pages:
https://uk.sloggi.com/10224737.html?color=0003_White
https://uk.triumph.com/comfort-allure/10226435.html?color=0003_White
