### PR TITLE
Detect github.com dark theme when color mode is auto

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -823,6 +823,12 @@ html
 MATCH
 [data-color-mode="dark"]
 
+MATCH SYSTEM DARK
+[data-color-mode="auto"][data-dark-theme^="dark"]
+
+MATCH SYSTEM LIGHT
+[data-color-mode="auto"][data-light-theme^="dark"]
+
 ================================
 
 gotquestions.org

--- a/src/definitions.d.ts
+++ b/src/definitions.d.ts
@@ -213,6 +213,8 @@ export interface DetectorHint {
     url: string[];
     target: string;
     match: string[];
+    matchSystemDark: string[];
+    matchSystemLight: string[];
     noDarkTheme: boolean;
     systemTheme: boolean;
     iframe: boolean;

--- a/src/generators/detector-hints.ts
+++ b/src/generators/detector-hints.ts
@@ -9,6 +9,8 @@ import type {SiteFixesIndex, SitesFixesParserOptions} from './utils/parse';
 const detectorHintsCommands: { [key: string]: keyof DetectorHint } = {
     'TARGET': 'target',
     'MATCH': 'match',
+    'MATCH SYSTEM DARK': 'matchSystemDark',
+    'MATCH SYSTEM LIGHT': 'matchSystemLight',
     'NO DARK THEME': 'noDarkTheme',
     'SYSTEM THEME': 'systemTheme',
     'IFRAME': 'iframe',

--- a/src/inject/detector.ts
+++ b/src/inject/detector.ts
@@ -202,10 +202,18 @@ export function stopDarkThemeDetector(): void {
 let hintTargetObserver: MutationObserver;
 let hintMatchObserver: MutationObserver;
 
+function getHintSelectors(hint: DetectorHint): string[] {
+    const systemSpecific = isSystemDarkModeEnabled() ? hint.matchSystemDark : hint.matchSystemLight;
+    return (hint.match || []).concat(systemSpecific || []);
+}
+
 function detectUsingHint(hint: DetectorHint, success: () => void) {
     stopDetectingUsingHint();
 
-    const matchSelector = (hint.match || []).join(', ');
+    const matchSelector = getHintSelectors(hint).join(', ');
+    if (!matchSelector) {
+        return;
+    }
 
     function checkMatch(target: Element) {
         if (target.matches?.(matchSelector)) {

--- a/tests/unit/config/config.tests.ts
+++ b/tests/unit/config/config.tests.ts
@@ -107,7 +107,7 @@ test('Detector Hints config', async () => {
 
     // selectors should have no comma
     const commaSelector = /\,(?![^\(|\"]*(\)|\"))/;
-    expect(hints.every(({target, match}) => ![target].concat(match).some((s) => commaSelector.test(s)))).toBe(true);
+    expect(hints.every(({target, match, matchSystemDark, matchSystemLight}) => ![target].concat(match, matchSystemDark, matchSystemLight).some((s) => commaSelector.test(s)))).toBe(true);
 
     // only a single selector is allowed for target
     expect(hints.every(({target, noDarkTheme, systemTheme}) => noDarkTheme || systemTheme || typeof target === 'string' && !target.includes('\n'))).toBe(true);
@@ -126,6 +126,12 @@ test('Detector Hints config', async () => {
         'MATCH', '.b', '#c',
         'UNSUPPORTED', 'c',
         '========',
+        'github.com',
+        'TARGET', 'html',
+        'MATCH', '[data-color-mode="dark"]',
+        'MATCH SYSTEM DARK', '[data-color-mode="auto"][data-dark-theme^="dark"]',
+        'MATCH SYSTEM LIGHT', '[data-color-mode="auto"][data-light-theme^="dark"]',
+        '========',
         'proton.me',
         'SYSTEM THEME',
         '========',
@@ -138,6 +144,7 @@ test('Detector Hints config', async () => {
         'NO DARK THEME',
     ].join('\n'))).toEqual([
         {url: ['inbox.google.com', 'mail.google.com'], target: 'a', match: ['.b', '#c']},
+        {url: ['github.com'], target: 'html', match: ['[data-color-mode="dark"]'], matchSystemDark: ['[data-color-mode="auto"][data-dark-theme^="dark"]'], matchSystemLight: ['[data-color-mode="auto"][data-light-theme^="dark"]']},
         {url: ['proton.me'], systemTheme: true},
         {url: ['twitter.com'], target: 'c', match: ['[d="e"]']},
         {url: ['wikipedia.org'], noDarkTheme: true},


### PR DESCRIPTION
Fix #15929

github only sets `data-color-mode="dark"` for "single theme". with "sync with system" it stays `auto` and the active theme comes from `data-light-theme` / `data-dark-theme` depending on `prefers-color-scheme`, so the current hint never matches and dark reader themes an already dark page.

`Element.matches` cant see `prefers-color-scheme`, so this adds two commands to detector-hints:

- `MATCH SYSTEM DARK` — selectors that only apply when `prefers-color-scheme: dark`
- `MATCH SYSTEM LIGHT` — selectors that only apply when `prefers-color-scheme: light`

they get appended to `MATCH` at detection time, nothing else changes. both are needed for github, because "sync with system" lets you pick any of the 12 themes per branch, so a dark theme can be selected for the light branch.

a plain `[data-color-mode="auto"]` match was tried in #11995 and removed in #15161 because it broke #15155 (light os, github actually light, dark reader turned itself off). this doesnt have that problem:

| github setting | os | matches | result |
| --- | --- | --- | --- |
| single theme, dark | any | yes | dark reader off, github dark |
| single theme, light | any | no | dark reader themes it |
| sync with system, dark theme picked | dark | yes | dark reader off, github dark |
| sync with system, light theme picked | dark | no | dark reader themes it |
| sync with system, light theme picked | light | no | dark reader themes it |
| sync with system, dark theme picked | light | yes | dark reader off, github dark |

`^="dark"` covers `dark_dimmed`, `dark_colorblind` etc, and excludes every `light*` value.

same idea as #15187, but only this, nothing else.

one thing i left out on purpose: flipping the os theme with the page open doesnt re-run detection. thats already true of `SYSTEM THEME` today, and with automation set to system dark reader re-applies anyway.

`npm run test:unit` (75 passed) and `npm run lint` pass.
