### PR TITLE
pixiv.net: remove stale dynamic fix, add NO DARK THEME detector hint

### DIFF
--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1363,6 +1363,13 @@ NO DARK THEME
 
 ================================
 
+pixiv.net
+*.pixiv.net
+
+NO DARK THEME
+
+================================
+
 pkmer.cn
 
 TARGET

--- a/src/config/detector-hints.config
+++ b/src/config/detector-hints.config
@@ -1364,9 +1364,12 @@ NO DARK THEME
 ================================
 
 pixiv.net
-*.pixiv.net
 
-NO DARK THEME
+TARGET
+html
+
+MATCH
+[data-theme="dark"]
 
 ================================
 

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -28529,16 +28529,6 @@ IGNORE IMAGE ANALYSIS
 
 ================================
 
-pixiv.net
-
-CSS
-.jAENWx,
-.iYRMgo {
-    color: ${aliceblue} !important;
-}
-
-================================
-
 pixivision.net
 
 INVERT


### PR DESCRIPTION
## Summary
Two related changes for pixiv.net:

1. **Remove** the stale dynamic theme fix added in 2020 (PR #4192).
2. **Add** a `NO DARK THEME` detector hint so that Dark Reader keeps transforming on this site, covering a first-paint theme race that produces a visible white flash for dark-theme users on every page load.

## Why the old fix is removed
It targets styled-components generated classes (`.jAENWx`, `.iYRMgo`) that no longer exist on the site — hash classes rotate on every deployment, and `document.querySelectorAll('.jAENWx, .iYRMgo').length` currently returns `0`. Additionally, dynamic fixes can never apply here: Dark Reader's dark theme detector sees `<html data-theme="dark">` (set by an inline head script before first paint) and stands down entirely, so no dynamic fix stylesheet is injected on this site at all.

## Root cause (why the hint is needed)
The site has a first-paint theme race, captured with a `CSSStyleSheet.insertRule` recorder (times relative to navigation start):

- An inline head script correctly sets `<html data-theme="dark">` before first paint.
- Despite that, the first styled-components batch is rendered with the **light** theme:
  - `t=1195ms` — `.kQLKe { background: #ffffff; border-radius: 8px 8px 0 0; }`
- ~157 ms later, the dark variant of the same component shape appears and components re-render with new class names:
  - `t=1352ms` — `.iiAyvy { background: #1f1f1f; border-radius: 8px 8px 0 0; }`
- All subsequently lazy-loaded chunks render dark directly (`t=1848ms`, `2538ms`, `3515ms`), confirming the theme context is correct after the initial sync.

Because the detector interprets `data-theme="dark"` as "this site handles dark on its own", Dark Reader stands down and the site's internal race is left exposed. The `NO DARK THEME` hint keeps Dark Reader transforming from the first paint, which covers the race window. On an already-dark token palette the transform is near-identity, so the result visually matches the native dark theme.

## Verification
Applied the same hint through this extension's Dev Tools → "Detect dark theme hints" editor (identical content to the `src/config/detector-hints.config` diff here): after a reload, the white flash on page load is gone for dark-theme users. The light/dark rule pair and timestamps above were captured from a single page load with all other extensions disabled.

## Maintenance note
If the site fixes its theme-initialization race (ThemeProvider synchronously initialized from `data-theme`/localStorage before first render), this hint is no longer needed and can be reverted in a follow-up PR.

The maintainer of the site has been informed of the bug, but there is no guarantee that it will be fixed (soon).