### PR TITLE
Add NO DARK THEME tag under focus.de

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -744,6 +744,12 @@ MATCH
 
 ================================
 
+focus.de
+
+NO DARK THEME
+
+================================
+
 foradeserie.sapo.pt
 
 TARGET

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -14418,6 +14418,13 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
+focus.de
+
+INVERT
+a.Share-Link svg
+
+================================
+
 foli.fi
 
 INVERT


### PR DESCRIPTION
Fix dark theme wrongly detected at:
https://www.focus.de/politik/ausland/sexuelle-uebergriffe-unter-ceuta-migranten-nehmen-massiv-zu_526c8dcd-060f-4c10-ad5a-3c520f36f6b1.html