### PR TITLE
Add dynamic theme fixes for cancerhealth.com and related websites

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -7643,6 +7643,18 @@ INVERT
 
 ================================
 
+cancerhealth.com
+covidhealth.com
+hepmag.com
+realhealthmag.com
+smartandstrong.com
+tusaludmag.com
+
+INVERT
+div.logo img.img-logo
+
+================================
+
 candidates.ibo.org
 
 INVERT


### PR DESCRIPTION
Invert logo on the following (similar) websites:
https://www.cancerhealth.com/
https://www.covidhealth.com/
https://www.hepmag.com/
https://www.realhealthmag.com/
https://www.smartandstrong.com/
https://www.tusaludmag.com/