### PR TITLE
Add dynamic theme fixes for oledtest.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26715,8 +26715,11 @@ CSS
 oledtest.org
 
 CSS
+:root {
+    --darkreader-background-edf7f11a: rgba(20, 46, 35, 0.5);
+}
 div.bg-white {
-    background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1)) !important;
+    background-color: rgb(255 255 255 / var(--tw-bg-opacity)) !important;
 }
 button.transition-all[style^="background-color:#FFFFFF;color:#000;"] {
     color: #000 !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -26712,6 +26712,35 @@ CSS
 
 ================================
 
+oledtest.org
+
+CSS
+div.bg-white {
+    background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1)) !important;
+}
+button.transition-all[style^="background-color:#FFFFFF;color:#000;"] {
+    color: #000 !important;
+}
+span.screen-tester-item-preview[style="background-color:#ffffff"] {
+    background-color: #ffffff !important;
+}
+span.screen-tester-item-preview[style="background-color:#ffff00"] {
+    background-color: #ffff00 !important;
+}
+
+IGNORE INLINE STYLE
+div.mt-10 > div
+div.screen-tester-stage
+div.transition-all
+div.transition-colors
+div.w-screen.h-screen
+button.rounded-full
+button.transition-all
+button.transition-transform
+span.screen-tester-item-preview
+
+================================
+
 oleole.pl
 
 INVERT


### PR DESCRIPTION
The purpose is to ignore several backgrounds and define backgrounds and colors where needed.
The fixes are required for the tests to work as intended.
For example, to test white uniformity on a monitor we require an actual white background.
The fixes target the tests listed in the following pages:
https://oledtest.org/
https://oledtest.org/tools/
