### PR TITLE
Fixes for jiki.io (dynamic)

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -19438,8 +19438,18 @@ INVERT
 
 CSS
 [class*="LessonNode_unlocked__"]:hover:not(:has([data-walkthrough-card]:hover)),
-[class*="LessonNode_inProgress__"]:hover:not(:has([data-walkthrough-card]:hover)) {
+[class*="LessonNode_inProgress__"]:hover:not(:has([data-walkthrough-card]:hover)),
+[class*="LessonNode_animatingUnlock__"] {
     background: color-mix(in oklch, ${#a855f7} 6%, ${white}) !important;
+}
+.media-default-skin .media-overlay {
+    background-image: linear-gradient(0deg, oklch(0 0 0 / .5), oklch(0 0 0 / .3) 25%, oklch(0 0 0 / 0)) !important;
+}
+.media-default-skin .media-menu .media-menu__item {
+    color: #e8e6e3 !important;
+}
+.media-default-skin .media-menu .media-menu__hint {
+    color: #e4e2de !important;
 }
 #faux-range {
     background-color: #dcdad7 !important;


### PR DESCRIPTION
Fixes for [jiki.io](https://jiki.io/) (dynamic):
- Fixes all videos being black in both light and dark mode.
- Fixes some text being invisible in video settings menu in light mode.
- Fixes lesson nodes being white during animations in dark mode.

Changes were tested in both light and dark mode on Firefox.

<details>
<summary>Before/After screenshots (<a href="https://jiki.io/lesson/welcome-to-coding-fundamentals">example page</a>)</summary>

Dark mode:

<img width="553.5" height="316.5" alt="before-dark" src="https://github.com/user-attachments/assets/e5f77881-bd1d-4276-b9fc-fd1592ed4ed2" />
<img width="545.5" height="312.5" alt="after-dark" src="https://github.com/user-attachments/assets/3d05a0d6-7d1d-46a7-b669-cbc400eec94e" />

Light mode:

<img width="553.5" height="316" alt="before-light" src="https://github.com/user-attachments/assets/a00529a2-5358-4884-948f-4d0b3d3eda1e" />
<img width="550.5" height="314" alt="after-light" src="https://github.com/user-attachments/assets/5d4f134b-455e-469b-a6fb-1e3d2097205d" />

</details>