### PR TITLE
Update dynamic theme fixes for hugoboss.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -17862,11 +17862,11 @@ div[style^="background-color: rgb(249, 249, 249) !important;"] *,
 section[style^="background-color: rgb(246, 246, 246) !important;"] :is(div, span) > svg {
     fill: #000000 !important;
 }
-div.dch-stage-image-item__content *,
-div.dch-head-teaser__image-area ~ div.dch-head-teaser__content-container *,
-div.dch-stories-teaser-row-item__image ~ div.dch-stories-teaser-row-item__content *,
-div.dch-fullbleed-grid-teaser-item__image ~ div.dch-fullbleed-grid-teaser-item__content *,
-div.product-tile-plp__flag {
+section.theme-boss div.dch-stage-image-item__content *,
+section.theme-boss div.dch-head-teaser__image-area ~ div.dch-head-teaser__content-container *,
+section.theme-boss div.dch-stories-teaser-row-item__image ~ div.dch-stories-teaser-row-item__content *,
+section.theme-boss div.dch-fullbleed-grid-teaser-item__image ~ div.dch-fullbleed-grid-teaser-item__content *,
+section.theme-boss div.product-tile-plp__flag {
     text-shadow: 1px 1px 0 ${#fff6}, -1px -1px 0 ${#fff6}, 1px -1px 0 ${#fff6}, -1px 1px 0 ${#fff6} !important;
 }
 


### PR DESCRIPTION
There are two themes defined in two classes .theme-boss and .theme-hugo.
The hugo theme always has red colored text and does not need text-shadow.
Here I propose text-shadow only for .theme-boss.
See the first and second slides in the following pages:
https://www.hugoboss.com/pt/en/men/
https://www.hugoboss.com/pt/en/all-brands/men/highlights/inspiration/styleinspotlight/
