### PR TITLE
Add detection hint for xda-developers.com

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1878,6 +1878,12 @@ MATCH
 
 ================================
 
+xda-developers.com
+
+SYSTEM THEME
+
+================================
+
 xtb.com
 
 NO DARK THEME


### PR DESCRIPTION
Is using the system theme.
https://www.xda-developers.com/