### PR TITLE
Add Dynamic Theme fix for 'status.claude.com'

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -33608,6 +33608,13 @@ table > tbody > tr > td {
 
 ================================
 
+status.claude.com
+
+INVERT
+img[alt="Claude logo"]
+
+================================
+
 status.epicgames.com
 
 INVERT


### PR DESCRIPTION
## Overview

Updates the Claude Status logo to be visible against the darkened background. You can test for yourself at the [Claude Status page](https://status.claude.com/).

### Rule Change

Queried the logo by its alt text "Claude logo"

```css
INVERT
img[alt="Claude logo"]
```

There's only one image on the page (the logo) so the alt text filter might be overkill, but I figured it wouldn't hurt to be specific in case anything changes in the future.

### Before

The logo is black and blends in with the background set by Dark Reader.

<img width="923" height="665" alt="image" src="https://github.com/user-attachments/assets/f27d8652-70ba-45f8-af0f-36dae43298ac" />

### After

The updated rule flips the text to be white.

<img width="903" height="654" alt="image" src="https://github.com/user-attachments/assets/4286b13d-fd2a-41a6-844e-269e5662c764" />


---

_Tested in Edge (pictured)_