### PR TITLE
Update dynamic theme fixes for *.jornaldenegocios.pt

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -884,7 +884,7 @@ CSS
 *.jornaldenegocios.pt
 
 INVERT
-:is(header.header, div#mainMenu) button span
+:is(header.header, div#mainMenu, div.headerBar) button span
 div.navbar-main-nav a.toggleMenuButton
 div.header_top a.logo
 nav.header_canais div.canais::before


### PR DESCRIPTION
Invert hamburguer menu at:
https://www.jornaldenegocios.pt/economia/europa/uniao-europeia/zona-euro/amp/estado-alemao-vai-dar-10-euros-todos-os-meses-as-criancas-para-a-reforma