### PR TITLE
Add Dynamic Theme fix for AI code blocks for 'bing.com'

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -6190,6 +6190,10 @@ div.icon > svg > g:nth-child(1) > path:nth-child(1) {
 .bg-gradient-to-r {
     background-image: linear-gradient(to right,var(--tw-gradient-stops)) !important;
 }
+.devmag_code {
+    background-color: var(--darkreader-neutral-background) !important;
+    color: var(--darkreader-neutral-text) !important;
+}
 
 IGNORE INLINE STYLE
 .b_header_bg


### PR DESCRIPTION
## Overview

Updates the code blocks generated as part of the AI overview when searching on Bing to be visible against the darkened background. You can test for yourself by making a code-related search on Bing (for instance, looking up [how to use the `StringBuilder` class in PowerShell](https://www.bing.com/search?q=powershell+string+builder).)

You will see the code blocks in the AI-generated overview (beneath the Copilot blurb). 

<img width="788" height="903" alt="Codeblock with white backgrounds and light grey text in Bing" src="https://github.com/user-attachments/assets/940b3c23-7923-4513-a056-f3afa0ecdb48" />


### Rule Change

Identified the code blocks via their class `.devmag_code`. We can set the `color` and `background-color` properties to use DarkReader's neutral colors.

```css
.devmag_code {
	background-color: var(--darkreader-neutral-background) !important;
	color: var(--darkreader-neutral-text) !important;
}
```

<img width="928" height="863" alt="Codeblock in Bing with corrected background and foreground color" src="https://github.com/user-attachments/assets/8c730c2e-e15f-4e0f-aec1-0fcc216f7814" />

This rule will hit each of the codeblocks in the summary, not just the first one.

<img width="725" height="911" alt="Multiple Codeblocks with corrected background and foreground color" src="https://github.com/user-attachments/assets/946634e7-cab1-4e11-bc6a-66752cc46c27" />

---

_Tested in Edge (pictured)_