### PR TITLE
Add brightness filter for grey placeholder images

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5633,6 +5633,7 @@ INVERT
 .orb-icon .orb-icon-arrow
 [class*="NavigationLink-LogoLink"] > span > svg
 span[class*="LogoIconWrapper"]
+img[src$="grey-placeholder.png"]
 
 CSS
 .wr-icon-weather-type__svg-background,
@@ -5650,9 +5651,6 @@ CSS
 .haCQWq,
 .fFEZuA {
     filter: invert(90%) !important;
-}
-img[src*="grey-placeholder"] {
-    filter: brightness(0) !important;
 }
 
 IGNORE IMAGE ANALYSIS

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5651,6 +5651,9 @@ CSS
 .fFEZuA {
     filter: invert(90%) !important;
 }
+img[src*="grey-placeholder"] {
+    filter: brightness(0) !important;
+}
 
 IGNORE IMAGE ANALYSIS
 *


### PR DESCRIPTION
FIX for bbc.com: When loading an article, white boxes appear where images will be displayed (which are lazily loaded later). Buxfix resolves this issue.