### PR TITLE
HMC Unofficial Transcript Viewer Dynamic Fixes

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -29083,6 +29083,14 @@ a.link-gray > p
 
 ================================
 
+portal.hmc.edu
+
+INVERT
+table[style^="background-image:"]
+table[style^="background-image:"] > *
+
+================================
+
 portal.qiniu.com
 
 INVERT


### PR DESCRIPTION
Provides dynamic-mode fixes for the unofficial transcript viewer at HMC.

URL: [portal.hmc.edu](https://portal.hmc.edu/) > Transcripts > Unofficial Transcript

<details>
<summary>Before</summary>
<img width="925" height="543" alt="hmc-portal-before" src="https://github.com/user-attachments/assets/d7ea7011-dc87-4f7c-9b55-7a49cb59e1b3" />
</details>

<details>
<summary>After</summary>
<img width="1072" height="502" alt="hmc-portal-after" src="https://github.com/user-attachments/assets/e1958994-9819-47e6-8176-3bcb719b3bb6" />
</details>