### PR TITLE
Add subtree opt-out for inline style mutations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,21 @@ lock.name = 'darkreader-lock';
 document.head.appendChild(lock);
 ```
 
+### Preventing inline style changes within a component
+
+Add `data-darkreader-ignore-inline` to prevent Dynamic mode from rewriting inline
+styles and color attributes throughout a subtree, including future descendants:
+
+```html
+<div data-darkreader-ignore-inline>
+    <span style="color: red">Editor content</span>
+</div>
+```
+
+Set the attribute before Dark Reader processes the component; it does not undo
+existing overrides or support live toggling. Stylesheet rules and inherited colors
+still apply. Mark containers inside shadow roots separately.
+
 ## Adding a website that is already dark
 
 If a website is **already dark** and meets the following requirements:

--- a/src/inject/dynamic-theme/inline-style.ts
+++ b/src/inject/dynamic-theme/inline-style.ts
@@ -363,6 +363,10 @@ function getSVGElementRoot(svgElement: SVGElement): SVGSVGElement | null {
 const inlineStringValueCache = new Map<string, Map<string, string>>();
 
 export function overrideInlineStyle(element: HTMLElement, theme: Theme, ignoreInlineSelectors: string[], ignoreImageSelectors: string[]): void {
+    if (element.closest('[data-darkreader-ignore-inline]')) {
+        return;
+    }
+
     if (elementsLastChanges.has(element)) {
         if (Date.now() - elementsLastChanges.get(element)! < LOOP_DETECTION_THRESHOLD) {
             const cycles = elementsLoopCycles.get(element) ?? 0;

--- a/tests/inject/dynamic/inline-override.tests.ts
+++ b/tests/inject/dynamic/inline-override.tests.ts
@@ -38,6 +38,41 @@ describe('INLINE STYLES', () => {
         expect(getComputedStyle(span).color).toBe('rgb(140, 255, 140)');
     });
 
+    for (const attribute of ['data-darkreader-ignore-inline', 'data-darkreader-ignore-inline="true"']) {
+        it(`should not mutate inline styles in a subtree with ${attribute}`, async () => {
+            container.innerHTML = multiline(
+                `<div ${attribute} style="color: red;">`,
+                '    <div><span style="color: red;">Editor content</span></div>',
+                '    <svg><path fill="red" d="M0 0h10v10z" /></svg>',
+                '</div>',
+                '<span style="color: red;">Outside editor</span>',
+            );
+            const editor = container.firstElementChild as HTMLElement;
+            const originalHTML = editor.outerHTML;
+            createOrUpdateDynamicTheme(theme, null, false);
+            await timeout(0);
+            expect(editor.outerHTML).toBe(originalHTML);
+            expect(getComputedStyle(container.lastElementChild!).color).toBe('rgb(255, 26, 26)');
+
+            editor.querySelector('span')!.style.color = 'green';
+            editor.firstElementChild!.insertAdjacentHTML('beforeend', '<span style="color: blue;">New content</span>');
+            const updatedHTML = editor.outerHTML;
+            await timeout(0);
+            expect(editor.outerHTML).toBe(updatedHTML);
+        });
+    }
+
+    it('should ignore inline styles in a dynamically inserted opted-out subtree', async () => {
+        createOrUpdateDynamicTheme(theme, null, false);
+        const element = document.createElement('div');
+        element.setAttribute('data-darkreader-ignore-inline', '');
+        element.innerHTML = '<div><span style="color: red;">New content</span></div>';
+        const originalHTML = element.outerHTML;
+        container.appendChild(element);
+        await timeout(0);
+        expect(element.outerHTML).toBe(originalHTML);
+    });
+
     it('should override only a single inline style property', async () => {
         container.innerHTML = multiline(
             '<style>.bg-gray { background: gray; }</style>',


### PR DESCRIPTION
Hi, long-time darkreader user here.

I make a rich text editing library called [BlockNote](https://github.com/TypeCellOS/BlockNote) and our editor does not play well with having attributes being stamped on it's elements.

It looks like this has already been an issue before, https://github.com/ueberdosis/tiptap/issues/3818#issuecomment-2247047938 https://github.com/darkreader/darkreader/issues/14790 , since I see that there is a ProseMirror carve out (our base rich text editing framework). But, BlockNote uses elements that are deeper in the tree, so the carve-out for ProseMirror is not enough for our needs.

I thought the most reasonable way to go about this was to contribute something to darkreader, rather than having to add extension-specific detection to our editing library (like [what was proposed here](https://github.com/TypeCellOS/BlockNote/pull/3062)). Rich-text editors based on ProseMirror have this issue because ProseMirror heavily relies on the MutationObserver API to watch for changes to the rich text content, but darkreader stamping attributes everywhere both causes a lot of noise or in some cases can cause infinite loops like what is happening in BlockNote.

So, my suggestion here is to not just try to ignore anything that is ProseMirror/Tiptap/BlockNote based, and instead offer an attribute that marks this specific behavior as being disabled on this sub-tree so that we don't get elements being stamped causing infinite loops in our library.
