### PR TITLE
Update dynamic theme fixes for timeanddate.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -35683,6 +35683,7 @@ CSS
 
 IGNORE IMAGE ANALYSIS
 #header
+.map-container
 
 ================================
 


### PR DESCRIPTION
Fix invisible map at:
https://www.timeanddate.com/eclipse/list.html?region=europe&type=total-solar