### PR TITLE
Add dynamic theme fixes for epey.com

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -13150,6 +13150,16 @@ select.input-small {
 
 ================================
 
+epey.com
+
+IGNORE IMAGE ANALYSIS
+#filtrele h2.close
+#filtrele h3.close
+#filtrele h2.open
+#filtrele h3.open
+
+================================
+
 eps.rs
 
 INVERT


### PR DESCRIPTION
Dark reader is trying to invert an image but its inverting the whole element. This cause the already dark background becoming light.

filter: invert(100%) hue-rotate(180deg) contrast(90%) !important;

Added some elements under IGNORE IMAGE ANALYSIS to prevent problematic inversion