### PR TITLE
GMail Account Selector Dynamic Fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1,6 +1,7 @@
 *
 
 INVERT
+.c01lDf
 .jfk-bubble.gtx-bubble
 .captcheck_answer_label > input + img
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
@@ -15,6 +16,9 @@ div.mc-ip-hide[style*="background: rgb(255, 255, 255) !important"]
 CSS
 .jfk-bubble.gtx-bubble {
     background-color: white !important;
+}
+.N2ncR {
+    --action-items-action-item-background-color: var(--darkreader-neutral-background) !important;
 }
 .vimvixen-hint {
     background-color: ${#ffd76e} !important;

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -1,7 +1,7 @@
 *
 
 INVERT
-.c01lDf
+c-wiz div > svg > circle
 .jfk-bubble.gtx-bubble
 .captcheck_answer_label > input + img
 span#closed_text > img[src^="https://www.gstatic.com/images/branding/googlelogo"]
@@ -14,11 +14,11 @@ div.mc-ip-hide[style*="background: rgb(255, 255, 255) !important"]
 [style*="color: rgb(0, 0, 1) !important;"]
 
 CSS
+c-wiz div {
+    --action-items-action-item-background-color: var(--darkreader-neutral-background) !important;
+}
 .jfk-bubble.gtx-bubble {
     background-color: white !important;
-}
-.N2ncR {
-    --action-items-action-item-background-color: var(--darkreader-neutral-background) !important;
 }
 .vimvixen-hint {
     background-color: ${#ffd76e} !important;


### PR DESCRIPTION
This PR fixes dynamic inversions of the account selector in GMail. (For me, the other GSuite services already work as-expected.)

As a note: GMail loads this as an iframe with
```html
<iframe role="presentation" frameborder="0" scrolling="no" name="account" src="about:blank" style="height: 100%; width: 100%; color-scheme: light; visibility: hidden;">
```
I wasn't exactly sure how to target this, so I threw these fixes in the global scope. If any maintainers have a better idea as to how to integrate this, I'm all ears!

URL: [mail.google.com](https://mail.google.com/)

<details>
<summary>Before</summary>
<img width="473" height="978" alt="gmail-before" src="https://github.com/user-attachments/assets/8aa715b7-6ee7-4cd8-9288-1a232bd49546" />
</details>

<details>
<summary>After</summary>
<img width="427" height="933" alt="gmail-after" src="https://github.com/user-attachments/assets/769b2daa-2d7c-4dc6-ae57-2d36724e7b05" />
</details>