### PR TITLE
Wait for startBarrier before DOCUMENT_CONNECT theme

### DIFF
--- a/src/background/extension.ts
+++ b/src/background/extension.ts
@@ -484,6 +484,7 @@ export class Extension {
     };
 
     private static async getConnectionMessage(tabURL: string, url: string, isTopFrame: boolean, topFrameHasDarkTheme?: boolean) {
+        await Extension.waitUntilReady();
         await Extension.loadData();
         return Extension.getTabMessage(tabURL, url, isTopFrame, topFrameHasDarkTheme);
     }


### PR DESCRIPTION
Fixes #15913

## Problem

On cold startup, DOCUMENT_CONNECT can be handled before ConfigManager.load() finishes. getConnectionMessage() only awaited Extension.loadData(), which does not load site-fix indexes. If getTabMessage() then ran with DETECTOR_HINTS_INDEX still undefined, content scripts hit TypeError and received no theme until reload.

onCommandInternal already waits on Extension.waitUntilReady() (startBarrier). start() resolves that barrier only after ConfigManager.load({local: true}).

## Change

In getConnectionMessage(), await Extension.waitUntilReady() before loadData() / getTabMessage(), matching onCommandInternal.

## Tests

No unit harness for src/background/extension.ts. Verified startBarrier is resolved after config load; npm run test:unit — 16 suites, 75 tests passed.

Drafted with Cursor (Grok); reviewed before opening.
